### PR TITLE
fix: react router imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,140 +1,141 @@
 {
-    "name": "victory-center",
-    "version": "0.1.0",
-    "private": true,
-    "engines": {
-        "node": ">=20"
-    },
-    "dependencies": {
-        "@emotion/react": "^11.14.0",
-        "@emotion/styled": "^11.14.1",
-        "@fontsource/mulish": "^5.2.5",
-        "@hookform/resolvers": "^5.1.1",
-        "@mui/material": "^7.3.1",
-        "@testing-library/dom": "^10.4.0",
-        "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.3.0",
-        "@testing-library/user-event": "^13.5.0",
-        "@types/jest": "^27.5.2",
-        "@types/node": "^16.18.126",
-        "axios": "^1.10.0",
-        "classnames": "^2.5.1",
-        "http-proxy-middleware": "^3.0.5",
-        "i18next": "^23.16.8",
-        "i18next-browser-languagedetector": "^8.2.0",
-        "prop-types": "^15.8.1",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
-        "react-hook-form": "^7.60.0",
-        "react-i18next": "^14.1.3",
-        "react-router-dom": "^7.5.3",
-        "react-scripts": "5.0.1",
-        "react-select": "^5.10.2",
-        "sass": "^1.87.0",
-        "swiper": "^11.2.10",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.9.2",
-        "web-vitals": "^2.1.4",
-        "yup": "^1.6.1"
-    },
-    "overrides": {
-        "react-scripts": {
-            "typescript": "^5.9.2"
-        }
-    },
-    "scripts": {
-        "start": "react-scripts start",
-        "start-with-cert": "node scripts/start-in-dev-over-https.mjs",
-        "build": "react-scripts build",
-        "test": "craco test",
-        "eject": "react-scripts eject",
-        "test:cover": "npm test -- --coverage --watchAll=false",
-        "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --ignore-path .gitignore --max-warnings 10",
-        "lint:fix": "eslint --fix",
-        "format": "prettier --write './**/*.{js,jsx,ts,tsx,css,scss,md,json}' --config ./.prettierrc"
-    },
-    "eslintConfig": {
-        "extends": [
-            "react-app",
-            "react-app/jest",
-            "plugin:prettier/recommended"
-        ],
-        "rules": {
-            "no-console": 1,
-            "no-unused-vars": "off",
-            "@typescript-eslint/no-unused-vars": [
-                "warn",
-                {
-                    "varsIgnorePattern": "^_",
-                    "argsIgnorePattern": "^_",
-                    "caughtErrorsIgnorePattern": "^_",
-                    "destructuredArrayIgnorePattern": "^_"
-                }
-            ],
-            "testing-library/no-wait-for-multiple-assertions": 0,
-            "testing-library/no-container": 0,
-            "testing-library/no-node-access": 0
-        }
-    },
-    "browserslist": {
-        "production": [
-            ">0.2%",
-            "not dead",
-            "not op_mini all"
-        ],
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ]
-    },
-    "jest": {
-        "moduleNameMapper": {
-            "^swiper/react$": "<rootDir>/src/__mocks__/swiperReactMock.js",
-            "^swiper/modules$": "<rootDir>/src/__mocks__/swiperModulesMock.js",
-            "\\.(css|scss)$": "<rootDir>/src/__mocks__/styleMock.js",
-            "^swiper/css$": "<rootDir>/src/__mocks__/styleMock.js",
-            "^swiper/css/navigation$": "<rootDir>/src/__mocks__/styleMock.js",
-            "^swiper/css/pagination$": "<rootDir>/src/__mocks__/styleMock.js",
-            "^swiper/css/scrollbar$": "<rootDir>/src/__mocks__/styleMock.js"
-        },
-        "transformIgnorePatterns": [
-            "node_modules/(?!axios)/"
-        ],
-        "collectCoverageFrom": [
-            "src/**/*.{ts,js,tsx,jsx}"
-        ],
-        "coveragePathIgnorePatterns": [
-            "src/utils/mock-data",
-            "src/const",
-            "index.tsx",
-            "react-app-env.d.ts",
-            "reportWebVitals.ts"
-        ],
-        "coverageThreshold": {
-            "global": {
-                "statements": 89,
-                "branches": 86.2,
-                "functions": 85.2,
-                "lines": 88.9
-            }
-        }
-    },
-    "devDependencies": {
-        "@babel/preset-env": "^7.28.0",
-        "@babel/preset-typescript": "^7.27.1",
-        "@craco/craco": "^7.1.0",
-        "@types/lodash": "^4.17.20",
-        "@types/react": "^19.1.3",
-        "@types/react-dom": "^19.1.3",
-        "@types/testing-library__react": "^10.0.1",
-        "babel-jest": "^29.7.0",
-        "cross-spawn": "^7.0.6",
-        "eslint-config-prettier": "^10.1.5",
-        "eslint-plugin-prettier": "^5.5.1",
-        "https-localhost": "^4.7.1",
-        "identity-obj-proxy": "^3.0.0",
-        "prettier": "^3.6.2",
-        "ts-jest": "^29.3.2"
+  "name": "victory-center",
+  "version": "0.1.0",
+  "private": true,
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "start-with-cert": "node scripts/start-in-dev-over-https.mjs",
+    "build": "react-scripts build",
+    "eject": "react-scripts eject",
+    "test": "craco test",
+    "test:cover": "npm test -- --coverage --watchAll=false",
+    "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx --ignore-path .gitignore --max-warnings 10",
+    "lint:fix": "eslint --fix",
+    "format": "prettier --write './**/*.{js,jsx,ts,tsx,css,scss,md,json}' --config ./.prettierrc"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@fontsource/mulish": "^5.2.5",
+    "@hookform/resolvers": "^5.1.1",
+    "@mui/material": "^7.3.1",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^13.5.0",
+    "@types/jest": "^27.5.2",
+    "@types/node": "^16.18.126",
+    "axios": "^1.10.0",
+    "classnames": "^2.5.1",
+    "http-proxy-middleware": "^3.0.5",
+    "i18next": "^23.16.8",
+    "i18next-browser-languagedetector": "^8.2.0",
+    "prop-types": "^15.8.1",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "react-hook-form": "^7.60.0",
+    "react-i18next": "^14.1.3",
+    "react-router-dom": "^7.5.3",
+    "react-scripts": "5.0.1",
+    "react-select": "^5.10.2",
+    "sass": "^1.87.0",
+    "swiper": "^11.2.10",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.2",
+    "web-vitals": "^2.1.4",
+    "yup": "^1.6.1"
+  },
+  "overrides": {
+    "react-scripts": {
+      "typescript": "^5.9.2"
     }
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest",
+      "plugin:prettier/recommended"
+    ],
+    "rules": {
+      "no-console": 1,
+      "no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          "varsIgnorePattern": "^_",
+          "argsIgnorePattern": "^_",
+          "caughtErrorsIgnorePattern": "^_",
+          "destructuredArrayIgnorePattern": "^_"
+        }
+      ],
+      "testing-library/no-wait-for-multiple-assertions": 0,
+      "testing-library/no-container": 0,
+      "testing-library/no-node-access": 0
+    }
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "jest": {
+    "moduleNameMapper": {
+      "^swiper/react$": "<rootDir>/src/__mocks__/swiperReactMock.js",
+      "^swiper/modules$": "<rootDir>/src/__mocks__/swiperModulesMock.js",
+      "\\.(css|scss)$": "<rootDir>/src/__mocks__/styleMock.js",
+      "^swiper/css$": "<rootDir>/src/__mocks__/styleMock.js",
+      "^swiper/css/navigation$": "<rootDir>/src/__mocks__/styleMock.js",
+      "^swiper/css/pagination$": "<rootDir>/src/__mocks__/styleMock.js",
+      "^swiper/css/scrollbar$": "<rootDir>/src/__mocks__/styleMock.js",
+      "^react-router-dom$": "<rootDir>/src/__mocks__/reactRouterDomMock.js"
+    },
+    "transformIgnorePatterns": [
+      "node_modules/(?!axios)/"
+    ],
+    "collectCoverageFrom": [
+      "src/**/*.{ts,js,tsx,jsx}"
+    ],
+    "coveragePathIgnorePatterns": [
+      "src/utils/mock-data",
+      "src/const",
+      "index.tsx",
+      "react-app-env.d.ts",
+      "reportWebVitals.ts"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "statements": 89,
+        "branches": 86.2,
+        "functions": 85.2,
+        "lines": 88.9
+      }
+    }
+  },
+  "devDependencies": {
+    "@babel/preset-env": "^7.28.0",
+    "@babel/preset-typescript": "^7.27.1",
+    "@craco/craco": "^7.1.0",
+    "@types/lodash": "^4.17.20",
+    "@types/react": "^19.1.3",
+    "@types/react-dom": "^19.1.3",
+    "@types/testing-library__react": "^10.0.1",
+    "babel-jest": "^29.7.0",
+    "cross-spawn": "^7.0.6",
+    "eslint-config-prettier": "^10.1.5",
+    "eslint-plugin-prettier": "^5.5.1",
+    "https-localhost": "^4.7.1",
+    "identity-obj-proxy": "^3.0.0",
+    "prettier": "^3.6.2",
+    "ts-jest": "^29.3.2"
+  }
 }

--- a/src/__mocks__/reactRouterDomMock.js
+++ b/src/__mocks__/reactRouterDomMock.js
@@ -1,0 +1,44 @@
+import React from 'react';
+
+const originalModule = jest.requireActual('react-router-dom');
+
+module.exports = {
+    __esModule: true,
+    ...originalModule,
+
+    useLocation: jest.fn().mockReturnValue({
+        pathname: '/',
+        search: '',
+        hash: '',
+        state: null,
+        key: 'testKey',
+    }),
+
+    useParams: jest.fn().mockReturnValue({}),
+
+    useNavigate: jest.fn().mockReturnValue(jest.fn()),
+
+    NavLink: (props) => {
+        const { to, children, ...rest } = props;
+        return (
+            <a href={to} {...rest}>
+                {children}
+            </a>
+        );
+    },
+
+    Link: (props) => {
+        const { to, children, ...rest } = props;
+        return (
+            <a href={to} {...rest}>
+                {children}
+            </a>
+        );
+    },
+
+    Outlet: () => <div>Mocked Outlet</div>,
+
+    Navigate: () => <div>Mocked Navigate</div>,
+
+    MemoryRouter: ({ children }) => <div>{children}</div>,
+};

--- a/src/components/admin/admin-context-wrapper/AdminContextWrapper.tsx
+++ b/src/components/admin/admin-context-wrapper/AdminContextWrapper.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router';
+import { Outlet } from 'react-router-dom';
 import { AdminContextProvider } from '../../../contexts/admin/admin-context-provider/AdminContextProvider';
 import { ToastProvider } from '../../../contexts/admin/toast-context-provider/ToastContextProvider';
 

--- a/src/components/admin/private-route/PrivateRoute.test.tsx
+++ b/src/components/admin/private-route/PrivateRoute.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { useLocation } from 'react-router';
+import { useLocation } from 'react-router-dom';
 import { PrivateRoute } from './PrivateRoute';
 import { ADMIN_ROUTES } from '../../../const/admin/routes';
 import { useAdminContext } from '../../../contexts/admin/admin-context-provider/AdminContextProvider';
@@ -7,7 +7,7 @@ import { useAdminContext } from '../../../contexts/admin/admin-context-provider/
 const mockUseAdminContext = useAdminContext as jest.MockedFunction<typeof useAdminContext>;
 const mockUseLocation = useLocation as jest.MockedFunction<typeof useLocation>;
 
-jest.mock('react-router', () => ({
+jest.mock('react-router-dom', () => ({
     Navigate: ({ to, state, replace }: any) => (
         <div data-testid="navigate" data-to={to} data-from={state.from.pathname} data-replace={String(replace)} />
     ),

--- a/src/components/admin/private-route/PrivateRoute.tsx
+++ b/src/components/admin/private-route/PrivateRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Outlet, useLocation } from 'react-router';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { ADMIN_ROUTES } from '../../../const/admin/routes';
 import { PageLoader } from '../../common/page-loader/PageLoader';
 import { useAdminContext } from '../../../contexts/admin/admin-context-provider/AdminContextProvider';

--- a/src/components/admin/public-route/PublicRoute.test.tsx
+++ b/src/components/admin/public-route/PublicRoute.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { useLocation } from 'react-router';
+import { useLocation } from 'react-router-dom';
 import { PublicRoute } from './PublicRoute';
 import { ADMIN_ROUTES } from '../../../const/admin/routes';
 import { useAdminContext } from '../../../contexts/admin/admin-context-provider/AdminContextProvider';
@@ -7,7 +7,7 @@ import { useAdminContext } from '../../../contexts/admin/admin-context-provider/
 const mockUseAdminContext = useAdminContext as jest.MockedFunction<typeof useAdminContext>;
 const mockUseLocation = useLocation as jest.MockedFunction<typeof useLocation>;
 
-jest.mock('react-router', () => ({
+jest.mock('react-router-dom', () => ({
     Navigate: ({ to, replace }: any) => <div data-testid="navigate" data-to={to} data-replace={String(replace)} />,
     Outlet: () => <div data-testid="outlet" />,
     useLocation: jest.fn(),

--- a/src/components/admin/public-route/PublicRoute.tsx
+++ b/src/components/admin/public-route/PublicRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Outlet, useLocation } from 'react-router';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { PageLoader } from '../../common/page-loader/PageLoader';
 import { ADMIN_ROUTES } from '../../../const/admin/routes';
 import { useAdminContext } from '../../../contexts/admin/admin-context-provider/AdminContextProvider';

--- a/src/components/public/dropdown-menu/DropdownMenu.test.tsx
+++ b/src/components/public/dropdown-menu/DropdownMenu.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { DropdownMenu, DropdownLink } from './DropdownMenu';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter } from 'react-router-dom';
 
 jest.mock('../../../assets/icons/chevron-up.svg', () => ({
     ReactComponent: () => <span data-testid="arrow-up" />,

--- a/src/components/public/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/public/dropdown-menu/DropdownMenu.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import './DropdownMenu.scss';
 import { ReactComponent as ArrowUp } from '../../../assets/icons/chevron-up.svg';
 import { ReactComponent as ArrowDown } from '../../../assets/icons/chevron-down.svg';
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 export interface DropdownLink {
     text: string;

--- a/src/components/public/footer/Footer.test.tsx
+++ b/src/components/public/footer/Footer.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { Footer } from './Footer';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter } from 'react-router-dom';
 import { PUBLIC_ROUTES } from '../../../const/public/routes';
 import footerUk from '../../../locales/uk/footer.json';
 

--- a/src/components/public/footer/Footer.tsx
+++ b/src/components/public/footer/Footer.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 import { ReactComponent as ArrowUpIcon } from '../../../assets/icons/arrow-up-right.svg';
 import { ReactComponent as PhoneIcon } from '../../../assets/icons/phone.svg';
 import { ReactComponent as MailIcon } from '../../../assets/icons/mail.svg';

--- a/src/components/public/header/Header.test.tsx
+++ b/src/components/public/header/Header.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { Header } from './Header';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter } from 'react-router-dom';
 import { PUBLIC_ROUTES } from '../../../const/public/routes';
 import headerUk from '../../../locales/uk/header.json';
 

--- a/src/components/public/header/Header.tsx
+++ b/src/components/public/header/Header.tsx
@@ -6,7 +6,7 @@ import { DropdownLink, DropdownMenu } from '../dropdown-menu/DropdownMenu';
 import { ReactComponent as BurgerIcon } from '../../../assets/icons/burger.svg';
 import { LanguageSwitcher } from '../language-switcher/LanguageSwitcher';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 
 export const Header = () => {
     const { t } = useTranslation('header');

--- a/src/layouts/admin-layout/AdminLayout.tsx
+++ b/src/layouts/admin-layout/AdminLayout.tsx
@@ -1,5 +1,5 @@
 import './AdminLayout.scss';
-import { Outlet } from 'react-router';
+import { Outlet } from 'react-router-dom';
 import { AdminNavigation } from '../../components/admin/admin-navigation/AdminNavigation';
 
 export const AdminLayout = () => (

--- a/src/layouts/public-layout/PublicLayout.tsx
+++ b/src/layouts/public-layout/PublicLayout.tsx
@@ -1,5 +1,5 @@
 import './PublicLayout.scss';
-import { useLocation, Outlet } from 'react-router';
+import { useLocation, Outlet } from 'react-router-dom';
 import { useEffect } from 'react';
 import { Header } from '../../components/public/header/Header';
 import { Footer } from '../../components/public/footer/Footer';

--- a/src/pages/admin/home/AdminHomePage.test.tsx
+++ b/src/pages/admin/home/AdminHomePage.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import { AdminHomePage } from './AdminHomePage';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter } from 'react-router-dom';
 
 jest.mock('../../../assets/icons/arrow-left.svg', () => ({
     ReactComponent: (props: any) => <svg {...props} data-testid="admin-page-action-hint-icon" />,

--- a/src/pages/admin/login/login-form/LoginForm.test.tsx
+++ b/src/pages/admin/login/login-form/LoginForm.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import * as AdminContext from '../../../../contexts/admin/admin-context-provider/AdminContextProvider';
 import { LoginForm } from './LoginForm';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter } from 'react-router-dom';
 import { LOGIN_CONST } from '../../../../const/admin/login';
 
 jest.mock('../../../../assets/icons/logo-with-text.svg', () => ({

--- a/src/pages/admin/login/login-form/LoginForm.tsx
+++ b/src/pages/admin/login/login-form/LoginForm.tsx
@@ -1,6 +1,6 @@
 import './LoginForm.scss';
 import React, { useState } from 'react';
-import { NavLink } from 'react-router';
+import { NavLink } from 'react-router-dom';
 import { ReactComponent as Logo } from '../../../../assets/icons/logo-with-text.svg';
 import { ReactComponent as EyeOpened } from '../../../../assets/icons/eye-opened.svg';
 import { ReactComponent as EyeClosed } from '../../../../assets/icons/eye-closed.svg';

--- a/src/pages/public/about-us-page/donate-section/DonateSection.test.tsx
+++ b/src/pages/public/about-us-page/donate-section/DonateSection.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { DonateSection } from './DonateSection';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter } from 'react-router-dom';
 import aboutUsPageUk from '../../../../locales/uk/about-us.json';
 
 describe('DonateSection', () => {

--- a/src/pages/public/about-us-page/donate-section/DonateSection.tsx
+++ b/src/pages/public/about-us-page/donate-section/DonateSection.tsx
@@ -1,5 +1,5 @@
 import background from '../../../../assets/images/public/about-us-page/donate-background.jpg';
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 import { PUBLIC_ROUTES } from '../../../../const/public/routes';
 import { useTranslation } from 'react-i18next';
 import './DonateSection.scss';

--- a/src/pages/public/about-us-page/our-mission/OurMission.test.tsx
+++ b/src/pages/public/about-us-page/our-mission/OurMission.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter } from 'react-router-dom';
 import aboutUsPageUk from '../../../../locales/uk/about-us.json';
 import { OurMission } from './OurMission';
 

--- a/src/pages/public/about-us-page/our-mission/OurMission.tsx
+++ b/src/pages/public/about-us-page/our-mission/OurMission.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from 'react-router';
+import { NavLink } from 'react-router-dom';
 import { ReactComponent as ArrowIcon } from '../../../../assets/icons/arrow-up-right.svg';
 import { PUBLIC_ROUTES } from '../../../../const/public/routes';
 import { ScrollableFrame } from './scrollable-frame/ScrollableFrame';

--- a/src/pages/public/about-us-page/our-team-section/OurTeam.test.tsx
+++ b/src/pages/public/about-us-page/our-team-section/OurTeam.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter } from 'react-router-dom';
 import { OurTeam } from './OurTeam';
 import aboutUsPageUk from '../../../../locales/uk/about-us.json';
 import { checkForSubstrings } from '../../../../utils/functions/test-helpers/test-helpers';

--- a/src/pages/public/about-us-page/our-team-section/OurTeam.tsx
+++ b/src/pages/public/about-us-page/our-team-section/OurTeam.tsx
@@ -1,5 +1,5 @@
 import ourTeam from '../../../../assets/images/public/about-us-page/our-team.jpg';
-import { NavLink } from 'react-router';
+import { NavLink } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { PUBLIC_ROUTES } from '../../../../const/public/routes';
 import './OurTeam.scss';

--- a/src/pages/public/not-found-page/not-found-message/NotFoundMessage.test.tsx
+++ b/src/pages/public/not-found-page/not-found-message/NotFoundMessage.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import { NotFoundMessage } from './NotFoundMessage';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter } from 'react-router-dom';
 
 describe('NotFoundMessage', () => {
     it('renders the component', () => {

--- a/src/pages/public/not-found-page/not-found-message/NotFoundMessage.tsx
+++ b/src/pages/public/not-found-page/not-found-message/NotFoundMessage.tsx
@@ -3,7 +3,7 @@ import './NotFoundMessage.scss';
 import { DESCRIPTION, TEXT, GO_BACK_BUTTON } from '../../../../const/public/notfound-page';
 import { ReactComponent as ArrowIcon } from '../../../../assets/icons/arrow-up-right.svg';
 import { PUBLIC_ROUTES } from '../../../../const/public/routes';
-import { NavLink } from 'react-router';
+import { NavLink } from 'react-router-dom';
 
 export const NotFoundMessage = () => {
     return (


### PR DESCRIPTION
## Description

Change all imports from `react-router` to `react-router-dom`
Mock `react-router-dom` for tests
Move `"scripts"` in the `package.json` on the top of file :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated React Router imports to align with current best practices across routing components and tests.
  * Added Jest configuration for module mapping and coverage thresholds to strengthen testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->