### PR TITLE
Feature/issue 424: Change responsive layout from flex approach to grid

### DIFF
--- a/src/components/common/partners/PartnerSection.scss
+++ b/src/components/common/partners/PartnerSection.scss
@@ -5,21 +5,32 @@
 .partners-content-section {
     padding: 5rem 0;
     background-color: white;
-    width: 99vw;
+    width: 100%;
     position: relative;
+
+    &::after {
+        content: '';
+        position: absolute;
+        left: 3.5rem;
+        right: 5rem;
+        bottom: 0;
+        height: 2px;
+        background: colors.$grey-400;
+    }
 
     .container {
         max-width: 100%;
         margin: 0 auto;
-        padding: 0 5rem;
+        padding: 0 5rem 0 3.5rem;
+        position: relative;
     }
 
     .partners-header {
-        margin-bottom: 3.5rem;
+        margin-bottom: 11.25rem;
         display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
-        column-gap: 4rem;
-        row-gap: 4rem;
+        grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
+        column-gap: 1rem;
+        row-gap: 1rem;
         align-items: start;
         justify-items: start;
 
@@ -27,7 +38,7 @@
             font-family: fonts.$mulish-regular-font;
             font-weight: 600;
             font-size: 2rem;
-            line-height: 1.2;
+            line-height: 2.375rem;
             color: colors.$blue-900;
             grid-column: 1 / span 2;
         }
@@ -45,8 +56,9 @@
 
     .partners-logos {
         display: grid;
-        grid-template-columns: repeat(auto-fill , minmax(10rem, 1rem));
-        gap: 4rem 4rem;
+        grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
+        column-gap: 1rem;
+        row-gap: 4rem;
         justify-items: center;
         align-items: start;
         width: 100%;
@@ -61,14 +73,13 @@
         gap: 1rem;
 
         .partner-logo {
-            width: 13rem;
-            height: 13rem;
+            width: 100%;
+            max-width: 13rem;
+            aspect-ratio: 1/1;
             object-fit: contain;
             display: block;
             background-color: white;
-            border-radius: 0.5rem;
-            flex: 0 0 auto;
-            align-self: center;
+            margin: 0 auto 0 0;
         }
 
         .partner-name {
@@ -81,66 +92,47 @@
             max-width: 12rem;
         }
     }
-
-    &::after {
-        content: '';
-        position: absolute;
-        bottom: 0;
-        left: 5rem;
-        right: 5rem;
-        width: calc(100% - 10rem);
-        height: 1px;
-        background-color: colors.$grey-50;
-    }
 }
 
-@media (max-width: 912px) {
+.partners-content-section:last-of-type .container::after {
+    display: none;
+}
+
+@media (max-width: 768px) {
     .partners-content-section {
-        padding: 3.75rem 0;
+        padding: 5.625rem 0 7.5rem 0;
+
+        &::after {
+            left: 1rem;
+            right: 1rem;
+        }
 
         .container {
-            padding: 0 1rem;
+            padding: 0 3.5rem 0 3.5rem;
         }
 
         .partners-header {
+            margin-bottom: 7.5rem;
             grid-template-columns: 1fr;
-            column-gap: 0;
-            row-gap: 1rem;
-            text-align: center;
-            justify-items: center;
+            text-align: start;
+            justify-items: start;
 
             .section-title {
                 grid-column: 1;
-                font-size: 2rem;
                 line-height: 1.25;
             }
 
             .section-description {
                 grid-column: 1;
-                font-size: 0.95rem;
+                font-size: 1.25rem;
                 line-height: 1.5;
-                text-align: center;
+                text-align: start;
             }
         }
+
 
         .partners-logos {
-            gap: 2.5rem 2rem;
-            justify-items: center;
-        }
-
-        .partner-item {
-            align-items: center;
-            text-align: center;
-
-            .partner-logo {
-                width: 8rem;
-                height: 8rem;
-            }
-
-            .partner-name {
-                max-width: 8rem;
-                font-size: 0.8rem;
-            }
+            grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
         }
 
         &::after {
@@ -154,13 +146,9 @@
 @media (max-width: 560px) {
 
     .partners-content-section {
-        .container {
-            padding: 4rem;
-        }
 
         .partners-logos {
-            grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
-            gap: 2rem 1.25rem;
+            column-gap: 2rem;
         }
 
         .partners-header {
@@ -171,11 +159,6 @@
             .section-description {
                 text-align: left;
             }
-        }
-
-        .partner-item .partner-logo {
-            width: 7rem;
-            height: 7rem;
         }
     }
 }
@@ -186,36 +169,41 @@
             padding: 0 1rem;
         }
 
+        &::after {
+            left: 1rem;
+            right: 1rem;
+        }
+
         .partners-header {
             text-align: left;
             justify-items: start;
 
-            .section-title,
+            .section-title{
+                font-size: 2rem;
+            }
             .section-description {
                 text-align: left;
+                font-size: 1.125rem;
             }
-        }   
+        }
 
         .partners-logos {
-            grid-template-columns: 1fr;
-            gap: 1.75rem;
-            justify-items: stretch;
+            grid-template-columns: repeat(auto-fill, minmax(6rem, 1fr));
+            column-gap: 1rem;
         }
 
         .partner-item {
-            flex-direction: row;
-            align-items: center;
-            gap: 1rem;
-            text-align: left;
+            min-width: 0;
 
             .partner-logo {
-                width: 5rem;
-                height: 5rem;
+                max-width: 7rem;
             }
 
             .partner-name {
-                font-size: 0.75rem;
-                max-width: 100%;
+                font-size: 0.875rem;
+                line-height: 1.25rem;
+                max-width: 7rem;
+                margin: 0 auto 0 0;
             }
         }
 

--- a/src/components/common/partners/PartnerSection.scss
+++ b/src/components/common/partners/PartnerSection.scss
@@ -134,12 +134,6 @@
         .partners-logos {
             grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
         }
-
-        &::after {
-            left: 1rem;
-            right: 1rem;
-            width: calc(100% - 2rem);
-        }
     }
 }
 
@@ -205,12 +199,6 @@
                 max-width: 7rem;
                 margin: 0 auto 0 0;
             }
-        }
-
-        &::after {
-            left: 1rem;
-            right: 1rem;
-            width: calc(100% - 2rem);
         }
     }
 }

--- a/src/components/common/partners/PartnerSection.scss
+++ b/src/components/common/partners/PartnerSection.scss
@@ -15,11 +15,13 @@
     }
 
     .partners-header {
-        margin-bottom: 5rem;
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-start;
-        gap: 2rem;
+        margin-bottom: 3.5rem;
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+        column-gap: 4rem;
+        row-gap: 4rem;
+        align-items: start;
+        justify-items: start;
 
         .section-title {
             font-family: fonts.$mulish-regular-font;
@@ -27,31 +29,27 @@
             font-size: 2rem;
             line-height: 1.2;
             color: colors.$blue-900;
-            margin: 0;
-            flex: 1;
-            max-width: 35%;
+            grid-column: 1 / span 2;
         }
 
         .section-description {
             font-family: fonts.$mulish-regular-font;
             font-weight: 500;
-            font-size: 1.25rem;
-            line-height: 1.4;
+            font-size: 1rem;
+            line-height: 1.45;
             color: colors.$blue-900;
-            margin: 0;
-            flex: 1;
-            max-width: 35%;
             text-align: left;
+            grid-column: -3 / -1;
         }
     }
 
     .partners-logos {
-        display: flex;
-        justify-content: flex-start;
-        align-items: flex-start;
-        gap: 4rem;
-        flex-wrap: wrap;
-        overflow-x: auto;
+        display: grid;
+        grid-template-columns: repeat(auto-fill , minmax(10rem, 1rem));
+        gap: 4rem 4rem;
+        justify-items: center;
+        align-items: start;
+        width: 100%;
     }
 
     .partner-item {
@@ -63,8 +61,8 @@
         gap: 1rem;
 
         .partner-logo {
-            width: 10rem;
-            height: 10rem;
+            width: 13rem;
+            height: 13rem;
             object-fit: contain;
             display: block;
             background-color: white;
@@ -105,36 +103,34 @@
         }
 
         .partners-header {
-            margin-bottom: 3rem;
-            flex-direction: column;
+            grid-template-columns: 1fr;
+            column-gap: 0;
+            row-gap: 1rem;
             text-align: center;
-            gap: 1rem;
+            justify-items: center;
 
             .section-title {
+                grid-column: 1;
                 font-size: 2rem;
                 line-height: 1.25;
-                max-width: none;
             }
 
             .section-description {
-                font-size: 1rem;
+                grid-column: 1;
+                font-size: 0.95rem;
                 line-height: 1.5;
-                max-width: none;
                 text-align: center;
             }
         }
 
         .partners-logos {
-            align-items: flex-start;
-            gap: 2.5rem;
-            flex-wrap: wrap;
-            overflow-x: visible;
+            gap: 2.5rem 2rem;
+            justify-items: center;
         }
 
         .partner-item {
-            flex-direction: column;
+            align-items: center;
             text-align: center;
-            gap: 1rem;
 
             .partner-logo {
                 width: 8rem;
@@ -142,7 +138,8 @@
             }
 
             .partner-name {
-                text-align: center;
+                max-width: 8rem;
+                font-size: 0.8rem;
             }
         }
 
@@ -154,41 +151,62 @@
     }
 }
 
+@media (max-width: 560px) {
+
+    .partners-content-section {
+        .container {
+            padding: 4rem;
+        }
+
+        .partners-logos {
+            grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
+            gap: 2rem 1.25rem;
+        }
+
+        .partners-header {
+            text-align: left;
+            justify-items: start;
+
+            .section-title,
+            .section-description {
+                text-align: left;
+            }
+        }
+
+        .partner-item .partner-logo {
+            width: 7rem;
+            height: 7rem;
+        }
+    }
+}
+
 @media (max-width: 375px) {
     .partners-content-section {
         .container {
-            margin: 0;
-            margin-left: 0;
             padding: 0 1rem;
         }
 
         .partners-header {
-            display: block;
             text-align: left;
-            margin-bottom: 2rem;
+            justify-items: start;
 
-            .section-title {
-                text-align: left;
-                max-width: 100%;
-                margin-bottom: 1rem;
-            }
-
+            .section-title,
             .section-description {
                 text-align: left;
-                max-width: 100%;
             }
-        }
+        }   
 
         .partners-logos {
-            flex-direction: column;
-            align-items: flex-start;
-            gap: 2rem;
+            grid-template-columns: 1fr;
+            gap: 1.75rem;
+            justify-items: stretch;
         }
 
         .partner-item {
             flex-direction: row;
             align-items: center;
             gap: 1rem;
+            text-align: left;
 
             .partner-logo {
                 width: 5rem;
@@ -196,8 +214,8 @@
             }
 
             .partner-name {
-                text-align: left;
                 font-size: 0.75rem;
+                max-width: 100%;
             }
         }
 


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/424#issue-3379179531)

## Description

* Fix partners page according to the figma
* Change responsive layout from flex approach to grid 

## How it looks
<img width="937" height="896" alt="image" src="https://github.com/user-attachments/assets/5a3fc02b-6b92-499a-9faf-f00e3c51a8ba" />
<img width="763" height="895" alt="image" src="https://github.com/user-attachments/assets/a2efc52c-1df0-4307-95ed-257779c4d540" />
<img width="562" height="892" alt="image" src="https://github.com/user-attachments/assets/c7a8765c-ef5a-426c-878c-f1597f78a40d" />
<img width="373" height="896" alt="image" src="https://github.com/user-attachments/assets/38446cb6-33fa-446a-bf8a-75aac93fb54a" />



## Summary of change

Change responsive layout from flex approach to grid via rewriting PartnerSection.scss

## How to recreate changes

pull this branch on your local machine, start web-server and go to partners page


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned Partners section with a responsive grid layout for headers and logos.
  * Improved spacing, alignment, and typography for titles and descriptions across breakpoints.
  * Enhanced logo presentation with responsive sizing and better centering.
  * Optimized mobile layouts (tablet and small screens) to single-column with adjusted gaps and text alignment.
  * Added a subtle decorative background element; removed the bottom divider on the last section.
  * General refinements to padding and widths for a cleaner, more consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->