### PR TITLE
i18n version update for ts5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "axios": "^1.10.0",
                 "classnames": "^2.5.1",
                 "http-proxy-middleware": "^3.0.5",
-                "i18next": "^23.16.8",
+                "i18next": "^25.5.3",
                 "i18next-browser-languagedetector": "^8.2.0",
                 "prop-types": "^15.8.1",
                 "react": "^19.1.0",
@@ -11548,9 +11548,9 @@
             }
         },
         "node_modules/i18next": {
-            "version": "23.16.8",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
-            "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+            "version": "25.5.3",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.5.3.tgz",
+            "integrity": "sha512-joFqorDeQ6YpIXni944upwnuHBf5IoPMuqAchGVeQLdWC2JOjxgM9V8UGLhNIIH/Q8QleRxIi0BSRQehSrDLcg==",
             "funding": [
                 {
                     "type": "individual",
@@ -11567,7 +11567,15 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.23.2"
+                "@babel/runtime": "^7.27.6"
+            },
+            "peerDependencies": {
+                "typescript": "^5"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/i18next-browser-languagedetector": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "axios": "^1.10.0",
         "classnames": "^2.5.1",
         "http-proxy-middleware": "^3.0.5",
-        "i18next": "^23.16.8",
+        "i18next": "^25.5.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "prop-types": "^15.8.1",
         "react": "^19.1.0",


### PR DESCRIPTION
## Description

Versions of i18next and i18next-browser-languagedetector are changed to suite ts5

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the i18next dependency to a newer version.
  * No other user-facing features or public APIs were changed; this is a dependency maintenance update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->