### PR TITLE
Fix publish button enabling logic in GenericForm and SupportOptionItem(Admin Donation Page)

### DIFF
--- a/src/pages/admin/donate/components/generic-form/GenericForm.tsx
+++ b/src/pages/admin/donate/components/generic-form/GenericForm.tsx
@@ -251,10 +251,6 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
                 });
             }, [formState]);
 
-            const hasErrors = useMemo(() => {
-                return Object.values(errors).some(Boolean);
-            }, [errors]);
-
             if (!isOpen) return null;
 
             return (

--- a/src/pages/admin/donate/components/generic-form/GenericForm.tsx
+++ b/src/pages/admin/donate/components/generic-form/GenericForm.tsx
@@ -405,9 +405,7 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
                                                           })
                                             }
                                             buttonStyle="primary"
-                                            disabled={
-                                                isSubmitting || hasEmptyRequiredFields || hasErrors || !isChanged()
-                                            }
+                                            disabled={isSubmitting || hasEmptyRequiredFields || !isChanged()}
                                         >
                                             {DONATE_TEXT.BUTTON.PUBLISH}
                                         </Button>

--- a/src/pages/admin/donate/components/support-options/support-option-item/SupportOptionItem.test.tsx
+++ b/src/pages/admin/donate/components/support-options/support-option-item/SupportOptionItem.test.tsx
@@ -181,7 +181,7 @@ describe('SupportOptionItem', () => {
         expect(screen.getByText('Name too short')).toBeInTheDocument();
     });
 
-    it('disables publish button when validation errors exist', () => {
+    it('enables publish button even when validation errors exist', () => {
         render(<SupportOptionItem data={defaultData} initialMode={SupportOptionItemMode.Edit} />);
 
         const nameInput = screen.getByTestId('input-name');
@@ -189,7 +189,8 @@ describe('SupportOptionItem', () => {
         fireEvent.blur(nameInput);
 
         const publishButton = screen.getByText(DONATE_TEXT.BUTTON.PUBLISH);
-        expect(publishButton).toBeDisabled();
+        expect(publishButton).not.toBeDisabled();
+        expect(screen.getByText('Name too short')).toBeInTheDocument();
     });
 
     it('updates state when data prop changes', () => {

--- a/src/pages/admin/donate/components/support-options/support-option-item/SupportOptionItem.tsx
+++ b/src/pages/admin/donate/components/support-options/support-option-item/SupportOptionItem.tsx
@@ -192,7 +192,7 @@ export const SupportOptionItem = ({ data, initialMode, onSave, onCancel, onDelet
                         type="button"
                         onClick={handleSaveClick}
                         buttonStyle="primary"
-                        disabled={isSubmitting || hasEmptyFields || !hasChanges || hasErrors}
+                        disabled={isSubmitting || hasEmptyFields || !hasChanges}
                     >
                         {DONATE_TEXT.BUTTON.PUBLISH}
                     </Button>

--- a/src/pages/admin/donate/components/support-options/support-option-item/SupportOptionItem.tsx
+++ b/src/pages/admin/donate/components/support-options/support-option-item/SupportOptionItem.tsx
@@ -47,7 +47,6 @@ export const SupportOptionItem = ({ data, initialMode, onSave, onCancel, onDelet
     const isViewMode = mode === SupportOptionItemMode.View;
     const isCreateMode = mode === SupportOptionItemMode.Create;
     const editable = !isViewMode;
-    const hasErrors = !!errors.name || !!errors.value;
     const hasEmptyFields = !name.trim() || !value.trim();
     const hasChanges = name !== (data?.name ?? '') || value !== (data?.value ?? '');
 


### PR DESCRIPTION
## JIRA or Github ticker

* [JIRA or Github ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)

## Description

Change the validation logic so that validation errors do not block the publish button.

## How it looks

<img width="778" height="833" alt="image" src="https://github.com/user-attachments/assets/a5579ce6-23cb-4e52-bd72-0bf10b71514c" />

## Summary of change

Changed the validation logic so that validation errors do not block the publish button.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Publish/Submit button no longer stays disabled solely due to validation errors; users can attempt publish while validation messages remain visible.
  * Button remains disabled during submission, when required fields are empty, or when no changes have been made.

* **Tests**
  * Updated tests to reflect the new Publish button enablement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->