### PR TITLE
Fixed z-index for videos

### DIFF
--- a/src/pages/public/partners-page/partners-sections/outro-section/OutroSection.scss
+++ b/src/pages/public/partners-page/partners-sections/outro-section/OutroSection.scss
@@ -21,7 +21,6 @@
     height: 100vh;
     transform: translate(-50%, -50%);
     object-fit: cover;
-    z-index: -1;
 }
 
 .quote-overlay-partners {

--- a/src/pages/public/team-page/TeamPage.scss
+++ b/src/pages/public/team-page/TeamPage.scss
@@ -109,7 +109,7 @@
         width: 100%;
         height: 70vh;
         overflow: hidden;
-        background: rgba(black, 0.5);
+        background: rgba(0, 0, 0, 0.5);
     }
 
     .background-video {
@@ -122,7 +122,7 @@
         height: auto;
         transform: translate(-50%, -50%);
         object-fit: cover;
-        z-index: -1;
+        z-index: 0;
     }
 
     .quote-overlay {
@@ -138,11 +138,11 @@
         font-weight: 600;
         padding: 5rem 0;
         justify-content: center;
+    }
 
-        p {
-            color: white;
-            display: inline-block;
-        }
+    .quote-overlay p {
+        color: white;
+        display: inline-block;
     }
 
     .author {

--- a/src/pages/public/team-page/TeamPage.scss
+++ b/src/pages/public/team-page/TeamPage.scss
@@ -109,7 +109,7 @@
         width: 100%;
         height: 70vh;
         overflow: hidden;
-        background: rgba(0, 0, 0, 0.5);
+        background: rgba(black, 0.5);
     }
 
     .background-video {
@@ -122,7 +122,6 @@
         height: auto;
         transform: translate(-50%, -50%);
         object-fit: cover;
-        z-index: 0;
     }
 
     .quote-overlay {

--- a/src/pages/public/team-page/TeamPage.tsx
+++ b/src/pages/public/team-page/TeamPage.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import './TeamPage.scss';
-// import horseVideo from '../../../assets/videos/public/team-page/quote_background.mp4';
 import horseVideo from '../../../assets/videos/public/team-page/quote_background.mp4';
 import classNames from 'classnames';
 import {

--- a/src/pages/public/team-page/TeamPage.tsx
+++ b/src/pages/public/team-page/TeamPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import './TeamPage.scss';
+// import horseVideo from '../../../assets/videos/public/team-page/quote_background.mp4';
 import horseVideo from '../../../assets/videos/public/team-page/quote_background.mp4';
 import classNames from 'classnames';
 import {


### PR DESCRIPTION
## Github ticket

## Description

Fixed video z-index, so it is not replaced by gray background.

## How it looks

<img width="2486" height="1348" alt="image" src="https://github.com/user-attachments/assets/30feb6a9-7781-4452-ad82-55977973b69e" />

<img width="2506" height="1364" alt="image" src="https://github.com/user-attachments/assets/afc66967-6ca4-4de1-8b1d-14b5999e11df" />


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions
