### PR TITLE
Fix/scroll who we are page

### DIFF
--- a/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.scss
+++ b/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.scss
@@ -2,11 +2,14 @@
 
 .who-we-are {
     &-main-box {
-        margin-top: 5.875rem;
         display: flex;
         flex-direction: column;
         gap: 5.25rem;
-        padding: 2.5rem;
+        padding: 8.4rem 2.5rem 3.375rem 2.5rem;
+        width: 100%;
+        height: 100vh;
+        box-sizing: border-box;
+        overflow-y: auto;
 
         &--pending {
             gap: 1rem;

--- a/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.scss
+++ b/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.scss
@@ -6,8 +6,8 @@
         flex-direction: column;
         gap: 5.25rem;
         padding: 8.4rem 2.5rem 3.375rem 2.5rem;
-        width: 100%;
         height: 100vh;
+        width: 100%;
         box-sizing: border-box;
         overflow-y: auto;
 


### PR DESCRIPTION
## How it looks

<img width="1919" height="1029" alt="image" src="https://github.com/user-attachments/assets/c609bcf8-6826-4c7f-aacf-bdf3ad498881" />

## Summary of change

fix bug with vertical scroll on the WhoWeAre page. 

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined the "Who We Are" section's visual presentation with improved spacing and responsive layout adjustments. The section now utilizes full viewport height with updated padding for better content spacing. Added vertical scrolling support to accommodate longer content while maintaining consistent design and improved user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->