### PR TITLE
fix bug 463 with wrong label text

### DIFF
--- a/src/const/admin/common.ts
+++ b/src/const/admin/common.ts
@@ -38,7 +38,7 @@ export const COMMON_TEXT_ADMIN = {
         },
         CATEGORY: {
             CATEGORY_LABEL: 'Категорія',
-            SELECT_CATEGORY: 'Виберіть категорію',
+            SELECT_CATEGORY: 'Оберіть категорію',
         },
     },
 

--- a/src/const/admin/programs.ts
+++ b/src/const/admin/programs.ts
@@ -32,7 +32,7 @@ export const PROGRAMS_TEXT = {
             NAME: 'Назва',
             DESCRIPTION: 'Опис',
             CATEGORY: 'Категорія',
-            SELECT_CATEGORY: 'Виберіть категорію',
+            SELECT_CATEGORY: 'Оберіть категорію',
             PHOTO: 'Фото',
         },
     },

--- a/src/const/admin/team.ts
+++ b/src/const/admin/team.ts
@@ -32,7 +32,7 @@ export const TEAM_MEMBERS_TEXT = {
             FULLNAME: "Ім'я та Прізвище",
             DESCRIPTION: 'Опис',
             CATEGORY: 'Категорія',
-            SELECT_CATEGORY: 'Виберіть категорію',
+            SELECT_CATEGORY: 'Оберіть категорію',
             PHOTO: 'Фото',
         },
     },


### PR DESCRIPTION
## JIRA or Github ticker

#463

## Description

Fix bug with wrong label

## How it looks



## Summary of change

fixed bug

## How to recreate changes

<!--- Please provide short instruction step-by-step how to see changes that was implemented by this PR --->


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Unified Ukrainian copy for the “Select category” label across admin interfaces. The text now reads “Оберіть категорію” (replacing “Виберіть категорію”) in filter dropdowns and form labels, including the Programs and Team sections. This improves consistency and polish across the admin UI. No functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->