### PR TITLE
Fixed admin page according to comments

### DIFF
--- a/src/components/admin/admin-navigation/admin-navigation.scss
+++ b/src/components/admin/admin-navigation/admin-navigation.scss
@@ -1,6 +1,6 @@
 .admin {
   &-logo {
-    height: 110px;
+    height: 150px;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -19,7 +19,7 @@
       color: black;
       text-decoration: none;
       position: relative;
-      padding: 10px 10px 10px 40px;
+      padding: 15px 10px 15px 40px;
     }
 
     &-selected {
@@ -31,7 +31,7 @@
         left: 0;
         top: 0;
         height: 100%;
-        width: 3%;
+        width: 8px;
         background-color: #081124;
       }
     }

--- a/src/components/common/select/Select.test.tsx
+++ b/src/components/common/select/Select.test.tsx
@@ -146,6 +146,8 @@ describe('Select Component', () => {
         expect(span).toHaveStyle('color: #61615C');
 
         fireEvent.click(selectContainer);
+        expect(span).toHaveStyle('color: #061125');
+        
         const option = screen.getByText('Option 1');
         fireEvent.click(option);
 

--- a/src/components/common/select/Select.tsx
+++ b/src/components/common/select/Select.tsx
@@ -39,7 +39,7 @@ export const Select = <TValue, >({
                      }
                  }}>
         <span
-            style={selectedValue !== null && selectedValue !== undefined ? {color: "#061125"} : {color: "#61615C"}}> {selectedValue !== null && selectedValue !== undefined ? selectedValue.toString() : 'Статус'}</span>
+            style={isOpen || (selectedValue !== null && selectedValue !== undefined) ? {color: "#061125"} : {color: "#61615C"}}> {selectedValue !== null && selectedValue !== undefined ? selectedValue.toString() : 'Статус'}</span>
         <img src={isOpen ? ArrowUp : ArrowDown} alt="arrow-down"/>
         <div className={`select-options ${isOpen ? 'select-options-visible' : ''}`}>
             {options.map((opt, index) => {

--- a/src/components/common/select/select.scss
+++ b/src/components/common/select/select.scss
@@ -15,7 +15,7 @@
   }
 
   &-closed {
-    justify-content: center;
+    justify-content: space-between;
   }
 
   &-options {
@@ -50,7 +50,6 @@
     &-selected {
       span {
         color: #061125;
-        width: 100%;
         border-bottom: 1px solid black;
       }
     }

--- a/src/pages/admin/team/components/members-list-item/members-list-item.scss
+++ b/src/pages/admin/team/components/members-list-item/members-list-item.scss
@@ -10,7 +10,7 @@
   box-sizing: border-box;
   background-color: white;
   box-shadow: 0 0 4px rgba(128, 128, 128, 0.45);
-  margin-bottom: 10px;
+  margin-bottom: 8px;
 }
 
 .members-dragger {

--- a/src/pages/admin/team/components/members-list/MembersList.tsx
+++ b/src/pages/admin/team/components/members-list/MembersList.tsx
@@ -451,6 +451,7 @@ export const MembersList = ({searchByNameQuery, statusFilter, onAutocompleteValu
                     </div>
                 </Modal.Title>
                 <Modal.Content>
+                <></>
                 </Modal.Content>
                 <Modal.Actions>
                     <div className='members-delete-modal-actions'>

--- a/src/pages/admin/team/components/members-list/members-list.scss
+++ b/src/pages/admin/team/components/members-list/members-list.scss
@@ -163,7 +163,6 @@
             box-shadow: 0 1px 0 0 #00000040;
 
             &-inner {
-              margin: 16px;
               border: 1px dashed #A1A1A1;
               width: 114px;
               height: 120px;

--- a/src/pages/admin/team/components/team-page-toolbar/TeamPageToolbar.tsx
+++ b/src/pages/admin/team/components/team-page-toolbar/TeamPageToolbar.tsx
@@ -82,6 +82,7 @@ const ConfirmPublishModal = ({
     <Modal isOpen={isOpen} onClose={onCancel} data-testid="publish-confirm-modal">
         <Modal.Title>{TEAM_PUBLISH_NEW_MEMBER}</Modal.Title>
         <Modal.Content>
+            <></>
         </Modal.Content>
         <Modal.Actions>
             <Button onClick={onCancel} buttonStyle="secondary">
@@ -106,7 +107,7 @@ const ConfirmCloseModal = ({
     <Modal isOpen={isOpen} onClose={onCancel} data-testid="confirm-close-modal">
         <Modal.Title>{TEAM_CHANGES_LOST}</Modal.Title>
         <Modal.Content>
-
+            <></>
         </Modal.Content>
         <Modal.Actions>
             <Button onClick={onCancel} buttonStyle="secondary">


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/204)

## Description

Compare and eliminate inconsistencies between the mockup (Figma) and the implemented frontend functionality of the admin team page according:
https://discord.com/channels/1344044167570915339/1372089997036879955/1387397757802647642

## How it looks

![image](https://github.com/user-attachments/assets/3eb19b45-91ad-4d63-bb7c-ec46d7abde40)

![image](https://github.com/user-attachments/assets/b26a77b9-075b-4f71-9df3-26f9702dea0d)

## Summary of change

 - side panel black line width is 8px;
 - side panel is aligned with tabs;
 - side panel buttons have 60px width;
 - team member cards have 8px identation;
 - updated category dropdown;
 - text in photo upload button is centered.

## How to recreate changes

1. Go to admin page(http://localhost:3000/admin-page/team)
2. Open Add-member modal


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions
