### PR TITLE
Feature/issue 354: Enable partners link on footer

### DIFF
--- a/src/components/public/footer/Footer.test.tsx
+++ b/src/components/public/footer/Footer.test.tsx
@@ -71,7 +71,7 @@ describe('Footer', () => {
         expect(screen.getByRole('link', { name: ABOUT_US })).toHaveAttribute('href', PUBLIC_ROUTES.ABOUT_US.FULL);
         expect(screen.getByRole('link', { name: OUR_HISTORY })).toHaveAttribute('href', PUBLIC_ROUTES.MOCK.FULL);
         expect(screen.getByRole('link', { name: OUR_TEAM })).toHaveAttribute('href', PUBLIC_ROUTES.TEAM.FULL);
-        expect(screen.getByRole('link', { name: PARTNERS })).toHaveAttribute('href', PUBLIC_ROUTES.MOCK.FULL);
+        expect(screen.getByRole('link', { name: PARTNERS })).toHaveAttribute('href', PUBLIC_ROUTES.PARTNERS.FULL);
         expect(screen.getByRole('link', { name: EVENTS_AND_NEWS })).toHaveAttribute('href', PUBLIC_ROUTES.MOCK.FULL);
     });
 

--- a/src/components/public/footer/Footer.tsx
+++ b/src/components/public/footer/Footer.tsx
@@ -95,9 +95,7 @@ export const Footer = () => {
                         {OUR_HISTORY}
                     </Link>
                     <Link to={PUBLIC_ROUTES.TEAM.FULL}>{OUR_TEAM}</Link>
-                    <Link to={PUBLIC_ROUTES.MOCK.FULL} className="disable">
-                        {PARTNERS}
-                    </Link>
+                    <Link to={PUBLIC_ROUTES.PARTNERS.FULL}>{PARTNERS}</Link>
                     <Link to={PUBLIC_ROUTES.MOCK.FULL} className="disable">
                         {EVENTS_AND_NEWS}
                     </Link>


### PR DESCRIPTION
## Description

 Enable partners link on footer

## How to recreate changes

Start front end and go to footer


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions
