### PR TITLE
Feature/issue 352: Z-index

### DIFF
--- a/src/assets/sass/variables/z-index.scss
+++ b/src/assets/sass/variables/z-index.scss
@@ -1,0 +1,26 @@
+$modal: 900;
+$full-page-loader: 1000;
+$single-select-input: 10;
+$scrollable-frame-arrows: 1;
+
+
+$public-layout: (
+    dropdown-menu: 700,
+    header: 5,
+    about-us-page-main-value-text: 1,
+    about-us-page-main-value-background: -1,
+    programs-page-intro-section-text: 1,
+    programs-page-intro-section-background: -1,
+    team-page-members-loader: 10,
+);
+
+$admin-layout: (
+    toast-container: 800,
+    tooltip: 700,
+    context-menu-button-options: 10,
+    drag-preview: 20,
+    infinite-scroll-list-arrow-up: 10,
+    multi-select-input: 10,
+    search-bar-suggestions: 10,
+    select: 10,
+);

--- a/src/assets/sass/variables/z-index.scss
+++ b/src/assets/sass/variables/z-index.scss
@@ -1,8 +1,14 @@
-$modal: 900;
+// Global z-index ranges:
+// 1000+ – global elements
+// 900-999  – modal
+// 800-899  – toast
+// 700-799  – tooltip, dropdowns
+// 1–100 – small elements (inputs, arrows, loaders etc.)
+
 $full-page-loader: 1000;
+$modal: 900;
 $single-select-input: 10;
 $scrollable-frame-arrows: 1;
-
 
 $public-layout: (
     dropdown-menu: 700,
@@ -24,3 +30,11 @@ $admin-layout: (
     search-bar-suggestions: 10,
     select: 10,
 );
+
+@function public($key) {
+  @return map-get($public-layout, $key);
+}
+
+@function admin($key) {
+  @return map-get($admin-layout, $key);
+}

--- a/src/assets/sass/variables/z-index.scss
+++ b/src/assets/sass/variables/z-index.scss
@@ -1,0 +1,6 @@
+$toast-container: 1000;
+$dropdown-menu: 900;
+$public-layout: (
+    header: 200,
+    main: 100,
+)

--- a/src/assets/sass/variables/z-index.scss
+++ b/src/assets/sass/variables/z-index.scss
@@ -1,6 +1,26 @@
-$toast-container: 1000;
-$dropdown-menu: 900;
+$modal: 900;
+$full-page-loader: 1000;
+$single-select-input: 10;
+$scrollable-frame-arrows: 1;
+
+
 $public-layout: (
-    header: 200,
-    main: 100,
+    dropdown-menu: 700,
+    header: 5,
+    about-us-page-main-value-text: 1,
+    about-us-page-main-value-background: -1,
+    programs-page-intro-section-text: 1,
+    programs-page-intro-section-background: -1,
+    team-page-members-loader: 10,
+);
+
+$admin-layout: (
+    toast-container: 800,
+    tooltip: 700,
+    context-menu-button-options: 10,
+    drag-preview: 20,
+    infinite-scroll-list-arrow-up: 10,
+    multi-select-input: 10,
+    search-bar-suggestions: 10,
+    select: 10,
 )

--- a/src/assets/sass/variables/z-index.scss
+++ b/src/assets/sass/variables/z-index.scss
@@ -23,4 +23,4 @@ $admin-layout: (
     multi-select-input: 10,
     search-bar-suggestions: 10,
     select: 10,
-)
+);

--- a/src/components/admin/context-menu-button/ContextMenuButton.scss
+++ b/src/components/admin/context-menu-button/ContextMenuButton.scss
@@ -1,4 +1,5 @@
 @use '../../../assets/sass/variables/colors';
+@use '../../../assets/sass/variables/z-index.scss';
 
 .context-menu-button {
     position: relative;
@@ -24,7 +25,7 @@
         top: calc(100% + 2px);
         left: 0;
         display: none;
-        z-index: 10;
+        z-index: map-get(z-index.$admin-layout, context-menu-button-options);
         width: 11.25rem;
         border: 1px solid colors.$blue-900;
         background: white;

--- a/src/components/admin/context-menu-button/ContextMenuButton.scss
+++ b/src/components/admin/context-menu-button/ContextMenuButton.scss
@@ -1,5 +1,5 @@
 @use '../../../assets/sass/variables/colors';
-@use '../../../assets/sass/variables/z-index.scss';
+@use '../../../assets/sass/variables/z-index';
 
 .context-menu-button {
     position: relative;
@@ -25,7 +25,7 @@
         top: calc(100% + 2px);
         left: 0;
         display: none;
-        z-index: map-get(z-index.$admin-layout, context-menu-button-options);
+        z-index: z-index.admin(context-menu-button-options);
         width: 11.25rem;
         border: 1px solid colors.$blue-900;
         background: white;

--- a/src/components/admin/drag-preview/DragPreview.scss
+++ b/src/components/admin/drag-preview/DragPreview.scss
@@ -1,8 +1,9 @@
 @use '../../../assets/sass/variables/colors';
+@use '../../../assets/sass/variables/z-index.scss';
 
 .drag-preview {
     position: fixed;
-    z-index: 12;
+    z-index: map-get(z-index.$admin-layout, drag-preview);
     pointer-events: none;
     background-color: white;
     border: 2px solid colors.$blue-50;

--- a/src/components/admin/drag-preview/DragPreview.scss
+++ b/src/components/admin/drag-preview/DragPreview.scss
@@ -1,9 +1,9 @@
 @use '../../../assets/sass/variables/colors';
-@use '../../../assets/sass/variables/z-index.scss';
+@use '../../../assets/sass/variables/z-index';
 
 .drag-preview {
     position: fixed;
-    z-index: map-get(z-index.$admin-layout, drag-preview);
+    z-index: z-index.admin(drag-preview);
     pointer-events: none;
     background-color: white;
     border: 2px solid colors.$blue-50;

--- a/src/components/admin/infinite-scroll-list/InfiniteScrollList.scss
+++ b/src/components/admin/infinite-scroll-list/InfiniteScrollList.scss
@@ -1,4 +1,5 @@
 @use '../../../assets/sass/variables/colors';
+@use '../../../assets/sass/variables/z-index.scss';
 
 .infinite-scroll-list-container {
     display: flex;
@@ -30,7 +31,7 @@
         position: absolute;
         right: 9.375rem;
         bottom: 3.125rem;
-        z-index: 10;
+        z-index: map-get(z-index.$admin-layout, infinite-scroll-list-arrow-up);
         display: flex;
         align-items: center;
         justify-content: center;

--- a/src/components/admin/infinite-scroll-list/InfiniteScrollList.scss
+++ b/src/components/admin/infinite-scroll-list/InfiniteScrollList.scss
@@ -1,5 +1,5 @@
 @use '../../../assets/sass/variables/colors';
-@use '../../../assets/sass/variables/z-index.scss';
+@use '../../../assets/sass/variables/z-index';
 
 .infinite-scroll-list-container {
     display: flex;
@@ -31,7 +31,7 @@
         position: absolute;
         right: 9.375rem;
         bottom: 3.125rem;
-        z-index: map-get(z-index.$admin-layout, infinite-scroll-list-arrow-up);
+        z-index: z-index.admin(infinite-scroll-list-arrow-up);
         display: flex;
         align-items: center;
         justify-content: center;

--- a/src/components/admin/multi-select-input/MultiSelectInput.scss
+++ b/src/components/admin/multi-select-input/MultiSelectInput.scss
@@ -1,5 +1,5 @@
 @use '../../../assets/sass/variables/colors';
-@use '../../../assets/sass/variables/z-index.scss';
+@use '../../../assets/sass/variables/z-index';
 
 .multiselect {
     position: relative;
@@ -69,7 +69,7 @@
         position: absolute;
         top: calc(100% + 0.25rem);
         left: 0;
-        z-index: map-get(z-index.$admin-layout, multi-select-input);
+        z-index: z-index.admin(multi-select-input);
         width: 100%;
         max-height: 12.5rem;
         overflow-y: auto;

--- a/src/components/admin/multi-select-input/MultiSelectInput.scss
+++ b/src/components/admin/multi-select-input/MultiSelectInput.scss
@@ -1,4 +1,5 @@
 @use '../../../assets/sass/variables/colors';
+@use '../../../assets/sass/variables/z-index.scss';
 
 .multiselect {
     position: relative;
@@ -68,7 +69,7 @@
         position: absolute;
         top: calc(100% + 0.25rem);
         left: 0;
-        z-index: 10;
+        z-index: map-get(z-index.$admin-layout, multi-select-input);
         width: 100%;
         max-height: 12.5rem;
         overflow-y: auto;

--- a/src/components/admin/search-bar/SearchBar.scss
+++ b/src/components/admin/search-bar/SearchBar.scss
@@ -1,5 +1,5 @@
 @use '../../../assets/sass/variables/colors';
-@use '../../../assets/sass/variables/z-index.scss';
+@use '../../../assets/sass/variables/z-index';
 
 .search-bar {
     position: relative;
@@ -65,7 +65,7 @@
         border: 0.5px solid colors.$grey-900;
         border-top: none;
         background: white;
-        z-index: map-get(z-index.$admin-layout, search-bar-suggestions);
+        z-index: z-index.admin(search-bar-suggestions);
         scroll-behavior: smooth;
     }
 

--- a/src/components/admin/search-bar/SearchBar.scss
+++ b/src/components/admin/search-bar/SearchBar.scss
@@ -1,4 +1,5 @@
 @use '../../../assets/sass/variables/colors';
+@use '../../../assets/sass/variables/z-index.scss';
 
 .search-bar {
     position: relative;
@@ -64,7 +65,7 @@
         border: 0.5px solid colors.$grey-900;
         border-top: none;
         background: white;
-        z-index: 10;
+        z-index: map-get(z-index.$admin-layout, search-bar-suggestions);
         scroll-behavior: smooth;
     }
 

--- a/src/components/admin/select/Select.scss
+++ b/src/components/admin/select/Select.scss
@@ -1,4 +1,5 @@
 @use '../../../assets/sass/variables/colors';
+@use '../../../assets/sass/variables/z-index.scss';
 
 .select {
     position: relative;
@@ -37,7 +38,7 @@
         width: 100%;
         border: 1px solid colors.$blue-500;
         background-color: white;
-        z-index: 4;
+        z-index: map-get(z-index.$admin-layout, select);
 
         button {
             color: black;

--- a/src/components/admin/select/Select.scss
+++ b/src/components/admin/select/Select.scss
@@ -1,5 +1,5 @@
 @use '../../../assets/sass/variables/colors';
-@use '../../../assets/sass/variables/z-index.scss';
+@use '../../../assets/sass/variables/z-index';
 
 .select {
     position: relative;
@@ -38,7 +38,7 @@
         width: 100%;
         border: 1px solid colors.$blue-500;
         background-color: white;
-        z-index: map-get(z-index.$admin-layout, select);
+        z-index: z-index.admin(select);
 
         button {
             color: black;

--- a/src/components/admin/toast/toast-container/ToastContainer.scss
+++ b/src/components/admin/toast/toast-container/ToastContainer.scss
@@ -1,4 +1,4 @@
-@use '../../../../assets/sass/variables/z-index.scss';
+@use '../../../../assets/sass/variables/z-index';
 
 .toast-container {
     position: fixed;
@@ -8,5 +8,5 @@
     display: flex;
     flex-direction: column;
     gap: 0.625rem;
-    z-index: map-get(z-index.$admin-layout, toast-container);
+    z-index: z-index.admin(toast-container);
 }

--- a/src/components/admin/toast/toast-container/ToastContainer.scss
+++ b/src/components/admin/toast/toast-container/ToastContainer.scss
@@ -1,3 +1,5 @@
+@use '../../../../assets/sass/variables/z-index.scss';
+
 .toast-container {
     position: fixed;
     top: 13%;
@@ -6,5 +8,5 @@
     display: flex;
     flex-direction: column;
     gap: 0.625rem;
-    z-index: 9999;
+    z-index: map-get(z-index.$admin-layout, toast-container);
 }

--- a/src/components/admin/tooltip/Tooltip.scss
+++ b/src/components/admin/tooltip/Tooltip.scss
@@ -1,4 +1,5 @@
 @use '../../../assets/sass/variables/colors';
+@use '../../../assets/sass/variables/z-index.scss';
 
 .tooltip-popup {
     position: absolute;
@@ -10,7 +11,7 @@
     word-wrap: break-word;
     border: 1px solid colors.$grey-700;
     transition: opacity 0.2s;
-    z-index: 20;
+    z-index: map-get(z-index.$admin-layout, tooltip);
 
     // Common arrow base styles (used for both before and after pseudo-elements)
     &::before,

--- a/src/components/admin/tooltip/Tooltip.scss
+++ b/src/components/admin/tooltip/Tooltip.scss
@@ -1,5 +1,5 @@
 @use '../../../assets/sass/variables/colors';
-@use '../../../assets/sass/variables/z-index.scss';
+@use '../../../assets/sass/variables/z-index';
 
 .tooltip-popup {
     position: absolute;
@@ -11,7 +11,7 @@
     word-wrap: break-word;
     border: 1px solid colors.$grey-700;
     transition: opacity 0.2s;
-    z-index: map-get(z-index.$admin-layout, tooltip);
+    z-index: z-index.admin(tooltip);
 
     // Common arrow base styles (used for both before and after pseudo-elements)
     &::before,

--- a/src/components/common/modal/Modal.scss
+++ b/src/components/common/modal/Modal.scss
@@ -1,5 +1,5 @@
 @use '../../../assets/sass/variables/colors';
-@use '../../../assets/sass/variables/z-index.scss';
+@use '../../../assets/sass/variables/z-index';
 
 .modal {
     &-overlay {

--- a/src/components/common/modal/Modal.scss
+++ b/src/components/common/modal/Modal.scss
@@ -1,4 +1,5 @@
 @use '../../../assets/sass/variables/colors';
+@use '../../../assets/sass/variables/z-index.scss';
 
 .modal {
     &-overlay {
@@ -11,7 +12,7 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        z-index: 13;
+        z-index: z-index.$modal;
         padding: 1rem;
         box-sizing: border-box;
     }

--- a/src/components/common/page-loader/PageLoader.scss
+++ b/src/components/common/page-loader/PageLoader.scss
@@ -1,3 +1,6 @@
+
+@use '../../../assets/sass/variables/z-index.scss';
+
 .full-page-loader {
     position: fixed;
     top: 0;
@@ -8,7 +11,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 15;
+    z-index: z-index.$full-page-loader;
 }
 
 .loader-icon {

--- a/src/components/common/page-loader/PageLoader.scss
+++ b/src/components/common/page-loader/PageLoader.scss
@@ -1,5 +1,5 @@
 
-@use '../../../assets/sass/variables/z-index.scss';
+@use '../../../assets/sass/variables/z-index';
 
 .full-page-loader {
     position: fixed;

--- a/src/components/common/single-select-input/SingleSelectInput.scss
+++ b/src/components/common/single-select-input/SingleSelectInput.scss
@@ -1,5 +1,5 @@
 @use '../../../assets/sass/variables/colors';
-@use '../../../assets/sass/variables/z-index.scss';
+@use '../../../assets/sass/variables/z-index';
 
 .singleselect {
     width: 100%;

--- a/src/components/common/single-select-input/SingleSelectInput.scss
+++ b/src/components/common/single-select-input/SingleSelectInput.scss
@@ -1,4 +1,5 @@
 @use '../../../assets/sass/variables/colors';
+@use '../../../assets/sass/variables/z-index.scss';
 
 .singleselect {
     width: 100%;
@@ -43,7 +44,7 @@
         background-color: white;
         border: 1px solid colors.$grey-700;
         border-radius: 8px;
-        z-index: 10;
+        z-index: z-index.$single-select-input;
         box-shadow: 0 4px 6px rgba(0, 0, 0, 0.08);
 
         .option {

--- a/src/components/public/dropdown-menu/DropdownMenu.scss
+++ b/src/components/public/dropdown-menu/DropdownMenu.scss
@@ -1,5 +1,6 @@
 @use '../../../assets/sass/variables/fonts';
 @use '../../../assets/sass/variables/colors';
+@use '../../../assets/sass/variables/z-index.scss';
 
 .dropdown {
     position: relative;
@@ -24,7 +25,7 @@
         top: 100%;
         width: 200%;
         background-color: white;
-        z-index: 5000;
+        z-index: map-get(z-index.$public-layout, dropdown-menu);
     }
 
     &-link {

--- a/src/components/public/dropdown-menu/DropdownMenu.scss
+++ b/src/components/public/dropdown-menu/DropdownMenu.scss
@@ -1,6 +1,6 @@
 @use '../../../assets/sass/variables/fonts';
 @use '../../../assets/sass/variables/colors';
-@use '../../../assets/sass/variables/z-index.scss';
+@use '../../../assets/sass/variables/z-index';
 
 .dropdown {
     position: relative;
@@ -25,7 +25,7 @@
         top: 100%;
         width: 200%;
         background-color: white;
-        z-index: map-get(z-index.$public-layout, dropdown-menu);
+        z-index: z-index.public(dropdown-menu);
     }
 
     &-link {

--- a/src/components/public/header/Header.scss
+++ b/src/components/public/header/Header.scss
@@ -1,7 +1,7 @@
 @use '../../../assets/sass/variables/colors';
 @use '../../../assets/sass/variables/fonts';
 @use '../../../assets/sass/mixins/utilits.mixins';
-@use '../../../assets/sass/variables/z-index.scss';
+@use '../../../assets/sass/variables/z-index';
 
 .header-block {
     display: flex;
@@ -11,7 +11,7 @@
     top: 0;
     left: 0;
     width: 100%;
-    z-index: map-get(z-index.$public-layout, header);
+    z-index: z-index.public(header);
 
     height: 4rem;
     padding-top: 0.85rem;

--- a/src/components/public/header/Header.scss
+++ b/src/components/public/header/Header.scss
@@ -1,6 +1,7 @@
 @use '../../../assets/sass/variables/colors';
 @use '../../../assets/sass/variables/fonts';
 @use '../../../assets/sass/mixins/utilits.mixins';
+@use '../../../assets/sass/variables/z-index.scss';
 
 .header-block {
     display: flex;
@@ -10,7 +11,7 @@
     top: 0;
     left: 0;
     width: 100%;
-    z-index: 5;
+    z-index: map-get(z-index.$public-layout, header);
 
     height: 4rem;
     padding-top: 0.85rem;
@@ -107,7 +108,6 @@
         background-color: white;
         width: 12rem;
         flex-direction: column;
-        z-index: 10;
 
         a {
             font-weight: 600;

--- a/src/components/public/header/Header.test.tsx
+++ b/src/components/public/header/Header.test.tsx
@@ -10,7 +10,6 @@ jest.mock('./Header.scss', () => ({}));
 jest.mock('../../../assets/icons/logo-with-text.svg', () => ({
     ReactComponent: () => <svg data-testid="logo-icon" />,
 }));
-
 jest.mock('../../../assets/icons/burger.svg', () => ({
     ReactComponent: () => <div data-testid="burger-icon" />,
 }));

--- a/src/components/public/header/Header.test.tsx
+++ b/src/components/public/header/Header.test.tsx
@@ -8,20 +8,9 @@ import { CONTACT_US, DONATE, HOW_TO_SUPPORT, PROGRAMS, REPORTING } from '../../.
 jest.mock('./Header.scss', () => ({}));
 
 jest.mock('../../../assets/icons/logo-with-text.svg', () => ({
-    ReactComponent: () => <svg data-testid="logo" />,
+    ReactComponent: () => <svg data-testid="logo-icon" />,
 }));
-jest.mock('../../../assets/icons/chevron-up.svg', () => ({
-    ReactComponent: () => <svg data-testid="chevron-up" />,
-}));
-jest.mock('../../../assets/icons/chevron-down.svg', () => ({
-    ReactComponent: () => <svg data-testid="chevron-down" />,
-}));
-jest.mock('../../../assets/icons/menu.svg', () => ({
-    ReactComponent: () => <svg data-testid="menu" />,
-}));
-jest.mock('../../../assets/icons/cross.svg', () => ({
-    ReactComponent: () => <svg data-testid="close" />,
-}));
+
 jest.mock('../../../assets/icons/burger.svg', () => ({
     ReactComponent: () => <div data-testid="burger-icon" />,
 }));

--- a/src/components/public/header/Header.test.tsx
+++ b/src/components/public/header/Header.test.tsx
@@ -8,7 +8,19 @@ import { CONTACT_US, DONATE, HOW_TO_SUPPORT, PROGRAMS, REPORTING } from '../../.
 jest.mock('./Header.scss', () => ({}));
 
 jest.mock('../../../assets/icons/logo-with-text.svg', () => ({
-    ReactComponent: () => <svg data-testid="logo-icon" />,
+    ReactComponent: () => <svg data-testid="logo" />,
+}));
+jest.mock('../../../assets/icons/chevron-up.svg', () => ({
+    ReactComponent: () => <svg data-testid="chevron-up" />,
+}));
+jest.mock('../../../assets/icons/chevron-down.svg', () => ({
+    ReactComponent: () => <svg data-testid="chevron-down" />,
+}));
+jest.mock('../../../assets/icons/menu.svg', () => ({
+    ReactComponent: () => <svg data-testid="menu" />,
+}));
+jest.mock('../../../assets/icons/cross.svg', () => ({
+    ReactComponent: () => <svg data-testid="close" />,
 }));
 jest.mock('../../../assets/icons/burger.svg', () => ({
     ReactComponent: () => <div data-testid="burger-icon" />,

--- a/src/pages/admin/home/AdminHomePage.scss
+++ b/src/pages/admin/home/AdminHomePage.scss
@@ -13,14 +13,12 @@
         no-repeat;
     background-blend-mode: multiply;
     position: relative;
-    z-index: 1;
 
     &::before {
         content: '';
         position: absolute;
         inset: 0;
         background: rgba(white, 0.4);
-        z-index: -1;
     }
 
     .admin-page-main-text {

--- a/src/pages/public/about-us-page/donate-section/DonateSection.scss
+++ b/src/pages/public/about-us-page/donate-section/DonateSection.scss
@@ -19,7 +19,6 @@
         position: absolute;
         top: 3.75rem;
         left: 14%;
-        z-index: 1;
         width: 72%;
         display: flex;
         flex-direction: column;

--- a/src/pages/public/about-us-page/intro-section/IntroSection.scss
+++ b/src/pages/public/about-us-page/intro-section/IntroSection.scss
@@ -21,14 +21,12 @@
         clip-path: inset(9rem 34rem 18rem 1.25rem);
         object-fit: cover;
         object-position: top;
-        z-index: 2;
-        filter: grayscale(0%) brightness(1) saturate(130%) sepia(0.1);
+        filter: grayscale(0%) contrast(100%) brightness(1);
         animation: revealColor 4s ease-out forwards;
     }
 
     .about-us-main-title {
         position: absolute;
-        z-index: 3;
         width: 39.75rem;
         top: 10.5rem;
         left: 5rem;
@@ -50,7 +48,6 @@
     .title-details {
         width: 27rem;
         position: absolute;
-        z-index: 3;
         top: 34rem;
         left: 66.25vw;
         font-family: fonts.$mulish-regular-font;

--- a/src/pages/public/about-us-page/main-value/MainValue.scss
+++ b/src/pages/public/about-us-page/main-value/MainValue.scss
@@ -1,5 +1,6 @@
 @use '../../../../assets/sass/variables/colors';
 @use '../../../../assets/sass/variables/fonts';
+@use '../../../../assets/sass/variables/z-index.scss';
 
 .main-values-block * {
     margin: 0;
@@ -36,6 +37,7 @@
             line-height: 4.5rem;
             text-align: center;
             text-transform: uppercase;
+            z-index: map-get(z-index.$public-layout, about-us-page-main-value-text);
         }
 
         span:nth-child(3) {
@@ -65,7 +67,7 @@
             background: colors.$yellow-300;
             position: absolute;
             top: 0;
-            z-index: -1;
+            z-index: map-get(z-index.$public-layout, about-us-page-main-value-background);
         }
     }
     .people-block {

--- a/src/pages/public/about-us-page/main-value/MainValue.scss
+++ b/src/pages/public/about-us-page/main-value/MainValue.scss
@@ -1,6 +1,6 @@
 @use '../../../../assets/sass/variables/colors';
 @use '../../../../assets/sass/variables/fonts';
-@use '../../../../assets/sass/variables/z-index.scss';
+@use '../../../../assets/sass/variables/z-index';
 
 .main-values-block * {
     margin: 0;
@@ -37,7 +37,7 @@
             line-height: 4.5rem;
             text-align: center;
             text-transform: uppercase;
-            z-index: map-get(z-index.$public-layout, about-us-page-main-value-text);
+            z-index: z-index.public(about-us-page-main-value-text);
         }
 
         span:nth-child(3) {
@@ -67,7 +67,7 @@
             background: colors.$yellow-300;
             position: absolute;
             top: 0;
-            z-index: map-get(z-index.$public-layout, about-us-page-main-value-background);
+            z-index: z-index.public(about-us-page-main-value-background);
         }
     }
     .people-block {

--- a/src/pages/public/about-us-page/our-mission/scrollable-frame/ScrollableFrame.scss
+++ b/src/pages/public/about-us-page/our-mission/scrollable-frame/ScrollableFrame.scss
@@ -1,6 +1,6 @@
 @use '../../../../../assets/sass/variables/colors';
 @use '../../../../../assets/sass/variables/fonts';
-@use '../../../../../assets/sass/variables/z-index.scss';
+@use '../../../../../assets/sass/variables/z-index';
 
 .scroll-block {
     position: relative;

--- a/src/pages/public/about-us-page/our-mission/scrollable-frame/ScrollableFrame.scss
+++ b/src/pages/public/about-us-page/our-mission/scrollable-frame/ScrollableFrame.scss
@@ -1,5 +1,6 @@
 @use '../../../../../assets/sass/variables/colors';
 @use '../../../../../assets/sass/variables/fonts';
+@use '../../../../../assets/sass/variables/z-index.scss';
 
 .scroll-block {
     position: relative;
@@ -24,7 +25,7 @@
         position: absolute;
         width: 100%;
         top: 42%;
-        z-index: 2;
+        z-index: z-index.$scrollable-frame-arrows;
         padding: 0 2rem;
 
         .arrow-button {

--- a/src/pages/public/donate-page/donate-section/DonateSection.scss
+++ b/src/pages/public/donate-page/donate-section/DonateSection.scss
@@ -85,7 +85,6 @@
             height: 100%;
             opacity: 0;
             cursor: inherit;
-            z-index: 1;
 
             -webkit-appearance: none;
             -moz-appearance: none;
@@ -171,7 +170,6 @@
     border-radius: 0.375rem;
     padding: 0.5rem 1.33rem;
     position: absolute;
-    z-index: 1;
     opacity: 0;
     transition:
         opacity 0.3s,

--- a/src/pages/public/partners-page/partners-sections/intro-section/IntroSection.scss
+++ b/src/pages/public/partners-page/partners-sections/intro-section/IntroSection.scss
@@ -19,12 +19,10 @@
     height: 100%;
     object-fit: cover;
     object-position: center;
-    z-index: 1;
 }
 
 .content-overlay {
     position: relative;
-    z-index: 2;
     text-align: center;
     color: white;
     max-width: 1200px;

--- a/src/pages/public/partners-page/partners-sections/outro-section/OutroSection.scss
+++ b/src/pages/public/partners-page/partners-sections/outro-section/OutroSection.scss
@@ -21,12 +21,10 @@
     height: 100vh;
     transform: translate(-50%, -50%);
     object-fit: cover;
-    z-index: -1;
 }
 
 .quote-overlay-partners {
     position: absolute;
-    z-index: 1;
     height: 100%;
     width: 100%;
     display: flex;

--- a/src/pages/public/programs-page/contact-section/ContactSection.scss
+++ b/src/pages/public/programs-page/contact-section/ContactSection.scss
@@ -11,7 +11,6 @@
         width: 100%;
         position: absolute;
         object-fit: cover;
-        z-index: 1;
         pointer-events: none;
     }
 
@@ -20,7 +19,6 @@
         padding-top: 3.75rem;
         width: 65rem;
         position: relative;
-        z-index: 2;
         text-align: center;
 
         .contact-title {

--- a/src/pages/public/programs-page/intro-section/IntroSection.scss
+++ b/src/pages/public/programs-page/intro-section/IntroSection.scss
@@ -1,6 +1,6 @@
 @use '../../../../assets/sass/variables/colors';
 @use '../../../../assets/sass/variables/fonts';
-@use '../../../../assets/sass/variables/z-index.scss';
+@use '../../../../assets/sass/variables/z-index';
 
 * {
     margin: 0;
@@ -58,7 +58,7 @@
     span:nth-child(2) {
         background: colors.$light-blue-200;
         position: relative;
-        z-index: map-get(z-index.$public-layout, programs-page-intro-section-text);
+        z-index: z-index.public(programs-page-intro-section-text);
     }
 
     span:nth-child(2):before {
@@ -67,7 +67,7 @@
         height: 7rem;
         background: colors.$light-blue-200;
         position: absolute;
-        z-index: map-get(z-index.$public-layout, programs-page-intro-section-background);
+        z-index: z-index.public(programs-page-intro-section-background);
     }
 
     .additional-info {

--- a/src/pages/public/programs-page/intro-section/IntroSection.scss
+++ b/src/pages/public/programs-page/intro-section/IntroSection.scss
@@ -1,5 +1,6 @@
 @use '../../../../assets/sass/variables/colors';
 @use '../../../../assets/sass/variables/fonts';
+@use '../../../../assets/sass/variables/z-index.scss';
 
 * {
     margin: 0;
@@ -57,7 +58,7 @@
     span:nth-child(2) {
         background: colors.$light-blue-200;
         position: relative;
-        z-index: 1;
+        z-index: map-get(z-index.$public-layout, programs-page-intro-section-text);
     }
 
     span:nth-child(2):before {
@@ -66,7 +67,7 @@
         height: 7rem;
         background: colors.$light-blue-200;
         position: absolute;
-        z-index: -1;
+        z-index: map-get(z-index.$public-layout, programs-page-intro-section-background);
     }
 
     .additional-info {

--- a/src/pages/public/team-page/TeamPage.scss
+++ b/src/pages/public/team-page/TeamPage.scss
@@ -1,5 +1,6 @@
 @use '../../../assets/sass/variables/colors';
 @use '../../../assets/sass/variables/fonts';
+@use '../../../assets/sass/variables/z-index.scss';
 
 .team-page-container {
     width: 100%;
@@ -14,7 +15,7 @@
         width: 70%;
         margin-bottom: 4rem;
         position: relative;
-        z-index: 10;
+        z-index: map-get(z-index.$public-layout, team-page-members-loader);
     }
 
     h2 {
@@ -122,7 +123,6 @@
         height: auto;
         transform: translate(-50%, -50%);
         object-fit: cover;
-        z-index: -1;
     }
 
     .quote-overlay {
@@ -132,7 +132,6 @@
         top: 50%;
         left: 50%;
         transform: translate(-50%, -50%);
-        z-index: 1;
         max-width: 70%;
         color: white;
         font-weight: 600;

--- a/src/pages/public/team-page/TeamPage.scss
+++ b/src/pages/public/team-page/TeamPage.scss
@@ -1,6 +1,6 @@
 @use '../../../assets/sass/variables/colors';
 @use '../../../assets/sass/variables/fonts';
-@use '../../../assets/sass/variables/z-index.scss';
+@use '../../../assets/sass/variables/z-index';
 
 .team-page-container {
     width: 100%;
@@ -15,7 +15,7 @@
         width: 70%;
         margin-bottom: 4rem;
         position: relative;
-        z-index: map-get(z-index.$public-layout, team-page-members-loader);
+        z-index: z-index.public(team-page-members-loader);
     }
 
     h2 {


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/352)

## Description

Z-indexes has been moved in constants for proper organization.

## Summary of change

z-indexes has been moved in separated file as a constants, some of z-indexes were removed as unnecessary

## How to recreate changes

run frontend in standard way


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Style
  * Introduces global z-index tokens and separate admin/public layout maps to standardize stacking across the app.
  * Applies the new layering system to modals, full-page loader, dropdowns/selects, search suggestions, tooltips, toasts, context menus, drag previews, and the infinite-scroll button.
  * Simplifies admin home page layering.

* Bug Fixes
  * Reduces element overlap and accidental hiding across admin and public pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->