### PR TITLE
Hotfix/ decrease description limit to 300 characters in WhoWeSupport section

### DIFF
--- a/src/pages/admin/who-we-are/components/sections/SectionsProps.ts
+++ b/src/pages/admin/who-we-are/components/sections/SectionsProps.ts
@@ -64,7 +64,7 @@ export const WhoWeSupportCardsProps: Omit<
     CardsSectionProps,
     'content' | 'onChange' | 'onPublish' | 'setIsPublishButtonActive' | 'isPublishButtonActive'
 > = {
-    descriptionLimit: 400,
+    descriptionLimit: 300,
     titleText: WHO_WE_ARE_TEXT.WHO_WE_SUPPORT,
     rows: 6,
     cardImageConfigs: [


### PR DESCRIPTION
## JIRA or Github ticker


## Description

decrease description limit to 300 characters in WhoWeSupport section

## How it looks

<img width="706" height="978" alt="image" src="https://github.com/user-attachments/assets/8121b578-b79b-4973-8a97-f8f39d7d47f6" />

## Summary of change

<!--- Please specify what was changed --->

## How to recreate changes

run the project


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Adjusted description character limit in the "Who We Support" cards section to 300 characters for improved display consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->