### PR TITLE
Feature/issue 837: Added backend integration on the public donation page

### DIFF
--- a/src/const/common/api-routes/main-api.ts
+++ b/src/const/common/api-routes/main-api.ts
@@ -40,6 +40,12 @@ export const API_ROUTES = {
         BANK_DETAILS_UAH: 'UahBankDetails',
         BANK_DETAILS_FOREIGN: 'ForeignBankDetails',
         CORRESPONDENT_BANK_DETAILS: 'CorrespondentBankDetails',
+
+        PUBLIC: {
+            UAH_BANK_DETAILS: 'UahBankDetails/published',
+            FOREIGN_BANK_DETAILS: 'ForeignBankDetails/published',
+            SUPPORT_OPTIONS: 'SupportOptions/published',
+        },
     },
     WHO_WE_ARE: {
         BASE: 'WhoWeAre',

--- a/src/const/common/api-routes/main-api.ts
+++ b/src/const/common/api-routes/main-api.ts
@@ -42,8 +42,8 @@ export const API_ROUTES = {
         CORRESPONDENT_BANK_DETAILS: 'CorrespondentBankDetails',
 
         PUBLIC: {
-            UAH_BANK_DETAILS: 'UahBankDetails/published',
-            FOREIGN_BANK_DETAILS: 'ForeignBankDetails/published',
+            BANK_DETAILS_UAH: 'UahBankDetails/published',
+            BANK_DETAILS_FOREIGN: 'ForeignBankDetails/published',
             SUPPORT_OPTIONS: 'SupportOptions/published',
         },
     },

--- a/src/const/public/donate-page.ts
+++ b/src/const/public/donate-page.ts
@@ -195,3 +195,7 @@ export const CORRESPONDENT_BANKS = {
         },
     ],
 };
+
+export const ERROR_MESSAGES = {
+    LOADING_ERROR: 'Не вдалося завантажити реквізити',
+};

--- a/src/pages/public/donate-page/DonatePage.scss
+++ b/src/pages/public/donate-page/DonatePage.scss
@@ -4,32 +4,31 @@
     background-color: colors.$light-blue-50;
     padding-top: 4.125rem;
 
-    .donatePageContent {
-        display: flex;
-        flex-direction: row;
-        justify-content: center;
-        gap: 7.94rem;
-        padding-top: 6rem;
-        padding-bottom: 6rem;
-        padding-left: 12.5rem;
-
-        .stickyBlock {
-            position: sticky;
-            top: 2rem;
-            display: flex;
-            height: 100%;
-        }
-    }
-
     &-loader {
         width: 70%;
-        position: relative;
         margin: 8rem auto 4rem;
+
+        .MuiLinearProgress-root {
+            height: 4px;
+        }
     }
 
     &-error-message {
         color: colors.$error;
         margin-top: 8rem;
         text-align: center;
+    }
+}
+
+.donatePageContent {
+    display: flex;
+    justify-content: center;
+    gap: 7.94rem;
+    padding: 6rem 0 6rem 12.5rem;
+
+    .stickyBlock {
+        position: sticky;
+        top: 2rem;
+        height: fit-content;
     }
 }

--- a/src/pages/public/donate-page/DonatePage.scss
+++ b/src/pages/public/donate-page/DonatePage.scss
@@ -20,4 +20,16 @@
             height: 100%;
         }
     }
+
+    &-loader {
+        width: 70%;
+        position: relative;
+        margin: 8rem auto 4rem;
+    }
+
+    &-error-message {
+        color: colors.$error;
+        margin-top: 8rem;
+        text-align: center;
+    }
 }

--- a/src/pages/public/donate-page/DonatePage.test.tsx
+++ b/src/pages/public/donate-page/DonatePage.test.tsx
@@ -65,7 +65,6 @@ describe('DonatePage', () => {
     ) => {
         mockUseDataFetch.mockReturnValue({
             data,
-            isLoading: false,
             error: null,
         });
     };
@@ -73,7 +72,6 @@ describe('DonatePage', () => {
     const mockUseDataFetchLoading = () => {
         mockUseDataFetch.mockReturnValue({
             data: null,
-            isLoading: true,
             error: null,
         });
     };
@@ -81,28 +79,8 @@ describe('DonatePage', () => {
     const mockUseDataFetchError = () => {
         mockUseDataFetch.mockReturnValue({
             data: null,
-            isLoading: false,
             error: 'Test error',
         });
-    };
-
-    const expectMainSectionsToBeInDocument = () => {
-        expect(screen.getByTestId('donate-page-intro')).toBeInTheDocument();
-        expect(screen.getByTestId('donate-section')).toBeInTheDocument();
-        expect(screen.getByTestId('right-section')).toBeInTheDocument();
-        expect(screen.getByTestId('faq-section')).toBeInTheDocument();
-    };
-
-    const expectCorrectDOMStructure = () => {
-        const donatePage = screen.getByTestId('donate-page-intro').closest('.donatePage');
-        expect(donatePage).toBeInTheDocument();
-
-        const donatePageContent = donatePage?.querySelector('.donatePageContent');
-        expect(donatePageContent).toBeInTheDocument();
-
-        const stickyBlock = donatePageContent?.querySelector('.stickyBlock');
-        expect(stickyBlock).toBeInTheDocument();
-        expect(stickyBlock).toContainElement(screen.getByTestId('donate-section'));
     };
 
     beforeEach(() => {
@@ -116,7 +94,7 @@ describe('DonatePage', () => {
             render(<DonatePage />);
 
             expect(screen.getByRole('progressbar')).toBeInTheDocument();
-            expect(screen.queryByTestId('donate-page-intro')).not.toBeInTheDocument();
+            expect(screen.getByTestId('donate-page-intro')).toBeInTheDocument();
             expect(screen.queryByTestId('right-section')).not.toBeInTheDocument();
         });
 
@@ -128,6 +106,15 @@ describe('DonatePage', () => {
             const loaderContainer = screen.getByRole('progressbar').closest('.donate-page-loader');
             expect(loaderContainer).toBeInTheDocument();
         });
+
+        it('shows intro section during loading', () => {
+            mockUseDataFetchLoading();
+
+            render(<DonatePage />);
+
+            expect(screen.getByTestId('donate-page-intro')).toBeInTheDocument();
+            expect(screen.getByText(/МИ ВДЯЧНІ/i)).toBeInTheDocument();
+        });
     });
 
     describe('successful data loading', () => {
@@ -138,7 +125,10 @@ describe('DonatePage', () => {
         it('renders all main components in correct order', () => {
             render(<DonatePage />);
 
-            expectMainSectionsToBeInDocument();
+            expect(screen.getByTestId('donate-page-intro')).toBeInTheDocument();
+            expect(screen.getByTestId('donate-section')).toBeInTheDocument();
+            expect(screen.getByTestId('right-section')).toBeInTheDocument();
+            expect(screen.getByTestId('faq-section')).toBeInTheDocument();
 
             const container = screen.getByTestId('donate-page-intro').closest('.donatePage');
             const children = container?.children;
@@ -146,28 +136,6 @@ describe('DonatePage', () => {
             expect(children?.[0]).toContainElement(screen.getByTestId('donate-page-intro'));
             expect(children?.[1]).toHaveClass('donatePageContent');
             expect(children?.[2]).toContainElement(screen.getByTestId('faq-section'));
-        });
-
-        it('renders DonatePageIntro with correct heading', () => {
-            render(<DonatePage />);
-
-            const heading = screen.getByRole('heading', { level: 1 });
-            expect(heading).toBeInTheDocument();
-            expect(heading).toHaveTextContent('МИ ВДЯЧНІ');
-        });
-
-        it('renders DonateSection with form elements', () => {
-            render(<DonatePage />);
-
-            expect(screen.getByTestId('donate-section-form')).toBeInTheDocument();
-            expect(screen.getByRole('button', { name: /Донатити/i })).toBeInTheDocument();
-        });
-
-        it('renders RightSection with payment details', () => {
-            render(<DonatePage />);
-
-            expect(screen.getByText(/Реквізити для донатів в Україні/i)).toBeInTheDocument();
-            expect(screen.getByText(/Інші варіанти підтримки/i)).toBeInTheDocument();
         });
 
         it('renders FaqSection with correct slug', () => {
@@ -198,7 +166,7 @@ describe('DonatePage', () => {
             expect(rightSection).toHaveAttribute('data-has-data', 'false');
         });
 
-        it('still renders all other components when error occurs', () => {
+        it('renders all components when error occurs', () => {
             mockUseDataFetchError();
 
             render(<DonatePage />);
@@ -210,41 +178,6 @@ describe('DonatePage', () => {
         });
     });
 
-    describe('section content', () => {
-        beforeEach(() => {
-            mockUseDataFetchSuccess();
-        });
-
-        it('renders all expected text content', () => {
-            render(<DonatePage />);
-
-            expect(screen.getByText(/МИ ВДЯЧНІ/i)).toBeInTheDocument();
-            expect(screen.getByText(/ЗА КОЖЕН ДОНАТ/i)).toBeInTheDocument();
-
-            expect(screen.getByText(/Разовий донат/i)).toBeInTheDocument();
-            expect(screen.getByText(/Підписка/i)).toBeInTheDocument();
-
-            expect(screen.getByText(/Реквізити для донатів в Україні/i)).toBeInTheDocument();
-            expect(screen.getByText(/Інші варіанти підтримки/i)).toBeInTheDocument();
-
-            expect(screen.getByText('FAQ Section')).toBeInTheDocument();
-        });
-
-        it('renders donate tab options', () => {
-            render(<DonatePage />);
-
-            expect(screen.getByText('Разовий донат')).toBeInTheDocument();
-            expect(screen.getByText('Підписка')).toBeInTheDocument();
-        });
-
-        it('renders donate button', () => {
-            render(<DonatePage />);
-
-            const donateButton = screen.getByRole('button', { name: /Донатити/i });
-            expect(donateButton).toBeInTheDocument();
-        });
-    });
-
     describe('DOM structure', () => {
         beforeEach(() => {
             mockUseDataFetchSuccess();
@@ -253,15 +186,15 @@ describe('DonatePage', () => {
         it('has correct CSS classes and structure', () => {
             render(<DonatePage />);
 
-            expectCorrectDOMStructure();
-        });
+            const donatePage = screen.getByTestId('donate-page-intro').closest('.donatePage');
+            expect(donatePage).toBeInTheDocument();
 
-        it('places DonateSection inside sticky block', () => {
-            render(<DonatePage />);
+            const donatePageContent = donatePage?.querySelector('.donatePageContent');
+            expect(donatePageContent).toBeInTheDocument();
 
-            const stickyBlock = screen.getByTestId('donate-section').closest('.stickyBlock');
+            const stickyBlock = donatePageContent?.querySelector('.stickyBlock');
             expect(stickyBlock).toBeInTheDocument();
-            expect(stickyBlock?.parentElement).toHaveClass('donatePageContent');
+            expect(stickyBlock).toContainElement(screen.getByTestId('donate-section'));
         });
 
         it('places RightSection in rightSectionContainer', () => {
@@ -273,32 +206,6 @@ describe('DonatePage', () => {
 
             const donatePageContent = rightSectionContainer?.closest('.donatePageContent');
             expect(donatePageContent).toBeInTheDocument();
-        });
-    });
-
-    describe('component integration', () => {
-        beforeEach(() => {
-            mockUseDataFetchSuccess();
-        });
-
-        it('renders all headings with proper hierarchy', () => {
-            render(<DonatePage />);
-
-            const headings = screen.getAllByRole('heading');
-            expect(headings.length).toBeGreaterThan(0);
-
-            expect(headings[0]).toHaveTextContent(/МИ ВДЯЧНІ/i);
-            expect(headings[0].tagName).toBe('H1');
-        });
-
-        it('renders interactive elements', () => {
-            render(<DonatePage />);
-
-            const buttons = screen.getAllByRole('button');
-            expect(buttons.length).toBeGreaterThan(0);
-
-            const donateButton = buttons.find((button) => button.textContent?.includes('Донатити'));
-            expect(donateButton).toBeInTheDocument();
         });
     });
 
@@ -315,18 +222,36 @@ describe('DonatePage', () => {
             });
         });
 
-        it('handles different data states correctly', () => {
+        it('shows loader when data is null and no error', () => {
             mockUseDataFetch.mockReturnValue({
                 data: null,
-                isLoading: false,
                 error: null,
             });
 
             render(<DonatePage />);
 
-            const rightSection = screen.getByTestId('right-section');
-            expect(rightSection).toHaveAttribute('data-has-data', 'false');
+            expect(screen.getByRole('progressbar')).toBeInTheDocument();
+            expect(screen.getByTestId('donate-page-intro')).toBeInTheDocument();
+
+            expect(screen.queryByTestId('right-section')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('donate-section')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('faq-section')).not.toBeInTheDocument();
+        });
+
+        it('handles data states correctly', () => {
+            mockUseDataFetchSuccess();
+            const { rerender } = render(<DonatePage />);
+
+            let rightSection = screen.getByTestId('right-section');
+            expect(rightSection).toHaveAttribute('data-has-data', 'true');
             expect(rightSection).toHaveAttribute('data-has-error', 'false');
+
+            mockUseDataFetchError();
+            rerender(<DonatePage />);
+
+            rightSection = screen.getByTestId('right-section');
+            expect(rightSection).toHaveAttribute('data-has-data', 'false');
+            expect(rightSection).toHaveAttribute('data-has-error', 'true');
         });
     });
 });

--- a/src/pages/public/donate-page/DonatePage.test.tsx
+++ b/src/pages/public/donate-page/DonatePage.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { DonatePage } from './DonatePage';
 
 jest.mock('./donate-page-intro/DonatePageIntro', () => ({
@@ -26,8 +27,8 @@ jest.mock('./donate-section/DonateSection', () => ({
 }));
 
 jest.mock('./right-section/RightSection', () => ({
-    RightSection: () => (
-        <div data-testid="right-section">
+    RightSection: ({ donateData, error }: { donateData: any; error?: string | null }) => (
+        <div data-testid="right-section" data-has-data={!!donateData} data-has-error={!!error}>
             <div>Реквізити для донатів в Україні</div>
             <div>Інші варіанти підтримки</div>
         </div>
@@ -48,7 +49,43 @@ jest.mock('../../../const/public/faq', () => ({
     },
 }));
 
+jest.mock('../../../hooks/common/use-data-fetch/useDataFetch', () => ({
+    useDataFetch: jest.fn(),
+}));
+
+jest.mock('../../../services/api/public/donate/donate-api', () => ({
+    donatePageDataFetch: jest.fn(),
+}));
+
+const mockUseDataFetch = require('../../../hooks/common/use-data-fetch/useDataFetch').useDataFetch;
+
 describe('DonatePage', () => {
+    const mockUseDataFetchSuccess = (
+        data: any = { uahBankDetails: [], foreignBankDetails: [], supportOptions: [] },
+    ) => {
+        mockUseDataFetch.mockReturnValue({
+            data,
+            isLoading: false,
+            error: null,
+        });
+    };
+
+    const mockUseDataFetchLoading = () => {
+        mockUseDataFetch.mockReturnValue({
+            data: null,
+            isLoading: true,
+            error: null,
+        });
+    };
+
+    const mockUseDataFetchError = () => {
+        mockUseDataFetch.mockReturnValue({
+            data: null,
+            isLoading: false,
+            error: 'Test error',
+        });
+    };
+
     const expectMainSectionsToBeInDocument = () => {
         expect(screen.getByTestId('donate-page-intro')).toBeInTheDocument();
         expect(screen.getByTestId('donate-section')).toBeInTheDocument();
@@ -68,7 +105,36 @@ describe('DonatePage', () => {
         expect(stickyBlock).toContainElement(screen.getByTestId('donate-section'));
     };
 
-    describe('component rendering', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('loading state', () => {
+        it('shows loading state when data is being fetched', () => {
+            mockUseDataFetchLoading();
+
+            render(<DonatePage />);
+
+            expect(screen.getByRole('progressbar')).toBeInTheDocument();
+            expect(screen.queryByTestId('donate-page-intro')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('right-section')).not.toBeInTheDocument();
+        });
+
+        it('shows loading with correct CSS class', () => {
+            mockUseDataFetchLoading();
+
+            render(<DonatePage />);
+
+            const loaderContainer = screen.getByRole('progressbar').closest('.donate-page-loader');
+            expect(loaderContainer).toBeInTheDocument();
+        });
+    });
+
+    describe('successful data loading', () => {
+        beforeEach(() => {
+            mockUseDataFetchSuccess();
+        });
+
         it('renders all main components in correct order', () => {
             render(<DonatePage />);
 
@@ -111,9 +177,44 @@ describe('DonatePage', () => {
             expect(faqSection).toBeInTheDocument();
             expect(faqSection).toHaveAttribute('data-slug', 'donate-page');
         });
+
+        it('passes data to RightSection', () => {
+            render(<DonatePage />);
+
+            const rightSection = screen.getByTestId('right-section');
+            expect(rightSection).toHaveAttribute('data-has-data', 'true');
+            expect(rightSection).toHaveAttribute('data-has-error', 'false');
+        });
+    });
+
+    describe('error handling', () => {
+        it('passes error to RightSection when fetch fails', () => {
+            mockUseDataFetchError();
+
+            render(<DonatePage />);
+
+            const rightSection = screen.getByTestId('right-section');
+            expect(rightSection).toHaveAttribute('data-has-error', 'true');
+            expect(rightSection).toHaveAttribute('data-has-data', 'false');
+        });
+
+        it('still renders all other components when error occurs', () => {
+            mockUseDataFetchError();
+
+            render(<DonatePage />);
+
+            expect(screen.getByTestId('donate-page-intro')).toBeInTheDocument();
+            expect(screen.getByTestId('donate-section')).toBeInTheDocument();
+            expect(screen.getByTestId('right-section')).toBeInTheDocument();
+            expect(screen.getByTestId('faq-section')).toBeInTheDocument();
+        });
     });
 
     describe('section content', () => {
+        beforeEach(() => {
+            mockUseDataFetchSuccess();
+        });
+
         it('renders all expected text content', () => {
             render(<DonatePage />);
 
@@ -145,6 +246,10 @@ describe('DonatePage', () => {
     });
 
     describe('DOM structure', () => {
+        beforeEach(() => {
+            mockUseDataFetchSuccess();
+        });
+
         it('has correct CSS classes and structure', () => {
             render(<DonatePage />);
 
@@ -159,20 +264,23 @@ describe('DonatePage', () => {
             expect(stickyBlock?.parentElement).toHaveClass('donatePageContent');
         });
 
-        it('places RightSection alongside sticky block', () => {
+        it('places RightSection in rightSectionContainer', () => {
             render(<DonatePage />);
 
             const rightSection = screen.getByTestId('right-section');
-            const donatePageContent = rightSection.closest('.donatePageContent');
-            expect(donatePageContent).toBeInTheDocument();
+            const rightSectionContainer = rightSection.closest('.rightSectionContainer');
+            expect(rightSectionContainer).toBeInTheDocument();
 
-            const stickyBlock = donatePageContent?.querySelector('.stickyBlock');
-            expect(stickyBlock).toBeInTheDocument();
-            expect(donatePageContent).toContainElement(rightSection);
+            const donatePageContent = rightSectionContainer?.closest('.donatePageContent');
+            expect(donatePageContent).toBeInTheDocument();
         });
     });
 
     describe('component integration', () => {
+        beforeEach(() => {
+            mockUseDataFetchSuccess();
+        });
+
         it('renders all headings with proper hierarchy', () => {
             render(<DonatePage />);
 
@@ -194,18 +302,31 @@ describe('DonatePage', () => {
         });
     });
 
-    describe('component props', () => {
-        it('passes correct slug to FaqSection', () => {
+    describe('data fetching', () => {
+        it('calls useDataFetch with correct parameters', () => {
+            mockUseDataFetchSuccess();
+
             render(<DonatePage />);
 
-            const faqSection = screen.getByTestId('faq-section');
-            expect(faqSection).toHaveAttribute('data-slug', 'donate-page');
+            expect(mockUseDataFetch).toHaveBeenCalledWith({
+                initialData: null,
+                fetchHandler: expect.any(Function),
+                autoFetchDependencies: [],
+            });
         });
 
-        it('renders without any required props', () => {
-            expect(() => render(<DonatePage />)).not.toThrow();
+        it('handles different data states correctly', () => {
+            mockUseDataFetch.mockReturnValue({
+                data: null,
+                isLoading: false,
+                error: null,
+            });
 
-            expectMainSectionsToBeInDocument();
+            render(<DonatePage />);
+
+            const rightSection = screen.getByTestId('right-section');
+            expect(rightSection).toHaveAttribute('data-has-data', 'false');
+            expect(rightSection).toHaveAttribute('data-has-error', 'false');
         });
     });
 });

--- a/src/pages/public/donate-page/DonatePage.test.tsx
+++ b/src/pages/public/donate-page/DonatePage.test.tsx
@@ -1,34 +1,211 @@
 import { render, screen } from '@testing-library/react';
 import { DonatePage } from './DonatePage';
 
+jest.mock('./donate-page-intro/DonatePageIntro', () => ({
+    DonatePageIntro: () => (
+        <div data-testid="donate-page-intro">
+            <h1>
+                МИ ВДЯЧНІ
+                <br />
+                ЗА КОЖЕН ДОНАТ
+            </h1>
+        </div>
+    ),
+}));
+
+jest.mock('./donate-section/DonateSection', () => ({
+    DonateSection: () => (
+        <div data-testid="donate-section">
+            <div data-testid="donate-section-form">
+                <div>Разовий донат</div>
+                <div>Підписка</div>
+                <button>Донатити</button>
+            </div>
+        </div>
+    ),
+}));
+
+jest.mock('./right-section/RightSection', () => ({
+    RightSection: () => (
+        <div data-testid="right-section">
+            <div>Реквізити для донатів в Україні</div>
+            <div>Інші варіанти підтримки</div>
+        </div>
+    ),
+}));
+
 jest.mock('../../../components/public/faq-section/FaqSection', () => ({
-    FaqSection: () => <div data-testid="faq-section"></div>,
+    FaqSection: ({ slug }: { slug: string }) => (
+        <div data-testid="faq-section" data-slug={slug}>
+            FAQ Section
+        </div>
+    ),
+}));
+
+jest.mock('../../../const/public/faq', () => ({
+    PAGE_SLUGS: {
+        DONATE: 'donate-page',
+    },
 }));
 
 describe('DonatePage', () => {
-    it('renders DonatePageIntro, DonateSection, and RightSection', () => {
-        render(<DonatePage />);
+    const expectMainSectionsToBeInDocument = () => {
+        expect(screen.getByTestId('donate-page-intro')).toBeInTheDocument();
+        expect(screen.getByTestId('donate-section')).toBeInTheDocument();
+        expect(screen.getByTestId('right-section')).toBeInTheDocument();
+        expect(screen.getByTestId('faq-section')).toBeInTheDocument();
+    };
 
-        const headings = screen.getAllByRole('heading');
-        expect(headings.length).toBeGreaterThan(0);
-        expect(headings[0]).toHaveTextContent(/МИ ВДЯЧНІ/i);
+    const expectCorrectDOMStructure = () => {
+        const donatePage = screen.getByTestId('donate-page-intro').closest('.donatePage');
+        expect(donatePage).toBeInTheDocument();
 
-        expect(screen.getByTestId('donate-section-form')).toBeInTheDocument();
+        const donatePageContent = donatePage?.querySelector('.donatePageContent');
+        expect(donatePageContent).toBeInTheDocument();
 
-        expect(screen.getByText('Разовий донат')).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: /Донатити/i })).toBeInTheDocument();
+        const stickyBlock = donatePageContent?.querySelector('.stickyBlock');
+        expect(stickyBlock).toBeInTheDocument();
+        expect(stickyBlock).toContainElement(screen.getByTestId('donate-section'));
+    };
+
+    describe('component rendering', () => {
+        it('renders all main components in correct order', () => {
+            render(<DonatePage />);
+
+            expectMainSectionsToBeInDocument();
+
+            const container = screen.getByTestId('donate-page-intro').closest('.donatePage');
+            const children = container?.children;
+
+            expect(children?.[0]).toContainElement(screen.getByTestId('donate-page-intro'));
+            expect(children?.[1]).toHaveClass('donatePageContent');
+            expect(children?.[2]).toContainElement(screen.getByTestId('faq-section'));
+        });
+
+        it('renders DonatePageIntro with correct heading', () => {
+            render(<DonatePage />);
+
+            const heading = screen.getByRole('heading', { level: 1 });
+            expect(heading).toBeInTheDocument();
+            expect(heading).toHaveTextContent('МИ ВДЯЧНІ');
+        });
+
+        it('renders DonateSection with form elements', () => {
+            render(<DonatePage />);
+
+            expect(screen.getByTestId('donate-section-form')).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /Донатити/i })).toBeInTheDocument();
+        });
+
+        it('renders RightSection with payment details', () => {
+            render(<DonatePage />);
+
+            expect(screen.getByText(/Реквізити для донатів в Україні/i)).toBeInTheDocument();
+            expect(screen.getByText(/Інші варіанти підтримки/i)).toBeInTheDocument();
+        });
+
+        it('renders FaqSection with correct slug', () => {
+            render(<DonatePage />);
+
+            const faqSection = screen.getByTestId('faq-section');
+            expect(faqSection).toBeInTheDocument();
+            expect(faqSection).toHaveAttribute('data-slug', 'donate-page');
+        });
     });
 
-    it('renders all main sections with correct content', () => {
-        render(<DonatePage />);
+    describe('section content', () => {
+        it('renders all expected text content', () => {
+            render(<DonatePage />);
 
-        expect(screen.getByText(/МИ ВДЯЧНІ/i)).toBeInTheDocument();
-        expect(screen.getByText(/ЗА КОЖЕН ДОНАТ/i)).toBeInTheDocument();
+            expect(screen.getByText(/МИ ВДЯЧНІ/i)).toBeInTheDocument();
+            expect(screen.getByText(/ЗА КОЖЕН ДОНАТ/i)).toBeInTheDocument();
 
-        expect(screen.getByText(/Разовий донат/i)).toBeInTheDocument();
-        expect(screen.getByText(/Підписка/i)).toBeInTheDocument();
+            expect(screen.getByText(/Разовий донат/i)).toBeInTheDocument();
+            expect(screen.getByText(/Підписка/i)).toBeInTheDocument();
 
-        expect(screen.getByText(/Реквізити для донатів в Україні/i)).toBeInTheDocument();
-        expect(screen.getByText(/Інші варіанти підтримки/i)).toBeInTheDocument();
+            expect(screen.getByText(/Реквізити для донатів в Україні/i)).toBeInTheDocument();
+            expect(screen.getByText(/Інші варіанти підтримки/i)).toBeInTheDocument();
+
+            expect(screen.getByText('FAQ Section')).toBeInTheDocument();
+        });
+
+        it('renders donate tab options', () => {
+            render(<DonatePage />);
+
+            expect(screen.getByText('Разовий донат')).toBeInTheDocument();
+            expect(screen.getByText('Підписка')).toBeInTheDocument();
+        });
+
+        it('renders donate button', () => {
+            render(<DonatePage />);
+
+            const donateButton = screen.getByRole('button', { name: /Донатити/i });
+            expect(donateButton).toBeInTheDocument();
+        });
+    });
+
+    describe('DOM structure', () => {
+        it('has correct CSS classes and structure', () => {
+            render(<DonatePage />);
+
+            expectCorrectDOMStructure();
+        });
+
+        it('places DonateSection inside sticky block', () => {
+            render(<DonatePage />);
+
+            const stickyBlock = screen.getByTestId('donate-section').closest('.stickyBlock');
+            expect(stickyBlock).toBeInTheDocument();
+            expect(stickyBlock?.parentElement).toHaveClass('donatePageContent');
+        });
+
+        it('places RightSection alongside sticky block', () => {
+            render(<DonatePage />);
+
+            const rightSection = screen.getByTestId('right-section');
+            const donatePageContent = rightSection.closest('.donatePageContent');
+            expect(donatePageContent).toBeInTheDocument();
+
+            const stickyBlock = donatePageContent?.querySelector('.stickyBlock');
+            expect(stickyBlock).toBeInTheDocument();
+            expect(donatePageContent).toContainElement(rightSection);
+        });
+    });
+
+    describe('component integration', () => {
+        it('renders all headings with proper hierarchy', () => {
+            render(<DonatePage />);
+
+            const headings = screen.getAllByRole('heading');
+            expect(headings.length).toBeGreaterThan(0);
+
+            expect(headings[0]).toHaveTextContent(/МИ ВДЯЧНІ/i);
+            expect(headings[0].tagName).toBe('H1');
+        });
+
+        it('renders interactive elements', () => {
+            render(<DonatePage />);
+
+            const buttons = screen.getAllByRole('button');
+            expect(buttons.length).toBeGreaterThan(0);
+
+            const donateButton = buttons.find((button) => button.textContent?.includes('Донатити'));
+            expect(donateButton).toBeInTheDocument();
+        });
+    });
+
+    describe('component props', () => {
+        it('passes correct slug to FaqSection', () => {
+            render(<DonatePage />);
+
+            const faqSection = screen.getByTestId('faq-section');
+            expect(faqSection).toHaveAttribute('data-slug', 'donate-page');
+        });
+
+        it('renders without any required props', () => {
+            expect(() => render(<DonatePage />)).not.toThrow();
+
+            expectMainSectionsToBeInDocument();
+        });
     });
 });

--- a/src/pages/public/donate-page/DonatePage.tsx
+++ b/src/pages/public/donate-page/DonatePage.tsx
@@ -1,34 +1,40 @@
-import { DonatePageIntro } from './donate-page-intro/DonatePageIntro';
-import { DonateSection } from './donate-section/DonateSection';
-import './DonatePage.scss';
-import { RightSection } from './right-section/RightSection';
-import { PAGE_SLUGS } from '../../../const/public/faq';
-import { FaqSection } from '../../../components/public/faq-section/FaqSection';
+import { useEffect, useState } from 'react';
+import { LinearProgress } from '@mui/material';
 import { useDataFetch } from '../../../hooks/common/use-data-fetch/useDataFetch';
 import { donatePageDataFetch } from '../../../services/api/public/donate/donate-api';
 import { DonatePageData } from '../../../types/public/donate-page';
-import { LinearProgress } from '@mui/material';
+import { PAGE_SLUGS } from '../../../const/public/faq';
+import { FaqSection } from '../../../components/public/faq-section/FaqSection';
+import { DonatePageIntro } from './donate-page-intro/DonatePageIntro';
+import { DonateSection } from './donate-section/DonateSection';
+import { RightSection } from './right-section/RightSection';
+import './DonatePage.scss';
 
 export const DonatePage = () => {
-    const {
-        data: donateData,
-        isLoading,
-        error,
-    } = useDataFetch<DonatePageData | null>({
+    const [isDataLoaded, setIsDataLoaded] = useState(false);
+
+    const { data: donateData, error } = useDataFetch<DonatePageData | null>({
         initialData: null,
         fetchHandler: donatePageDataFetch,
         autoFetchDependencies: [],
     });
 
-    if (isLoading) {
-        return (
+    useEffect(() => {
+        if (donateData !== null || error) {
+            setIsDataLoaded(true);
+        }
+    }, [donateData, error]);
+
+    const renderLoader = () => (
+        <div className="donatePage">
+            <DonatePageIntro />
             <div className="donate-page-loader">
                 <LinearProgress />
             </div>
-        );
-    }
+        </div>
+    );
 
-    return (
+    const renderContent = () => (
         <div className="donatePage">
             <DonatePageIntro />
             <div className="donatePageContent">
@@ -42,4 +48,6 @@ export const DonatePage = () => {
             <FaqSection slug={PAGE_SLUGS.DONATE} />
         </div>
     );
+
+    return !isDataLoaded ? renderLoader() : renderContent();
 };

--- a/src/pages/public/donate-page/DonatePage.tsx
+++ b/src/pages/public/donate-page/DonatePage.tsx
@@ -4,8 +4,30 @@ import './DonatePage.scss';
 import { RightSection } from './right-section/RightSection';
 import { PAGE_SLUGS } from '../../../const/public/faq';
 import { FaqSection } from '../../../components/public/faq-section/FaqSection';
+import { useDataFetch } from '../../../hooks/common/use-data-fetch/useDataFetch';
+import { donatePageDataFetch } from '../../../services/api/public/donate/donate-api';
+import { DonatePageData } from '../../../types/public/donate-page';
+import { LinearProgress } from '@mui/material';
 
 export const DonatePage = () => {
+    const {
+        data: donateData,
+        isLoading,
+        error,
+    } = useDataFetch<DonatePageData | null>({
+        initialData: null,
+        fetchHandler: donatePageDataFetch,
+        autoFetchDependencies: [],
+    });
+
+    if (isLoading) {
+        return (
+            <div className="donate-page-loader">
+                <LinearProgress />
+            </div>
+        );
+    }
+
     return (
         <div className="donatePage">
             <DonatePageIntro />
@@ -14,7 +36,7 @@ export const DonatePage = () => {
                     <DonateSection />
                 </div>
                 <div className="rightSectionContainer">
-                    <RightSection />
+                    <RightSection donateData={donateData} error={error} />
                 </div>
             </div>
             <FaqSection slug={PAGE_SLUGS.DONATE} />

--- a/src/pages/public/donate-page/DonatePage.tsx
+++ b/src/pages/public/donate-page/DonatePage.tsx
@@ -13,7 +13,9 @@ export const DonatePage = () => {
                 <div className="stickyBlock">
                     <DonateSection />
                 </div>
-                <RightSection />
+                <div className="rightSectionContainer">
+                    <RightSection />
+                </div>
             </div>
             <FaqSection slug={PAGE_SLUGS.DONATE} />
         </div>

--- a/src/pages/public/donate-page/right-section/RightSection.scss
+++ b/src/pages/public/donate-page/right-section/RightSection.scss
@@ -65,3 +65,11 @@
 .donatePaymentDetails {
     padding-top: 1.5rem;
 }
+
+.donate-loader {
+    padding: 24px;
+}
+
+.donate-error-message {
+    color: colors.$error;
+}

--- a/src/pages/public/donate-page/right-section/RightSection.test.tsx
+++ b/src/pages/public/donate-page/right-section/RightSection.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { RightSection } from './RightSection';
 import { Currency } from '../../../../types/public/donate-page';
@@ -109,6 +110,19 @@ describe('RightSection', () => {
     const queryUkrainePaymentSection = () => screen.queryByTestId('ukraine-payment');
     const queryAbroadPaymentSection = () => screen.queryByTestId('abroad-payment');
 
+    const testForeignCurrencySwitch = async (currency: 'USD' | 'EUR') => {
+        render(<RightSection />);
+
+        fireEvent.click(getTabByLabel(currency));
+
+        await waitFor(() => {
+            expect(getAbroadPaymentSection()).toBeInTheDocument();
+            expect(getAbroadPaymentSection()).toHaveTextContent(currency);
+            expect(queryUkrainePaymentSection()).not.toBeInTheDocument();
+            expect(getTabByLabel(currency)).toHaveClass('active');
+        });
+    };
+
     beforeEach(() => {
         jest.clearAllMocks();
     });
@@ -159,29 +173,11 @@ describe('RightSection', () => {
         });
 
         it('switches to USD tab and shows AbroadPaymentDetails', async () => {
-            render(<RightSection />);
-
-            fireEvent.click(getTabByLabel('USD'));
-
-            await waitFor(() => {
-                expect(getAbroadPaymentSection()).toBeInTheDocument();
-                expect(getAbroadPaymentSection()).toHaveTextContent('USD');
-                expect(queryUkrainePaymentSection()).not.toBeInTheDocument();
-                expect(getTabByLabel('USD')).toHaveClass('active');
-            });
+            await testForeignCurrencySwitch('USD');
         });
 
         it('switches to EUR tab and shows AbroadPaymentDetails', async () => {
-            render(<RightSection />);
-
-            fireEvent.click(getTabByLabel('EUR'));
-
-            await waitFor(() => {
-                expect(getAbroadPaymentSection()).toBeInTheDocument();
-                expect(getAbroadPaymentSection()).toHaveTextContent('EUR');
-                expect(queryUkrainePaymentSection()).not.toBeInTheDocument();
-                expect(getTabByLabel('EUR')).toHaveClass('active');
-            });
+            await testForeignCurrencySwitch('EUR');
         });
 
         it('switches between all tabs correctly', async () => {

--- a/src/pages/public/donate-page/right-section/RightSection.test.tsx
+++ b/src/pages/public/donate-page/right-section/RightSection.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { RightSection } from './RightSection';
 import { Currency } from '../../../../types/public/donate-page';

--- a/src/pages/public/donate-page/right-section/RightSection.test.tsx
+++ b/src/pages/public/donate-page/right-section/RightSection.test.tsx
@@ -103,6 +103,28 @@ describe('RightSection', () => {
         });
     };
 
+    const testTabSwitch = async (
+        tabName: string,
+        expectedContent: string,
+        expectedPaymentType: 'ukraine-payment' | 'abroad-payment',
+        previousTab?: string,
+    ) => {
+        fireEvent.click(screen.getByTestId(`tab-${tabName}`));
+
+        await waitFor(() => {
+            expect(screen.getByTestId(expectedPaymentType)).toBeInTheDocument();
+            expect(screen.getByTestId(`tab-${tabName}`)).toHaveClass('active');
+
+            if (previousTab) {
+                expect(screen.getByTestId(`tab-${previousTab}`)).not.toHaveClass('active');
+            }
+
+            if (expectedContent && expectedPaymentType === 'abroad-payment') {
+                expect(screen.getByTestId('abroad-payment')).toHaveTextContent(expectedContent);
+            }
+        });
+    };
+
     const testForeignCurrencySwitch = async (currency: 'USD' | 'EUR') => {
         render(<RightSection />);
 
@@ -179,26 +201,9 @@ describe('RightSection', () => {
             expect(screen.getByTestId('ukraine-payment')).toBeInTheDocument();
             expect(screen.getByTestId('tab-uah')).toHaveClass('active');
 
-            fireEvent.click(screen.getByTestId('tab-usd'));
-            await waitFor(() => {
-                expect(screen.getByTestId('abroad-payment')).toBeInTheDocument();
-                expect(screen.getByTestId('tab-usd')).toHaveClass('active');
-                expect(screen.getByTestId('tab-uah')).not.toHaveClass('active');
-            });
-
-            fireEvent.click(screen.getByTestId('tab-eur'));
-            await waitFor(() => {
-                expect(screen.getByTestId('abroad-payment')).toBeInTheDocument();
-                expect(screen.getByTestId('tab-eur')).toHaveClass('active');
-                expect(screen.getByTestId('tab-usd')).not.toHaveClass('active');
-            });
-
-            fireEvent.click(screen.getByTestId('tab-uah'));
-            await waitFor(() => {
-                expect(screen.getByTestId('ukraine-payment')).toBeInTheDocument();
-                expect(screen.getByTestId('tab-uah')).toHaveClass('active');
-                expect(screen.getByTestId('tab-eur')).not.toHaveClass('active');
-            });
+            await testTabSwitch('usd', 'USD', 'abroad-payment', 'uah');
+            await testTabSwitch('eur', 'EUR', 'abroad-payment', 'usd');
+            await testTabSwitch('uah', '', 'ukraine-payment', 'eur');
         });
 
         it('always renders AlternativeSupportWays with current currency', async () => {

--- a/src/pages/public/donate-page/right-section/RightSection.test.tsx
+++ b/src/pages/public/donate-page/right-section/RightSection.test.tsx
@@ -1,79 +1,320 @@
-import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { RightSection } from './RightSection';
-import '@testing-library/jest-dom';
+import { Currency } from '../../../../types/public/donate-page';
 
-jest.mock('./ukraine-payment-details/UkrainePaymentDetails.tsx', () => ({
-    UkrainePaymentDetails: () => <div data-testid="ukraine-payment">Ukraine Payment Details</div>,
+jest.mock('./ukraine-payment-details/UkrainePaymentDetails', () => ({
+    UkrainePaymentDetails: ({ bankDetails }: { bankDetails: any[] }) => (
+        <div data-testid="ukraine-payment">Ukraine Payment Details ({bankDetails.length} items)</div>
+    ),
 }));
 
 jest.mock('./abroad-payment-details/AbroadPaymentDetails', () => ({
-    AbroadPaymentDetails: () => <div data-testid="abroad-payment">Abroad Payment Details</div>,
+    AbroadPaymentDetails: ({ currency, foreignBankDetails }: { currency: number; foreignBankDetails: any[] }) => (
+        <div data-testid="abroad-payment">
+            Abroad Payment Details - {currency === 1 ? 'USD' : 'EUR'} ({foreignBankDetails.length} items)
+        </div>
+    ),
 }));
 
 jest.mock('./alternative-support-ways/AlternativeSupportWays', () => ({
-    AlternativeSupportWays: () => <div data-testid="alt-support">Alternative Support</div>,
+    AlternativeSupportWays: ({
+        supportOptions,
+        currentCurrency,
+    }: {
+        supportOptions: any[];
+        currentCurrency: number;
+    }) => (
+        <div data-testid="alt-support">
+            Alternative Support - {currentCurrency} ({supportOptions.length} options)
+        </div>
+    ),
 }));
 
-describe('RightSection', () => {
-    const getUahTab = () => screen.getByText(/UAH/i);
-    const getUsdTab = () => screen.getByText(/USD/i);
-    const getEurTab = () => screen.getByText(/EUR/i);
+jest.mock('../../../../components/common/tabs/Tabs', () => ({
+    Tabs: ({ activeTab, setActiveTab, tabs }: any) => (
+        <div data-testid="tabs-container">
+            {tabs.map((tab: any) => (
+                <button
+                    key={tab.id}
+                    className={activeTab === tab.id ? 'active tab' : 'tab'}
+                    onClick={() => setActiveTab(tab.id)}
+                    data-testid={`tab-${tab.label.toLowerCase()}`}
+                >
+                    {tab.label}
+                </button>
+            ))}
+        </div>
+    ),
+}));
 
-    const queryUkrainePaymentSection = () => screen.queryByTestId('ukraine-payment');
-    const queryAbroadPaymentSection = () => screen.queryByTestId('abroad-payment');
+jest.mock('../../../../const/public/donate-page', () => ({
+    CURRENCY_TABS: {
+        UAH: 'UAH',
+        USD: 'USD',
+        EUR: 'EUR',
+    },
+}));
+
+jest.mock('../../../../hooks/common/use-data-fetch/useDataFetch', () => ({
+    useDataFetch: jest.fn(),
+}));
+
+jest.mock('../../../../services/api/public/donate/donate-api', () => ({
+    donatePageDataFetch: jest.fn(),
+}));
+
+const mockUseDataFetch = require('../../../../hooks/common/use-data-fetch/useDataFetch').useDataFetch;
+
+describe('RightSection', () => {
+    const createMockDonateData = () => ({
+        uahBankDetails: [{ id: 1, name: 'UAH Bank', iban: 'UA123', receiver: 'UAH Receiver' }],
+        foreignBankDetails: [
+            { id: 1, currency: Currency.USD, name: 'USD Bank', iban: 'US123' },
+            { id: 2, currency: Currency.EUR, name: 'EUR Bank', iban: 'EU123' },
+        ],
+        supportOptions: [
+            { id: 1, name: 'PayPal', value: 'test@paypal.com', currency: Currency.UAH },
+            { id: 2, name: 'Stripe', value: 'test@stripe.com', currency: Currency.USD },
+        ],
+    });
+
+    const mockUseDataFetchSuccess = (data: any = createMockDonateData()) => {
+        mockUseDataFetch.mockReturnValue({
+            data,
+            isLoading: false,
+            error: null,
+        });
+    };
+
+    const mockUseDataFetchLoading = () => {
+        mockUseDataFetch.mockReturnValue({
+            data: null,
+            isLoading: true,
+            error: null,
+        });
+    };
+
+    const mockUseDataFetchError = () => {
+        mockUseDataFetch.mockReturnValue({
+            data: null,
+            isLoading: false,
+            error: 'Test error',
+        });
+    };
+
+    const getTabByLabel = (label: string) => screen.getByTestId(`tab-${label.toLowerCase()}`);
     const getUkrainePaymentSection = () => screen.getByTestId('ukraine-payment');
     const getAbroadPaymentSection = () => screen.getByTestId('abroad-payment');
     const getAlternativeSupportSection = () => screen.getByTestId('alt-support');
+    const queryUkrainePaymentSection = () => screen.queryByTestId('ukraine-payment');
+    const queryAbroadPaymentSection = () => screen.queryByTestId('abroad-payment');
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    it('renders with default UAH tab and UkrainePaymentDetails', () => {
-        render(<RightSection />);
-        expect(getUkrainePaymentSection()).toBeInTheDocument();
-        expect(getUahTab()).toHaveClass('active');
+    describe('loading state', () => {
+        it('shows loading state when data is being fetched', async () => {
+            mockUseDataFetchLoading();
+
+            render(<RightSection />);
+
+            expect(screen.getByRole('progressbar')).toBeInTheDocument();
+            expect(queryUkrainePaymentSection()).not.toBeInTheDocument();
+        });
     });
 
-    it('switches between tabs and shows appropriate content', () => {
-        render(<RightSection />);
-        fireEvent.click(getUsdTab());
-        expect(getAbroadPaymentSection()).toBeInTheDocument();
-        expect(queryUkrainePaymentSection()).not.toBeInTheDocument();
+    describe('error state', () => {
+        it('shows error message when data fetch fails', () => {
+            mockUseDataFetchError();
 
-        fireEvent.click(getEurTab());
-        expect(getAbroadPaymentSection()).toBeInTheDocument();
-        expect(queryUkrainePaymentSection()).not.toBeInTheDocument();
+            render(<RightSection />);
 
-        fireEvent.click(getUahTab());
-        expect(getUkrainePaymentSection()).toBeInTheDocument();
-        expect(queryAbroadPaymentSection()).not.toBeInTheDocument();
+            const errorElement = screen.getByRole('alert');
+            expect(errorElement).toBeInTheDocument();
+            expect(errorElement).toHaveTextContent('Не вдалося завантажити реквізити');
+            expect(queryUkrainePaymentSection()).not.toBeInTheDocument();
+        });
     });
 
-    it('always renders AlternativeSupportWays', () => {
-        render(<RightSection />);
-        expect(getAlternativeSupportSection()).toBeInTheDocument();
+    describe('successful data loading', () => {
+        beforeEach(() => {
+            mockUseDataFetchSuccess();
+        });
+
+        it('renders with default UAH tab and UkrainePaymentDetails', () => {
+            render(<RightSection />);
+
+            expect(getUkrainePaymentSection()).toBeInTheDocument();
+            expect(getTabByLabel('UAH')).toHaveClass('active');
+            expect(getAlternativeSupportSection()).toBeInTheDocument();
+        });
+
+        it('renders all currency tabs', () => {
+            render(<RightSection />);
+
+            expect(getTabByLabel('UAH')).toBeInTheDocument();
+            expect(getTabByLabel('USD')).toBeInTheDocument();
+            expect(getTabByLabel('EUR')).toBeInTheDocument();
+        });
+
+        it('switches to USD tab and shows AbroadPaymentDetails', async () => {
+            render(<RightSection />);
+
+            fireEvent.click(getTabByLabel('USD'));
+
+            await waitFor(() => {
+                expect(getAbroadPaymentSection()).toBeInTheDocument();
+                expect(getAbroadPaymentSection()).toHaveTextContent('USD');
+                expect(queryUkrainePaymentSection()).not.toBeInTheDocument();
+                expect(getTabByLabel('USD')).toHaveClass('active');
+            });
+        });
+
+        it('switches to EUR tab and shows AbroadPaymentDetails', async () => {
+            render(<RightSection />);
+
+            fireEvent.click(getTabByLabel('EUR'));
+
+            await waitFor(() => {
+                expect(getAbroadPaymentSection()).toBeInTheDocument();
+                expect(getAbroadPaymentSection()).toHaveTextContent('EUR');
+                expect(queryUkrainePaymentSection()).not.toBeInTheDocument();
+                expect(getTabByLabel('EUR')).toHaveClass('active');
+            });
+        });
+
+        it('switches between all tabs correctly', async () => {
+            render(<RightSection />);
+
+            expect(getUkrainePaymentSection()).toBeInTheDocument();
+            expect(getTabByLabel('UAH')).toHaveClass('active');
+
+            fireEvent.click(getTabByLabel('USD'));
+            await waitFor(() => {
+                expect(getAbroadPaymentSection()).toBeInTheDocument();
+                expect(getTabByLabel('USD')).toHaveClass('active');
+                expect(getTabByLabel('UAH')).not.toHaveClass('active');
+            });
+
+            fireEvent.click(getTabByLabel('EUR'));
+            await waitFor(() => {
+                expect(getAbroadPaymentSection()).toBeInTheDocument();
+                expect(getTabByLabel('EUR')).toHaveClass('active');
+                expect(getTabByLabel('USD')).not.toHaveClass('active');
+            });
+
+            fireEvent.click(getTabByLabel('UAH'));
+            await waitFor(() => {
+                expect(getUkrainePaymentSection()).toBeInTheDocument();
+                expect(getTabByLabel('UAH')).toHaveClass('active');
+                expect(getTabByLabel('EUR')).not.toHaveClass('active');
+            });
+        });
+
+        it('always renders AlternativeSupportWays with current currency', async () => {
+            render(<RightSection />);
+
+            expect(getAlternativeSupportSection()).toHaveTextContent('Alternative Support - 0');
+
+            fireEvent.click(getTabByLabel('USD'));
+            await waitFor(() => {
+                expect(getAlternativeSupportSection()).toHaveTextContent('Alternative Support - 1');
+            });
+
+            fireEvent.click(getTabByLabel('EUR'));
+            await waitFor(() => {
+                expect(getAlternativeSupportSection()).toHaveTextContent('Alternative Support - 2');
+            });
+        });
     });
 
-    it('has correct active class', () => {
-        render(<RightSection />);
-        const uahTab = getUahTab();
-        const usdTab = getUsdTab();
-        const eurTab = getEurTab();
+    describe('data filtering', () => {
+        it('filters foreign bank details by currency for USD', async () => {
+            mockUseDataFetchSuccess();
+            render(<RightSection />);
 
-        expect(uahTab).toHaveClass('active');
-        expect(usdTab).not.toHaveClass('active');
-        expect(eurTab).not.toHaveClass('active');
+            fireEvent.click(getTabByLabel('USD'));
 
-        fireEvent.click(usdTab);
-        expect(uahTab).not.toHaveClass('active');
-        expect(usdTab).toHaveClass('active');
-        expect(eurTab).not.toHaveClass('active');
+            await waitFor(() => {
+                const abroadSection = getAbroadPaymentSection();
+                expect(abroadSection).toHaveTextContent('USD (1 items)');
+            });
+        });
 
-        fireEvent.click(eurTab);
-        expect(uahTab).not.toHaveClass('active');
-        expect(usdTab).not.toHaveClass('active');
-        expect(eurTab).toHaveClass('active');
+        it('filters foreign bank details by currency for EUR', async () => {
+            mockUseDataFetchSuccess();
+            render(<RightSection />);
+
+            fireEvent.click(getTabByLabel('EUR'));
+
+            await waitFor(() => {
+                const abroadSection = getAbroadPaymentSection();
+                expect(abroadSection).toHaveTextContent('EUR (1 items)');
+            });
+        });
+
+        it('passes support options to AlternativeSupportWays', () => {
+            mockUseDataFetchSuccess();
+            render(<RightSection />);
+
+            expect(getAlternativeSupportSection()).toHaveTextContent('(2 options)');
+        });
+    });
+
+    describe('edge cases', () => {
+        it('handles empty data gracefully', () => {
+            mockUseDataFetchSuccess({
+                uahBankDetails: [],
+                foreignBankDetails: [],
+                supportOptions: [],
+            });
+
+            render(<RightSection />);
+
+            expect(getUkrainePaymentSection()).toHaveTextContent('(0 items)');
+            expect(getAlternativeSupportSection()).toHaveTextContent('(0 options)');
+        });
+
+        it('handles null data gracefully', () => {
+            mockUseDataFetch.mockReturnValue({
+                data: null,
+                isLoading: false,
+                error: null,
+            });
+
+            render(<RightSection />);
+
+            expect(queryUkrainePaymentSection()).not.toBeInTheDocument();
+            expect(queryAbroadPaymentSection()).not.toBeInTheDocument();
+
+            expect(getAlternativeSupportSection()).toHaveTextContent('(0 options)');
+        });
+    });
+
+    describe('DOM structure', () => {
+        beforeEach(() => {
+            mockUseDataFetchSuccess();
+        });
+
+        it('has correct CSS classes and structure', () => {
+            render(<RightSection />);
+
+            const rightSection = screen.getByTestId('tabs-container').closest('.rightSection');
+            expect(rightSection).toBeInTheDocument();
+
+            const locationToggleContainer = rightSection?.querySelector('.locationToggleContainer');
+            expect(locationToggleContainer).toBeInTheDocument();
+
+            const donatePaymentDetails = rightSection?.querySelector('.donatePaymentDetails');
+            expect(donatePaymentDetails).toBeInTheDocument();
+        });
+
+        it('renders tabs container with switch class', () => {
+            render(<RightSection />);
+
+            const switchContainer = screen.getByTestId('tabs-container').closest('.switch');
+            expect(switchContainer).toBeInTheDocument();
+        });
     });
 });

--- a/src/pages/public/donate-page/right-section/RightSection.test.tsx
+++ b/src/pages/public/donate-page/right-section/RightSection.test.tsx
@@ -1,16 +1,29 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { RightSection } from './RightSection';
-import { Currency } from '../../../../types/public/donate-page';
+import {
+    Currency,
+    DonatePageData,
+    PublishedUahBankDetailsDto,
+    PublishedForeignBankDetailsDto,
+    PublishedSupportOptionsDto,
+} from '../../../../types/public/donate-page';
+import { ERROR_MESSAGES } from '../../../../const/public/donate-page';
 
 jest.mock('./ukraine-payment-details/UkrainePaymentDetails', () => ({
-    UkrainePaymentDetails: ({ bankDetails }: { bankDetails: any[] }) => (
+    UkrainePaymentDetails: ({ bankDetails }: { bankDetails: PublishedUahBankDetailsDto[] }) => (
         <div data-testid="ukraine-payment">Ukraine Payment Details ({bankDetails.length} items)</div>
     ),
 }));
 
 jest.mock('./abroad-payment-details/AbroadPaymentDetails', () => ({
-    AbroadPaymentDetails: ({ currency, foreignBankDetails }: { currency: number; foreignBankDetails: any[] }) => (
+    AbroadPaymentDetails: ({
+        currency,
+        foreignBankDetails,
+    }: {
+        currency: number;
+        foreignBankDetails: PublishedForeignBankDetailsDto[];
+    }) => (
         <div data-testid="abroad-payment">
             Abroad Payment Details - {currency === 1 ? 'USD' : 'EUR'} ({foreignBankDetails.length} items)
         </div>
@@ -22,7 +35,7 @@ jest.mock('./alternative-support-ways/AlternativeSupportWays', () => ({
         supportOptions,
         currentCurrency,
     }: {
-        supportOptions: any[];
+        supportOptions: PublishedSupportOptionsDto[];
         currentCurrency: number;
     }) => (
         <div data-testid="alt-support">
@@ -39,7 +52,7 @@ jest.mock('../../../../components/common/tabs/Tabs', () => ({
                     key={tab.id}
                     className={activeTab === tab.id ? 'active tab' : 'tab'}
                     onClick={() => setActiveTab(tab.id)}
-                    data-testid={`tab-${tab.label.toLowerCase()}`}
+                    data-testid={`tab-${tab.label.toLowerCase().split(' / ')[0]}`}
                 >
                     {tab.label}
                 </button>
@@ -48,65 +61,66 @@ jest.mock('../../../../components/common/tabs/Tabs', () => ({
     ),
 }));
 
-jest.mock('../../../../const/public/donate-page', () => ({
-    CURRENCY_TABS: {
-        UAH: 'UAH',
-        USD: 'USD',
-        EUR: 'EUR',
-    },
-}));
-
-jest.mock('../../../../hooks/common/use-data-fetch/useDataFetch', () => ({
-    useDataFetch: jest.fn(),
-}));
-
-jest.mock('../../../../services/api/public/donate/donate-api', () => ({
-    donatePageDataFetch: jest.fn(),
-}));
-
-const mockUseDataFetch = require('../../../../hooks/common/use-data-fetch/useDataFetch').useDataFetch;
-
 describe('RightSection', () => {
-    const createMockDonateData = () => ({
-        uahBankDetails: [{ id: 1, name: 'UAH Bank', iban: 'UA123', receiver: 'UAH Receiver' }],
-        foreignBankDetails: [
-            { id: 1, currency: Currency.USD, name: 'USD Bank', iban: 'US123' },
-            { id: 2, currency: Currency.EUR, name: 'EUR Bank', iban: 'EU123' },
-        ],
-        supportOptions: [
-            { id: 1, name: 'PayPal', value: 'test@paypal.com', currency: Currency.UAH },
-            { id: 2, name: 'Stripe', value: 'test@stripe.com', currency: Currency.USD },
-        ],
+    const createMockUahBankDetails = (): PublishedUahBankDetailsDto[] => [
+        {
+            id: 1,
+            name: 'UAH Bank',
+            iban: 'UA123456789012345678901234567',
+            receiver: 'UAH Receiver',
+            edrpou: '12345678',
+            paymentPurpose: 'Donation purpose',
+        },
+    ];
+
+    const createMockForeignBankDetails = (): PublishedForeignBankDetailsDto[] => [
+        {
+            id: 1,
+            currency: Currency.USD,
+            name: 'USD Bank',
+            iban: 'US123456789012345678901234567',
+            receiver: 'USD Receiver',
+            swift: 'USDBANK',
+            address: 'USD Bank Address',
+            correspondentBanks: [],
+        },
+        {
+            id: 2,
+            currency: Currency.EUR,
+            name: 'EUR Bank',
+            iban: 'EU123456789012345678901234567',
+            receiver: 'EUR Receiver',
+            swift: 'EURBANK',
+            address: 'EUR Bank Address',
+            correspondentBanks: [],
+        },
+    ];
+
+    const createMockSupportOptions = (): PublishedSupportOptionsDto[] => [
+        {
+            id: 1,
+            name: 'PayPal',
+            value: 'test@paypal.com',
+            currency: Currency.UAH,
+        },
+        {
+            id: 2,
+            name: 'Stripe',
+            value: 'test@stripe.com',
+            currency: Currency.USD,
+        },
+    ];
+
+    const createMockDonateData = (): DonatePageData => ({
+        uahBankDetails: createMockUahBankDetails(),
+        foreignBankDetails: createMockForeignBankDetails(),
+        supportOptions: createMockSupportOptions(),
     });
-
-    const mockUseDataFetchSuccess = (data: any = createMockDonateData()) => {
-        mockUseDataFetch.mockReturnValue({
-            data,
-            isLoading: false,
-            error: null,
-        });
-    };
-
-    const mockUseDataFetchLoading = () => {
-        mockUseDataFetch.mockReturnValue({
-            data: null,
-            isLoading: true,
-            error: null,
-        });
-    };
-
-    const mockUseDataFetchError = () => {
-        mockUseDataFetch.mockReturnValue({
-            data: null,
-            isLoading: false,
-            error: 'Test error',
-        });
-    };
 
     const testTabSwitch = async (
         tabName: string,
-        expectedContent: string,
         expectedPaymentType: 'ukraine-payment' | 'abroad-payment',
+        expectedContent?: string,
         previousTab?: string,
     ) => {
         fireEvent.click(screen.getByTestId(`tab-${tabName}`));
@@ -125,119 +139,99 @@ describe('RightSection', () => {
         });
     };
 
-    const testForeignCurrencySwitch = async (currency: 'USD' | 'EUR') => {
-        render(<RightSection />);
-
-        fireEvent.click(screen.getByTestId(`tab-${currency.toLowerCase()}`));
-
-        await waitFor(() => {
-            expect(screen.getByTestId('abroad-payment')).toBeInTheDocument();
-            expect(screen.getByTestId('abroad-payment')).toHaveTextContent(currency);
-            expect(screen.queryByTestId('ukraine-payment')).not.toBeInTheDocument();
-            expect(screen.getByTestId(`tab-${currency.toLowerCase()}`)).toHaveClass('active');
-        });
-    };
-
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    describe('loading state', () => {
-        it('shows loading state when data is being fetched', () => {
-            mockUseDataFetchLoading();
-
-            render(<RightSection />);
-
-            expect(screen.getByRole('progressbar')).toBeInTheDocument();
-            expect(screen.queryByTestId('ukraine-payment')).not.toBeInTheDocument();
-        });
-    });
-
     describe('error state', () => {
-        it('shows error message when data fetch fails', () => {
-            mockUseDataFetchError();
+        it('shows error message when error prop provided', () => {
+            const mockData = createMockDonateData();
 
-            render(<RightSection />);
+            render(<RightSection donateData={mockData} error="Test error" />);
 
             const errorElement = screen.getByRole('alert');
             expect(errorElement).toBeInTheDocument();
-            expect(errorElement).toHaveTextContent('Не вдалося завантажити реквізити');
+            expect(errorElement).toHaveTextContent(ERROR_MESSAGES.LOADING_ERROR);
             expect(screen.queryByTestId('ukraine-payment')).not.toBeInTheDocument();
         });
     });
 
     describe('with available currencies', () => {
-        beforeEach(() => {
-            mockUseDataFetchSuccess();
-        });
+        const mockData = createMockDonateData();
 
         it('renders with default UAH tab and UkrainePaymentDetails', () => {
-            render(<RightSection />);
+            render(<RightSection donateData={mockData} />);
 
             expect(screen.getByTestId('ukraine-payment')).toBeInTheDocument();
-            expect(screen.getByTestId('tab-uah')).toHaveClass('active');
+            expect(screen.getByTestId('tab-гривня')).toHaveClass('active');
             expect(screen.getByTestId('alt-support')).toBeInTheDocument();
         });
 
         it('renders all available currency tabs', () => {
-            render(<RightSection />);
+            render(<RightSection donateData={mockData} />);
 
-            expect(screen.getByTestId('tab-uah')).toBeInTheDocument();
-            expect(screen.getByTestId('tab-usd')).toBeInTheDocument();
-            expect(screen.getByTestId('tab-eur')).toBeInTheDocument();
+            expect(screen.getByTestId('tab-гривня')).toBeInTheDocument();
+            expect(screen.getByTestId('tab-долар')).toBeInTheDocument();
+            expect(screen.getByTestId('tab-євро')).toBeInTheDocument();
         });
 
         it('switches to USD tab and shows AbroadPaymentDetails', async () => {
-            await testForeignCurrencySwitch('USD');
+            render(<RightSection donateData={mockData} />);
+
+            await testTabSwitch('долар', 'abroad-payment', 'USD');
+            expect(screen.queryByTestId('ukraine-payment')).not.toBeInTheDocument();
         });
 
         it('switches to EUR tab and shows AbroadPaymentDetails', async () => {
-            await testForeignCurrencySwitch('EUR');
+            render(<RightSection donateData={mockData} />);
+
+            await testTabSwitch('євро', 'abroad-payment', 'EUR');
+            expect(screen.queryByTestId('ukraine-payment')).not.toBeInTheDocument();
         });
 
         it('switches between all tabs correctly', async () => {
-            render(<RightSection />);
+            render(<RightSection donateData={mockData} />);
 
             expect(screen.getByTestId('ukraine-payment')).toBeInTheDocument();
-            expect(screen.getByTestId('tab-uah')).toHaveClass('active');
+            expect(screen.getByTestId('tab-гривня')).toHaveClass('active');
 
-            await testTabSwitch('usd', 'USD', 'abroad-payment', 'uah');
-            await testTabSwitch('eur', 'EUR', 'abroad-payment', 'usd');
-            await testTabSwitch('uah', '', 'ukraine-payment', 'eur');
+            await testTabSwitch('долар', 'abroad-payment', 'USD', 'гривня');
+            await testTabSwitch('євро', 'abroad-payment', 'EUR', 'долар');
+            await testTabSwitch('гривня', 'ukraine-payment', undefined, 'євро');
         });
 
         it('always renders AlternativeSupportWays with current currency', async () => {
-            render(<RightSection />);
+            render(<RightSection donateData={mockData} />);
 
-            expect(screen.getByTestId('alt-support')).toHaveTextContent('Alternative Support - 0');
+            expect(screen.getByTestId('alt-support')).toHaveTextContent(`Alternative Support - ${Currency.UAH}`);
 
-            fireEvent.click(screen.getByTestId('tab-usd'));
+            fireEvent.click(screen.getByTestId('tab-долар'));
             await waitFor(() => {
-                expect(screen.getByTestId('alt-support')).toHaveTextContent('Alternative Support - 1');
+                expect(screen.getByTestId('alt-support')).toHaveTextContent(`Alternative Support - ${Currency.USD}`);
             });
 
-            fireEvent.click(screen.getByTestId('tab-eur'));
+            fireEvent.click(screen.getByTestId('tab-євро'));
             await waitFor(() => {
-                expect(screen.getByTestId('alt-support')).toHaveTextContent('Alternative Support - 2');
+                expect(screen.getByTestId('alt-support')).toHaveTextContent(`Alternative Support - ${Currency.EUR}`);
             });
         });
 
         it('filters foreign bank details by currency correctly', async () => {
-            render(<RightSection />);
+            render(<RightSection donateData={mockData} />);
 
-            fireEvent.click(screen.getByTestId('tab-usd'));
+            fireEvent.click(screen.getByTestId('tab-долар'));
             await waitFor(() => {
                 expect(screen.getByTestId('abroad-payment')).toHaveTextContent('USD (1 items)');
             });
 
-            fireEvent.click(screen.getByTestId('tab-eur'));
+            fireEvent.click(screen.getByTestId('tab-євро'));
             await waitFor(() => {
                 expect(screen.getByTestId('abroad-payment')).toHaveTextContent('EUR (1 items)');
             });
         });
 
         it('renders correct DOM structure', () => {
-            render(<RightSection />);
+            render(<RightSection donateData={mockData} />);
 
             const rightSection = screen.getByTestId('tabs-container').closest('.rightSection');
             expect(rightSection).toBeInTheDocument();
@@ -252,55 +246,49 @@ describe('RightSection', () => {
 
     describe('no available currencies scenarios', () => {
         it('returns null when no data available for any currency', () => {
-            mockUseDataFetchSuccess({
+            const emptyData: DonatePageData = {
                 uahBankDetails: [],
                 foreignBankDetails: [],
                 supportOptions: [],
-            });
+            };
 
-            const { container } = render(<RightSection />);
+            const { container } = render(<RightSection donateData={emptyData} />);
 
             expect(container.firstChild).toBeNull();
         });
 
         it('returns null when data is null', () => {
-            mockUseDataFetch.mockReturnValue({
-                data: null,
-                isLoading: false,
-                error: null,
-            });
-
-            const { container } = render(<RightSection />);
+            const { container } = render(<RightSection donateData={null} />);
 
             expect(container.firstChild).toBeNull();
         });
 
         it('shows only UAH tab when only UAH bank details available', () => {
-            mockUseDataFetchSuccess({
-                uahBankDetails: [{ id: 1, name: 'UAH Bank' }],
+            const uahOnlyData: DonatePageData = {
+                uahBankDetails: createMockUahBankDetails(),
                 foreignBankDetails: [],
                 supportOptions: [],
-            });
+            };
 
-            render(<RightSection />);
+            render(<RightSection donateData={uahOnlyData} />);
 
-            expect(screen.getByTestId('tab-uah')).toBeInTheDocument();
-            expect(screen.queryByTestId('tab-usd')).not.toBeInTheDocument();
-            expect(screen.queryByTestId('tab-eur')).not.toBeInTheDocument();
+            expect(screen.getByTestId('tab-гривня')).toBeInTheDocument();
+            expect(screen.queryByTestId('tab-долар')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('tab-євро')).not.toBeInTheDocument();
         });
 
         it('shows only USD tab when only USD support options available', () => {
-            mockUseDataFetchSuccess({
+            const usdOnlyData: DonatePageData = {
                 uahBankDetails: [],
                 foreignBankDetails: [],
-                supportOptions: [{ id: 1, currency: Currency.USD }],
-            });
+                supportOptions: [{ id: 1, name: 'PayPal', value: 'test@paypal.com', currency: Currency.USD }],
+            };
 
-            render(<RightSection />);
+            render(<RightSection donateData={usdOnlyData} />);
 
-            expect(screen.getByTestId('tab-usd')).toBeInTheDocument();
-            expect(screen.queryByTestId('tab-uah')).not.toBeInTheDocument();
-            expect(screen.queryByTestId('tab-eur')).not.toBeInTheDocument();
+            expect(screen.getByTestId('tab-долар')).toBeInTheDocument();
+            expect(screen.queryByTestId('tab-гривня')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('tab-євро')).not.toBeInTheDocument();
         });
     });
 });

--- a/src/pages/public/donate-page/right-section/RightSection.test.tsx
+++ b/src/pages/public/donate-page/right-section/RightSection.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { RightSection } from './RightSection';
 import { Currency } from '../../../../types/public/donate-page';
 
@@ -102,23 +103,16 @@ describe('RightSection', () => {
         });
     };
 
-    const getTabByLabel = (label: string) => screen.getByTestId(`tab-${label.toLowerCase()}`);
-    const getUkrainePaymentSection = () => screen.getByTestId('ukraine-payment');
-    const getAbroadPaymentSection = () => screen.getByTestId('abroad-payment');
-    const getAlternativeSupportSection = () => screen.getByTestId('alt-support');
-    const queryUkrainePaymentSection = () => screen.queryByTestId('ukraine-payment');
-    const queryAbroadPaymentSection = () => screen.queryByTestId('abroad-payment');
-
     const testForeignCurrencySwitch = async (currency: 'USD' | 'EUR') => {
         render(<RightSection />);
 
-        fireEvent.click(getTabByLabel(currency));
+        fireEvent.click(screen.getByTestId(`tab-${currency.toLowerCase()}`));
 
         await waitFor(() => {
-            expect(getAbroadPaymentSection()).toBeInTheDocument();
-            expect(getAbroadPaymentSection()).toHaveTextContent(currency);
-            expect(queryUkrainePaymentSection()).not.toBeInTheDocument();
-            expect(getTabByLabel(currency)).toHaveClass('active');
+            expect(screen.getByTestId('abroad-payment')).toBeInTheDocument();
+            expect(screen.getByTestId('abroad-payment')).toHaveTextContent(currency);
+            expect(screen.queryByTestId('ukraine-payment')).not.toBeInTheDocument();
+            expect(screen.getByTestId(`tab-${currency.toLowerCase()}`)).toHaveClass('active');
         });
     };
 
@@ -127,13 +121,13 @@ describe('RightSection', () => {
     });
 
     describe('loading state', () => {
-        it('shows loading state when data is being fetched', async () => {
+        it('shows loading state when data is being fetched', () => {
             mockUseDataFetchLoading();
 
             render(<RightSection />);
 
             expect(screen.getByRole('progressbar')).toBeInTheDocument();
-            expect(queryUkrainePaymentSection()).not.toBeInTheDocument();
+            expect(screen.queryByTestId('ukraine-payment')).not.toBeInTheDocument();
         });
     });
 
@@ -146,11 +140,11 @@ describe('RightSection', () => {
             const errorElement = screen.getByRole('alert');
             expect(errorElement).toBeInTheDocument();
             expect(errorElement).toHaveTextContent('Не вдалося завантажити реквізити');
-            expect(queryUkrainePaymentSection()).not.toBeInTheDocument();
+            expect(screen.queryByTestId('ukraine-payment')).not.toBeInTheDocument();
         });
     });
 
-    describe('successful data loading', () => {
+    describe('with available currencies', () => {
         beforeEach(() => {
             mockUseDataFetchSuccess();
         });
@@ -158,17 +152,17 @@ describe('RightSection', () => {
         it('renders with default UAH tab and UkrainePaymentDetails', () => {
             render(<RightSection />);
 
-            expect(getUkrainePaymentSection()).toBeInTheDocument();
-            expect(getTabByLabel('UAH')).toHaveClass('active');
-            expect(getAlternativeSupportSection()).toBeInTheDocument();
+            expect(screen.getByTestId('ukraine-payment')).toBeInTheDocument();
+            expect(screen.getByTestId('tab-uah')).toHaveClass('active');
+            expect(screen.getByTestId('alt-support')).toBeInTheDocument();
         });
 
-        it('renders all currency tabs', () => {
+        it('renders all available currency tabs', () => {
             render(<RightSection />);
 
-            expect(getTabByLabel('UAH')).toBeInTheDocument();
-            expect(getTabByLabel('USD')).toBeInTheDocument();
-            expect(getTabByLabel('EUR')).toBeInTheDocument();
+            expect(screen.getByTestId('tab-uah')).toBeInTheDocument();
+            expect(screen.getByTestId('tab-usd')).toBeInTheDocument();
+            expect(screen.getByTestId('tab-eur')).toBeInTheDocument();
         });
 
         it('switches to USD tab and shows AbroadPaymentDetails', async () => {
@@ -182,117 +176,62 @@ describe('RightSection', () => {
         it('switches between all tabs correctly', async () => {
             render(<RightSection />);
 
-            expect(getUkrainePaymentSection()).toBeInTheDocument();
-            expect(getTabByLabel('UAH')).toHaveClass('active');
+            expect(screen.getByTestId('ukraine-payment')).toBeInTheDocument();
+            expect(screen.getByTestId('tab-uah')).toHaveClass('active');
 
-            fireEvent.click(getTabByLabel('USD'));
+            fireEvent.click(screen.getByTestId('tab-usd'));
             await waitFor(() => {
-                expect(getAbroadPaymentSection()).toBeInTheDocument();
-                expect(getTabByLabel('USD')).toHaveClass('active');
-                expect(getTabByLabel('UAH')).not.toHaveClass('active');
+                expect(screen.getByTestId('abroad-payment')).toBeInTheDocument();
+                expect(screen.getByTestId('tab-usd')).toHaveClass('active');
+                expect(screen.getByTestId('tab-uah')).not.toHaveClass('active');
             });
 
-            fireEvent.click(getTabByLabel('EUR'));
+            fireEvent.click(screen.getByTestId('tab-eur'));
             await waitFor(() => {
-                expect(getAbroadPaymentSection()).toBeInTheDocument();
-                expect(getTabByLabel('EUR')).toHaveClass('active');
-                expect(getTabByLabel('USD')).not.toHaveClass('active');
+                expect(screen.getByTestId('abroad-payment')).toBeInTheDocument();
+                expect(screen.getByTestId('tab-eur')).toHaveClass('active');
+                expect(screen.getByTestId('tab-usd')).not.toHaveClass('active');
             });
 
-            fireEvent.click(getTabByLabel('UAH'));
+            fireEvent.click(screen.getByTestId('tab-uah'));
             await waitFor(() => {
-                expect(getUkrainePaymentSection()).toBeInTheDocument();
-                expect(getTabByLabel('UAH')).toHaveClass('active');
-                expect(getTabByLabel('EUR')).not.toHaveClass('active');
+                expect(screen.getByTestId('ukraine-payment')).toBeInTheDocument();
+                expect(screen.getByTestId('tab-uah')).toHaveClass('active');
+                expect(screen.getByTestId('tab-eur')).not.toHaveClass('active');
             });
         });
 
         it('always renders AlternativeSupportWays with current currency', async () => {
             render(<RightSection />);
 
-            expect(getAlternativeSupportSection()).toHaveTextContent('Alternative Support - 0');
+            expect(screen.getByTestId('alt-support')).toHaveTextContent('Alternative Support - 0');
 
-            fireEvent.click(getTabByLabel('USD'));
+            fireEvent.click(screen.getByTestId('tab-usd'));
             await waitFor(() => {
-                expect(getAlternativeSupportSection()).toHaveTextContent('Alternative Support - 1');
+                expect(screen.getByTestId('alt-support')).toHaveTextContent('Alternative Support - 1');
             });
 
-            fireEvent.click(getTabByLabel('EUR'));
+            fireEvent.click(screen.getByTestId('tab-eur'));
             await waitFor(() => {
-                expect(getAlternativeSupportSection()).toHaveTextContent('Alternative Support - 2');
+                expect(screen.getByTestId('alt-support')).toHaveTextContent('Alternative Support - 2');
             });
         });
-    });
 
-    describe('data filtering', () => {
-        it('filters foreign bank details by currency for USD', async () => {
-            mockUseDataFetchSuccess();
+        it('filters foreign bank details by currency correctly', async () => {
             render(<RightSection />);
 
-            fireEvent.click(getTabByLabel('USD'));
-
+            fireEvent.click(screen.getByTestId('tab-usd'));
             await waitFor(() => {
-                const abroadSection = getAbroadPaymentSection();
-                expect(abroadSection).toHaveTextContent('USD (1 items)');
+                expect(screen.getByTestId('abroad-payment')).toHaveTextContent('USD (1 items)');
             });
-        });
 
-        it('filters foreign bank details by currency for EUR', async () => {
-            mockUseDataFetchSuccess();
-            render(<RightSection />);
-
-            fireEvent.click(getTabByLabel('EUR'));
-
+            fireEvent.click(screen.getByTestId('tab-eur'));
             await waitFor(() => {
-                const abroadSection = getAbroadPaymentSection();
-                expect(abroadSection).toHaveTextContent('EUR (1 items)');
+                expect(screen.getByTestId('abroad-payment')).toHaveTextContent('EUR (1 items)');
             });
         });
 
-        it('passes support options to AlternativeSupportWays', () => {
-            mockUseDataFetchSuccess();
-            render(<RightSection />);
-
-            expect(getAlternativeSupportSection()).toHaveTextContent('(2 options)');
-        });
-    });
-
-    describe('edge cases', () => {
-        it('handles empty data gracefully', () => {
-            mockUseDataFetchSuccess({
-                uahBankDetails: [],
-                foreignBankDetails: [],
-                supportOptions: [],
-            });
-
-            render(<RightSection />);
-
-            expect(getUkrainePaymentSection()).toHaveTextContent('(0 items)');
-            expect(getAlternativeSupportSection()).toHaveTextContent('(0 options)');
-        });
-
-        it('handles null data gracefully', () => {
-            mockUseDataFetch.mockReturnValue({
-                data: null,
-                isLoading: false,
-                error: null,
-            });
-
-            render(<RightSection />);
-
-            expect(queryUkrainePaymentSection()).not.toBeInTheDocument();
-            expect(queryAbroadPaymentSection()).not.toBeInTheDocument();
-
-            expect(getAlternativeSupportSection()).toHaveTextContent('(0 options)');
-        });
-    });
-
-    describe('DOM structure', () => {
-        beforeEach(() => {
-            mockUseDataFetchSuccess();
-        });
-
-        it('has correct CSS classes and structure', () => {
+        it('renders correct DOM structure', () => {
             render(<RightSection />);
 
             const rightSection = screen.getByTestId('tabs-container').closest('.rightSection');
@@ -304,12 +243,59 @@ describe('RightSection', () => {
             const donatePaymentDetails = rightSection?.querySelector('.donatePaymentDetails');
             expect(donatePaymentDetails).toBeInTheDocument();
         });
+    });
 
-        it('renders tabs container with switch class', () => {
+    describe('no available currencies scenarios', () => {
+        it('returns null when no data available for any currency', () => {
+            mockUseDataFetchSuccess({
+                uahBankDetails: [],
+                foreignBankDetails: [],
+                supportOptions: [],
+            });
+
+            const { container } = render(<RightSection />);
+
+            expect(container.firstChild).toBeNull();
+        });
+
+        it('returns null when data is null', () => {
+            mockUseDataFetch.mockReturnValue({
+                data: null,
+                isLoading: false,
+                error: null,
+            });
+
+            const { container } = render(<RightSection />);
+
+            expect(container.firstChild).toBeNull();
+        });
+
+        it('shows only UAH tab when only UAH bank details available', () => {
+            mockUseDataFetchSuccess({
+                uahBankDetails: [{ id: 1, name: 'UAH Bank' }],
+                foreignBankDetails: [],
+                supportOptions: [],
+            });
+
             render(<RightSection />);
 
-            const switchContainer = screen.getByTestId('tabs-container').closest('.switch');
-            expect(switchContainer).toBeInTheDocument();
+            expect(screen.getByTestId('tab-uah')).toBeInTheDocument();
+            expect(screen.queryByTestId('tab-usd')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('tab-eur')).not.toBeInTheDocument();
+        });
+
+        it('shows only USD tab when only USD support options available', () => {
+            mockUseDataFetchSuccess({
+                uahBankDetails: [],
+                foreignBankDetails: [],
+                supportOptions: [{ id: 1, currency: Currency.USD }],
+            });
+
+            render(<RightSection />);
+
+            expect(screen.getByTestId('tab-usd')).toBeInTheDocument();
+            expect(screen.queryByTestId('tab-uah')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('tab-eur')).not.toBeInTheDocument();
         });
     });
 });

--- a/src/pages/public/donate-page/right-section/RightSection.tsx
+++ b/src/pages/public/donate-page/right-section/RightSection.tsx
@@ -1,27 +1,19 @@
 import { useState, useEffect } from 'react';
 import './RightSection.scss';
-import { LinearProgress } from '@mui/material';
 
 import { AbroadPaymentDetails } from './abroad-payment-details/AbroadPaymentDetails';
 import { AlternativeSupportWays } from './alternative-support-ways/AlternativeSupportWays';
 import { Tabs } from '../../../../components/common/tabs/Tabs';
 import { UkrainePaymentDetails } from './ukraine-payment-details/UkrainePaymentDetails';
 import { Currency, DonatePageData } from '../../../../types/public/donate-page';
-import { CURRENCY_TABS } from '../../../../const/public/donate-page';
-import { donatePageDataFetch } from '../../../../services/api/public/donate/donate-api';
-import { useDataFetch } from '../../../../hooks/common/use-data-fetch/useDataFetch';
+import { CURRENCY_TABS, ERROR_MESSAGES } from '../../../../const/public/donate-page';
 
-export const RightSection = () => {
-    const {
-        data: donateData,
-        isLoading,
-        error,
-    } = useDataFetch<DonatePageData | null>({
-        initialData: null,
-        fetchHandler: donatePageDataFetch,
-        autoFetchDependencies: [],
-    });
+interface RightSectionProps {
+    donateData: DonatePageData | null;
+    error?: string | null;
+}
 
+export const RightSection = ({ donateData, error }: RightSectionProps) => {
     const getAvailableCurrencies = () => {
         if (!donateData) return [];
 
@@ -81,18 +73,10 @@ export const RightSection = () => {
         }
     };
 
-    if (isLoading) {
-        return (
-            <div className="donate-loader">
-                <LinearProgress />
-            </div>
-        );
-    }
-
     if (error) {
         return (
             <div className="donate-error-message" role="alert">
-                Не вдалося завантажити реквізити
+                {ERROR_MESSAGES.LOADING_ERROR}
             </div>
         );
     }

--- a/src/pages/public/donate-page/right-section/RightSection.tsx
+++ b/src/pages/public/donate-page/right-section/RightSection.tsx
@@ -1,26 +1,71 @@
 import { useState } from 'react';
 import './RightSection.scss';
+import { LinearProgress } from '@mui/material';
 
 import { AbroadPaymentDetails } from './abroad-payment-details/AbroadPaymentDetails';
 import { AlternativeSupportWays } from './alternative-support-ways/AlternativeSupportWays';
 import { Tabs } from '../../../../components/common/tabs/Tabs';
 import { UkrainePaymentDetails } from './ukraine-payment-details/UkrainePaymentDetails';
-import { Currency } from '../../../../types/public/donate-page';
+import { Currency, DonatePageData, BankCurrency } from '../../../../types/public/donate-page';
 import { CURRENCY_TABS } from '../../../../const/public/donate-page';
+import { donatePageDataFetch } from '../../../../services/api/public/donate/donate-api';
+import { useDataFetch } from '../../../../hooks/common/use-data-fetch/useDataFetch';
 
 export const RightSection = () => {
     const [activeTab, setActiveTab] = useState<Currency>(Currency.UAH);
 
+    const {
+        data: donateData,
+        isLoading,
+        error,
+    } = useDataFetch<DonatePageData | null>({
+        initialData: null,
+        fetchHandler: donatePageDataFetch,
+        autoFetchDependencies: [],
+    });
+
     const paymentDetails = () => {
+        if (!donateData) return null;
+
         switch (activeTab) {
             case Currency.UAH:
-                return <UkrainePaymentDetails />;
+                return <UkrainePaymentDetails bankDetails={donateData.uahBankDetails} />;
             case Currency.USD:
-                return <AbroadPaymentDetails currency={activeTab} />;
+                return (
+                    <AbroadPaymentDetails
+                        currency={activeTab}
+                        foreignBankDetails={donateData.foreignBankDetails.filter(
+                            (b) => b.currency === BankCurrency.Usd,
+                        )}
+                    />
+                );
             case Currency.EUR:
-                return <AbroadPaymentDetails currency={activeTab} />;
+                return (
+                    <AbroadPaymentDetails
+                        currency={activeTab}
+                        foreignBankDetails={donateData.foreignBankDetails.filter(
+                            (b) => b.currency === BankCurrency.Eur,
+                        )}
+                    />
+                );
         }
     };
+
+    if (isLoading) {
+        return (
+            <div className="donate-loader">
+                <LinearProgress />
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="donate-error-message" role="alert">
+                Не вдалося завантажити реквізити
+            </div>
+        );
+    }
 
     return (
         <div className="rightSection">
@@ -34,12 +79,12 @@ export const RightSection = () => {
                             { id: Currency.USD, label: CURRENCY_TABS.USD },
                             { id: Currency.EUR, label: CURRENCY_TABS.EUR },
                         ]}
-                    ></Tabs>
+                    />
                 </div>
             </div>
             <div className="donatePaymentDetails">
                 {paymentDetails()}
-                <AlternativeSupportWays />
+                <AlternativeSupportWays supportOptions={donateData?.supportOptions || []} />
             </div>
         </div>
     );

--- a/src/pages/public/donate-page/right-section/RightSection.tsx
+++ b/src/pages/public/donate-page/right-section/RightSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import './RightSection.scss';
 import { LinearProgress } from '@mui/material';
 
@@ -12,8 +12,6 @@ import { donatePageDataFetch } from '../../../../services/api/public/donate/dona
 import { useDataFetch } from '../../../../hooks/common/use-data-fetch/useDataFetch';
 
 export const RightSection = () => {
-    const [activeTab, setActiveTab] = useState<Currency>(Currency.UAH);
-
     const {
         data: donateData,
         isLoading,
@@ -23,6 +21,42 @@ export const RightSection = () => {
         fetchHandler: donatePageDataFetch,
         autoFetchDependencies: [],
     });
+
+    const getAvailableCurrencies = () => {
+        if (!donateData) return [];
+
+        const availableCurrencies: Currency[] = [];
+
+        if (
+            donateData.uahBankDetails.length > 0 ||
+            donateData.supportOptions.some((s) => s.currency === Currency.UAH)
+        ) {
+            availableCurrencies.push(Currency.UAH);
+        }
+
+        const usdBankDetails = donateData.foreignBankDetails.filter((b) => b.currency === Currency.USD);
+        const usdSupportOptions = donateData.supportOptions.filter((s) => s.currency === Currency.USD);
+        if (usdBankDetails.length > 0 || usdSupportOptions.length > 0) {
+            availableCurrencies.push(Currency.USD);
+        }
+
+        const eurBankDetails = donateData.foreignBankDetails.filter((b) => b.currency === Currency.EUR);
+        const eurSupportOptions = donateData.supportOptions.filter((s) => s.currency === Currency.EUR);
+        if (eurBankDetails.length > 0 || eurSupportOptions.length > 0) {
+            availableCurrencies.push(Currency.EUR);
+        }
+
+        return availableCurrencies;
+    };
+
+    const availableCurrencies = getAvailableCurrencies();
+    const [activeTab, setActiveTab] = useState<Currency>(availableCurrencies[0] || Currency.UAH);
+
+    useEffect(() => {
+        if (availableCurrencies.length > 0 && !availableCurrencies.includes(activeTab)) {
+            setActiveTab(availableCurrencies[0]);
+        }
+    }, [availableCurrencies, activeTab]);
 
     const paymentDetails = () => {
         if (!donateData) return null;
@@ -63,19 +97,20 @@ export const RightSection = () => {
         );
     }
 
+    if (availableCurrencies.length === 0) {
+        return null;
+    }
+
+    const tabs = availableCurrencies.map((currency) => ({
+        id: currency,
+        label: CURRENCY_TABS[Currency[currency] as keyof typeof CURRENCY_TABS],
+    }));
+
     return (
         <div className="rightSection">
             <div className="locationToggleContainer">
                 <div className="switch">
-                    <Tabs
-                        activeTab={activeTab}
-                        setActiveTab={setActiveTab}
-                        tabs={[
-                            { id: Currency.UAH, label: CURRENCY_TABS.UAH },
-                            { id: Currency.USD, label: CURRENCY_TABS.USD },
-                            { id: Currency.EUR, label: CURRENCY_TABS.EUR },
-                        ]}
-                    />
+                    <Tabs activeTab={activeTab} setActiveTab={setActiveTab} tabs={tabs} />
                 </div>
             </div>
             <div className="donatePaymentDetails">

--- a/src/pages/public/donate-page/right-section/RightSection.tsx
+++ b/src/pages/public/donate-page/right-section/RightSection.tsx
@@ -6,7 +6,7 @@ import { AbroadPaymentDetails } from './abroad-payment-details/AbroadPaymentDeta
 import { AlternativeSupportWays } from './alternative-support-ways/AlternativeSupportWays';
 import { Tabs } from '../../../../components/common/tabs/Tabs';
 import { UkrainePaymentDetails } from './ukraine-payment-details/UkrainePaymentDetails';
-import { Currency, DonatePageData, BankCurrency } from '../../../../types/public/donate-page';
+import { Currency, DonatePageData } from '../../../../types/public/donate-page';
 import { CURRENCY_TABS } from '../../../../const/public/donate-page';
 import { donatePageDataFetch } from '../../../../services/api/public/donate/donate-api';
 import { useDataFetch } from '../../../../hooks/common/use-data-fetch/useDataFetch';
@@ -34,18 +34,14 @@ export const RightSection = () => {
                 return (
                     <AbroadPaymentDetails
                         currency={activeTab}
-                        foreignBankDetails={donateData.foreignBankDetails.filter(
-                            (b) => b.currency === BankCurrency.Usd,
-                        )}
+                        foreignBankDetails={donateData.foreignBankDetails.filter((b) => b.currency === Currency.USD)}
                     />
                 );
             case Currency.EUR:
                 return (
                     <AbroadPaymentDetails
                         currency={activeTab}
-                        foreignBankDetails={donateData.foreignBankDetails.filter(
-                            (b) => b.currency === BankCurrency.Eur,
-                        )}
+                        foreignBankDetails={donateData.foreignBankDetails.filter((b) => b.currency === Currency.EUR)}
                     />
                 );
         }
@@ -84,7 +80,7 @@ export const RightSection = () => {
             </div>
             <div className="donatePaymentDetails">
                 {paymentDetails()}
-                <AlternativeSupportWays supportOptions={donateData?.supportOptions || []} />
+                <AlternativeSupportWays supportOptions={donateData?.supportOptions || []} currentCurrency={activeTab} />
             </div>
         </div>
     );

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.scss
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.scss
@@ -5,6 +5,17 @@
     display: flex;
     flex-direction: column;
     gap: 4rem;
+
+    .bankGroup {
+        display: flex;
+        flex-direction: column;
+        gap: 4rem;
+
+        &.separated {
+            padding-top: 1.5rem;
+            border-top: 1px solid colors.$blue-900;
+        }
+    }
 }
 
 .abroadPaymentDetailsBlock {

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.test.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { AbroadPaymentDetails } from './AbroadPaymentDetails';
-import { Currency } from '../../../../../types/public/donate-page';
 import {
+    Currency,
     PublishedForeignBankDetailsDto,
     PublishedCorrespondentBankDetailsDto,
 } from '../../../../../types/public/donate-page';
@@ -12,10 +12,10 @@ jest.mock('./PaymentDetailsSection', () => ({
             <div data-testid="title">{title}</div>
             <div data-testid="iban-label">{ibanLabel}</div>
             <div data-testid="iban-value">{ibanValue}</div>
-            <div data-testid="receiver-name">{receiverName || 'fallback-receiver'}</div>
-            <div data-testid="bank-name">{bankName || 'fallback-bank'}</div>
-            <div data-testid="swift">{swift || 'fallback-swift'}</div>
-            <div data-testid="address">{address || 'fallback-address'}</div>
+            <div data-testid="receiver-name">{receiverName}</div>
+            <div data-testid="bank-name">{bankName}</div>
+            <div data-testid="swift">{swift}</div>
+            <div data-testid="address">{address}</div>
         </div>
     ),
 }));
@@ -43,8 +43,6 @@ jest.mock('../../../../../const/public/donate-page', () => ({
         EUR_PAYMENT_DETAILS_LABEL: 'Реквізити для донатів в EUR',
         IBAN_USD_LABEL: 'IBAN (USD)',
         IBAN_EUR_LABEL: 'IBAN (EUR)',
-        IBAN_USD_NUMBER_LABEL: 'US29NWBK60161331926819',
-        IBAN_EUR_NUMBER_LABEL: 'GB29NWBK60161331926819',
     },
 }));
 
@@ -117,20 +115,6 @@ describe('AbroadPaymentDetails', () => {
             expectElementToHaveTestId('correspondent-banks-count', '1');
             expectElementToHaveTestId('correspondent-bank', 'Test Correspondent Bank');
         });
-
-        it('renders USD payment details with fallback constants when no API data', () => {
-            render(<AbroadPaymentDetails currency={Currency.USD} foreignBankDetails={[]} />);
-
-            expectElementToHaveTestId('title', 'Реквізити для донатів в USD');
-            expectElementToHaveTestId('iban-label', 'IBAN (USD)');
-            expectElementToHaveTestId('iban-value', 'US29NWBK60161331926819');
-            expectElementToHaveTestId('receiver-name', 'fallback-receiver');
-            expectElementToHaveTestId('bank-name', 'fallback-bank');
-            expectElementToHaveTestId('swift', 'fallback-swift');
-            expectElementToHaveTestId('address', 'fallback-address');
-
-            expectElementToHaveTestId('correspondent-banks-count', '0');
-        });
     });
 
     describe('EUR currency', () => {
@@ -157,36 +141,37 @@ describe('AbroadPaymentDetails', () => {
             expect(correspondentBanks[0]).toHaveTextContent('EUR Correspondent 1');
             expect(correspondentBanks[1]).toHaveTextContent('EUR Correspondent 2');
         });
+    });
 
-        it('renders EUR payment details with fallback constants when no API data', () => {
-            render(<AbroadPaymentDetails currency={Currency.EUR} foreignBankDetails={[]} />);
+    describe('no data scenarios', () => {
+        it('returns null when no API data provided', () => {
+            const { container } = render(<AbroadPaymentDetails currency={Currency.USD} foreignBankDetails={[]} />);
 
-            expectElementToHaveTestId('title', 'Реквізити для донатів в EUR');
-            expectElementToHaveTestId('iban-label', 'IBAN (EUR)');
-            expectElementToHaveTestId('iban-value', 'GB29NWBK60161331926819');
+            expect(container.firstChild).toBeNull();
+        });
+
+        it('returns null when foreignBankDetails is empty array', () => {
+            const { container } = render(<AbroadPaymentDetails currency={Currency.EUR} foreignBankDetails={[]} />);
+
+            expect(container.firstChild).toBeNull();
         });
     });
 
     describe('edge cases', () => {
-        it('handles partial API data with some null values', () => {
+        it('handles foreign bank without correspondent banks', () => {
             const mockForeignBankDetails = [
                 createMockForeignBankDetails({
-                    receiver: null as any,
-                    name: undefined as any,
-                    address: '',
                     correspondentBanks: [],
                 }),
             ];
 
             render(<AbroadPaymentDetails currency={Currency.USD} foreignBankDetails={mockForeignBankDetails} />);
 
-            expectElementToHaveTestId('receiver-name', 'fallback-receiver');
-            expectElementToHaveTestId('bank-name', 'fallback-bank');
-            expectElementToHaveTestId('address', '');
+            expectElementToHaveTestId('correspondent-banks-section');
             expectElementToHaveTestId('correspondent-banks-count', '0');
         });
 
-        it('handles multiple foreign banks but uses only first one primary', () => {
+        it('handles multiple foreign banks but uses only first one', () => {
             const mockForeignBankDetails = [
                 createMockForeignBankDetails({ name: 'Primary Bank', receiver: 'Primary Receiver' }),
                 createMockForeignBankDetails({ name: 'Secondary Bank', receiver: 'Secondary Receiver' }),
@@ -198,10 +183,10 @@ describe('AbroadPaymentDetails', () => {
             expectElementToHaveTestId('bank-name', 'Primary Bank');
         });
 
-        it('handles foreign bank without correspondent banks', () => {
+        it('handles foreign bank with undefined correspondent banks', () => {
             const mockForeignBankDetails = [
                 createMockForeignBankDetails({
-                    correspondentBanks: [],
+                    correspondentBanks: undefined as any,
                 }),
             ];
 

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.test.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.test.tsx
@@ -171,18 +171,6 @@ describe('AbroadPaymentDetails', () => {
             expectElementToHaveTestId('correspondent-banks-count', '0');
         });
 
-        it('handles multiple foreign banks but uses only first one', () => {
-            const mockForeignBankDetails = [
-                createMockForeignBankDetails({ name: 'Primary Bank', receiver: 'Primary Receiver' }),
-                createMockForeignBankDetails({ name: 'Secondary Bank', receiver: 'Secondary Receiver' }),
-            ];
-
-            render(<AbroadPaymentDetails currency={Currency.USD} foreignBankDetails={mockForeignBankDetails} />);
-
-            expectElementToHaveTestId('receiver-name', 'Primary Receiver');
-            expectElementToHaveTestId('bank-name', 'Primary Bank');
-        });
-
         it('handles foreign bank with undefined correspondent banks', () => {
             const mockForeignBankDetails = [
                 createMockForeignBankDetails({

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.test.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.test.tsx
@@ -1,15 +1,214 @@
 import { render, screen } from '@testing-library/react';
 import { AbroadPaymentDetails } from './AbroadPaymentDetails';
 import { Currency } from '../../../../../types/public/donate-page';
+import {
+    PublishedForeignBankDetailsDto,
+    PublishedCorrespondentBankDetailsDto,
+} from '../../../../../types/public/donate-page';
+
+jest.mock('./PaymentDetailsSection', () => ({
+    PaymentDetailsSection: ({ title, ibanLabel, ibanValue, receiverName, bankName, swift, address }: any) => (
+        <div data-testid="payment-details-section">
+            <div data-testid="title">{title}</div>
+            <div data-testid="iban-label">{ibanLabel}</div>
+            <div data-testid="iban-value">{ibanValue}</div>
+            <div data-testid="receiver-name">{receiverName || 'fallback-receiver'}</div>
+            <div data-testid="bank-name">{bankName || 'fallback-bank'}</div>
+            <div data-testid="swift">{swift || 'fallback-swift'}</div>
+            <div data-testid="address">{address || 'fallback-address'}</div>
+        </div>
+    ),
+}));
+
+jest.mock('./CorrespondentBanksSection', () => ({
+    CorrespondentBanksSection: ({
+        correspondentBanks,
+    }: {
+        correspondentBanks: PublishedCorrespondentBankDetailsDto[];
+    }) => (
+        <div data-testid="correspondent-banks-section">
+            <div data-testid="correspondent-banks-count">{correspondentBanks.length}</div>
+            {correspondentBanks.map((bank, index) => (
+                <div key={index} data-testid="correspondent-bank">
+                    {bank.name}
+                </div>
+            ))}
+        </div>
+    ),
+}));
+
+jest.mock('../../../../../const/public/donate-page', () => ({
+    ABROAD_PAYMENT_DETAILS: {
+        USD_PAYMENT_DETAILS_LABEL: 'Реквізити для донатів в USD',
+        EUR_PAYMENT_DETAILS_LABEL: 'Реквізити для донатів в EUR',
+        IBAN_USD_LABEL: 'IBAN (USD)',
+        IBAN_EUR_LABEL: 'IBAN (EUR)',
+        IBAN_USD_NUMBER_LABEL: 'US29NWBK60161331926819',
+        IBAN_EUR_NUMBER_LABEL: 'GB29NWBK60161331926819',
+    },
+}));
+
+jest.mock('../../../../../utils/functions/mappers/public/donate', () => ({
+    currencyToString: (currency: number) => {
+        switch (currency) {
+            case 1:
+                return 'USD';
+            case 2:
+                return 'EUR';
+            case 0:
+            default:
+                return 'UAH';
+        }
+    },
+}));
 
 describe('AbroadPaymentDetails', () => {
-    it('renders all main payment sections', () => {
-        render(<AbroadPaymentDetails currency={Currency.USD} />);
-        expect(screen.getAllByText(/USD/i).length).toBeGreaterThan(0);
-        const correspondentBanksElements = screen.queryAllByText((content, _) => {
-            return content.includes('Кореспондентські банки');
+    const createMockCorrespondentBank = (
+        overrides: Partial<PublishedCorrespondentBankDetailsDto> = {},
+    ): PublishedCorrespondentBankDetailsDto => ({
+        id: 1,
+        name: 'Test Correspondent Bank',
+        swift: 'CORRBANK',
+        account: '987654321',
+        iban: 'US29CORR60161331926819',
+        foreignBankDetailsId: 1,
+        ...overrides,
+    });
+
+    const createMockForeignBankDetails = (
+        overrides: Partial<PublishedForeignBankDetailsDto> = {},
+    ): PublishedForeignBankDetailsDto => ({
+        id: 1,
+        name: 'Test Foreign Bank',
+        receiver: 'Test Receiver Organization',
+        iban: 'US29NWBK60161331926819',
+        swift: 'TESTBANK',
+        address: '123 Test Street, Test City',
+        currency: Currency.USD,
+        correspondentBanks: [createMockCorrespondentBank()],
+        ...overrides,
+    });
+
+    const expectElementToHaveTestId = (testId: string, expectedText?: string) => {
+        const element = screen.getByTestId(testId);
+        expect(element).toBeInTheDocument();
+        if (expectedText) {
+            expect(element).toHaveTextContent(expectedText);
+        }
+        return element;
+    };
+
+    describe('USD currency', () => {
+        it('renders USD payment details with API data', () => {
+            const mockForeignBankDetails = [createMockForeignBankDetails()];
+
+            render(<AbroadPaymentDetails currency={Currency.USD} foreignBankDetails={mockForeignBankDetails} />);
+
+            expectElementToHaveTestId('payment-details-section');
+            expectElementToHaveTestId('title', 'Реквізити для донатів в USD');
+            expectElementToHaveTestId('iban-label', 'IBAN (USD)');
+            expectElementToHaveTestId('iban-value', 'US29NWBK60161331926819');
+            expectElementToHaveTestId('receiver-name', 'Test Receiver Organization');
+            expectElementToHaveTestId('bank-name', 'Test Foreign Bank');
+            expectElementToHaveTestId('swift', 'TESTBANK');
+            expectElementToHaveTestId('address', '123 Test Street, Test City');
+
+            expectElementToHaveTestId('correspondent-banks-section');
+            expectElementToHaveTestId('correspondent-banks-count', '1');
+            expectElementToHaveTestId('correspondent-bank', 'Test Correspondent Bank');
         });
-        expect(correspondentBanksElements.length).toBeGreaterThan(0);
-        expect(screen.getAllByRole('button').length).toBeGreaterThan(0);
+
+        it('renders USD payment details with fallback constants when no API data', () => {
+            render(<AbroadPaymentDetails currency={Currency.USD} foreignBankDetails={[]} />);
+
+            expectElementToHaveTestId('title', 'Реквізити для донатів в USD');
+            expectElementToHaveTestId('iban-label', 'IBAN (USD)');
+            expectElementToHaveTestId('iban-value', 'US29NWBK60161331926819');
+            expectElementToHaveTestId('receiver-name', 'fallback-receiver');
+            expectElementToHaveTestId('bank-name', 'fallback-bank');
+            expectElementToHaveTestId('swift', 'fallback-swift');
+            expectElementToHaveTestId('address', 'fallback-address');
+
+            expectElementToHaveTestId('correspondent-banks-count', '0');
+        });
+    });
+
+    describe('EUR currency', () => {
+        it('renders EUR payment details with API data', () => {
+            const mockForeignBankDetails = [
+                createMockForeignBankDetails({
+                    currency: Currency.EUR,
+                    iban: 'GB29NWBK60161331926819',
+                    correspondentBanks: [
+                        createMockCorrespondentBank({ name: 'EUR Correspondent 1' }),
+                        createMockCorrespondentBank({ name: 'EUR Correspondent 2' }),
+                    ],
+                }),
+            ];
+
+            render(<AbroadPaymentDetails currency={Currency.EUR} foreignBankDetails={mockForeignBankDetails} />);
+
+            expectElementToHaveTestId('title', 'Реквізити для донатів в EUR');
+            expectElementToHaveTestId('iban-label', 'IBAN (EUR)');
+            expectElementToHaveTestId('iban-value', 'GB29NWBK60161331926819');
+
+            expectElementToHaveTestId('correspondent-banks-count', '2');
+            const correspondentBanks = screen.getAllByTestId('correspondent-bank');
+            expect(correspondentBanks[0]).toHaveTextContent('EUR Correspondent 1');
+            expect(correspondentBanks[1]).toHaveTextContent('EUR Correspondent 2');
+        });
+
+        it('renders EUR payment details with fallback constants when no API data', () => {
+            render(<AbroadPaymentDetails currency={Currency.EUR} foreignBankDetails={[]} />);
+
+            expectElementToHaveTestId('title', 'Реквізити для донатів в EUR');
+            expectElementToHaveTestId('iban-label', 'IBAN (EUR)');
+            expectElementToHaveTestId('iban-value', 'GB29NWBK60161331926819');
+        });
+    });
+
+    describe('edge cases', () => {
+        it('handles partial API data with some null values', () => {
+            const mockForeignBankDetails = [
+                createMockForeignBankDetails({
+                    receiver: null as any,
+                    name: undefined as any,
+                    address: '',
+                    correspondentBanks: [],
+                }),
+            ];
+
+            render(<AbroadPaymentDetails currency={Currency.USD} foreignBankDetails={mockForeignBankDetails} />);
+
+            expectElementToHaveTestId('receiver-name', 'fallback-receiver');
+            expectElementToHaveTestId('bank-name', 'fallback-bank');
+            expectElementToHaveTestId('address', '');
+            expectElementToHaveTestId('correspondent-banks-count', '0');
+        });
+
+        it('handles multiple foreign banks but uses only first one primary', () => {
+            const mockForeignBankDetails = [
+                createMockForeignBankDetails({ name: 'Primary Bank', receiver: 'Primary Receiver' }),
+                createMockForeignBankDetails({ name: 'Secondary Bank', receiver: 'Secondary Receiver' }),
+            ];
+
+            render(<AbroadPaymentDetails currency={Currency.USD} foreignBankDetails={mockForeignBankDetails} />);
+
+            expectElementToHaveTestId('receiver-name', 'Primary Receiver');
+            expectElementToHaveTestId('bank-name', 'Primary Bank');
+        });
+
+        it('handles foreign bank without correspondent banks', () => {
+            const mockForeignBankDetails = [
+                createMockForeignBankDetails({
+                    correspondentBanks: [],
+                }),
+            ];
+
+            render(<AbroadPaymentDetails currency={Currency.USD} foreignBankDetails={mockForeignBankDetails} />);
+
+            expectElementToHaveTestId('correspondent-banks-section');
+            expectElementToHaveTestId('correspondent-banks-count', '0');
+        });
     });
 });

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.tsx
@@ -4,13 +4,13 @@ import { PaymentDetailsSection } from './PaymentDetailsSection';
 import { Currency } from '../../../../../types/public/donate-page';
 import { ABROAD_PAYMENT_DETAILS } from '../../../../../const/public/donate-page';
 import { currencyToString } from '../../../../../utils/functions/mappers/public/donate';
-import { PublicForeignBankDetailsDto } from '../../../../../types/public/donate-page';
+import { PublishedForeignBankDetailsDto } from '../../../../../types/public/donate-page';
 
 type AbroadCurrency = 'USD' | 'EUR';
 
 interface AbroadPaymentDetailsProps {
     currency: Exclude<Currency, Currency.UAH>;
-    foreignBankDetails: PublicForeignBankDetailsDto[];
+    foreignBankDetails: PublishedForeignBankDetailsDto[];
 }
 
 export const AbroadPaymentDetails = ({ currency, foreignBankDetails }: AbroadPaymentDetailsProps) => {
@@ -33,7 +33,7 @@ export const AbroadPaymentDetails = ({ currency, foreignBankDetails }: AbroadPay
                 address={primary?.address}
             />
 
-            <CorrespondentBanksSection currency={currency} />
+            <CorrespondentBanksSection correspondentBanks={primary?.correspondentBanks || []} />
         </div>
     );
 };

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.tsx
@@ -13,9 +13,7 @@ interface AbroadPaymentDetailsProps {
 }
 
 export const AbroadPaymentDetails = ({ currency, foreignBankDetails }: AbroadPaymentDetailsProps) => {
-    const primary = foreignBankDetails[0];
-
-    if (!primary) {
+    if (!foreignBankDetails.length) {
         return null;
     }
 
@@ -25,17 +23,21 @@ export const AbroadPaymentDetails = ({ currency, foreignBankDetails }: AbroadPay
 
     return (
         <div className="abroadPaymentDetails">
-            <PaymentDetailsSection
-                title={title}
-                ibanLabel={ibanLabel}
-                ibanValue={primary.iban}
-                receiverName={primary.receiver}
-                bankName={primary.name}
-                swift={primary.swift}
-                address={primary.address}
-            />
+            {foreignBankDetails.map((bank, index) => (
+                <div key={bank.id} className={`bankGroup ${index > 0 ? 'separated' : ''}`}>
+                    <PaymentDetailsSection
+                        title={index === 0 ? title : ''}
+                        ibanLabel={ibanLabel}
+                        ibanValue={bank.iban}
+                        receiverName={bank.receiver}
+                        bankName={bank.name}
+                        swift={bank.swift}
+                        address={bank.address}
+                    />
 
-            <CorrespondentBanksSection correspondentBanks={primary.correspondentBanks || []} />
+                    <CorrespondentBanksSection correspondentBanks={bank.correspondentBanks || []} />
+                </div>
+            ))}
         </div>
     );
 };

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.tsx
@@ -4,18 +4,33 @@ import { PaymentDetailsSection } from './PaymentDetailsSection';
 import { Currency } from '../../../../../types/public/donate-page';
 import { ABROAD_PAYMENT_DETAILS } from '../../../../../const/public/donate-page';
 import { currencyToString } from '../../../../../utils/functions/mappers/public/donate';
+import { PublicForeignBankDetailsDto } from '../../../../../types/public/donate-page';
 
 type AbroadCurrency = 'USD' | 'EUR';
 
-export const AbroadPaymentDetails = ({ currency }: { currency: Exclude<Currency, Currency.UAH> }) => {
+interface AbroadPaymentDetailsProps {
+    currency: Exclude<Currency, Currency.UAH>;
+    foreignBankDetails: PublicForeignBankDetailsDto[];
+}
+
+export const AbroadPaymentDetails = ({ currency, foreignBankDetails }: AbroadPaymentDetailsProps) => {
     const currencyString = currencyToString(currency) as AbroadCurrency;
+    const primary = foreignBankDetails[0];
+
+    const title = ABROAD_PAYMENT_DETAILS[`${currencyString}_PAYMENT_DETAILS_LABEL`];
+    const ibanLabel = ABROAD_PAYMENT_DETAILS[`IBAN_${currencyString}_LABEL`];
+    const ibanValue = primary?.iban || ABROAD_PAYMENT_DETAILS[`IBAN_${currencyString}_NUMBER_LABEL`];
 
     return (
         <div className="abroadPaymentDetails">
             <PaymentDetailsSection
-                title={ABROAD_PAYMENT_DETAILS[`${currencyString}_PAYMENT_DETAILS_LABEL`]}
-                ibanLabel={ABROAD_PAYMENT_DETAILS[`IBAN_${currencyString}_LABEL`]}
-                ibanValue={ABROAD_PAYMENT_DETAILS[`IBAN_${currencyString}_NUMBER_LABEL`]}
+                title={title}
+                ibanLabel={ibanLabel}
+                ibanValue={ibanValue}
+                receiverName={primary?.receiver}
+                bankName={primary?.name}
+                swift={primary?.swift}
+                address={primary?.address}
             />
 
             <CorrespondentBanksSection currency={currency} />

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.tsx
@@ -1,10 +1,9 @@
 import './AbroadPaymentDetails.scss';
 import { CorrespondentBanksSection } from './CorrespondentBanksSection';
 import { PaymentDetailsSection } from './PaymentDetailsSection';
-import { Currency } from '../../../../../types/public/donate-page';
+import { Currency, PublishedForeignBankDetailsDto } from '../../../../../types/public/donate-page';
 import { ABROAD_PAYMENT_DETAILS } from '../../../../../const/public/donate-page';
 import { currencyToString } from '../../../../../utils/functions/mappers/public/donate';
-import { PublishedForeignBankDetailsDto } from '../../../../../types/public/donate-page';
 
 type AbroadCurrency = 'USD' | 'EUR';
 
@@ -14,26 +13,29 @@ interface AbroadPaymentDetailsProps {
 }
 
 export const AbroadPaymentDetails = ({ currency, foreignBankDetails }: AbroadPaymentDetailsProps) => {
-    const currencyString = currencyToString(currency) as AbroadCurrency;
     const primary = foreignBankDetails[0];
 
+    if (!primary) {
+        return null;
+    }
+
+    const currencyString = currencyToString(currency) as AbroadCurrency;
     const title = ABROAD_PAYMENT_DETAILS[`${currencyString}_PAYMENT_DETAILS_LABEL`];
     const ibanLabel = ABROAD_PAYMENT_DETAILS[`IBAN_${currencyString}_LABEL`];
-    const ibanValue = primary?.iban || ABROAD_PAYMENT_DETAILS[`IBAN_${currencyString}_NUMBER_LABEL`];
 
     return (
         <div className="abroadPaymentDetails">
             <PaymentDetailsSection
                 title={title}
                 ibanLabel={ibanLabel}
-                ibanValue={ibanValue}
-                receiverName={primary?.receiver}
-                bankName={primary?.name}
-                swift={primary?.swift}
-                address={primary?.address}
+                ibanValue={primary.iban}
+                receiverName={primary.receiver}
+                bankName={primary.name}
+                swift={primary.swift}
+                address={primary.address}
             />
 
-            <CorrespondentBanksSection correspondentBanks={primary?.correspondentBanks || []} />
+            <CorrespondentBanksSection correspondentBanks={primary.correspondentBanks || []} />
         </div>
     );
 };

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBankBlock.test.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBankBlock.test.tsx
@@ -1,0 +1,300 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { CorrespondentBankBlock } from './CorrespondentBankBlock';
+
+jest.mock('../../copy-text-button/CopyTextButton', () => ({
+    CopyTextButton: ({ textToCopy }: { textToCopy: string }) => (
+        <button data-testid="copy-button" data-copy-text={textToCopy}>
+            Copy
+        </button>
+    ),
+}));
+
+describe('CorrespondentBankBlock', () => {
+    const createProps = (overrides = {}) => ({
+        title: 'Test Bank',
+        fields: [
+            { label: 'SWIFT', value: 'TESTUS33' },
+            { label: 'Account', value: '123456789' },
+        ],
+        ...overrides,
+    });
+
+    const expectCorrectDOMStructure = (title: string, fieldsCount: number) => {
+        const paymentLabel = screen.getByRole('heading', { level: 3 }).closest('.paymentLabel');
+        expect(paymentLabel).toBeInTheDocument();
+
+        expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(title);
+
+        const labelsContainers = paymentLabel?.querySelector('.labelsContainers');
+        expect(labelsContainers).toBeInTheDocument();
+
+        const labelsContainer = labelsContainers?.querySelectorAll('.labelsContainer');
+        expect(labelsContainer).toHaveLength(fieldsCount);
+
+        const copyButtons = screen.getAllByTestId('copy-button');
+        expect(copyButtons).toHaveLength(fieldsCount);
+    };
+
+    describe('rendering with valid props', () => {
+        it('should render title and fields correctly', () => {
+            const props = createProps();
+
+            render(<CorrespondentBankBlock {...props} />);
+
+            expectCorrectDOMStructure('Test Bank', 2);
+
+            expect(screen.getByText('SWIFT')).toBeInTheDocument();
+            expect(screen.getByText('SWIFT')).toHaveClass('highlightedLabel');
+            expect(screen.getByText('TESTUS33')).toBeInTheDocument();
+            expect(screen.getByText('TESTUS33')).toHaveClass('label');
+
+            expect(screen.getByText('Account')).toBeInTheDocument();
+            expect(screen.getByText('Account')).toHaveClass('highlightedLabel');
+            expect(screen.getByText('123456789')).toBeInTheDocument();
+            expect(screen.getByText('123456789')).toHaveClass('label');
+
+            const copyButtons = screen.getAllByTestId('copy-button');
+            expect(copyButtons[0]).toHaveAttribute('data-copy-text', 'TESTUS33');
+            expect(copyButtons[1]).toHaveAttribute('data-copy-text', '123456789');
+        });
+
+        it('should render single field correctly', () => {
+            const props = createProps({
+                fields: [{ label: 'IBAN', value: 'GB82WEST12345698765432' }],
+            });
+
+            render(<CorrespondentBankBlock {...props} />);
+
+            expectCorrectDOMStructure('Test Bank', 1);
+
+            expect(screen.getByText('IBAN')).toHaveClass('highlightedLabel');
+            expect(screen.getByText('GB82WEST12345698765432')).toHaveClass('label');
+
+            const copyButton = screen.getByTestId('copy-button');
+            expect(copyButton).toHaveAttribute('data-copy-text', 'GB82WEST12345698765432');
+        });
+
+        it('should render multiple fields correctly', () => {
+            const props = createProps({
+                fields: [
+                    { label: 'Bank Name', value: 'Test Bank Corp' },
+                    { label: 'SWIFT', value: 'TESTUS33' },
+                    { label: 'Account', value: '123456789' },
+                    { label: 'IBAN', value: 'GB82WEST12345698765432' },
+                    { label: 'Address', value: '123 Test Street' },
+                ],
+            });
+
+            render(<CorrespondentBankBlock {...props} />);
+
+            expectCorrectDOMStructure('Test Bank', 5);
+
+            const labels = ['Bank Name', 'SWIFT', 'Account', 'IBAN', 'Address'];
+            const values = ['Test Bank Corp', 'TESTUS33', '123456789', 'GB82WEST12345698765432', '123 Test Street'];
+
+            labels.forEach((label) => {
+                expect(screen.getByText(label)).toHaveClass('highlightedLabel');
+            });
+
+            values.forEach((value) => {
+                expect(screen.getByText(value)).toHaveClass('label');
+            });
+
+            const copyButtons = screen.getAllByTestId('copy-button');
+            values.forEach((value, index) => {
+                expect(copyButtons[index]).toHaveAttribute('data-copy-text', value);
+            });
+        });
+    });
+
+    describe('rendering with edge case props', () => {
+        it('should handle empty fields array', () => {
+            const props = createProps({
+                fields: [],
+            });
+
+            render(<CorrespondentBankBlock {...props} />);
+
+            expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('Test Bank');
+
+            const labelsContainers = screen
+                .getByRole('heading', { level: 3 })
+                .closest('.paymentLabel')
+                ?.querySelector('.labelsContainers');
+            expect(labelsContainers).toBeInTheDocument();
+
+            const labelsContainer = labelsContainers?.querySelectorAll('.labelsContainer');
+            expect(labelsContainer).toHaveLength(0);
+
+            expect(screen.queryByTestId('copy-button')).not.toBeInTheDocument();
+        });
+
+        it('should handle empty string values', () => {
+            const props = createProps({
+                fields: [
+                    { label: '', value: '' },
+                    { label: 'Valid Label', value: 'Valid Value' },
+                    { label: 'Empty Value', value: '' },
+                ],
+            });
+
+            render(<CorrespondentBankBlock {...props} />);
+
+            expectCorrectDOMStructure('Test Bank', 3);
+
+            expect(screen.getByText('Valid Label')).toHaveClass('highlightedLabel');
+            expect(screen.getByText('Valid Value')).toHaveClass('label');
+            expect(screen.getByText('Empty Value')).toHaveClass('highlightedLabel');
+
+            const copyButtons = screen.getAllByTestId('copy-button');
+            expect(copyButtons[0]).toHaveAttribute('data-copy-text', '');
+            expect(copyButtons[1]).toHaveAttribute('data-copy-text', 'Valid Value');
+            expect(copyButtons[2]).toHaveAttribute('data-copy-text', '');
+        });
+
+        it('should handle empty title', () => {
+            const props = createProps({
+                title: '',
+            });
+
+            render(<CorrespondentBankBlock {...props} />);
+
+            expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('');
+            expectCorrectDOMStructure('', 2);
+        });
+
+        it('should handle very long values', () => {
+            const longLabel = 'A'.repeat(100);
+            const longValue = 'B'.repeat(200);
+
+            const props = createProps({
+                fields: [
+                    { label: longLabel, value: longValue },
+                    { label: 'Short', value: 'Short' },
+                ],
+            });
+
+            render(<CorrespondentBankBlock {...props} />);
+
+            expect(screen.getByText(longLabel)).toHaveClass('highlightedLabel');
+            expect(screen.getByText(longValue)).toHaveClass('label');
+
+            const copyButtons = screen.getAllByTestId('copy-button');
+            expect(copyButtons[0]).toHaveAttribute('data-copy-text', longValue);
+        });
+    });
+
+    describe('key generation for fields', () => {
+        it('should handle duplicate field values with unique keys', () => {
+            const props = createProps({
+                fields: [
+                    { label: 'Label1', value: 'Duplicate' },
+                    { label: 'Label2', value: 'Duplicate' },
+                    { label: 'Label3', value: 'Duplicate' },
+                ],
+            });
+
+            render(<CorrespondentBankBlock {...props} />);
+
+            expectCorrectDOMStructure('Test Bank', 3);
+
+            const duplicateElements = screen.getAllByText('Duplicate');
+            expect(duplicateElements).toHaveLength(3);
+            duplicateElements.forEach((element) => expect(element).toHaveClass('label'));
+
+            const labelElements = screen.getAllByText(/Label[123]/);
+            expect(labelElements).toHaveLength(3);
+            labelElements.forEach((element) => expect(element).toHaveClass('highlightedLabel'));
+        });
+
+        it('should handle fields that could create conflicting keys', () => {
+            const props = createProps({
+                fields: [
+                    { label: 'test-0', value: 'value-0' },
+                    { label: 'test', value: 'value' },
+                    { label: 'test-1', value: 'value-1' },
+                ],
+            });
+
+            render(<CorrespondentBankBlock {...props} />);
+
+            expect(screen.getByText('test-0')).toBeInTheDocument();
+            expect(screen.getByText('test')).toBeInTheDocument();
+            expect(screen.getByText('test-1')).toBeInTheDocument();
+            expect(screen.getByText('value-0')).toBeInTheDocument();
+            expect(screen.getByText('value')).toBeInTheDocument();
+            expect(screen.getByText('value-1')).toBeInTheDocument();
+        });
+    });
+
+    describe('DOM structure and CSS classes', () => {
+        it('should have correct CSS class structure', () => {
+            const props = createProps();
+
+            render(<CorrespondentBankBlock {...props} />);
+
+            const paymentLabel = screen.getByRole('heading', { level: 3 }).closest('.paymentLabel');
+            expect(paymentLabel).toBeInTheDocument();
+
+            const heading = paymentLabel?.querySelector('h3');
+            expect(heading).toBeInTheDocument();
+
+            const labelsContainers = paymentLabel?.querySelector('.labelsContainers');
+            expect(labelsContainers).toBeInTheDocument();
+
+            const labelsContainer = labelsContainers?.querySelectorAll('.labelsContainer');
+            expect(labelsContainer).toHaveLength(2);
+
+            labelsContainer?.forEach((container) => {
+                const labelWithCopyButton = container.querySelector('.labelWithCopyButton');
+                expect(labelWithCopyButton).toBeInTheDocument();
+
+                const highlightedLabel = labelWithCopyButton?.querySelector('.highlightedLabel');
+                expect(highlightedLabel).toBeInTheDocument();
+
+                const label = labelWithCopyButton?.querySelector('.label');
+                expect(label).toBeInTheDocument();
+
+                const copyButton = labelWithCopyButton?.querySelector('[data-testid="copy-button"]');
+                expect(copyButton).toBeInTheDocument();
+            });
+        });
+
+        it('should render heading with correct level', () => {
+            const props = createProps({
+                title: 'Bank Title',
+            });
+
+            render(<CorrespondentBankBlock {...props} />);
+
+            const heading = screen.getByRole('heading', { level: 3 });
+            expect(heading.tagName).toBe('H3');
+            expect(heading).toHaveTextContent('Bank Title');
+        });
+    });
+
+    describe('component integration', () => {
+        it('should integrate correctly with CopyTextButton for each field', () => {
+            const props = createProps({
+                fields: [
+                    { label: 'First', value: 'First Value' },
+                    { label: 'Second', value: 'Second Value' },
+                    { label: 'Third', value: 'Third Value' },
+                ],
+            });
+
+            render(<CorrespondentBankBlock {...props} />);
+
+            const copyButtons = screen.getAllByTestId('copy-button');
+            expect(copyButtons).toHaveLength(3);
+
+            expect(copyButtons[0]).toHaveAttribute('data-copy-text', 'First Value');
+            expect(copyButtons[1]).toHaveAttribute('data-copy-text', 'Second Value');
+            expect(copyButtons[2]).toHaveAttribute('data-copy-text', 'Third Value');
+
+            expect(screen.getByText('First')).toHaveClass('highlightedLabel');
+            expect(screen.getByText('First Value')).toHaveClass('label');
+        });
+    });
+});

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.test.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.test.tsx
@@ -38,49 +38,46 @@ describe('CorrespondentBanksSection', () => {
         ...overrides,
     });
 
+    const expectBasicBankElements = () => {
+        expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
+        expect(screen.getByTestId('bank-block')).toBeInTheDocument();
+    };
+
+    const expectBankFields = (expectedFields: string[], expectedCount: number) => {
+        const bankFields = screen.getAllByTestId('bank-field');
+        expect(bankFields).toHaveLength(expectedCount);
+        expectedFields.forEach((expectedContent, index) => {
+            expect(bankFields[index]).toHaveTextContent(expectedContent);
+        });
+    };
+
+    const renderAndExpectBasics = (mockBanks: PublishedCorrespondentBankDetailsDto[], expectedTitle: string) => {
+        render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
+        expectBasicBankElements();
+        expect(screen.getByTestId('bank-title')).toHaveTextContent(expectedTitle);
+    };
+
     describe('with correspondent banks data', () => {
         it('renders correspondent banks with all fields including IBAN', () => {
             const mockBanks = [createMockCorrespondentBank()];
 
-            render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
-
-            expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
-            expect(screen.getByTestId('bank-block')).toBeInTheDocument();
-            expect(screen.getByTestId('bank-title')).toHaveTextContent('Test Bank USD');
-
-            const bankFields = screen.getAllByTestId('bank-field');
-            expect(bankFields).toHaveLength(3);
-            expect(bankFields[0]).toHaveTextContent('SWIFT: TEST123');
-            expect(bankFields[1]).toHaveTextContent('Account: 123456789');
-            expect(bankFields[2]).toHaveTextContent('IBAN: US29NWBK60161331926819');
+            renderAndExpectBasics(mockBanks, 'Test Bank USD');
+            expectBankFields(['SWIFT: TEST123', 'Account: 123456789', 'IBAN: US29NWBK60161331926819'], 3);
         });
 
         it('renders correspondent banks without IBAN when not provided', () => {
             const mockBanks = [createMockCorrespondentBank({ iban: undefined })];
 
-            render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
-
-            expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
-            expect(screen.getByTestId('bank-block')).toBeInTheDocument();
-            expect(screen.getByTestId('bank-title')).toHaveTextContent('Test Bank USD');
-
-            const bankFields = screen.getAllByTestId('bank-field');
-            expect(bankFields).toHaveLength(2);
-            expect(bankFields[0]).toHaveTextContent('SWIFT: TEST123');
-            expect(bankFields[1]).toHaveTextContent('Account: 123456789');
+            renderAndExpectBasics(mockBanks, 'Test Bank USD');
+            expectBankFields(['SWIFT: TEST123', 'Account: 123456789'], 2);
         });
 
         it('renders correspondent banks with empty IBAN when provided but empty', () => {
             const mockBanks = [createMockCorrespondentBank({ iban: '' })];
 
             render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
-
             expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
-
-            const bankFields = screen.getAllByTestId('bank-field');
-            expect(bankFields).toHaveLength(2);
-            expect(bankFields[0]).toHaveTextContent('SWIFT: TEST123');
-            expect(bankFields[1]).toHaveTextContent('Account: 123456789');
+            expectBankFields(['SWIFT: TEST123', 'Account: 123456789'], 2);
         });
 
         it('renders multiple correspondent banks', () => {
@@ -114,29 +111,16 @@ describe('CorrespondentBanksSection', () => {
                 }),
             ];
 
-            render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
-
-            expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
-            expect(screen.getByTestId('bank-block')).toBeInTheDocument();
-            expect(screen.getByTestId('bank-title')).toHaveTextContent('');
-
-            const bankFields = screen.getAllByTestId('bank-field');
-            expect(bankFields).toHaveLength(2);
-            expect(bankFields[0]).toHaveTextContent('SWIFT:');
-            expect(bankFields[1]).toHaveTextContent('Account:');
+            renderAndExpectBasics(mockBanks, '');
+            expectBankFields(['SWIFT:', 'Account:'], 2);
         });
 
         it('handles banks with null IBAN value', () => {
             const mockBanks = [createMockCorrespondentBank({ iban: null as any })];
 
             render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
-
             expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
-
-            const bankFields = screen.getAllByTestId('bank-field');
-            expect(bankFields).toHaveLength(2);
-            expect(bankFields[0]).toHaveTextContent('SWIFT: TEST123');
-            expect(bankFields[1]).toHaveTextContent('Account: 123456789');
+            expectBankFields(['SWIFT: TEST123', 'Account: 123456789'], 2);
         });
     });
 

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.test.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { CorrespondentBanksSection } from './CorrespondentBanksSection';
 import { PublishedCorrespondentBankDetailsDto } from '../../../../../types/public/donate-page';
 
@@ -37,14 +38,13 @@ describe('CorrespondentBanksSection', () => {
         ...overrides,
     });
 
-    describe('with API data', () => {
+    describe('with correspondent banks data', () => {
         it('renders correspondent banks with all fields including IBAN', () => {
             const mockBanks = [createMockCorrespondentBank()];
 
             render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
 
             expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
-
             expect(screen.getByTestId('bank-block')).toBeInTheDocument();
             expect(screen.getByTestId('bank-title')).toHaveTextContent('Test Bank USD');
 
@@ -61,7 +61,6 @@ describe('CorrespondentBanksSection', () => {
             render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
 
             expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
-
             expect(screen.getByTestId('bank-block')).toBeInTheDocument();
             expect(screen.getByTestId('bank-title')).toHaveTextContent('Test Bank USD');
 
@@ -75,6 +74,8 @@ describe('CorrespondentBanksSection', () => {
             const mockBanks = [createMockCorrespondentBank({ iban: '' })];
 
             render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
+
+            expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
 
             const bankFields = screen.getAllByTestId('bank-field');
             expect(bankFields).toHaveLength(2);
@@ -102,32 +103,8 @@ describe('CorrespondentBanksSection', () => {
             const bankFields = screen.getAllByTestId('bank-field');
             expect(bankFields).toHaveLength(5);
         });
-    });
 
-    describe('without API data empty array', () => {
-        it('renders only header when no correspondent banks provided', () => {
-            render(<CorrespondentBanksSection correspondentBanks={[]} />);
-
-            expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
-
-            expect(screen.queryByTestId('bank-block')).not.toBeInTheDocument();
-
-            const contentContainer = screen.getByText('Кореспондентські банки').nextElementSibling;
-            expect(contentContainer).toBeInTheDocument();
-            expect(contentContainer).toBeEmptyDOMElement();
-        });
-
-        it('renders only header when correspondentBanks prop is undefined default', () => {
-            render(<CorrespondentBanksSection />);
-
-            expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
-
-            expect(screen.queryByTestId('bank-block')).not.toBeInTheDocument();
-        });
-    });
-
-    describe('edge cases', () => {
-        it('handles banks with null undefined values gracefully', () => {
+        it('handles banks with empty values', () => {
             const mockBanks = [
                 createMockCorrespondentBank({
                     name: '',
@@ -139,6 +116,7 @@ describe('CorrespondentBanksSection', () => {
 
             render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
 
+            expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
             expect(screen.getByTestId('bank-block')).toBeInTheDocument();
             expect(screen.getByTestId('bank-title')).toHaveTextContent('');
 
@@ -148,16 +126,31 @@ describe('CorrespondentBanksSection', () => {
             expect(bankFields[1]).toHaveTextContent('Account:');
         });
 
-        it('handles mixed data types in correspondent banks array', () => {
-            const mockBanks = [
-                createMockCorrespondentBank({ name: 'Valid Bank', swift: 'VALID123' }),
-                createMockCorrespondentBank({ name: '', swift: '', account: '', iban: undefined }),
-            ];
+        it('handles banks with null IBAN value', () => {
+            const mockBanks = [createMockCorrespondentBank({ iban: null as any })];
 
             render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
 
-            const bankBlocks = screen.getAllByTestId('bank-block');
-            expect(bankBlocks).toHaveLength(2);
+            expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
+
+            const bankFields = screen.getAllByTestId('bank-field');
+            expect(bankFields).toHaveLength(2);
+            expect(bankFields[0]).toHaveTextContent('SWIFT: TEST123');
+            expect(bankFields[1]).toHaveTextContent('Account: 123456789');
+        });
+    });
+
+    describe('no correspondent banks scenarios', () => {
+        it('returns null when no correspondent banks provided', () => {
+            const { container } = render(<CorrespondentBanksSection correspondentBanks={[]} />);
+
+            expect(container.firstChild).toBeNull();
+        });
+
+        it('returns null when correspondentBanks prop is undefined', () => {
+            const { container } = render(<CorrespondentBanksSection />);
+
+            expect(container.firstChild).toBeNull();
         });
     });
 });

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.test.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.test.tsx
@@ -1,44 +1,163 @@
 import { render, screen } from '@testing-library/react';
 import { CorrespondentBanksSection } from './CorrespondentBanksSection';
-import { Currency } from '../../../../../types/public/donate-page';
+import { PublishedCorrespondentBankDetailsDto } from '../../../../../types/public/donate-page';
 
 jest.mock('../../../../../const/public/donate-page', () => ({
     ABROAD_PAYMENT_DETAILS: {
         CORRESPONDENT_BANKS_LABEL: 'Кореспондентські банки',
-    },
-    CORRESPONDENT_BANKS: {
-        USD: [
-            {
-                title: 'Test Bank USD',
-                fields: [{ label: 'SWIFT:', value: 'TEST123' }],
-            },
-        ],
+        SWIFT_LABEL: 'SWIFT:',
+        ACCOUNT_LABEL: 'Account:',
+        IBAN_LABEL: 'IBAN:',
     },
 }));
 
 jest.mock('./CorrespondentBankBlock', () => ({
-    CorrespondentBankBlock: ({ title }: { title: string }) => <div data-testid="bank-block">{title}</div>,
+    CorrespondentBankBlock: ({ title, fields }: { title: string; fields: Array<{ label: string; value: string }> }) => (
+        <div data-testid="bank-block">
+            <div data-testid="bank-title">{title}</div>
+            {fields.map((field, index) => (
+                <div key={index} data-testid="bank-field">
+                    {field.label} {field.value}
+                </div>
+            ))}
+        </div>
+    ),
 }));
 
 describe('CorrespondentBanksSection', () => {
-    it('renders correspondent banks when they exist for currency', () => {
-        render(<CorrespondentBanksSection currency={Currency.USD} />);
-
-        expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
-
-        expect(screen.getByText('Test Bank USD')).toBeInTheDocument();
-        expect(screen.getByTestId('bank-block')).toBeInTheDocument();
+    const createMockCorrespondentBank = (
+        overrides: Partial<PublishedCorrespondentBankDetailsDto> = {},
+    ): PublishedCorrespondentBankDetailsDto => ({
+        id: 1,
+        name: 'Test Bank USD',
+        swift: 'TEST123',
+        account: '123456789',
+        iban: 'US29NWBK60161331926819',
+        foreignBankDetailsId: 1,
+        ...overrides,
     });
 
-    it('handles currency with no correspondent banks (fallback to empty array)', () => {
-        render(<CorrespondentBanksSection currency={Currency.EUR} />);
+    describe('with API data', () => {
+        it('renders correspondent banks with all fields including IBAN', () => {
+            const mockBanks = [createMockCorrespondentBank()];
 
-        expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
+            render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
 
-        expect(screen.queryByTestId('bank-block')).not.toBeInTheDocument();
+            expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
 
-        const contentContainer = screen.getByText('Кореспондентські банки').nextElementSibling;
-        expect(contentContainer).toBeInTheDocument();
-        expect(contentContainer).toBeEmptyDOMElement();
+            expect(screen.getByTestId('bank-block')).toBeInTheDocument();
+            expect(screen.getByTestId('bank-title')).toHaveTextContent('Test Bank USD');
+
+            const bankFields = screen.getAllByTestId('bank-field');
+            expect(bankFields).toHaveLength(3);
+            expect(bankFields[0]).toHaveTextContent('SWIFT: TEST123');
+            expect(bankFields[1]).toHaveTextContent('Account: 123456789');
+            expect(bankFields[2]).toHaveTextContent('IBAN: US29NWBK60161331926819');
+        });
+
+        it('renders correspondent banks without IBAN when not provided', () => {
+            const mockBanks = [createMockCorrespondentBank({ iban: undefined })];
+
+            render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
+
+            expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
+
+            expect(screen.getByTestId('bank-block')).toBeInTheDocument();
+            expect(screen.getByTestId('bank-title')).toHaveTextContent('Test Bank USD');
+
+            const bankFields = screen.getAllByTestId('bank-field');
+            expect(bankFields).toHaveLength(2);
+            expect(bankFields[0]).toHaveTextContent('SWIFT: TEST123');
+            expect(bankFields[1]).toHaveTextContent('Account: 123456789');
+        });
+
+        it('renders correspondent banks with empty IBAN when provided but empty', () => {
+            const mockBanks = [createMockCorrespondentBank({ iban: '' })];
+
+            render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
+
+            const bankFields = screen.getAllByTestId('bank-field');
+            expect(bankFields).toHaveLength(2);
+            expect(bankFields[0]).toHaveTextContent('SWIFT: TEST123');
+            expect(bankFields[1]).toHaveTextContent('Account: 123456789');
+        });
+
+        it('renders multiple correspondent banks', () => {
+            const mockBanks = [
+                createMockCorrespondentBank({ name: 'Bank 1', swift: 'BANK1' }),
+                createMockCorrespondentBank({ name: 'Bank 2', swift: 'BANK2', iban: undefined }),
+            ];
+
+            render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
+
+            expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
+
+            const bankBlocks = screen.getAllByTestId('bank-block');
+            expect(bankBlocks).toHaveLength(2);
+
+            const bankTitles = screen.getAllByTestId('bank-title');
+            expect(bankTitles[0]).toHaveTextContent('Bank 1');
+            expect(bankTitles[1]).toHaveTextContent('Bank 2');
+
+            const bankFields = screen.getAllByTestId('bank-field');
+            expect(bankFields).toHaveLength(5);
+        });
+    });
+
+    describe('without API data empty array', () => {
+        it('renders only header when no correspondent banks provided', () => {
+            render(<CorrespondentBanksSection correspondentBanks={[]} />);
+
+            expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
+
+            expect(screen.queryByTestId('bank-block')).not.toBeInTheDocument();
+
+            const contentContainer = screen.getByText('Кореспондентські банки').nextElementSibling;
+            expect(contentContainer).toBeInTheDocument();
+            expect(contentContainer).toBeEmptyDOMElement();
+        });
+
+        it('renders only header when correspondentBanks prop is undefined default', () => {
+            render(<CorrespondentBanksSection />);
+
+            expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
+
+            expect(screen.queryByTestId('bank-block')).not.toBeInTheDocument();
+        });
+    });
+
+    describe('edge cases', () => {
+        it('handles banks with null undefined values gracefully', () => {
+            const mockBanks = [
+                createMockCorrespondentBank({
+                    name: '',
+                    swift: '',
+                    account: '',
+                    iban: null as any,
+                }),
+            ];
+
+            render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
+
+            expect(screen.getByTestId('bank-block')).toBeInTheDocument();
+            expect(screen.getByTestId('bank-title')).toHaveTextContent('');
+
+            const bankFields = screen.getAllByTestId('bank-field');
+            expect(bankFields).toHaveLength(2);
+            expect(bankFields[0]).toHaveTextContent('SWIFT:');
+            expect(bankFields[1]).toHaveTextContent('Account:');
+        });
+
+        it('handles mixed data types in correspondent banks array', () => {
+            const mockBanks = [
+                createMockCorrespondentBank({ name: 'Valid Bank', swift: 'VALID123' }),
+                createMockCorrespondentBank({ name: '', swift: '', account: '', iban: undefined }),
+            ];
+
+            render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
+
+            const bankBlocks = screen.getAllByTestId('bank-block');
+            expect(bankBlocks).toHaveLength(2);
+        });
     });
 });

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.tsx
@@ -7,6 +7,10 @@ export const CorrespondentBanksSection = ({
 }: {
     correspondentBanks?: PublishedCorrespondentBankDetailsDto[];
 }) => {
+    if (correspondentBanks.length === 0) {
+        return null;
+    }
+
     const banks = correspondentBanks.map((apiBank) => ({
         title: apiBank.name,
         fields: [

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.tsx
@@ -1,13 +1,20 @@
-import { ABROAD_PAYMENT_DETAILS, CORRESPONDENT_BANKS } from '../../../../../const/public/donate-page';
+import { ABROAD_PAYMENT_DETAILS } from '../../../../../const/public/donate-page';
 import { CorrespondentBankBlock } from './CorrespondentBankBlock';
-import { Currency } from '../../../../../types/public/donate-page';
-import { currencyToString } from '../../../../../utils/functions/mappers/public/donate';
+import { PublishedCorrespondentBankDetailsDto } from '../../../../../types/public/donate-page';
 
-type CorrespondentBankCurrency = keyof typeof CORRESPONDENT_BANKS;
-
-export const CorrespondentBanksSection = ({ currency }: { currency: Currency }) => {
-    const currencyString = currencyToString(currency) as CorrespondentBankCurrency;
-    const banks = CORRESPONDENT_BANKS[currencyString] || [];
+export const CorrespondentBanksSection = ({
+    correspondentBanks = [],
+}: {
+    correspondentBanks?: PublishedCorrespondentBankDetailsDto[];
+}) => {
+    const banks = correspondentBanks.map((apiBank) => ({
+        title: apiBank.name,
+        fields: [
+            { label: ABROAD_PAYMENT_DETAILS.SWIFT_LABEL, value: apiBank.swift },
+            { label: ABROAD_PAYMENT_DETAILS.ACCOUNT_LABEL, value: apiBank.account },
+            ...(apiBank.iban ? [{ label: ABROAD_PAYMENT_DETAILS.IBAN_LABEL, value: apiBank.iban }] : []),
+        ],
+    }));
 
     return (
         <div className="abroadPaymentDetailsBlock">

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/MultiFieldLabelWithCopy.test.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/MultiFieldLabelWithCopy.test.tsx
@@ -1,0 +1,229 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MultiFieldLabelWithCopy } from './MultiFieldLabelWithCopy';
+
+jest.mock('../../copy-text-button/CopyTextButton', () => ({
+    CopyTextButton: ({ textToCopy }: { textToCopy: string }) => (
+        <button data-testid="copy-button" data-copy-text={textToCopy}>
+            Copy
+        </button>
+    ),
+}));
+
+describe('MultiFieldLabelWithCopy', () => {
+    const createProps = (overrides = {}) => ({
+        label: 'Test Label',
+        values: ['Value 1', 'Value 2'],
+        copyValue: 'Copy Text',
+        ...overrides,
+    });
+
+    const expectCorrectDOMStructure = () => {
+        const paymentLabel = screen.getByText('Test Label').closest('.paymentLabel');
+        expect(paymentLabel).toBeInTheDocument();
+
+        const labelWithCopyButton = paymentLabel?.querySelector('.labelWithCopyButton');
+        expect(labelWithCopyButton).toBeInTheDocument();
+
+        const copyButton = screen.getByTestId('copy-button');
+        expect(copyButton).toBeInTheDocument();
+    };
+
+    describe('rendering with valid props', () => {
+        it('should render label as string correctly', () => {
+            const props = createProps();
+
+            render(<MultiFieldLabelWithCopy {...props} />);
+
+            expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('Test Label');
+            expectCorrectDOMStructure();
+        });
+
+        it('should render multiple values correctly', () => {
+            const props = createProps({
+                values: ['First Value', 'Second Value', 'Third Value'],
+            });
+
+            render(<MultiFieldLabelWithCopy {...props} />);
+
+            expect(screen.getByText('First Value')).toBeInTheDocument();
+            expect(screen.getByText('Second Value')).toBeInTheDocument();
+            expect(screen.getByText('Third Value')).toBeInTheDocument();
+
+            const valueParagraphs = screen.getAllByText(/Value/);
+            expect(valueParagraphs).toHaveLength(3);
+            valueParagraphs.forEach((p) => expect(p).toHaveClass('label'));
+        });
+
+        it('should render single value correctly', () => {
+            const props = createProps({
+                values: ['Single Value'],
+            });
+
+            render(<MultiFieldLabelWithCopy {...props} />);
+
+            expect(screen.getByText('Single Value')).toBeInTheDocument();
+            expect(screen.getByText('Single Value')).toHaveClass('label');
+        });
+
+        it('should pass correct copyValue to CopyTextButton', () => {
+            const props = createProps({
+                copyValue: 'Specific Copy Text',
+            });
+
+            render(<MultiFieldLabelWithCopy {...props} />);
+
+            const copyButton = screen.getByTestId('copy-button');
+            expect(copyButton).toHaveAttribute('data-copy-text', 'Specific Copy Text');
+        });
+    });
+
+    describe('rendering with edge case props', () => {
+        it('should handle empty values array', () => {
+            const props = createProps({
+                values: [],
+            });
+
+            render(<MultiFieldLabelWithCopy {...props} />);
+
+            expect(screen.getByText('Test Label')).toBeInTheDocument();
+            expect(screen.getByTestId('copy-button')).toBeInTheDocument();
+
+            const valueParagraphs = screen.queryAllByText(/Value/);
+            expect(valueParagraphs).toHaveLength(0);
+        });
+
+        it('should handle empty string values', () => {
+            const props = createProps({
+                values: ['', 'Valid Value', ''],
+            });
+
+            render(<MultiFieldLabelWithCopy {...props} />);
+
+            const allParagraphs = screen.getAllByText(
+                (content, element) => element?.tagName.toLowerCase() === 'p' && element?.className === 'label',
+            );
+            expect(allParagraphs).toHaveLength(3);
+            expect(screen.getByText('Valid Value')).toBeInTheDocument();
+        });
+
+        it('should handle empty copyValue', () => {
+            const props = createProps({
+                copyValue: '',
+            });
+
+            render(<MultiFieldLabelWithCopy {...props} />);
+
+            const copyButton = screen.getByTestId('copy-button');
+            expect(copyButton).toHaveAttribute('data-copy-text', '');
+        });
+
+        it('should handle very long values', () => {
+            const longValue = 'A'.repeat(1000);
+            const props = createProps({
+                values: [longValue, 'Short'],
+                copyValue: longValue,
+            });
+
+            render(<MultiFieldLabelWithCopy {...props} />);
+
+            expect(screen.getByText(longValue)).toBeInTheDocument();
+            expect(screen.getByText('Short')).toBeInTheDocument();
+
+            const copyButton = screen.getByTestId('copy-button');
+            expect(copyButton).toHaveAttribute('data-copy-text', longValue);
+        });
+    });
+
+    describe('key generation for values', () => {
+        it('should handle duplicate values with unique keys', () => {
+            const props = createProps({
+                values: ['Duplicate', 'Duplicate', 'Duplicate'],
+            });
+
+            render(<MultiFieldLabelWithCopy {...props} />);
+
+            const duplicateElements = screen.getAllByText('Duplicate');
+            expect(duplicateElements).toHaveLength(3);
+            duplicateElements.forEach((element) => expect(element).toHaveClass('label'));
+        });
+
+        it('should handle values that could create conflicting keys', () => {
+            const props = createProps({
+                values: ['test-0', 'test', 'test-1'],
+            });
+
+            render(<MultiFieldLabelWithCopy {...props} />);
+
+            expect(screen.getByText('test-0')).toBeInTheDocument();
+            expect(screen.getByText('test')).toBeInTheDocument();
+            expect(screen.getByText('test-1')).toBeInTheDocument();
+        });
+    });
+
+    describe('DOM structure and CSS classes', () => {
+        it('should have correct CSS class structure', () => {
+            const props = createProps();
+
+            render(<MultiFieldLabelWithCopy {...props} />);
+
+            const paymentLabel = screen.getByText('Test Label').closest('.paymentLabel');
+            expect(paymentLabel).toBeInTheDocument();
+
+            const heading = paymentLabel?.querySelector('h3');
+            expect(heading).toBeInTheDocument();
+
+            const labelWithCopyButton = paymentLabel?.querySelector('.labelWithCopyButton');
+            expect(labelWithCopyButton).toBeInTheDocument();
+
+            const valueContainer = labelWithCopyButton?.querySelector('div');
+            expect(valueContainer).toBeInTheDocument();
+
+            const labelParagraphs = valueContainer?.querySelectorAll('p.label');
+            expect(labelParagraphs).toHaveLength(2);
+        });
+
+        it('should render heading with correct level', () => {
+            const props = createProps();
+
+            render(<MultiFieldLabelWithCopy {...props} />);
+
+            const heading = screen.getByRole('heading', { level: 3 });
+            expect(heading).toHaveTextContent('Test Label');
+        });
+    });
+
+    describe('component integration', () => {
+        it('should integrate correctly with CopyTextButton', () => {
+            const props = createProps({
+                values: ['Value 1', 'Value 2', 'Value 3'],
+                copyValue: 'All values combined',
+            });
+
+            render(<MultiFieldLabelWithCopy {...props} />);
+
+            expect(screen.getByText('Value 1')).toBeInTheDocument();
+            expect(screen.getByText('Value 2')).toBeInTheDocument();
+            expect(screen.getByText('Value 3')).toBeInTheDocument();
+
+            const copyButton = screen.getByTestId('copy-button');
+            expect(copyButton).toHaveAttribute('data-copy-text', 'All values combined');
+        });
+
+        it('should handle null and undefined in values array', () => {
+            const props = createProps({
+                values: ['Valid', null as any, undefined as any, 'Another Valid'],
+            });
+
+            render(<MultiFieldLabelWithCopy {...props} />);
+
+            expect(screen.getByText('Valid')).toBeInTheDocument();
+            expect(screen.getByText('Another Valid')).toBeInTheDocument();
+
+            const allParagraphs = screen.getAllByText(
+                (content, element) => element?.tagName.toLowerCase() === 'p' && element?.className === 'label',
+            );
+            expect(allParagraphs).toHaveLength(4);
+        });
+    });
+});

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/PaymentDetailsSection.test.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/PaymentDetailsSection.test.tsx
@@ -1,0 +1,267 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PaymentDetailsSection } from './PaymentDetailsSection';
+
+jest.mock('./PaymentLabelWithCopy', () => ({
+    PaymentLabelWithCopy: ({ label, value, copyValue }: { label: string; value: string; copyValue: string }) => (
+        <div data-testid="payment-label" data-label={label} data-value={value} data-copy-value={copyValue}>
+            {label}: {value}
+        </div>
+    ),
+}));
+
+jest.mock('./MultiFieldLabelWithCopy', () => ({
+    MultiFieldLabelWithCopy: ({ label, values, copyValue }: { label: string; values: string[]; copyValue: string }) => (
+        <div
+            data-testid="multi-field-label"
+            data-label={label}
+            data-values={values.join('|')}
+            data-copy-value={copyValue}
+        >
+            {label}: {values.join(', ')}
+        </div>
+    ),
+}));
+
+jest.mock('../../../../../const/public/donate-page', () => ({
+    PAYMENT_DETAILS_COMMON: {
+        RECIPIENT_LABEL: 'Recipient',
+        RECIPIENT_NAME_LABEL: 'Default Recipient Name',
+    },
+    ABROAD_PAYMENT_DETAILS: {
+        SWIFT_CODE_LABEL: 'SWIFT Code',
+        SWIFT_CODE_VALUE_LABEL: 'Default SWIFT',
+        BANK_RECEIVER_LABEL: 'Bank',
+        ADDRESS_LABEL: 'Address',
+        BANK_NAME_TRANSLITERATED_LABEL: 'Bank Name',
+        BANK_STREET_TRANSLITERATED_LABEL: 'Bank Street',
+        BANK_CITY_AND_COUNTRY_TRANSLITERATED_LABEL: 'Bank City Country',
+        COUNTRY_LABEL: 'Country',
+        CITY_LABEL: 'City',
+    },
+}));
+
+describe('PaymentDetailsSection', () => {
+    const createProps = (overrides = {}) => ({
+        title: 'Test Payment Details',
+        ibanLabel: 'IBAN (USD)',
+        ibanValue: 'US1234567890123456789012',
+        receiverName: 'Test Receiver',
+        bankName: 'Test Bank',
+        swift: 'TESTUS33',
+        address: 'Test Address',
+        ...overrides,
+    });
+
+    const expectBasicStructure = (title: string) => {
+        expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(title);
+        expect(screen.getByText(title).closest('.abroadPaymentDetailsBlock')).toBeInTheDocument();
+        expect(
+            screen
+                .getByText(title)
+                .closest('.abroadPaymentDetailsBlock')
+                ?.querySelector('.abroadPaymentDetailsContent'),
+        ).toBeInTheDocument();
+    };
+
+    const expectPaymentLabel = (label: string, value: string, copyValue: string) => {
+        const element = screen.getByTestId('payment-label');
+        expect(element).toHaveAttribute('data-label', label);
+        expect(element).toHaveAttribute('data-value', value);
+        expect(element).toHaveAttribute('data-copy-value', copyValue);
+    };
+
+    describe('rendering with all props provided', () => {
+        it('should render all required fields with provided values', () => {
+            const props = createProps();
+
+            render(<PaymentDetailsSection {...props} />);
+
+            expectBasicStructure('Test Payment Details');
+
+            const paymentLabels = screen.getAllByTestId('payment-label');
+            expect(paymentLabels).toHaveLength(5);
+
+            expect(paymentLabels[0]).toHaveAttribute('data-label', 'Recipient');
+            expect(paymentLabels[0]).toHaveAttribute('data-value', 'Test Receiver');
+            expect(paymentLabels[0]).toHaveAttribute('data-copy-value', 'Test Receiver');
+
+            expect(paymentLabels[1]).toHaveAttribute('data-label', 'IBAN (USD)');
+            expect(paymentLabels[1]).toHaveAttribute('data-value', 'US1234567890123456789012');
+            expect(paymentLabels[1]).toHaveAttribute('data-copy-value', 'US1234567890123456789012');
+
+            expect(paymentLabels[2]).toHaveAttribute('data-label', 'SWIFT Code');
+            expect(paymentLabels[2]).toHaveAttribute('data-value', 'TESTUS33');
+            expect(paymentLabels[2]).toHaveAttribute('data-copy-value', 'TESTUS33');
+
+            expect(paymentLabels[3]).toHaveAttribute('data-label', 'Bank');
+            expect(paymentLabels[3]).toHaveAttribute('data-value', 'Test Bank');
+            expect(paymentLabels[3]).toHaveAttribute('data-copy-value', 'Test Bank');
+
+            expect(paymentLabels[4]).toHaveAttribute('data-label', 'Address');
+            expect(paymentLabels[4]).toHaveAttribute('data-value', 'Test Address');
+            expect(paymentLabels[4]).toHaveAttribute('data-copy-value', 'Test Address');
+
+            expect(screen.queryByTestId('multi-field-label')).not.toBeInTheDocument();
+        });
+    });
+
+    describe('rendering with missing optional props', () => {
+        it('should use default values and MultiFieldLabelWithCopy when receiverName is null', () => {
+            const props = createProps({ receiverName: null });
+
+            render(<PaymentDetailsSection {...props} />);
+
+            const paymentLabels = screen.getAllByTestId('payment-label');
+            expect(paymentLabels[0]).toHaveAttribute('data-label', 'Recipient');
+            expect(paymentLabels[0]).toHaveAttribute('data-value', 'Default Recipient Name');
+            expect(paymentLabels[0]).toHaveAttribute('data-copy-value', 'Default Recipient Name');
+        });
+
+        it('should use default values when swift is null', () => {
+            const props = createProps({ swift: null });
+
+            render(<PaymentDetailsSection {...props} />);
+
+            const paymentLabels = screen.getAllByTestId('payment-label');
+            const swiftLabel = paymentLabels.find((label) => label.getAttribute('data-label') === 'SWIFT Code');
+            expect(swiftLabel).toHaveAttribute('data-value', 'Default SWIFT');
+            expect(swiftLabel).toHaveAttribute('data-copy-value', 'Default SWIFT');
+        });
+
+        it('should render MultiFieldLabelWithCopy when bankName is null', () => {
+            const props = createProps({ bankName: null });
+
+            render(<PaymentDetailsSection {...props} />);
+
+            const multiFieldLabel = screen.getByTestId('multi-field-label');
+            expect(multiFieldLabel).toHaveAttribute('data-label', 'Bank');
+            expect(multiFieldLabel).toHaveAttribute('data-values', 'Bank Name|Bank Street|Bank City Country');
+            expect(multiFieldLabel).toHaveAttribute('data-copy-value', 'Bank NameBank StreetBank City Country');
+
+            const paymentLabels = screen.getAllByTestId('payment-label');
+            const bankLabel = paymentLabels.find((label) => label.getAttribute('data-label') === 'Bank');
+            expect(bankLabel).toBeUndefined();
+        });
+
+        it('should render MultiFieldLabelWithCopy when address is null', () => {
+            const props = createProps({ address: null });
+
+            render(<PaymentDetailsSection {...props} />);
+
+            const multiFieldLabel = screen.getByTestId('multi-field-label');
+            expect(multiFieldLabel).toHaveAttribute('data-label', 'Address');
+            expect(multiFieldLabel).toHaveAttribute('data-values', 'Country|City');
+            expect(multiFieldLabel).toHaveAttribute('data-copy-value', 'CountryCity');
+
+            const paymentLabels = screen.getAllByTestId('payment-label');
+            const addressLabel = paymentLabels.find((label) => label.getAttribute('data-label') === 'Address');
+            expect(addressLabel).toBeUndefined();
+        });
+
+        it('should handle both bankName and address as null', () => {
+            const props = createProps({ bankName: null, address: null });
+
+            render(<PaymentDetailsSection {...props} />);
+
+            const multiFieldLabels = screen.getAllByTestId('multi-field-label');
+            expect(multiFieldLabels).toHaveLength(2);
+
+            expect(multiFieldLabels[0]).toHaveAttribute('data-label', 'Bank');
+            expect(multiFieldLabels[1]).toHaveAttribute('data-label', 'Address');
+
+            const paymentLabels = screen.getAllByTestId('payment-label');
+            expect(paymentLabels).toHaveLength(3);
+        });
+    });
+
+    describe('rendering with undefined values', () => {
+        it('should handle undefined optional props', () => {
+            const props = createProps({
+                receiverName: undefined,
+                bankName: undefined,
+                swift: undefined,
+                address: undefined,
+            });
+
+            render(<PaymentDetailsSection {...props} />);
+
+            expectBasicStructure('Test Payment Details');
+
+            const paymentLabels = screen.getAllByTestId('payment-label');
+            expect(paymentLabels).toHaveLength(3);
+
+            const multiFieldLabels = screen.getAllByTestId('multi-field-label');
+            expect(multiFieldLabels).toHaveLength(2);
+        });
+    });
+
+    describe('rendering with empty string values', () => {
+        it('should treat empty strings as falsy for conditional rendering', () => {
+            const props = createProps({
+                receiverName: '',
+                bankName: '',
+                swift: '',
+                address: '',
+            });
+
+            render(<PaymentDetailsSection {...props} />);
+
+            expectBasicStructure('Test Payment Details');
+
+            const paymentLabels = screen.getAllByTestId('payment-label');
+            expect(paymentLabels).toHaveLength(3);
+
+            const multiFieldLabels = screen.getAllByTestId('multi-field-label');
+            expect(multiFieldLabels).toHaveLength(2);
+        });
+    });
+
+    describe('rendering with edge case titles and values', () => {
+        it('should handle empty title', () => {
+            const props = createProps({ title: '' });
+
+            render(<PaymentDetailsSection {...props} />);
+
+            const heading = screen.getByRole('heading', { level: 2 });
+            expect(heading).toHaveTextContent('');
+        });
+
+        it('should handle special characters in values', () => {
+            const props = createProps({
+                title: 'Title with "quotes" & symbols',
+                receiverName: 'Receiver & Co. "Special"',
+                bankName: 'Bank <with> tags',
+                swift: 'SWIFT/CODE',
+                address: 'Address\nwith\nnewlines',
+            });
+
+            render(<PaymentDetailsSection {...props} />);
+
+            expectBasicStructure('Title with "quotes" & symbols');
+
+            const paymentLabels = screen.getAllByTestId('payment-label');
+            expect(paymentLabels[0]).toHaveAttribute('data-value', 'Receiver & Co. "Special"');
+            expect(paymentLabels[2]).toHaveAttribute('data-value', 'SWIFT/CODE');
+            expect(paymentLabels[3]).toHaveAttribute('data-value', 'Bank <with> tags');
+            expect(paymentLabels[4]).toHaveAttribute('data-value', 'Address\nwith\nnewlines');
+        });
+    });
+
+    describe('DOM structure validation', () => {
+        it('should have correct CSS class structure', () => {
+            const props = createProps();
+
+            render(<PaymentDetailsSection {...props} />);
+
+            const block = screen.getByText('Test Payment Details').closest('.abroadPaymentDetailsBlock');
+            expect(block).toBeInTheDocument();
+
+            const content = block?.querySelector('.abroadPaymentDetailsContent');
+            expect(content).toBeInTheDocument();
+
+            const heading = block?.querySelector('h2');
+            expect(heading).toHaveTextContent('Test Payment Details');
+        });
+    });
+});

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/PaymentDetailsSection.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/PaymentDetailsSection.tsx
@@ -2,46 +2,56 @@ import { PaymentLabelWithCopy } from './PaymentLabelWithCopy';
 import { MultiFieldLabelWithCopy } from './MultiFieldLabelWithCopy';
 import { PAYMENT_DETAILS_COMMON, ABROAD_PAYMENT_DETAILS } from '../../../../../const/public/donate-page';
 
+interface PaymentDetailsSectionProps {
+    title: string;
+    ibanLabel: string;
+    ibanValue: string;
+    receiverName?: string | null;
+    bankName?: string | null;
+    swift?: string | null;
+    address?: string | null;
+}
+
 export const PaymentDetailsSection = ({
     title,
     ibanLabel,
     ibanValue,
-}: {
-    title: string;
-    ibanLabel: string;
-    ibanValue: string;
-}) => (
+    receiverName,
+    bankName,
+    swift,
+    address,
+}: PaymentDetailsSectionProps) => (
     <div className="abroadPaymentDetailsBlock">
         <h2>{title}</h2>
         <div className="abroadPaymentDetailsContent">
             <PaymentLabelWithCopy
                 label={PAYMENT_DETAILS_COMMON.RECIPIENT_LABEL}
-                value={PAYMENT_DETAILS_COMMON.RECIPIENT_NAME_LABEL}
-                copyValue={PAYMENT_DETAILS_COMMON.RECIPIENT_NAME_LABEL}
+                value={receiverName || PAYMENT_DETAILS_COMMON.RECIPIENT_NAME_LABEL}
+                copyValue={receiverName || PAYMENT_DETAILS_COMMON.RECIPIENT_NAME_LABEL}
             />
             <PaymentLabelWithCopy label={ibanLabel} value={ibanValue} copyValue={ibanValue} />
             <PaymentLabelWithCopy
                 label={ABROAD_PAYMENT_DETAILS.SWIFT_CODE_LABEL}
-                value={ABROAD_PAYMENT_DETAILS.SWIFT_CODE_VALUE_LABEL}
-                copyValue={ABROAD_PAYMENT_DETAILS.SWIFT_CODE_VALUE_LABEL}
+                value={swift || ABROAD_PAYMENT_DETAILS.SWIFT_CODE_VALUE_LABEL}
+                copyValue={swift || ABROAD_PAYMENT_DETAILS.SWIFT_CODE_VALUE_LABEL}
             />
             <MultiFieldLabelWithCopy
                 label={ABROAD_PAYMENT_DETAILS.BANK_RECEIVER_LABEL}
                 values={[
-                    ABROAD_PAYMENT_DETAILS.BANK_NAME_TRANSLITERATED_LABEL,
+                    bankName || ABROAD_PAYMENT_DETAILS.BANK_NAME_TRANSLITERATED_LABEL,
                     ABROAD_PAYMENT_DETAILS.BANK_STREET_TRANSLITERATED_LABEL,
                     ABROAD_PAYMENT_DETAILS.BANK_CITY_AND_COUNTRY_TRANSLITERATED_LABEL,
                 ]}
                 copyValue={
-                    ABROAD_PAYMENT_DETAILS.BANK_NAME_TRANSLITERATED_LABEL +
+                    (bankName || ABROAD_PAYMENT_DETAILS.BANK_NAME_TRANSLITERATED_LABEL) +
                     ABROAD_PAYMENT_DETAILS.BANK_STREET_TRANSLITERATED_LABEL +
                     ABROAD_PAYMENT_DETAILS.BANK_CITY_AND_COUNTRY_TRANSLITERATED_LABEL
                 }
             />
             <MultiFieldLabelWithCopy
                 label={ABROAD_PAYMENT_DETAILS.ADDRESS_LABEL}
-                values={[ABROAD_PAYMENT_DETAILS.COUNTRY_LABEL, ABROAD_PAYMENT_DETAILS.CITY_LABEL]}
-                copyValue={ABROAD_PAYMENT_DETAILS.COUNTRY_LABEL + ABROAD_PAYMENT_DETAILS.CITY_LABEL}
+                values={[address || ABROAD_PAYMENT_DETAILS.COUNTRY_LABEL, ABROAD_PAYMENT_DETAILS.CITY_LABEL]}
+                copyValue={(address || ABROAD_PAYMENT_DETAILS.COUNTRY_LABEL) + ABROAD_PAYMENT_DETAILS.CITY_LABEL}
             />
         </div>
     </div>

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/PaymentDetailsSection.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/PaymentDetailsSection.tsx
@@ -35,24 +35,42 @@ export const PaymentDetailsSection = ({
                 value={swift || ABROAD_PAYMENT_DETAILS.SWIFT_CODE_VALUE_LABEL}
                 copyValue={swift || ABROAD_PAYMENT_DETAILS.SWIFT_CODE_VALUE_LABEL}
             />
-            <MultiFieldLabelWithCopy
-                label={ABROAD_PAYMENT_DETAILS.BANK_RECEIVER_LABEL}
-                values={[
-                    bankName || ABROAD_PAYMENT_DETAILS.BANK_NAME_TRANSLITERATED_LABEL,
-                    ABROAD_PAYMENT_DETAILS.BANK_STREET_TRANSLITERATED_LABEL,
-                    ABROAD_PAYMENT_DETAILS.BANK_CITY_AND_COUNTRY_TRANSLITERATED_LABEL,
-                ]}
-                copyValue={
-                    (bankName || ABROAD_PAYMENT_DETAILS.BANK_NAME_TRANSLITERATED_LABEL) +
-                    ABROAD_PAYMENT_DETAILS.BANK_STREET_TRANSLITERATED_LABEL +
-                    ABROAD_PAYMENT_DETAILS.BANK_CITY_AND_COUNTRY_TRANSLITERATED_LABEL
-                }
-            />
-            <MultiFieldLabelWithCopy
-                label={ABROAD_PAYMENT_DETAILS.ADDRESS_LABEL}
-                values={[address || ABROAD_PAYMENT_DETAILS.COUNTRY_LABEL, ABROAD_PAYMENT_DETAILS.CITY_LABEL]}
-                copyValue={(address || ABROAD_PAYMENT_DETAILS.COUNTRY_LABEL) + ABROAD_PAYMENT_DETAILS.CITY_LABEL}
-            />
+
+            {bankName ? (
+                <PaymentLabelWithCopy
+                    label={ABROAD_PAYMENT_DETAILS.BANK_RECEIVER_LABEL}
+                    value={bankName}
+                    copyValue={bankName}
+                />
+            ) : (
+                <MultiFieldLabelWithCopy
+                    label={ABROAD_PAYMENT_DETAILS.BANK_RECEIVER_LABEL}
+                    values={[
+                        ABROAD_PAYMENT_DETAILS.BANK_NAME_TRANSLITERATED_LABEL,
+                        ABROAD_PAYMENT_DETAILS.BANK_STREET_TRANSLITERATED_LABEL,
+                        ABROAD_PAYMENT_DETAILS.BANK_CITY_AND_COUNTRY_TRANSLITERATED_LABEL,
+                    ]}
+                    copyValue={
+                        ABROAD_PAYMENT_DETAILS.BANK_NAME_TRANSLITERATED_LABEL +
+                        ABROAD_PAYMENT_DETAILS.BANK_STREET_TRANSLITERATED_LABEL +
+                        ABROAD_PAYMENT_DETAILS.BANK_CITY_AND_COUNTRY_TRANSLITERATED_LABEL
+                    }
+                />
+            )}
+
+            {address ? (
+                <PaymentLabelWithCopy
+                    label={ABROAD_PAYMENT_DETAILS.ADDRESS_LABEL}
+                    value={address}
+                    copyValue={address}
+                />
+            ) : (
+                <MultiFieldLabelWithCopy
+                    label={ABROAD_PAYMENT_DETAILS.ADDRESS_LABEL}
+                    values={[ABROAD_PAYMENT_DETAILS.COUNTRY_LABEL, ABROAD_PAYMENT_DETAILS.CITY_LABEL]}
+                    copyValue={ABROAD_PAYMENT_DETAILS.COUNTRY_LABEL + ABROAD_PAYMENT_DETAILS.CITY_LABEL}
+                />
+            )}
         </div>
     </div>
 );

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/PaymentLabelWithCopy.test.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/PaymentLabelWithCopy.test.tsx
@@ -1,0 +1,295 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PaymentLabelWithCopy } from './PaymentLabelWithCopy';
+
+jest.mock('../../copy-text-button/CopyTextButton', () => ({
+    CopyTextButton: ({ textToCopy }: { textToCopy: string }) => (
+        <button data-testid="copy-button" data-copy-text={textToCopy}>
+            Copy
+        </button>
+    ),
+}));
+
+describe('PaymentLabelWithCopy', () => {
+    const createProps = (overrides = {}) => ({
+        label: 'Test Label',
+        value: 'Test Value',
+        copyValue: 'Copy Text',
+        ...overrides,
+    });
+
+    const expectCorrectDOMStructure = () => {
+        const paymentLabel = screen.getByRole('heading', { level: 3 }).closest('.paymentLabel');
+        expect(paymentLabel).toBeInTheDocument();
+
+        const labelWithCopyButton = paymentLabel?.querySelector('.labelWithCopyButton');
+        expect(labelWithCopyButton).toBeInTheDocument();
+
+        const valueSpan = labelWithCopyButton?.querySelector('span.label');
+        expect(valueSpan).toBeInTheDocument();
+
+        const copyButton = screen.getByTestId('copy-button');
+        expect(copyButton).toBeInTheDocument();
+    };
+
+    describe('rendering with string props', () => {
+        it('should render string label and value correctly', () => {
+            const props = createProps();
+
+            render(<PaymentLabelWithCopy {...props} />);
+
+            expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('Test Label');
+            expect(screen.getByText('Test Value')).toBeInTheDocument();
+            expect(screen.getByText('Test Value')).toHaveClass('label');
+            expectCorrectDOMStructure();
+        });
+
+        it('should pass correct copyValue to CopyTextButton', () => {
+            const props = createProps({
+                copyValue: 'Specific Copy Text',
+            });
+
+            render(<PaymentLabelWithCopy {...props} />);
+
+            const copyButton = screen.getByTestId('copy-button');
+            expect(copyButton).toHaveAttribute('data-copy-text', 'Specific Copy Text');
+        });
+    });
+
+    describe('rendering with React element props', () => {
+        it('should render React element as label', () => {
+            const props = createProps({
+                label: <span data-testid="custom-label">Custom Label Element</span>,
+            });
+
+            render(<PaymentLabelWithCopy {...props} />);
+
+            expect(screen.getByTestId('custom-label')).toHaveTextContent('Custom Label Element');
+            expect(screen.getByRole('heading', { level: 3 })).toContainElement(screen.getByTestId('custom-label'));
+            expectCorrectDOMStructure();
+        });
+
+        it('should render React element as value', () => {
+            const props = createProps({
+                value: <strong data-testid="custom-value">Bold Value</strong>,
+            });
+
+            render(<PaymentLabelWithCopy {...props} />);
+
+            expect(screen.getByTestId('custom-value')).toHaveTextContent('Bold Value');
+            expect(screen.getByText('Bold Value')).toBeInTheDocument();
+
+            const valueSpan = screen.getByText('Bold Value').closest('span.label');
+            expect(valueSpan).toContainElement(screen.getByTestId('custom-value'));
+        });
+
+        it('should render complex React elements', () => {
+            const complexLabel = (
+                <div data-testid="complex-label">
+                    <span>Part 1</span>
+                    <em>Part 2</em>
+                </div>
+            );
+
+            const complexValue = (
+                <div data-testid="complex-value">
+                    <p>Line 1</p>
+                    <p>Line 2</p>
+                </div>
+            );
+
+            const props = createProps({
+                label: complexLabel,
+                value: complexValue,
+            });
+
+            render(<PaymentLabelWithCopy {...props} />);
+
+            expect(screen.getByTestId('complex-label')).toBeInTheDocument();
+            expect(screen.getByTestId('complex-value')).toBeInTheDocument();
+            expect(screen.getByText('Part 1')).toBeInTheDocument();
+            expect(screen.getByText('Part 2')).toBeInTheDocument();
+            expect(screen.getByText('Line 1')).toBeInTheDocument();
+            expect(screen.getByText('Line 2')).toBeInTheDocument();
+        });
+    });
+
+    describe('rendering with edge case values', () => {
+        it('should handle empty string values', () => {
+            const props = createProps({
+                label: '',
+                value: '',
+                copyValue: '',
+            });
+
+            render(<PaymentLabelWithCopy {...props} />);
+
+            expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('');
+            expect(screen.getByTestId('copy-button')).toHaveAttribute('data-copy-text', '');
+            expectCorrectDOMStructure();
+        });
+
+        it('should handle null and undefined values', () => {
+            const props = createProps({
+                label: null,
+                value: undefined,
+            });
+
+            render(<PaymentLabelWithCopy {...props} />);
+
+            expectCorrectDOMStructure();
+            const copyButton = screen.getByTestId('copy-button');
+            expect(copyButton).toHaveAttribute('data-copy-text', 'Copy Text');
+        });
+
+        it('should handle numeric values', () => {
+            const props = createProps({
+                label: 123,
+                value: 456.78,
+                copyValue: '789',
+            });
+
+            render(<PaymentLabelWithCopy {...props} />);
+
+            expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('123');
+            expect(screen.getByText('456.78')).toBeInTheDocument();
+            expect(screen.getByTestId('copy-button')).toHaveAttribute('data-copy-text', '789');
+        });
+
+        it('should handle special characters in values', () => {
+            const props = createProps({
+                label: 'Label with "quotes" & symbols',
+                value: 'Value <with> tags & entities',
+                copyValue: 'Copy\nwith\nnewlines',
+            });
+
+            render(<PaymentLabelWithCopy {...props} />);
+
+            expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('Label with "quotes" & symbols');
+            expect(screen.getByText('Value <with> tags & entities')).toBeInTheDocument();
+            expect(screen.getByTestId('copy-button')).toHaveAttribute('data-copy-text', 'Copy\nwith\nnewlines');
+        });
+
+        it('should handle very long values', () => {
+            const longLabel = 'A'.repeat(100);
+            const longValue = 'B'.repeat(200);
+            const longCopyValue = 'C'.repeat(300);
+
+            const props = createProps({
+                label: longLabel,
+                value: longValue,
+                copyValue: longCopyValue,
+            });
+
+            render(<PaymentLabelWithCopy {...props} />);
+
+            expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(longLabel);
+            expect(screen.getByText(longValue)).toBeInTheDocument();
+            expect(screen.getByTestId('copy-button')).toHaveAttribute('data-copy-text', longCopyValue);
+        });
+    });
+
+    describe('DOM structure and CSS classes', () => {
+        it('should have correct CSS class structure', () => {
+            const props = createProps();
+
+            render(<PaymentLabelWithCopy {...props} />);
+
+            const paymentLabel = screen.getByRole('heading', { level: 3 }).closest('.paymentLabel');
+            expect(paymentLabel).toBeInTheDocument();
+
+            const heading = paymentLabel?.querySelector('h3');
+            expect(heading).toBeInTheDocument();
+            expect(heading).toHaveTextContent('Test Label');
+
+            const labelWithCopyButton = paymentLabel?.querySelector('.labelWithCopyButton');
+            expect(labelWithCopyButton).toBeInTheDocument();
+
+            const valueSpan = labelWithCopyButton?.querySelector('span.label');
+            expect(valueSpan).toBeInTheDocument();
+            expect(valueSpan).toHaveTextContent('Test Value');
+
+            const copyButton = labelWithCopyButton?.querySelector('[data-testid="copy-button"]');
+            expect(copyButton).toBeInTheDocument();
+        });
+
+        it('should render heading with correct level', () => {
+            const props = createProps();
+
+            render(<PaymentLabelWithCopy {...props} />);
+
+            const heading = screen.getByRole('heading', { level: 3 });
+            expect(heading.tagName).toBe('H3');
+            expect(heading).toHaveTextContent('Test Label');
+        });
+    });
+
+    describe('component integration', () => {
+        it('should integrate correctly with CopyTextButton', () => {
+            const props = createProps({
+                value: 'Display Value',
+                copyValue: 'Different Copy Value',
+            });
+
+            render(<PaymentLabelWithCopy {...props} />);
+
+            expect(screen.getByText('Display Value')).toBeInTheDocument();
+
+            const copyButton = screen.getByTestId('copy-button');
+            expect(copyButton).toHaveAttribute('data-copy-text', 'Different Copy Value');
+        });
+
+        it('should handle when value and copyValue are different types', () => {
+            const props = createProps({
+                value: <span data-testid="react-value">React Element Value</span>,
+                copyValue: 'String Copy Value',
+            });
+
+            render(<PaymentLabelWithCopy {...props} />);
+
+            expect(screen.getByTestId('react-value')).toHaveTextContent('React Element Value');
+            expect(screen.getByTestId('copy-button')).toHaveAttribute('data-copy-text', 'String Copy Value');
+        });
+    });
+
+    describe('accessibility', () => {
+        it('should have proper heading hierarchy', () => {
+            const props = createProps({
+                label: 'Payment Label',
+            });
+
+            render(<PaymentLabelWithCopy {...props} />);
+
+            const heading = screen.getByRole('heading', { level: 3 });
+            expect(heading).toBeInTheDocument();
+            expect(heading).toHaveTextContent('Payment Label');
+        });
+
+        it('should maintain semantic structure with complex elements', () => {
+            const props = createProps({
+                label: (
+                    <div>
+                        <span>Primary</span>
+                        <small>Secondary</small>
+                    </div>
+                ),
+                value: (
+                    <div>
+                        <strong>Important</strong>
+                        <span>Normal</span>
+                    </div>
+                ),
+            });
+
+            render(<PaymentLabelWithCopy {...props} />);
+
+            const heading = screen.getByRole('heading', { level: 3 });
+            expect(heading).toContainElement(screen.getByText('Primary'));
+            expect(heading).toContainElement(screen.getByText('Secondary'));
+
+            const valueSpan = screen.getByText('Important').closest('span.label');
+            expect(valueSpan).toContainElement(screen.getByText('Important'));
+            expect(valueSpan).toContainElement(screen.getByText('Normal'));
+        });
+    });
+});

--- a/src/pages/public/donate-page/right-section/alternative-support-ways/AlternativeSupportWays.test.tsx
+++ b/src/pages/public/donate-page/right-section/alternative-support-ways/AlternativeSupportWays.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { AlternativeSupportWays } from './AlternativeSupportWays';
 import { PublishedSupportOptionsDto, Currency } from '../../../../../types/public/donate-page';
 
@@ -21,10 +22,6 @@ jest.mock('../../copy-text-button/CopyTextButton', () => ({
 jest.mock('../../../../../const/public/donate-page', () => ({
     ALTERNATIVE_SUPPORT_WAYS: {
         ALTERNATIVE_SUPPORT_WAYS_LABEL: 'Інші варіанти підтримки',
-        PAY_PAL_LABEL: 'PayPal',
-        PAY_PAL_EMAIL_LABEL: 'test@paypal.com',
-        MONOBANK_JAR_LABEL: 'Monobank Jar',
-        MONOBANK_JAR_LINK_LABEL: 'https://send.monobank.ua/jar/test',
         DOWNLOAD_PAYMENT_DETAILS_BUTTON_LABEL: 'Завантажити реквізити',
     },
 }));
@@ -40,31 +37,7 @@ describe('AlternativeSupportWays', () => {
         ...overrides,
     });
 
-    const expectBasicElementsToBeInDocument = () => {
-        expect(screen.getByText('Інші варіанти підтримки')).toBeInTheDocument();
-        expect(screen.getByText('Завантажити реквізити')).toBeInTheDocument();
-        expect(screen.getByTestId('arrow-up-right-icon')).toBeInTheDocument();
-        expect(screen.getByTestId('forward-icon')).toBeInTheDocument();
-    };
-
-    const expectButtonsCount = (expectedCount: number) => {
-        const allButtons = screen.getAllByRole('button');
-        expect(allButtons).toHaveLength(expectedCount);
-    };
-
-    const expectFallbackConstants = () => {
-        expect(screen.getByText('PayPal')).toBeInTheDocument();
-        expect(screen.getByText('test@paypal.com')).toBeInTheDocument();
-        expect(screen.getByText('Monobank Jar')).toBeInTheDocument();
-        expect(screen.getByText('https://send.monobank.ua/jar/test')).toBeInTheDocument();
-
-        const monobankLink = screen.getByRole('link');
-        expect(monobankLink).toHaveAttribute('href', 'https://send.monobank.ua/jar/test');
-        expect(monobankLink).toHaveAttribute('target', '_blank');
-        expect(monobankLink).toHaveAttribute('rel', 'noreferrer');
-    };
-
-    describe('with API data', () => {
+    describe('with support options for current currency', () => {
         it('renders single support option for current currency', () => {
             const supportOptions = [
                 createMockSupportOption({
@@ -76,14 +49,17 @@ describe('AlternativeSupportWays', () => {
 
             render(<AlternativeSupportWays supportOptions={supportOptions} currentCurrency={Currency.UAH} />);
 
-            expectBasicElementsToBeInDocument();
-
+            expect(screen.getByText('Інші варіанти підтримки')).toBeInTheDocument();
             expect(screen.getByText('PayPal API')).toBeInTheDocument();
             expect(screen.getByText('api@paypal.com')).toBeInTheDocument();
-
             expect(screen.getByTestId('copy-button')).toHaveAttribute('data-copy-text', 'api@paypal.com');
 
-            expectButtonsCount(3);
+            expect(screen.getByText('Завантажити реквізити')).toBeInTheDocument();
+            expect(screen.getByTestId('arrow-up-right-icon')).toBeInTheDocument();
+            expect(screen.getByTestId('forward-icon')).toBeInTheDocument();
+
+            const allButtons = screen.getAllByRole('button');
+            expect(allButtons).toHaveLength(3);
         });
 
         it('renders multiple support options for current currency', () => {
@@ -104,14 +80,14 @@ describe('AlternativeSupportWays', () => {
 
             render(<AlternativeSupportWays supportOptions={supportOptions} currentCurrency={Currency.USD} />);
 
-            expectBasicElementsToBeInDocument();
-
+            expect(screen.getByText('Інші варіанти підтримки')).toBeInTheDocument();
             expect(screen.getByText('PayPal USD')).toBeInTheDocument();
             expect(screen.getByText('usd@paypal.com')).toBeInTheDocument();
             expect(screen.getByText('Stripe USD')).toBeInTheDocument();
             expect(screen.getByText('usd@stripe.com')).toBeInTheDocument();
 
-            expectButtonsCount(4);
+            const allButtons = screen.getAllByRole('button');
+            expect(allButtons).toHaveLength(4);
         });
 
         it('filters options by current currency correctly', () => {
@@ -143,41 +119,6 @@ describe('AlternativeSupportWays', () => {
             expect(screen.queryByText('uah@paypal.com')).not.toBeInTheDocument();
             expect(screen.queryByText('eur@paypal.com')).not.toBeInTheDocument();
         });
-    });
-
-    describe('fallback to constants', () => {
-        it('renders fallback constants when no support options provided', () => {
-            render(<AlternativeSupportWays supportOptions={[]} currentCurrency={Currency.UAH} />);
-
-            expectBasicElementsToBeInDocument();
-            expectFallbackConstants();
-
-            expectButtonsCount(4);
-        });
-
-        it('renders fallback constants when no options match current currency', () => {
-            const supportOptions = [
-                createMockSupportOption({ currency: Currency.USD }),
-                createMockSupportOption({ currency: Currency.EUR }),
-            ];
-
-            render(<AlternativeSupportWays supportOptions={supportOptions} currentCurrency={Currency.UAH} />);
-
-            expectBasicElementsToBeInDocument();
-            expectFallbackConstants();
-
-            expect(screen.queryByText('Test Option')).not.toBeInTheDocument();
-            expect(screen.queryByText('test-value')).not.toBeInTheDocument();
-        });
-    });
-
-    describe('edge cases', () => {
-        it('handles empty support options array', () => {
-            render(<AlternativeSupportWays supportOptions={[]} currentCurrency={Currency.EUR} />);
-
-            expectBasicElementsToBeInDocument();
-            expectFallbackConstants();
-        });
 
         it('handles support options with empty values', () => {
             const supportOptions = [
@@ -191,11 +132,7 @@ describe('AlternativeSupportWays', () => {
             render(<AlternativeSupportWays supportOptions={supportOptions} currentCurrency={Currency.UAH} />);
 
             expect(screen.getByText('Empty Test')).toBeInTheDocument();
-
-            const copyButton = screen.getByTestId('copy-button');
-            expect(copyButton).toHaveAttribute('data-copy-text', '');
-
-            expectBasicElementsToBeInDocument();
+            expect(screen.getByTestId('copy-button')).toHaveAttribute('data-copy-text', '');
         });
 
         it('handles multiple currencies but shows only current one', () => {
@@ -211,13 +148,14 @@ describe('AlternativeSupportWays', () => {
             expect(screen.getByText('Option 2')).toBeInTheDocument();
             expect(screen.queryByText('Option 3')).not.toBeInTheDocument();
 
-            expectButtonsCount(4);
+            const allButtons = screen.getAllByRole('button');
+            expect(allButtons).toHaveLength(4);
         });
-    });
 
-    describe('UI elements', () => {
         it('renders download and share buttons with correct icons', () => {
-            render(<AlternativeSupportWays supportOptions={[]} currentCurrency={Currency.UAH} />);
+            const supportOptions = [createMockSupportOption()];
+
+            render(<AlternativeSupportWays supportOptions={supportOptions} currentCurrency={Currency.UAH} />);
 
             const downloadButton = screen.getByText('Завантажити реквізити').closest('button');
             expect(downloadButton).toHaveClass('downloadPaymentDetailsButton');
@@ -227,6 +165,33 @@ describe('AlternativeSupportWays', () => {
 
             expect(screen.getByTestId('arrow-up-right-icon')).toBeInTheDocument();
             expect(screen.getByTestId('forward-icon')).toBeInTheDocument();
+        });
+    });
+
+    describe('no support options scenarios', () => {
+        it('returns null when no support options provided', () => {
+            const { container } = render(<AlternativeSupportWays supportOptions={[]} currentCurrency={Currency.UAH} />);
+
+            expect(container.firstChild).toBeNull();
+        });
+
+        it('returns null when no options match current currency', () => {
+            const supportOptions = [
+                createMockSupportOption({ currency: Currency.USD }),
+                createMockSupportOption({ currency: Currency.EUR }),
+            ];
+
+            const { container } = render(
+                <AlternativeSupportWays supportOptions={supportOptions} currentCurrency={Currency.UAH} />,
+            );
+
+            expect(container.firstChild).toBeNull();
+        });
+
+        it('returns null when empty support options array', () => {
+            const { container } = render(<AlternativeSupportWays supportOptions={[]} currentCurrency={Currency.EUR} />);
+
+            expect(container.firstChild).toBeNull();
         });
     });
 });

--- a/src/pages/public/donate-page/right-section/alternative-support-ways/AlternativeSupportWays.test.tsx
+++ b/src/pages/public/donate-page/right-section/alternative-support-ways/AlternativeSupportWays.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { AlternativeSupportWays } from './AlternativeSupportWays';
+import { PublishedSupportOptionsDto, Currency } from '../../../../../types/public/donate-page';
 
 jest.mock('../../../../../assets/icons/arrow-up-right.svg', () => ({
     ReactComponent: (props: any) => <svg {...props} data-testid="arrow-up-right-icon" />,
@@ -9,13 +10,223 @@ jest.mock('../../../../../assets/icons/forward.svg', () => ({
     ReactComponent: (props: any) => <svg {...props} data-testid="forward-icon" />,
 }));
 
+jest.mock('../../copy-text-button/CopyTextButton', () => ({
+    CopyTextButton: ({ textToCopy }: { textToCopy: string }) => (
+        <button data-testid="copy-button" data-copy-text={textToCopy}>
+            Copy
+        </button>
+    ),
+}));
+
+jest.mock('../../../../../const/public/donate-page', () => ({
+    ALTERNATIVE_SUPPORT_WAYS: {
+        ALTERNATIVE_SUPPORT_WAYS_LABEL: 'Інші варіанти підтримки',
+        PAY_PAL_LABEL: 'PayPal',
+        PAY_PAL_EMAIL_LABEL: 'test@paypal.com',
+        MONOBANK_JAR_LABEL: 'Monobank Jar',
+        MONOBANK_JAR_LINK_LABEL: 'https://send.monobank.ua/jar/test',
+        DOWNLOAD_PAYMENT_DETAILS_BUTTON_LABEL: 'Завантажити реквізити',
+    },
+}));
+
 describe('AlternativeSupportWays', () => {
-    it('renders all alternative support labels and buttons', () => {
-        render(<AlternativeSupportWays />);
-        expect(screen.getByText(/Pay Pal/i)).toBeInTheDocument();
-        expect(screen.getAllByText(/Monobank/i).length).toBeGreaterThan(0);
-        expect(screen.getAllByRole('button')).toHaveLength(4);
+    const createMockSupportOption = (
+        overrides: Partial<PublishedSupportOptionsDto> = {},
+    ): PublishedSupportOptionsDto => ({
+        id: 1,
+        name: 'Test Option',
+        value: 'test-value',
+        currency: Currency.UAH,
+        ...overrides,
+    });
+
+    const expectBasicElementsToBeInDocument = () => {
+        expect(screen.getByText('Інші варіанти підтримки')).toBeInTheDocument();
+        expect(screen.getByText('Завантажити реквізити')).toBeInTheDocument();
         expect(screen.getByTestId('arrow-up-right-icon')).toBeInTheDocument();
         expect(screen.getByTestId('forward-icon')).toBeInTheDocument();
+    };
+
+    const expectButtonsCount = (expectedCount: number) => {
+        const allButtons = screen.getAllByRole('button');
+        expect(allButtons).toHaveLength(expectedCount);
+    };
+
+    const expectFallbackConstants = () => {
+        expect(screen.getByText('PayPal')).toBeInTheDocument();
+        expect(screen.getByText('test@paypal.com')).toBeInTheDocument();
+        expect(screen.getByText('Monobank Jar')).toBeInTheDocument();
+        expect(screen.getByText('https://send.monobank.ua/jar/test')).toBeInTheDocument();
+
+        const monobankLink = screen.getByRole('link');
+        expect(monobankLink).toHaveAttribute('href', 'https://send.monobank.ua/jar/test');
+        expect(monobankLink).toHaveAttribute('target', '_blank');
+        expect(monobankLink).toHaveAttribute('rel', 'noreferrer');
+    };
+
+    describe('with API data', () => {
+        it('renders single support option for current currency', () => {
+            const supportOptions = [
+                createMockSupportOption({
+                    name: 'PayPal API',
+                    value: 'api@paypal.com',
+                    currency: Currency.UAH,
+                }),
+            ];
+
+            render(<AlternativeSupportWays supportOptions={supportOptions} currentCurrency={Currency.UAH} />);
+
+            expectBasicElementsToBeInDocument();
+
+            expect(screen.getByText('PayPal API')).toBeInTheDocument();
+            expect(screen.getByText('api@paypal.com')).toBeInTheDocument();
+
+            expect(screen.getByTestId('copy-button')).toHaveAttribute('data-copy-text', 'api@paypal.com');
+
+            expectButtonsCount(3);
+        });
+
+        it('renders multiple support options for current currency', () => {
+            const supportOptions = [
+                createMockSupportOption({
+                    id: 1,
+                    name: 'PayPal USD',
+                    value: 'usd@paypal.com',
+                    currency: Currency.USD,
+                }),
+                createMockSupportOption({
+                    id: 2,
+                    name: 'Stripe USD',
+                    value: 'usd@stripe.com',
+                    currency: Currency.USD,
+                }),
+            ];
+
+            render(<AlternativeSupportWays supportOptions={supportOptions} currentCurrency={Currency.USD} />);
+
+            expectBasicElementsToBeInDocument();
+
+            expect(screen.getByText('PayPal USD')).toBeInTheDocument();
+            expect(screen.getByText('usd@paypal.com')).toBeInTheDocument();
+            expect(screen.getByText('Stripe USD')).toBeInTheDocument();
+            expect(screen.getByText('usd@stripe.com')).toBeInTheDocument();
+
+            expectButtonsCount(4);
+        });
+
+        it('filters options by current currency correctly', () => {
+            const supportOptions = [
+                createMockSupportOption({
+                    name: 'PayPal UAH',
+                    value: 'uah@paypal.com',
+                    currency: Currency.UAH,
+                }),
+                createMockSupportOption({
+                    name: 'PayPal USD',
+                    value: 'usd@paypal.com',
+                    currency: Currency.USD,
+                }),
+                createMockSupportOption({
+                    name: 'PayPal EUR',
+                    value: 'eur@paypal.com',
+                    currency: Currency.EUR,
+                }),
+            ];
+
+            render(<AlternativeSupportWays supportOptions={supportOptions} currentCurrency={Currency.USD} />);
+
+            expect(screen.getByText('PayPal USD')).toBeInTheDocument();
+            expect(screen.getByText('usd@paypal.com')).toBeInTheDocument();
+
+            expect(screen.queryByText('PayPal UAH')).not.toBeInTheDocument();
+            expect(screen.queryByText('PayPal EUR')).not.toBeInTheDocument();
+            expect(screen.queryByText('uah@paypal.com')).not.toBeInTheDocument();
+            expect(screen.queryByText('eur@paypal.com')).not.toBeInTheDocument();
+        });
+    });
+
+    describe('fallback to constants', () => {
+        it('renders fallback constants when no support options provided', () => {
+            render(<AlternativeSupportWays supportOptions={[]} currentCurrency={Currency.UAH} />);
+
+            expectBasicElementsToBeInDocument();
+            expectFallbackConstants();
+
+            expectButtonsCount(4);
+        });
+
+        it('renders fallback constants when no options match current currency', () => {
+            const supportOptions = [
+                createMockSupportOption({ currency: Currency.USD }),
+                createMockSupportOption({ currency: Currency.EUR }),
+            ];
+
+            render(<AlternativeSupportWays supportOptions={supportOptions} currentCurrency={Currency.UAH} />);
+
+            expectBasicElementsToBeInDocument();
+            expectFallbackConstants();
+
+            expect(screen.queryByText('Test Option')).not.toBeInTheDocument();
+            expect(screen.queryByText('test-value')).not.toBeInTheDocument();
+        });
+    });
+
+    describe('edge cases', () => {
+        it('handles empty support options array', () => {
+            render(<AlternativeSupportWays supportOptions={[]} currentCurrency={Currency.EUR} />);
+
+            expectBasicElementsToBeInDocument();
+            expectFallbackConstants();
+        });
+
+        it('handles support options with empty values', () => {
+            const supportOptions = [
+                createMockSupportOption({
+                    name: 'Empty Test',
+                    value: '',
+                    currency: Currency.UAH,
+                }),
+            ];
+
+            render(<AlternativeSupportWays supportOptions={supportOptions} currentCurrency={Currency.UAH} />);
+
+            expect(screen.getByText('Empty Test')).toBeInTheDocument();
+
+            const copyButton = screen.getByTestId('copy-button');
+            expect(copyButton).toHaveAttribute('data-copy-text', '');
+
+            expectBasicElementsToBeInDocument();
+        });
+
+        it('handles multiple currencies but shows only current one', () => {
+            const supportOptions = [
+                createMockSupportOption({ name: 'Option 1', currency: Currency.UAH }),
+                createMockSupportOption({ name: 'Option 2', currency: Currency.UAH }),
+                createMockSupportOption({ name: 'Option 3', currency: Currency.USD }),
+            ];
+
+            render(<AlternativeSupportWays supportOptions={supportOptions} currentCurrency={Currency.UAH} />);
+
+            expect(screen.getByText('Option 1')).toBeInTheDocument();
+            expect(screen.getByText('Option 2')).toBeInTheDocument();
+            expect(screen.queryByText('Option 3')).not.toBeInTheDocument();
+
+            expectButtonsCount(4);
+        });
+    });
+
+    describe('UI elements', () => {
+        it('renders download and share buttons with correct icons', () => {
+            render(<AlternativeSupportWays supportOptions={[]} currentCurrency={Currency.UAH} />);
+
+            const downloadButton = screen.getByText('Завантажити реквізити').closest('button');
+            expect(downloadButton).toHaveClass('downloadPaymentDetailsButton');
+
+            const shareButton = screen.getByTestId('forward-icon').closest('button');
+            expect(shareButton).toHaveClass('shareButton');
+
+            expect(screen.getByTestId('arrow-up-right-icon')).toBeInTheDocument();
+            expect(screen.getByTestId('forward-icon')).toBeInTheDocument();
+        });
     });
 });

--- a/src/pages/public/donate-page/right-section/alternative-support-ways/AlternativeSupportWays.tsx
+++ b/src/pages/public/donate-page/right-section/alternative-support-ways/AlternativeSupportWays.tsx
@@ -13,46 +13,23 @@ interface AlternativeSupportWaysProps {
 export const AlternativeSupportWays = ({ supportOptions, currentCurrency }: AlternativeSupportWaysProps) => {
     const currentCurrencyOptions = supportOptions.filter((option) => option.currency === currentCurrency);
 
+    if (currentCurrencyOptions.length === 0) {
+        return null;
+    }
+
     return (
         <div className="alternativeSupportWays">
             <h2>{ALTERNATIVE_SUPPORT_WAYS.ALTERNATIVE_SUPPORT_WAYS_LABEL}</h2>
 
-            {currentCurrencyOptions.length > 0 ? (
-                currentCurrencyOptions.map((option) => (
-                    <div key={option.id} className="labelContainer">
-                        <h3>{option.name}</h3>
-                        <div className="labelWithCopyButton">
-                            <span className="label">{option.value}</span>
-                            <CopyTextButton textToCopy={option.value} />
-                        </div>
+            {currentCurrencyOptions.map((option) => (
+                <div key={option.id} className="labelContainer">
+                    <h3>{option.name}</h3>
+                    <div className="labelWithCopyButton">
+                        <span className="label">{option.value}</span>
+                        <CopyTextButton textToCopy={option.value} />
                     </div>
-                ))
-            ) : (
-                <>
-                    <div className="labelContainer">
-                        <h3>{ALTERNATIVE_SUPPORT_WAYS.PAY_PAL_LABEL}</h3>
-                        <div className="labelWithCopyButton">
-                            <span className="label">{ALTERNATIVE_SUPPORT_WAYS.PAY_PAL_EMAIL_LABEL}</span>
-                            <CopyTextButton textToCopy={ALTERNATIVE_SUPPORT_WAYS.PAY_PAL_EMAIL_LABEL} />
-                        </div>
-                    </div>
-
-                    <div className="labelContainer">
-                        <h3>{ALTERNATIVE_SUPPORT_WAYS.MONOBANK_JAR_LABEL}</h3>
-                        <div className="labelWithCopyButton">
-                            <a
-                                className="label"
-                                href={ALTERNATIVE_SUPPORT_WAYS.MONOBANK_JAR_LINK_LABEL}
-                                target="_blank"
-                                rel="noreferrer"
-                            >
-                                {ALTERNATIVE_SUPPORT_WAYS.MONOBANK_JAR_LINK_LABEL}
-                            </a>
-                            <CopyTextButton textToCopy={ALTERNATIVE_SUPPORT_WAYS.MONOBANK_JAR_LINK_LABEL} />
-                        </div>
-                    </div>
-                </>
-            )}
+                </div>
+            ))}
 
             <div className="buttonsContainer">
                 <button className="downloadPaymentDetailsButton">

--- a/src/pages/public/donate-page/right-section/alternative-support-ways/AlternativeSupportWays.tsx
+++ b/src/pages/public/donate-page/right-section/alternative-support-ways/AlternativeSupportWays.tsx
@@ -3,27 +3,41 @@ import { CopyTextButton } from '../../copy-text-button/CopyTextButton';
 import { ReactComponent as ArrowUpRight } from '../../../../../assets/icons/arrow-up-right.svg';
 import { ReactComponent as ShareForwardArrow } from '../../../../../assets/icons/forward.svg';
 import { ALTERNATIVE_SUPPORT_WAYS } from '../../../../../const/public/donate-page';
+import { PublicSupportOptionsDto } from '../../../../../types/public/donate-page';
 
-export const AlternativeSupportWays = () => {
+interface AlternativeSupportWaysProps {
+    supportOptions: PublicSupportOptionsDto[];
+}
+
+export const AlternativeSupportWays = ({ supportOptions }: AlternativeSupportWaysProps) => {
+    const payPal = supportOptions.find((x) => x.name.toLowerCase() === 'paypal');
+    const monobank = supportOptions.find((x) => x.name.toLowerCase() === 'monobank');
+
+    const payPalValue = payPal?.value || ALTERNATIVE_SUPPORT_WAYS.PAY_PAL_EMAIL_LABEL;
+    const monobankLink = monobank?.value || ALTERNATIVE_SUPPORT_WAYS.MONOBANK_JAR_LINK_LABEL;
+
     return (
         <div className="alternativeSupportWays">
             <h2>{ALTERNATIVE_SUPPORT_WAYS.ALTERNATIVE_SUPPORT_WAYS_LABEL}</h2>
+
             <div className="labelContainer">
                 <h3>{ALTERNATIVE_SUPPORT_WAYS.PAY_PAL_LABEL}</h3>
                 <div className="labelWithCopyButton">
-                    <span className="label">{ALTERNATIVE_SUPPORT_WAYS.PAY_PAL_EMAIL_LABEL}</span>
-                    <CopyTextButton textToCopy={ALTERNATIVE_SUPPORT_WAYS.PAY_PAL_EMAIL_LABEL} />
+                    <span className="label">{payPalValue}</span>
+                    <CopyTextButton textToCopy={payPalValue} />
                 </div>
             </div>
+
             <div className="labelContainer">
                 <h3>{ALTERNATIVE_SUPPORT_WAYS.MONOBANK_JAR_LABEL}</h3>
                 <div className="labelWithCopyButton">
-                    <a className="label" href={ALTERNATIVE_SUPPORT_WAYS.MONOBANK_JAR_LINK_LABEL}>
-                        {ALTERNATIVE_SUPPORT_WAYS.MONOBANK_JAR_LINK_LABEL}
+                    <a className="label" href={monobankLink} target="_blank" rel="noreferrer">
+                        {monobankLink}
                     </a>
-                    <CopyTextButton textToCopy={ALTERNATIVE_SUPPORT_WAYS.MONOBANK_JAR_LINK_LABEL} />
+                    <CopyTextButton textToCopy={monobankLink} />
                 </div>
             </div>
+
             <div className="buttonsContainer">
                 <button className="downloadPaymentDetailsButton">
                     {ALTERNATIVE_SUPPORT_WAYS.DOWNLOAD_PAYMENT_DETAILS_BUTTON_LABEL}

--- a/src/pages/public/donate-page/right-section/alternative-support-ways/AlternativeSupportWays.tsx
+++ b/src/pages/public/donate-page/right-section/alternative-support-ways/AlternativeSupportWays.tsx
@@ -3,40 +3,56 @@ import { CopyTextButton } from '../../copy-text-button/CopyTextButton';
 import { ReactComponent as ArrowUpRight } from '../../../../../assets/icons/arrow-up-right.svg';
 import { ReactComponent as ShareForwardArrow } from '../../../../../assets/icons/forward.svg';
 import { ALTERNATIVE_SUPPORT_WAYS } from '../../../../../const/public/donate-page';
-import { PublicSupportOptionsDto } from '../../../../../types/public/donate-page';
+import { PublishedSupportOptionsDto, Currency } from '../../../../../types/public/donate-page';
 
 interface AlternativeSupportWaysProps {
-    supportOptions: PublicSupportOptionsDto[];
+    supportOptions: PublishedSupportOptionsDto[];
+    currentCurrency: Currency;
 }
 
-export const AlternativeSupportWays = ({ supportOptions }: AlternativeSupportWaysProps) => {
-    const payPal = supportOptions.find((x) => x.name.toLowerCase() === 'paypal');
-    const monobank = supportOptions.find((x) => x.name.toLowerCase() === 'monobank');
-
-    const payPalValue = payPal?.value || ALTERNATIVE_SUPPORT_WAYS.PAY_PAL_EMAIL_LABEL;
-    const monobankLink = monobank?.value || ALTERNATIVE_SUPPORT_WAYS.MONOBANK_JAR_LINK_LABEL;
+export const AlternativeSupportWays = ({ supportOptions, currentCurrency }: AlternativeSupportWaysProps) => {
+    const currentCurrencyOptions = supportOptions.filter((option) => option.currency === currentCurrency);
 
     return (
         <div className="alternativeSupportWays">
             <h2>{ALTERNATIVE_SUPPORT_WAYS.ALTERNATIVE_SUPPORT_WAYS_LABEL}</h2>
 
-            <div className="labelContainer">
-                <h3>{ALTERNATIVE_SUPPORT_WAYS.PAY_PAL_LABEL}</h3>
-                <div className="labelWithCopyButton">
-                    <span className="label">{payPalValue}</span>
-                    <CopyTextButton textToCopy={payPalValue} />
-                </div>
-            </div>
+            {currentCurrencyOptions.length > 0 ? (
+                currentCurrencyOptions.map((option) => (
+                    <div key={option.id} className="labelContainer">
+                        <h3>{option.name}</h3>
+                        <div className="labelWithCopyButton">
+                            <span className="label">{option.value}</span>
+                            <CopyTextButton textToCopy={option.value} />
+                        </div>
+                    </div>
+                ))
+            ) : (
+                <>
+                    <div className="labelContainer">
+                        <h3>{ALTERNATIVE_SUPPORT_WAYS.PAY_PAL_LABEL}</h3>
+                        <div className="labelWithCopyButton">
+                            <span className="label">{ALTERNATIVE_SUPPORT_WAYS.PAY_PAL_EMAIL_LABEL}</span>
+                            <CopyTextButton textToCopy={ALTERNATIVE_SUPPORT_WAYS.PAY_PAL_EMAIL_LABEL} />
+                        </div>
+                    </div>
 
-            <div className="labelContainer">
-                <h3>{ALTERNATIVE_SUPPORT_WAYS.MONOBANK_JAR_LABEL}</h3>
-                <div className="labelWithCopyButton">
-                    <a className="label" href={monobankLink} target="_blank" rel="noreferrer">
-                        {monobankLink}
-                    </a>
-                    <CopyTextButton textToCopy={monobankLink} />
-                </div>
-            </div>
+                    <div className="labelContainer">
+                        <h3>{ALTERNATIVE_SUPPORT_WAYS.MONOBANK_JAR_LABEL}</h3>
+                        <div className="labelWithCopyButton">
+                            <a
+                                className="label"
+                                href={ALTERNATIVE_SUPPORT_WAYS.MONOBANK_JAR_LINK_LABEL}
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                {ALTERNATIVE_SUPPORT_WAYS.MONOBANK_JAR_LINK_LABEL}
+                            </a>
+                            <CopyTextButton textToCopy={ALTERNATIVE_SUPPORT_WAYS.MONOBANK_JAR_LINK_LABEL} />
+                        </div>
+                    </div>
+                </>
+            )}
 
             <div className="buttonsContainer">
                 <button className="downloadPaymentDetailsButton">

--- a/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.scss
+++ b/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.scss
@@ -15,6 +15,12 @@
         gap: 1.5rem;
         padding-top: 2rem;
 
+        &.separated {
+            margin-top: 3rem;
+            padding-top: 3rem;
+            border-top: 1px solid colors.$blue-900;
+        }
+
         h3 {
             font-weight: 600;
             font-size: 1.5rem;

--- a/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.test.tsx
+++ b/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.test.tsx
@@ -25,72 +25,110 @@ jest.mock('../../../../../const/public/donate-page', () => ({
 }));
 
 describe('UkrainePaymentDetails', () => {
-    const createMockBankDetails = (
-        overrides: Partial<PublishedUahBankDetailsDto> = {},
-    ): PublishedUahBankDetailsDto[] => [
-        {
-            id: 1,
-            name: 'Test Bank',
-            receiver: 'Test Receiver',
-            edrpou: '12345678',
-            iban: 'UA123456789012345678901234567',
-            paymentPurpose: 'Test Payment Purpose',
-            ...overrides,
-        },
-    ];
+    const createMockBank = (overrides: Partial<PublishedUahBankDetailsDto> = {}): PublishedUahBankDetailsDto => ({
+        id: 1,
+        name: 'Test Bank',
+        receiver: 'Test Receiver',
+        edrpou: '12345678',
+        iban: 'UA123456789012345678901234567',
+        paymentPurpose: 'Test Payment Purpose',
+        ...overrides,
+    });
 
-    describe('with bank details data', () => {
-        it('renders all payment details with API data', () => {
-            const mockBankDetails = createMockBankDetails();
+    const createMultipleBanks = (count: number): PublishedUahBankDetailsDto[] =>
+        Array.from({ length: count }, (_, index) =>
+            createMockBank({
+                id: index + 1,
+                name: `Test Bank ${index + 1}`,
+                receiver: `Test Receiver ${index + 1}`,
+                edrpou: `1234567${index}`,
+                iban: `UA12345678901234567890123456${index}`,
+                paymentPurpose: `Test Payment Purpose ${index + 1}`,
+            }),
+        );
 
-            render(<UkrainePaymentDetails bankDetails={mockBankDetails} />);
+    const expectAllLabelsToBePresent = () => {
+        expect(screen.getByText('Реквізити для донатів в Україні')).toBeInTheDocument();
+        expect(screen.getAllByText('Одержувач')).toHaveLength(1);
+        expect(screen.getAllByText('ЄДРПОУ')).toHaveLength(1);
+        expect(screen.getAllByText('Банк')).toHaveLength(1);
+        expect(screen.getAllByText('IBAN (UAH)')).toHaveLength(1);
+        expect(screen.getAllByText('Призначення платежу')).toHaveLength(1);
+    };
+
+    const expectBankDataToBePresent = (bank: PublishedUahBankDetailsDto) => {
+        expect(screen.getByText(bank.receiver)).toBeInTheDocument();
+        expect(screen.getByText(bank.edrpou)).toBeInTheDocument();
+        expect(screen.getByText(bank.name)).toBeInTheDocument();
+        expect(screen.getByText(bank.iban)).toBeInTheDocument();
+        expect(screen.getByText(bank.paymentPurpose)).toBeInTheDocument();
+    };
+
+    const expectCopyButtonsWithCorrectData = (banks: PublishedUahBankDetailsDto[]) => {
+        const copyButtons = screen.getAllByTestId('copy-button');
+        const expectedButtonCount = banks.length * 5;
+        expect(copyButtons).toHaveLength(expectedButtonCount);
+
+        banks.forEach((bank, bankIndex) => {
+            const startIndex = bankIndex * 5;
+            expect(copyButtons[startIndex]).toHaveAttribute('data-copy-text', bank.receiver);
+            expect(copyButtons[startIndex + 1]).toHaveAttribute('data-copy-text', bank.edrpou);
+            expect(copyButtons[startIndex + 2]).toHaveAttribute('data-copy-text', bank.name);
+            expect(copyButtons[startIndex + 3]).toHaveAttribute('data-copy-text', bank.iban);
+            expect(copyButtons[startIndex + 4]).toHaveAttribute('data-copy-text', bank.paymentPurpose);
+        });
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('rendering with valid data', () => {
+        it('should render single bank details correctly', () => {
+            const mockBank = createMockBank();
+            const bankDetails = [mockBank];
+
+            render(<UkrainePaymentDetails bankDetails={bankDetails} />);
+
+            expectAllLabelsToBePresent();
+            expectBankDataToBePresent(mockBank);
+            expectCopyButtonsWithCorrectData(bankDetails);
+        });
+
+        it('should render multiple banks with all details', () => {
+            const bankDetails = createMultipleBanks(2);
+
+            render(<UkrainePaymentDetails bankDetails={bankDetails} />);
 
             expect(screen.getByText('Реквізити для донатів в Україні')).toBeInTheDocument();
 
-            expect(screen.getByText('Одержувач')).toBeInTheDocument();
-            expect(screen.getByText('ЄДРПОУ')).toBeInTheDocument();
-            expect(screen.getByText('Банк')).toBeInTheDocument();
-            expect(screen.getByText('IBAN (UAH)')).toBeInTheDocument();
-            expect(screen.getByText('Призначення платежу')).toBeInTheDocument();
+            expect(screen.getAllByText('Одержувач')).toHaveLength(2);
+            expect(screen.getAllByText('ЄДРПОУ')).toHaveLength(2);
+            expect(screen.getAllByText('Банк')).toHaveLength(2);
+            expect(screen.getAllByText('IBAN (UAH)')).toHaveLength(2);
+            expect(screen.getAllByText('Призначення платежу')).toHaveLength(2);
 
-            expect(screen.getByText('Test Receiver')).toBeInTheDocument();
-            expect(screen.getByText('12345678')).toBeInTheDocument();
-            expect(screen.getByText('Test Bank')).toBeInTheDocument();
-            expect(screen.getByText('UA123456789012345678901234567')).toBeInTheDocument();
-            expect(screen.getByText('Test Payment Purpose')).toBeInTheDocument();
-
-            const copyButtons = screen.getAllByTestId('copy-button');
-            expect(copyButtons).toHaveLength(5);
-            expect(copyButtons[0]).toHaveAttribute('data-copy-text', 'Test Receiver');
-            expect(copyButtons[1]).toHaveAttribute('data-copy-text', '12345678');
-            expect(copyButtons[2]).toHaveAttribute('data-copy-text', 'Test Bank');
-            expect(copyButtons[3]).toHaveAttribute('data-copy-text', 'UA123456789012345678901234567');
-            expect(copyButtons[4]).toHaveAttribute('data-copy-text', 'Test Payment Purpose');
+            bankDetails.forEach((bank) => expectBankDataToBePresent(bank));
+            expectCopyButtonsWithCorrectData(bankDetails);
         });
 
-        it('renders with multiple banks but uses only first one primary', () => {
-            const mockBankDetails = [
-                createMockBankDetails()[0],
-                {
-                    id: 2,
-                    name: 'Secondary Bank',
-                    receiver: 'Secondary Receiver',
-                    edrpou: '87654321',
-                    iban: 'UA987654321098765432109876543',
-                    paymentPurpose: 'Secondary Purpose',
-                },
-            ];
+        it('should apply separated class to non-first banks', () => {
+            const bankDetails = createMultipleBanks(2);
 
-            render(<UkrainePaymentDetails bankDetails={mockBankDetails} />);
+            render(<UkrainePaymentDetails bankDetails={bankDetails} />);
 
-            expect(screen.getByText('Test Receiver')).toBeInTheDocument();
-            expect(screen.getByText('Test Bank')).toBeInTheDocument();
-            expect(screen.queryByText('Secondary Receiver')).not.toBeInTheDocument();
-            expect(screen.queryByText('Secondary Bank')).not.toBeInTheDocument();
+            const container = screen.getByText('Реквізити для донатів в Україні').closest('.UkrainePaymentDetails');
+            const paymentDetailsContainers = container?.querySelectorAll('.paymentDetails');
+
+            expect(paymentDetailsContainers).toHaveLength(2);
+            expect(paymentDetailsContainers?.[0]).not.toHaveClass('separated');
+            expect(paymentDetailsContainers?.[1]).toHaveClass('separated');
         });
+    });
 
-        it('handles bank details with empty string values', () => {
-            const mockBankDetails = createMockBankDetails({
+    describe('rendering with edge case data', () => {
+        it('should handle empty string values', () => {
+            const mockBank = createMockBank({
                 name: '',
                 receiver: '',
                 edrpou: '',
@@ -98,44 +136,119 @@ describe('UkrainePaymentDetails', () => {
                 paymentPurpose: '',
             });
 
-            render(<UkrainePaymentDetails bankDetails={mockBankDetails} />);
+            render(<UkrainePaymentDetails bankDetails={[mockBank]} />);
 
-            expect(screen.getByText('Реквізити для донатів в Україні')).toBeInTheDocument();
-
-            const spans = screen.getAllByText('');
-            expect(spans.length).toBeGreaterThan(0);
-
-            const copyButtons = screen.getAllByTestId('copy-button');
-            expect(copyButtons[0]).toHaveAttribute('data-copy-text', '');
-            expect(copyButtons[1]).toHaveAttribute('data-copy-text', '');
+            expectAllLabelsToBePresent();
+            expectCopyButtonsWithCorrectData([mockBank]);
         });
 
-        it('handles bank details with null undefined values', () => {
-            const mockBankDetails = createMockBankDetails({
+        it('should handle null and undefined values', () => {
+            const mockBank = createMockBank({
                 name: null as any,
                 receiver: undefined as any,
+                edrpou: null as any,
+                iban: undefined as any,
+                paymentPurpose: null as any,
             });
 
-            render(<UkrainePaymentDetails bankDetails={mockBankDetails} />);
+            render(<UkrainePaymentDetails bankDetails={[mockBank]} />);
 
-            expect(screen.getByText('Реквізити для донатів в Україні')).toBeInTheDocument();
-
+            expectAllLabelsToBePresent();
             const copyButtons = screen.getAllByTestId('copy-button');
             expect(copyButtons).toHaveLength(5);
         });
+
+        it('should handle banks with special characters in data', () => {
+            const mockBank = createMockBank({
+                name: 'Test Bank & Co. "Special" Characters',
+                receiver: 'Test Receiver №1 (Main)',
+                paymentPurpose: 'Donation for Victory Center project',
+            });
+
+            render(<UkrainePaymentDetails bankDetails={[mockBank]} />);
+
+            expectBankDataToBePresent(mockBank);
+        });
     });
 
-    describe('no bank details scenarios', () => {
-        it('returns null when no bank details provided', () => {
+    describe('empty state handling', () => {
+        it('should return null for empty array', () => {
             const { container } = render(<UkrainePaymentDetails bankDetails={[]} />);
 
             expect(container.firstChild).toBeNull();
         });
+    });
 
-        it('returns null when bankDetails array is empty', () => {
-            const { container } = render(<UkrainePaymentDetails bankDetails={[]} />);
+    describe('DOM structure validation', () => {
+        it('should have correct CSS classes structure', () => {
+            const bankDetails = createMultipleBanks(2);
 
-            expect(container.firstChild).toBeNull();
+            render(<UkrainePaymentDetails bankDetails={bankDetails} />);
+
+            const mainContainer = screen.getByText('Реквізити для донатів в Україні').closest('.UkrainePaymentDetails');
+            expect(mainContainer).toBeInTheDocument();
+
+            const paymentDetailsContainers = mainContainer?.querySelectorAll('.paymentDetails');
+            expect(paymentDetailsContainers).toHaveLength(2);
+
+            paymentDetailsContainers?.forEach((container) => {
+                const paymentLabels = container.querySelectorAll('.paymentLabel');
+                expect(paymentLabels).toHaveLength(5);
+
+                paymentLabels.forEach((label) => {
+                    const labelWithCopyButton = label.querySelector('.labelWithCopyButton');
+                    expect(labelWithCopyButton).toBeInTheDocument();
+
+                    const span = labelWithCopyButton?.querySelector('.label');
+                    expect(span).toBeInTheDocument();
+                });
+            });
+        });
+
+        it('should render correct heading structure', () => {
+            const bankDetails = createMultipleBanks(2);
+
+            render(<UkrainePaymentDetails bankDetails={bankDetails} />);
+
+            const mainHeading = screen.getByRole('heading', { level: 2 });
+            expect(mainHeading).toHaveTextContent('Реквізити для донатів в Україні');
+
+            const subHeadings = screen.getAllByRole('heading', { level: 3 });
+            expect(subHeadings).toHaveLength(10);
+        });
+    });
+
+    describe('component behavior with different bank counts', () => {
+        it('should handle 1 bank correctly', () => {
+            const bankDetails = createMultipleBanks(1);
+
+            render(<UkrainePaymentDetails bankDetails={bankDetails} />);
+
+            expectAllLabelsToBePresent();
+            expectCopyButtonsWithCorrectData(bankDetails);
+
+            const separatedContainers = screen
+                .getByText('Реквізити для донатів в Україні')
+                .closest('.UkrainePaymentDetails')
+                ?.querySelectorAll('.paymentDetails.separated');
+
+            expect(separatedContainers).toHaveLength(0);
+        });
+
+        it('should handle 3 banks correctly', () => {
+            const bankDetails = createMultipleBanks(3);
+
+            render(<UkrainePaymentDetails bankDetails={bankDetails} />);
+
+            expect(screen.getAllByText('Одержувач')).toHaveLength(3);
+            expectCopyButtonsWithCorrectData(bankDetails);
+
+            const separatedContainers = screen
+                .getByText('Реквізити для донатів в Україні')
+                .closest('.UkrainePaymentDetails')
+                ?.querySelectorAll('.paymentDetails.separated');
+
+            expect(separatedContainers).toHaveLength(2);
         });
     });
 });

--- a/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.test.tsx
+++ b/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.test.tsx
@@ -1,10 +1,145 @@
 import { render, screen } from '@testing-library/react';
 import { UkrainePaymentDetails } from './UkrainePaymentDetails';
+import { PublishedUahBankDetailsDto } from '../../../../../types/public/donate-page';
+import { UKRAINE_PAYMENT_DETAILS, PAYMENT_DETAILS_COMMON } from '../../../../../const/public/donate-page';
+
+jest.mock('../../../../../const/public/donate-page', () => ({
+    UKRAINE_PAYMENT_DETAILS: {
+        UKRAINE_PAYMENT_DETAILS_LABEL: 'Реквізити для донатів в Україні',
+        UIDSREOU_LABEL: 'ЄДРПОУ',
+        UIDSREOU_NUMBER_LABEL: '45262516',
+        BANK_LABEL: 'Банк',
+        BANK_NAME_LABEL: 'АТ КБ «ПРИВАТБАНК»',
+        IBAN_UAH_LABEL: 'IBAN (UAH)',
+        IBAN_UAH_NUMBER_LABEL: 'UA463052990000026000040142147',
+        PAYMENT_DESTINATION_LABEL: 'Призначення платежу',
+        PAYMENT_DESTINATION_NAME_LABEL: 'Благодійна допомога на статутну діяльність',
+    },
+    PAYMENT_DETAILS_COMMON: {
+        RECIPIENT_LABEL: 'Одержувач',
+        RECIPIENT_NAME_LABEL: 'ГО «ЦЕНТР ПЕРЕМОГИ»',
+    },
+}));
 
 describe('UkrainePaymentDetails', () => {
-    it('renders all payment labels and copy buttons', () => {
-        render(<UkrainePaymentDetails />);
-        expect(screen.getByText(/IBAN/i)).toBeInTheDocument();
-        expect(screen.getAllByRole('button').length).toBeGreaterThan(0);
+    const createMockBankDetails = (
+        overrides: Partial<PublishedUahBankDetailsDto> = {},
+    ): PublishedUahBankDetailsDto[] => [
+        {
+            id: 1,
+            name: 'Test Bank',
+            receiver: 'Test Receiver',
+            edrpou: '12345678',
+            iban: 'UA123456789012345678901234567',
+            paymentPurpose: 'Test Payment Purpose',
+            ...overrides,
+        },
+    ];
+
+    const expectElementsToBeInDocument = (texts: string[]) => {
+        texts.forEach((text) => {
+            expect(screen.getByText(text)).toBeInTheDocument();
+        });
+    };
+
+    const expectCopyButtonsCount = (expectedCount: number) => {
+        const copyButtons = screen.getAllByRole('button');
+        expect(copyButtons).toHaveLength(expectedCount);
+    };
+
+    describe('with API data', () => {
+        it('renders all payment labels with API data', () => {
+            const mockBankDetails = createMockBankDetails();
+
+            render(<UkrainePaymentDetails bankDetails={mockBankDetails} />);
+
+            expect(screen.getByText(UKRAINE_PAYMENT_DETAILS.UKRAINE_PAYMENT_DETAILS_LABEL)).toBeInTheDocument();
+
+            expectElementsToBeInDocument([
+                PAYMENT_DETAILS_COMMON.RECIPIENT_LABEL,
+                UKRAINE_PAYMENT_DETAILS.UIDSREOU_LABEL,
+                UKRAINE_PAYMENT_DETAILS.BANK_LABEL,
+                UKRAINE_PAYMENT_DETAILS.IBAN_UAH_LABEL,
+                UKRAINE_PAYMENT_DETAILS.PAYMENT_DESTINATION_LABEL,
+            ]);
+
+            expectElementsToBeInDocument([
+                'Test Receiver',
+                '12345678',
+                'Test Bank',
+                'UA123456789012345678901234567',
+                'Test Payment Purpose',
+            ]);
+
+            expectCopyButtonsCount(5);
+        });
+
+        it('handles partial API data with fallbacks', () => {
+            const mockBankDetails = createMockBankDetails({
+                name: '',
+                receiver: '',
+            });
+
+            render(<UkrainePaymentDetails bankDetails={mockBankDetails} />);
+
+            expect(screen.getByText(PAYMENT_DETAILS_COMMON.RECIPIENT_NAME_LABEL)).toBeInTheDocument();
+            expect(screen.getByText(UKRAINE_PAYMENT_DETAILS.BANK_NAME_LABEL)).toBeInTheDocument();
+
+            expectElementsToBeInDocument(['12345678', 'UA123456789012345678901234567', 'Test Payment Purpose']);
+        });
+    });
+
+    describe('with empty array fallback to constants', () => {
+        it('renders all payment labels with fallback constants', () => {
+            render(<UkrainePaymentDetails bankDetails={[]} />);
+
+            expect(screen.getByText(UKRAINE_PAYMENT_DETAILS.UKRAINE_PAYMENT_DETAILS_LABEL)).toBeInTheDocument();
+
+            expectElementsToBeInDocument([
+                PAYMENT_DETAILS_COMMON.RECIPIENT_LABEL,
+                UKRAINE_PAYMENT_DETAILS.UIDSREOU_LABEL,
+                UKRAINE_PAYMENT_DETAILS.BANK_LABEL,
+                UKRAINE_PAYMENT_DETAILS.IBAN_UAH_LABEL,
+                UKRAINE_PAYMENT_DETAILS.PAYMENT_DESTINATION_LABEL,
+            ]);
+
+            expectElementsToBeInDocument([
+                PAYMENT_DETAILS_COMMON.RECIPIENT_NAME_LABEL,
+                UKRAINE_PAYMENT_DETAILS.UIDSREOU_NUMBER_LABEL,
+                UKRAINE_PAYMENT_DETAILS.BANK_NAME_LABEL,
+                UKRAINE_PAYMENT_DETAILS.IBAN_UAH_NUMBER_LABEL,
+                UKRAINE_PAYMENT_DETAILS.PAYMENT_DESTINATION_NAME_LABEL,
+            ]);
+
+            expectCopyButtonsCount(5);
+        });
+    });
+
+    describe('edge cases', () => {
+        it('handles undefined values in API data', () => {
+            const mockBankDetails = createMockBankDetails({
+                name: undefined as any,
+                receiver: null as any,
+            });
+
+            render(<UkrainePaymentDetails bankDetails={mockBankDetails} />);
+
+            expect(screen.getByText(PAYMENT_DETAILS_COMMON.RECIPIENT_NAME_LABEL)).toBeInTheDocument();
+            expect(screen.getByText(UKRAINE_PAYMENT_DETAILS.BANK_NAME_LABEL)).toBeInTheDocument();
+        });
+
+        it('handles empty string values in API data', () => {
+            const mockBankDetails = createMockBankDetails({
+                edrpou: '',
+                iban: '',
+                paymentPurpose: '',
+            });
+
+            render(<UkrainePaymentDetails bankDetails={mockBankDetails} />);
+
+            expect(screen.getByText(UKRAINE_PAYMENT_DETAILS.UIDSREOU_NUMBER_LABEL)).toBeInTheDocument();
+            expect(screen.getByText(UKRAINE_PAYMENT_DETAILS.IBAN_UAH_NUMBER_LABEL)).toBeInTheDocument();
+            expect(screen.getByText(UKRAINE_PAYMENT_DETAILS.PAYMENT_DESTINATION_NAME_LABEL)).toBeInTheDocument();
+        });
     });
 });

--- a/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.test.tsx
+++ b/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.test.tsx
@@ -1,23 +1,26 @@
 import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { UkrainePaymentDetails } from './UkrainePaymentDetails';
 import { PublishedUahBankDetailsDto } from '../../../../../types/public/donate-page';
-import { UKRAINE_PAYMENT_DETAILS, PAYMENT_DETAILS_COMMON } from '../../../../../const/public/donate-page';
+
+jest.mock('../../copy-text-button/CopyTextButton', () => ({
+    CopyTextButton: ({ textToCopy }: { textToCopy: string }) => (
+        <button data-testid="copy-button" data-copy-text={textToCopy}>
+            Copy
+        </button>
+    ),
+}));
 
 jest.mock('../../../../../const/public/donate-page', () => ({
     UKRAINE_PAYMENT_DETAILS: {
         UKRAINE_PAYMENT_DETAILS_LABEL: 'Реквізити для донатів в Україні',
         UIDSREOU_LABEL: 'ЄДРПОУ',
-        UIDSREOU_NUMBER_LABEL: '45262516',
         BANK_LABEL: 'Банк',
-        BANK_NAME_LABEL: 'АТ КБ «ПРИВАТБАНК»',
         IBAN_UAH_LABEL: 'IBAN (UAH)',
-        IBAN_UAH_NUMBER_LABEL: 'UA463052990000026000040142147',
         PAYMENT_DESTINATION_LABEL: 'Призначення платежу',
-        PAYMENT_DESTINATION_NAME_LABEL: 'Благодійна допомога на статутну діяльність',
     },
     PAYMENT_DETAILS_COMMON: {
         RECIPIENT_LABEL: 'Одержувач',
-        RECIPIENT_NAME_LABEL: 'ГО «ЦЕНТР ПЕРЕМОГИ»',
     },
 }));
 
@@ -36,100 +39,60 @@ describe('UkrainePaymentDetails', () => {
         },
     ];
 
-    const expectElementsToBeInDocument = (texts: string[]) => {
-        texts.forEach((text) => {
-            expect(screen.getByText(text)).toBeInTheDocument();
-        });
-    };
-
-    const expectCopyButtonsCount = (expectedCount: number) => {
-        const copyButtons = screen.getAllByRole('button');
-        expect(copyButtons).toHaveLength(expectedCount);
-    };
-
-    describe('with API data', () => {
-        it('renders all payment labels with API data', () => {
+    describe('with bank details data', () => {
+        it('renders all payment details with API data', () => {
             const mockBankDetails = createMockBankDetails();
 
             render(<UkrainePaymentDetails bankDetails={mockBankDetails} />);
 
-            expect(screen.getByText(UKRAINE_PAYMENT_DETAILS.UKRAINE_PAYMENT_DETAILS_LABEL)).toBeInTheDocument();
+            expect(screen.getByText('Реквізити для донатів в Україні')).toBeInTheDocument();
 
-            expectElementsToBeInDocument([
-                PAYMENT_DETAILS_COMMON.RECIPIENT_LABEL,
-                UKRAINE_PAYMENT_DETAILS.UIDSREOU_LABEL,
-                UKRAINE_PAYMENT_DETAILS.BANK_LABEL,
-                UKRAINE_PAYMENT_DETAILS.IBAN_UAH_LABEL,
-                UKRAINE_PAYMENT_DETAILS.PAYMENT_DESTINATION_LABEL,
-            ]);
+            expect(screen.getByText('Одержувач')).toBeInTheDocument();
+            expect(screen.getByText('ЄДРПОУ')).toBeInTheDocument();
+            expect(screen.getByText('Банк')).toBeInTheDocument();
+            expect(screen.getByText('IBAN (UAH)')).toBeInTheDocument();
+            expect(screen.getByText('Призначення платежу')).toBeInTheDocument();
 
-            expectElementsToBeInDocument([
-                'Test Receiver',
-                '12345678',
-                'Test Bank',
-                'UA123456789012345678901234567',
-                'Test Payment Purpose',
-            ]);
+            expect(screen.getByText('Test Receiver')).toBeInTheDocument();
+            expect(screen.getByText('12345678')).toBeInTheDocument();
+            expect(screen.getByText('Test Bank')).toBeInTheDocument();
+            expect(screen.getByText('UA123456789012345678901234567')).toBeInTheDocument();
+            expect(screen.getByText('Test Payment Purpose')).toBeInTheDocument();
 
-            expectCopyButtonsCount(5);
+            const copyButtons = screen.getAllByTestId('copy-button');
+            expect(copyButtons).toHaveLength(5);
+            expect(copyButtons[0]).toHaveAttribute('data-copy-text', 'Test Receiver');
+            expect(copyButtons[1]).toHaveAttribute('data-copy-text', '12345678');
+            expect(copyButtons[2]).toHaveAttribute('data-copy-text', 'Test Bank');
+            expect(copyButtons[3]).toHaveAttribute('data-copy-text', 'UA123456789012345678901234567');
+            expect(copyButtons[4]).toHaveAttribute('data-copy-text', 'Test Payment Purpose');
         });
 
-        it('handles partial API data with fallbacks', () => {
+        it('renders with multiple banks but uses only first one primary', () => {
+            const mockBankDetails = [
+                createMockBankDetails()[0],
+                {
+                    id: 2,
+                    name: 'Secondary Bank',
+                    receiver: 'Secondary Receiver',
+                    edrpou: '87654321',
+                    iban: 'UA987654321098765432109876543',
+                    paymentPurpose: 'Secondary Purpose',
+                },
+            ];
+
+            render(<UkrainePaymentDetails bankDetails={mockBankDetails} />);
+
+            expect(screen.getByText('Test Receiver')).toBeInTheDocument();
+            expect(screen.getByText('Test Bank')).toBeInTheDocument();
+            expect(screen.queryByText('Secondary Receiver')).not.toBeInTheDocument();
+            expect(screen.queryByText('Secondary Bank')).not.toBeInTheDocument();
+        });
+
+        it('handles bank details with empty string values', () => {
             const mockBankDetails = createMockBankDetails({
                 name: '',
                 receiver: '',
-            });
-
-            render(<UkrainePaymentDetails bankDetails={mockBankDetails} />);
-
-            expect(screen.getByText(PAYMENT_DETAILS_COMMON.RECIPIENT_NAME_LABEL)).toBeInTheDocument();
-            expect(screen.getByText(UKRAINE_PAYMENT_DETAILS.BANK_NAME_LABEL)).toBeInTheDocument();
-
-            expectElementsToBeInDocument(['12345678', 'UA123456789012345678901234567', 'Test Payment Purpose']);
-        });
-    });
-
-    describe('with empty array fallback to constants', () => {
-        it('renders all payment labels with fallback constants', () => {
-            render(<UkrainePaymentDetails bankDetails={[]} />);
-
-            expect(screen.getByText(UKRAINE_PAYMENT_DETAILS.UKRAINE_PAYMENT_DETAILS_LABEL)).toBeInTheDocument();
-
-            expectElementsToBeInDocument([
-                PAYMENT_DETAILS_COMMON.RECIPIENT_LABEL,
-                UKRAINE_PAYMENT_DETAILS.UIDSREOU_LABEL,
-                UKRAINE_PAYMENT_DETAILS.BANK_LABEL,
-                UKRAINE_PAYMENT_DETAILS.IBAN_UAH_LABEL,
-                UKRAINE_PAYMENT_DETAILS.PAYMENT_DESTINATION_LABEL,
-            ]);
-
-            expectElementsToBeInDocument([
-                PAYMENT_DETAILS_COMMON.RECIPIENT_NAME_LABEL,
-                UKRAINE_PAYMENT_DETAILS.UIDSREOU_NUMBER_LABEL,
-                UKRAINE_PAYMENT_DETAILS.BANK_NAME_LABEL,
-                UKRAINE_PAYMENT_DETAILS.IBAN_UAH_NUMBER_LABEL,
-                UKRAINE_PAYMENT_DETAILS.PAYMENT_DESTINATION_NAME_LABEL,
-            ]);
-
-            expectCopyButtonsCount(5);
-        });
-    });
-
-    describe('edge cases', () => {
-        it('handles undefined values in API data', () => {
-            const mockBankDetails = createMockBankDetails({
-                name: undefined as any,
-                receiver: null as any,
-            });
-
-            render(<UkrainePaymentDetails bankDetails={mockBankDetails} />);
-
-            expect(screen.getByText(PAYMENT_DETAILS_COMMON.RECIPIENT_NAME_LABEL)).toBeInTheDocument();
-            expect(screen.getByText(UKRAINE_PAYMENT_DETAILS.BANK_NAME_LABEL)).toBeInTheDocument();
-        });
-
-        it('handles empty string values in API data', () => {
-            const mockBankDetails = createMockBankDetails({
                 edrpou: '',
                 iban: '',
                 paymentPurpose: '',
@@ -137,9 +100,42 @@ describe('UkrainePaymentDetails', () => {
 
             render(<UkrainePaymentDetails bankDetails={mockBankDetails} />);
 
-            expect(screen.getByText(UKRAINE_PAYMENT_DETAILS.UIDSREOU_NUMBER_LABEL)).toBeInTheDocument();
-            expect(screen.getByText(UKRAINE_PAYMENT_DETAILS.IBAN_UAH_NUMBER_LABEL)).toBeInTheDocument();
-            expect(screen.getByText(UKRAINE_PAYMENT_DETAILS.PAYMENT_DESTINATION_NAME_LABEL)).toBeInTheDocument();
+            expect(screen.getByText('Реквізити для донатів в Україні')).toBeInTheDocument();
+
+            const spans = screen.getAllByText('');
+            expect(spans.length).toBeGreaterThan(0);
+
+            const copyButtons = screen.getAllByTestId('copy-button');
+            expect(copyButtons[0]).toHaveAttribute('data-copy-text', '');
+            expect(copyButtons[1]).toHaveAttribute('data-copy-text', '');
+        });
+
+        it('handles bank details with null undefined values', () => {
+            const mockBankDetails = createMockBankDetails({
+                name: null as any,
+                receiver: undefined as any,
+            });
+
+            render(<UkrainePaymentDetails bankDetails={mockBankDetails} />);
+
+            expect(screen.getByText('Реквізити для донатів в Україні')).toBeInTheDocument();
+
+            const copyButtons = screen.getAllByTestId('copy-button');
+            expect(copyButtons).toHaveLength(5);
+        });
+    });
+
+    describe('no bank details scenarios', () => {
+        it('returns null when no bank details provided', () => {
+            const { container } = render(<UkrainePaymentDetails bankDetails={[]} />);
+
+            expect(container.firstChild).toBeNull();
+        });
+
+        it('returns null when bankDetails array is empty', () => {
+            const { container } = render(<UkrainePaymentDetails bankDetails={[]} />);
+
+            expect(container.firstChild).toBeNull();
         });
     });
 });

--- a/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.tsx
+++ b/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.tsx
@@ -1,8 +1,15 @@
 import './UkrainePaymentDetails.scss';
 import { CopyTextButton } from '../../copy-text-button/CopyTextButton';
 import { UKRAINE_PAYMENT_DETAILS, PAYMENT_DETAILS_COMMON } from '../../../../../const/public/donate-page';
+import { PublicUahBankDetailsDto } from '../../../../../types/public/donate-page';
 
-export const UkrainePaymentDetails = () => {
+interface UkrainePaymentDetailsProps {
+    bankDetails: PublicUahBankDetailsDto[];
+}
+
+export const UkrainePaymentDetails = ({ bankDetails }: UkrainePaymentDetailsProps) => {
+    const primaryBank = bankDetails[0];
+
     return (
         <div className="UkrainePaymentDetails">
             <h2>{UKRAINE_PAYMENT_DETAILS.UKRAINE_PAYMENT_DETAILS_LABEL}</h2>
@@ -10,36 +17,54 @@ export const UkrainePaymentDetails = () => {
                 <div className="paymentLabel">
                     <h3>{PAYMENT_DETAILS_COMMON.RECIPIENT_LABEL}</h3>
                     <div className="labelWithCopyButton">
-                        <span className="label">{PAYMENT_DETAILS_COMMON.RECIPIENT_NAME_LABEL}</span>
-                        <CopyTextButton textToCopy={PAYMENT_DETAILS_COMMON.RECIPIENT_NAME_LABEL} />
+                        <span className="label">
+                            {primaryBank?.receiver || PAYMENT_DETAILS_COMMON.RECIPIENT_NAME_LABEL}
+                        </span>
+                        <CopyTextButton
+                            textToCopy={primaryBank?.receiver || PAYMENT_DETAILS_COMMON.RECIPIENT_NAME_LABEL}
+                        />
                     </div>
                 </div>
                 <div className="paymentLabel">
                     <h3>{UKRAINE_PAYMENT_DETAILS.UIDSREOU_LABEL}</h3>
                     <div className="labelWithCopyButton">
-                        <span className="label">{UKRAINE_PAYMENT_DETAILS.UIDSREOU_NUMBER_LABEL}</span>
-                        <CopyTextButton textToCopy={UKRAINE_PAYMENT_DETAILS.UIDSREOU_NUMBER_LABEL} />
+                        <span className="label">
+                            {primaryBank?.edrpou || UKRAINE_PAYMENT_DETAILS.UIDSREOU_NUMBER_LABEL}
+                        </span>
+                        <CopyTextButton
+                            textToCopy={primaryBank?.edrpou || UKRAINE_PAYMENT_DETAILS.UIDSREOU_NUMBER_LABEL}
+                        />
                     </div>
                 </div>
                 <div className="paymentLabel">
                     <h3>{UKRAINE_PAYMENT_DETAILS.BANK_LABEL}</h3>
                     <div className="labelWithCopyButton">
-                        <span className="label">{UKRAINE_PAYMENT_DETAILS.BANK_NAME_LABEL}</span>
-                        <CopyTextButton textToCopy={UKRAINE_PAYMENT_DETAILS.BANK_NAME_LABEL} />
+                        <span className="label">{primaryBank?.name || UKRAINE_PAYMENT_DETAILS.BANK_NAME_LABEL}</span>
+                        <CopyTextButton textToCopy={primaryBank?.name || UKRAINE_PAYMENT_DETAILS.BANK_NAME_LABEL} />
                     </div>
                 </div>
                 <div className="paymentLabel">
                     <h3>{UKRAINE_PAYMENT_DETAILS.IBAN_UAH_LABEL}</h3>
                     <div className="labelWithCopyButton">
-                        <span className="label">{UKRAINE_PAYMENT_DETAILS.IBAN_UAH_NUMBER_LABEL}</span>
-                        <CopyTextButton textToCopy={UKRAINE_PAYMENT_DETAILS.IBAN_UAH_NUMBER_LABEL} />
+                        <span className="label">
+                            {primaryBank?.iban || UKRAINE_PAYMENT_DETAILS.IBAN_UAH_NUMBER_LABEL}
+                        </span>
+                        <CopyTextButton
+                            textToCopy={primaryBank?.iban || UKRAINE_PAYMENT_DETAILS.IBAN_UAH_NUMBER_LABEL}
+                        />
                     </div>
                 </div>
                 <div className="paymentLabel">
                     <h3>{UKRAINE_PAYMENT_DETAILS.PAYMENT_DESTINATION_LABEL}</h3>
                     <div className="labelWithCopyButton">
-                        <span className="label">{UKRAINE_PAYMENT_DETAILS.PAYMENT_DESTINATION_NAME_LABEL}</span>
-                        <CopyTextButton textToCopy={UKRAINE_PAYMENT_DETAILS.PAYMENT_DESTINATION_NAME_LABEL} />
+                        <span className="label">
+                            {primaryBank?.paymentPurpose || UKRAINE_PAYMENT_DETAILS.PAYMENT_DESTINATION_NAME_LABEL}
+                        </span>
+                        <CopyTextButton
+                            textToCopy={
+                                primaryBank?.paymentPurpose || UKRAINE_PAYMENT_DETAILS.PAYMENT_DESTINATION_NAME_LABEL
+                            }
+                        />
                     </div>
                 </div>
             </div>

--- a/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.tsx
+++ b/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.tsx
@@ -8,52 +8,52 @@ interface UkrainePaymentDetailsProps {
 }
 
 export const UkrainePaymentDetails = ({ bankDetails }: UkrainePaymentDetailsProps) => {
-    const primaryBank = bankDetails[0];
-
-    if (!primaryBank) {
+    if (!bankDetails.length) {
         return null;
     }
 
     return (
         <div className="UkrainePaymentDetails">
             <h2>{UKRAINE_PAYMENT_DETAILS.UKRAINE_PAYMENT_DETAILS_LABEL}</h2>
-            <div className="paymentDetails">
-                <div className="paymentLabel">
-                    <h3>{PAYMENT_DETAILS_COMMON.RECIPIENT_LABEL}</h3>
-                    <div className="labelWithCopyButton">
-                        <span className="label">{primaryBank.receiver}</span>
-                        <CopyTextButton textToCopy={primaryBank.receiver} />
+            {bankDetails.map((bank, index) => (
+                <div key={bank.id} className={`paymentDetails ${index > 0 ? 'separated' : ''}`}>
+                    <div className="paymentLabel">
+                        <h3>{PAYMENT_DETAILS_COMMON.RECIPIENT_LABEL}</h3>
+                        <div className="labelWithCopyButton">
+                            <span className="label">{bank.receiver}</span>
+                            <CopyTextButton textToCopy={bank.receiver} />
+                        </div>
+                    </div>
+                    <div className="paymentLabel">
+                        <h3>{UKRAINE_PAYMENT_DETAILS.UIDSREOU_LABEL}</h3>
+                        <div className="labelWithCopyButton">
+                            <span className="label">{bank.edrpou}</span>
+                            <CopyTextButton textToCopy={bank.edrpou} />
+                        </div>
+                    </div>
+                    <div className="paymentLabel">
+                        <h3>{UKRAINE_PAYMENT_DETAILS.BANK_LABEL}</h3>
+                        <div className="labelWithCopyButton">
+                            <span className="label">{bank.name}</span>
+                            <CopyTextButton textToCopy={bank.name} />
+                        </div>
+                    </div>
+                    <div className="paymentLabel">
+                        <h3>{UKRAINE_PAYMENT_DETAILS.IBAN_UAH_LABEL}</h3>
+                        <div className="labelWithCopyButton">
+                            <span className="label">{bank.iban}</span>
+                            <CopyTextButton textToCopy={bank.iban} />
+                        </div>
+                    </div>
+                    <div className="paymentLabel">
+                        <h3>{UKRAINE_PAYMENT_DETAILS.PAYMENT_DESTINATION_LABEL}</h3>
+                        <div className="labelWithCopyButton">
+                            <span className="label">{bank.paymentPurpose}</span>
+                            <CopyTextButton textToCopy={bank.paymentPurpose} />
+                        </div>
                     </div>
                 </div>
-                <div className="paymentLabel">
-                    <h3>{UKRAINE_PAYMENT_DETAILS.UIDSREOU_LABEL}</h3>
-                    <div className="labelWithCopyButton">
-                        <span className="label">{primaryBank.edrpou}</span>
-                        <CopyTextButton textToCopy={primaryBank.edrpou} />
-                    </div>
-                </div>
-                <div className="paymentLabel">
-                    <h3>{UKRAINE_PAYMENT_DETAILS.BANK_LABEL}</h3>
-                    <div className="labelWithCopyButton">
-                        <span className="label">{primaryBank.name}</span>
-                        <CopyTextButton textToCopy={primaryBank.name} />
-                    </div>
-                </div>
-                <div className="paymentLabel">
-                    <h3>{UKRAINE_PAYMENT_DETAILS.IBAN_UAH_LABEL}</h3>
-                    <div className="labelWithCopyButton">
-                        <span className="label">{primaryBank.iban}</span>
-                        <CopyTextButton textToCopy={primaryBank.iban} />
-                    </div>
-                </div>
-                <div className="paymentLabel">
-                    <h3>{UKRAINE_PAYMENT_DETAILS.PAYMENT_DESTINATION_LABEL}</h3>
-                    <div className="labelWithCopyButton">
-                        <span className="label">{primaryBank.paymentPurpose}</span>
-                        <CopyTextButton textToCopy={primaryBank.paymentPurpose} />
-                    </div>
-                </div>
-            </div>
+            ))}
         </div>
     );
 };

--- a/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.tsx
+++ b/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.tsx
@@ -10,6 +10,10 @@ interface UkrainePaymentDetailsProps {
 export const UkrainePaymentDetails = ({ bankDetails }: UkrainePaymentDetailsProps) => {
     const primaryBank = bankDetails[0];
 
+    if (!primaryBank) {
+        return null;
+    }
+
     return (
         <div className="UkrainePaymentDetails">
             <h2>{UKRAINE_PAYMENT_DETAILS.UKRAINE_PAYMENT_DETAILS_LABEL}</h2>
@@ -17,54 +21,36 @@ export const UkrainePaymentDetails = ({ bankDetails }: UkrainePaymentDetailsProp
                 <div className="paymentLabel">
                     <h3>{PAYMENT_DETAILS_COMMON.RECIPIENT_LABEL}</h3>
                     <div className="labelWithCopyButton">
-                        <span className="label">
-                            {primaryBank?.receiver || PAYMENT_DETAILS_COMMON.RECIPIENT_NAME_LABEL}
-                        </span>
-                        <CopyTextButton
-                            textToCopy={primaryBank?.receiver || PAYMENT_DETAILS_COMMON.RECIPIENT_NAME_LABEL}
-                        />
+                        <span className="label">{primaryBank.receiver}</span>
+                        <CopyTextButton textToCopy={primaryBank.receiver} />
                     </div>
                 </div>
                 <div className="paymentLabel">
                     <h3>{UKRAINE_PAYMENT_DETAILS.UIDSREOU_LABEL}</h3>
                     <div className="labelWithCopyButton">
-                        <span className="label">
-                            {primaryBank?.edrpou || UKRAINE_PAYMENT_DETAILS.UIDSREOU_NUMBER_LABEL}
-                        </span>
-                        <CopyTextButton
-                            textToCopy={primaryBank?.edrpou || UKRAINE_PAYMENT_DETAILS.UIDSREOU_NUMBER_LABEL}
-                        />
+                        <span className="label">{primaryBank.edrpou}</span>
+                        <CopyTextButton textToCopy={primaryBank.edrpou} />
                     </div>
                 </div>
                 <div className="paymentLabel">
                     <h3>{UKRAINE_PAYMENT_DETAILS.BANK_LABEL}</h3>
                     <div className="labelWithCopyButton">
-                        <span className="label">{primaryBank?.name || UKRAINE_PAYMENT_DETAILS.BANK_NAME_LABEL}</span>
-                        <CopyTextButton textToCopy={primaryBank?.name || UKRAINE_PAYMENT_DETAILS.BANK_NAME_LABEL} />
+                        <span className="label">{primaryBank.name}</span>
+                        <CopyTextButton textToCopy={primaryBank.name} />
                     </div>
                 </div>
                 <div className="paymentLabel">
                     <h3>{UKRAINE_PAYMENT_DETAILS.IBAN_UAH_LABEL}</h3>
                     <div className="labelWithCopyButton">
-                        <span className="label">
-                            {primaryBank?.iban || UKRAINE_PAYMENT_DETAILS.IBAN_UAH_NUMBER_LABEL}
-                        </span>
-                        <CopyTextButton
-                            textToCopy={primaryBank?.iban || UKRAINE_PAYMENT_DETAILS.IBAN_UAH_NUMBER_LABEL}
-                        />
+                        <span className="label">{primaryBank.iban}</span>
+                        <CopyTextButton textToCopy={primaryBank.iban} />
                     </div>
                 </div>
                 <div className="paymentLabel">
                     <h3>{UKRAINE_PAYMENT_DETAILS.PAYMENT_DESTINATION_LABEL}</h3>
                     <div className="labelWithCopyButton">
-                        <span className="label">
-                            {primaryBank?.paymentPurpose || UKRAINE_PAYMENT_DETAILS.PAYMENT_DESTINATION_NAME_LABEL}
-                        </span>
-                        <CopyTextButton
-                            textToCopy={
-                                primaryBank?.paymentPurpose || UKRAINE_PAYMENT_DETAILS.PAYMENT_DESTINATION_NAME_LABEL
-                            }
-                        />
+                        <span className="label">{primaryBank.paymentPurpose}</span>
+                        <CopyTextButton textToCopy={primaryBank.paymentPurpose} />
                     </div>
                 </div>
             </div>

--- a/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.tsx
+++ b/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.tsx
@@ -1,10 +1,10 @@
 import './UkrainePaymentDetails.scss';
 import { CopyTextButton } from '../../copy-text-button/CopyTextButton';
 import { UKRAINE_PAYMENT_DETAILS, PAYMENT_DETAILS_COMMON } from '../../../../../const/public/donate-page';
-import { PublicUahBankDetailsDto } from '../../../../../types/public/donate-page';
+import { PublishedUahBankDetailsDto } from '../../../../../types/public/donate-page';
 
 interface UkrainePaymentDetailsProps {
-    bankDetails: PublicUahBankDetailsDto[];
+    bankDetails: PublishedUahBankDetailsDto[];
 }
 
 export const UkrainePaymentDetails = ({ bankDetails }: UkrainePaymentDetailsProps) => {

--- a/src/services/api/public/donate/donate-api.test.ts
+++ b/src/services/api/public/donate/donate-api.test.ts
@@ -94,11 +94,11 @@ describe('donatePageDataFetch', () => {
             await donatePageDataFetch();
 
             expect(mockAxiosInstance.get).toHaveBeenCalledTimes(6);
-            expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(1, API_ROUTES.DONATE.PUBLIC.UAH_BANK_DETAILS);
-            expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(2, API_ROUTES.DONATE.PUBLIC.FOREIGN_BANK_DETAILS, {
+            expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(1, API_ROUTES.DONATE.PUBLIC.BANK_DETAILS_UAH);
+            expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(2, API_ROUTES.DONATE.PUBLIC.BANK_DETAILS_FOREIGN, {
                 params: { currency: Currency.USD },
             });
-            expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(3, API_ROUTES.DONATE.PUBLIC.FOREIGN_BANK_DETAILS, {
+            expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(3, API_ROUTES.DONATE.PUBLIC.BANK_DETAILS_FOREIGN, {
                 params: { currency: Currency.EUR },
             });
             expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(4, API_ROUTES.DONATE.PUBLIC.SUPPORT_OPTIONS, {

--- a/src/services/api/public/donate/donate-api.test.ts
+++ b/src/services/api/public/donate/donate-api.test.ts
@@ -44,6 +44,20 @@ describe('donatePageDataFetch', () => {
         },
     ];
 
+    const testApiError = async (failAtIndex: number, errorMessage: string) => {
+        const error = new Error(errorMessage);
+
+        for (let i = 0; i < 6; i++) {
+            if (i === failAtIndex) {
+                mockAxiosInstance.get.mockRejectedValueOnce(error);
+            } else {
+                mockAxiosInstance.get.mockResolvedValueOnce({ data: [] });
+            }
+        }
+
+        await expect(donatePageDataFetch()).rejects.toThrow(errorMessage);
+    };
+
     beforeEach(() => {
         jest.clearAllMocks();
     });
@@ -80,25 +94,19 @@ describe('donatePageDataFetch', () => {
             await donatePageDataFetch();
 
             expect(mockAxiosInstance.get).toHaveBeenCalledTimes(6);
-
             expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(1, API_ROUTES.DONATE.PUBLIC.UAH_BANK_DETAILS);
-
             expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(2, API_ROUTES.DONATE.PUBLIC.FOREIGN_BANK_DETAILS, {
                 params: { currency: Currency.USD },
             });
-
             expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(3, API_ROUTES.DONATE.PUBLIC.FOREIGN_BANK_DETAILS, {
                 params: { currency: Currency.EUR },
             });
-
             expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(4, API_ROUTES.DONATE.PUBLIC.SUPPORT_OPTIONS, {
                 params: { currency: Currency.UAH },
             });
-
             expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(5, API_ROUTES.DONATE.PUBLIC.SUPPORT_OPTIONS, {
                 params: { currency: Currency.USD },
             });
-
             expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(6, API_ROUTES.DONATE.PUBLIC.SUPPORT_OPTIONS, {
                 params: { currency: Currency.EUR },
             });
@@ -142,38 +150,27 @@ describe('donatePageDataFetch', () => {
 
     describe('API error handling', () => {
         it('throws error when UAH bank details request fails', async () => {
-            const error = new Error('UAH API Error');
-            mockAxiosInstance.get.mockRejectedValueOnce(error);
-
-            await expect(donatePageDataFetch()).rejects.toThrow('UAH API Error');
+            await testApiError(0, 'UAH API Error');
         });
 
         it('throws error when USD foreign bank details request fails', async () => {
-            const error = new Error('USD API Error');
-            mockAxiosInstance.get.mockResolvedValueOnce({ data: [] }).mockRejectedValueOnce(error);
-
-            await expect(donatePageDataFetch()).rejects.toThrow('USD API Error');
+            await testApiError(1, 'USD API Error');
         });
 
         it('throws error when EUR foreign bank details request fails', async () => {
-            const error = new Error('EUR API Error');
-            mockAxiosInstance.get
-                .mockResolvedValueOnce({ data: [] })
-                .mockResolvedValueOnce({ data: [] })
-                .mockRejectedValueOnce(error);
-
-            await expect(donatePageDataFetch()).rejects.toThrow('EUR API Error');
+            await testApiError(2, 'EUR API Error');
         });
 
-        it('throws error when support options request fails', async () => {
-            const error = new Error('Support Options API Error');
-            mockAxiosInstance.get
-                .mockResolvedValueOnce({ data: [] })
-                .mockResolvedValueOnce({ data: [] })
-                .mockResolvedValueOnce({ data: [] })
-                .mockRejectedValueOnce(error);
+        it('throws error when UAH support options request fails', async () => {
+            await testApiError(3, 'UAH Support API Error');
+        });
 
-            await expect(donatePageDataFetch()).rejects.toThrow('Support Options API Error');
+        it('throws error when USD support options request fails', async () => {
+            await testApiError(4, 'USD Support API Error');
+        });
+
+        it('throws error when EUR support options request fails', async () => {
+            await testApiError(5, 'EUR Support API Error');
         });
 
         it('throws error when multiple requests fail', async () => {

--- a/src/services/api/public/donate/donate-api.test.ts
+++ b/src/services/api/public/donate/donate-api.test.ts
@@ -1,0 +1,272 @@
+import { donatePageDataFetch } from './donate-api';
+import { API_ROUTES } from '../../../../const/common/api-routes/main-api';
+import { Currency } from '../../../../types/public/donate-page';
+
+jest.mock('../../axios', () => ({
+    axiosInstance: {
+        get: jest.fn(),
+    },
+}));
+
+const mockAxiosInstance = require('../../axios').axiosInstance;
+
+describe('donatePageDataFetch', () => {
+    const createMockUahBankDetails = () => [
+        {
+            id: 1,
+            name: 'UAH Bank',
+            receiver: 'Test Receiver',
+            edrpou: '12345678',
+            iban: 'UA123456789012345678901234567',
+            paymentPurpose: 'Test Purpose',
+        },
+    ];
+
+    const createMockForeignBankDetails = (currency: Currency) => [
+        {
+            id: 1,
+            name: `${currency === Currency.USD ? 'USD' : 'EUR'} Bank`,
+            receiver: `${currency === Currency.USD ? 'USD' : 'EUR'} Receiver`,
+            iban: `${currency === Currency.USD ? 'US' : 'GB'}123456789012345678901234567`,
+            swift: 'TESTBANK',
+            address: 'Test Address',
+            currency,
+            correspondentBanks: [],
+        },
+    ];
+
+    const createMockSupportOptions = (currency: Currency) => [
+        {
+            id: 1,
+            name: `PayPal ${currency === Currency.UAH ? 'UAH' : currency === Currency.USD ? 'USD' : 'EUR'}`,
+            value: `test@paypal-${currency === Currency.UAH ? 'uah' : currency === Currency.USD ? 'usd' : 'eur'}.com`,
+            currency,
+        },
+    ];
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('successful API calls', () => {
+        it('fetches all data successfully and returns combined result', async () => {
+            const mockUahBankDetails = createMockUahBankDetails();
+            const mockUsdForeignBankDetails = createMockForeignBankDetails(Currency.USD);
+            const mockEurForeignBankDetails = createMockForeignBankDetails(Currency.EUR);
+            const mockUahSupportOptions = createMockSupportOptions(Currency.UAH);
+            const mockUsdSupportOptions = createMockSupportOptions(Currency.USD);
+            const mockEurSupportOptions = createMockSupportOptions(Currency.EUR);
+
+            mockAxiosInstance.get
+                .mockResolvedValueOnce({ data: mockUahBankDetails })
+                .mockResolvedValueOnce({ data: mockUsdForeignBankDetails })
+                .mockResolvedValueOnce({ data: mockEurForeignBankDetails })
+                .mockResolvedValueOnce({ data: mockUahSupportOptions })
+                .mockResolvedValueOnce({ data: mockUsdSupportOptions })
+                .mockResolvedValueOnce({ data: mockEurSupportOptions });
+
+            const result = await donatePageDataFetch();
+
+            expect(result).toEqual({
+                uahBankDetails: mockUahBankDetails,
+                foreignBankDetails: [...mockUsdForeignBankDetails, ...mockEurForeignBankDetails],
+                supportOptions: [...mockUahSupportOptions, ...mockUsdSupportOptions, ...mockEurSupportOptions],
+            });
+        });
+
+        it('makes correct API calls with proper endpoints and parameters', async () => {
+            mockAxiosInstance.get.mockResolvedValue({ data: [] });
+
+            await donatePageDataFetch();
+
+            expect(mockAxiosInstance.get).toHaveBeenCalledTimes(6);
+
+            expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(1, API_ROUTES.DONATE.PUBLIC.UAH_BANK_DETAILS);
+
+            expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(2, API_ROUTES.DONATE.PUBLIC.FOREIGN_BANK_DETAILS, {
+                params: { currency: Currency.USD },
+            });
+
+            expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(3, API_ROUTES.DONATE.PUBLIC.FOREIGN_BANK_DETAILS, {
+                params: { currency: Currency.EUR },
+            });
+
+            expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(4, API_ROUTES.DONATE.PUBLIC.SUPPORT_OPTIONS, {
+                params: { currency: Currency.UAH },
+            });
+
+            expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(5, API_ROUTES.DONATE.PUBLIC.SUPPORT_OPTIONS, {
+                params: { currency: Currency.USD },
+            });
+
+            expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(6, API_ROUTES.DONATE.PUBLIC.SUPPORT_OPTIONS, {
+                params: { currency: Currency.EUR },
+            });
+        });
+    });
+
+    describe('empty API responses', () => {
+        it('handles empty arrays from all endpoints', async () => {
+            mockAxiosInstance.get.mockResolvedValue({ data: [] });
+
+            const result = await donatePageDataFetch();
+
+            expect(result).toEqual({
+                uahBankDetails: [],
+                foreignBankDetails: [],
+                supportOptions: [],
+            });
+        });
+
+        it('handles mixed empty and non-empty responses', async () => {
+            const mockUsdForeignBankDetails = createMockForeignBankDetails(Currency.USD);
+            const mockUahSupportOptions = createMockSupportOptions(Currency.UAH);
+
+            mockAxiosInstance.get
+                .mockResolvedValueOnce({ data: [] })
+                .mockResolvedValueOnce({ data: mockUsdForeignBankDetails })
+                .mockResolvedValueOnce({ data: [] })
+                .mockResolvedValueOnce({ data: mockUahSupportOptions })
+                .mockResolvedValueOnce({ data: [] })
+                .mockResolvedValueOnce({ data: [] });
+
+            const result = await donatePageDataFetch();
+
+            expect(result).toEqual({
+                uahBankDetails: [],
+                foreignBankDetails: mockUsdForeignBankDetails,
+                supportOptions: mockUahSupportOptions,
+            });
+        });
+    });
+
+    describe('API error handling', () => {
+        it('throws error when UAH bank details request fails', async () => {
+            const error = new Error('UAH API Error');
+            mockAxiosInstance.get.mockRejectedValueOnce(error);
+
+            await expect(donatePageDataFetch()).rejects.toThrow('UAH API Error');
+        });
+
+        it('throws error when USD foreign bank details request fails', async () => {
+            const error = new Error('USD API Error');
+            mockAxiosInstance.get.mockResolvedValueOnce({ data: [] }).mockRejectedValueOnce(error);
+
+            await expect(donatePageDataFetch()).rejects.toThrow('USD API Error');
+        });
+
+        it('throws error when EUR foreign bank details request fails', async () => {
+            const error = new Error('EUR API Error');
+            mockAxiosInstance.get
+                .mockResolvedValueOnce({ data: [] })
+                .mockResolvedValueOnce({ data: [] })
+                .mockRejectedValueOnce(error);
+
+            await expect(donatePageDataFetch()).rejects.toThrow('EUR API Error');
+        });
+
+        it('throws error when support options request fails', async () => {
+            const error = new Error('Support Options API Error');
+            mockAxiosInstance.get
+                .mockResolvedValueOnce({ data: [] })
+                .mockResolvedValueOnce({ data: [] })
+                .mockResolvedValueOnce({ data: [] })
+                .mockRejectedValueOnce(error);
+
+            await expect(donatePageDataFetch()).rejects.toThrow('Support Options API Error');
+        });
+
+        it('throws error when multiple requests fail', async () => {
+            const error = new Error('Multiple API Errors');
+            mockAxiosInstance.get.mockRejectedValue(error);
+
+            await expect(donatePageDataFetch()).rejects.toThrow('Multiple API Errors');
+        });
+    });
+
+    describe('data combination logic', () => {
+        it('combines foreign bank details in correct order USD then EUR', async () => {
+            const mockUsdBanks = [
+                { id: 1, currency: Currency.USD, name: 'USD Bank 1' },
+                { id: 2, currency: Currency.USD, name: 'USD Bank 2' },
+            ];
+            const mockEurBanks = [{ id: 3, currency: Currency.EUR, name: 'EUR Bank 1' }];
+
+            mockAxiosInstance.get
+                .mockResolvedValueOnce({ data: [] })
+                .mockResolvedValueOnce({ data: mockUsdBanks })
+                .mockResolvedValueOnce({ data: mockEurBanks })
+                .mockResolvedValueOnce({ data: [] })
+                .mockResolvedValueOnce({ data: [] })
+                .mockResolvedValueOnce({ data: [] });
+
+            const result = await donatePageDataFetch();
+
+            expect(result.foreignBankDetails).toEqual([...mockUsdBanks, ...mockEurBanks]);
+            expect(result.foreignBankDetails).toHaveLength(3);
+            expect(result.foreignBankDetails[0].name).toBe('USD Bank 1');
+            expect(result.foreignBankDetails[1].name).toBe('USD Bank 2');
+            expect(result.foreignBankDetails[2].name).toBe('EUR Bank 1');
+        });
+
+        it('combines support options in correct order UAH then USD then EUR', async () => {
+            const mockUahOptions = [{ id: 1, currency: Currency.UAH, name: 'UAH Option' }];
+            const mockUsdOptions = [{ id: 2, currency: Currency.USD, name: 'USD Option' }];
+            const mockEurOptions = [{ id: 3, currency: Currency.EUR, name: 'EUR Option' }];
+
+            mockAxiosInstance.get
+                .mockResolvedValueOnce({ data: [] })
+                .mockResolvedValueOnce({ data: [] })
+                .mockResolvedValueOnce({ data: [] })
+                .mockResolvedValueOnce({ data: mockUahOptions })
+                .mockResolvedValueOnce({ data: mockUsdOptions })
+                .mockResolvedValueOnce({ data: mockEurOptions });
+
+            const result = await donatePageDataFetch();
+
+            expect(result.supportOptions).toEqual([...mockUahOptions, ...mockUsdOptions, ...mockEurOptions]);
+            expect(result.supportOptions).toHaveLength(3);
+            expect(result.supportOptions[0].name).toBe('UAH Option');
+            expect(result.supportOptions[1].name).toBe('USD Option');
+            expect(result.supportOptions[2].name).toBe('EUR Option');
+        });
+    });
+
+    describe('return type validation', () => {
+        it('returns correct DonatePageData structure', async () => {
+            mockAxiosInstance.get.mockResolvedValue({ data: [] });
+
+            const result = await donatePageDataFetch();
+
+            expect(result).toHaveProperty('uahBankDetails');
+            expect(result).toHaveProperty('foreignBankDetails');
+            expect(result).toHaveProperty('supportOptions');
+            expect(Array.isArray(result.uahBankDetails)).toBe(true);
+            expect(Array.isArray(result.foreignBankDetails)).toBe(true);
+            expect(Array.isArray(result.supportOptions)).toBe(true);
+        });
+
+        it('maintains data types in returned arrays', async () => {
+            const mockUahBankDetails = createMockUahBankDetails();
+            const mockUsdForeignBankDetails = createMockForeignBankDetails(Currency.USD);
+            const mockUahSupportOptions = createMockSupportOptions(Currency.UAH);
+
+            mockAxiosInstance.get
+                .mockResolvedValueOnce({ data: mockUahBankDetails })
+                .mockResolvedValueOnce({ data: mockUsdForeignBankDetails })
+                .mockResolvedValueOnce({ data: [] })
+                .mockResolvedValueOnce({ data: mockUahSupportOptions })
+                .mockResolvedValueOnce({ data: [] })
+                .mockResolvedValueOnce({ data: [] });
+
+            const result = await donatePageDataFetch();
+
+            expect(result.uahBankDetails[0]).toHaveProperty('edrpou');
+            expect(result.uahBankDetails[0]).toHaveProperty('paymentPurpose');
+            expect(result.foreignBankDetails[0]).toHaveProperty('swift');
+            expect(result.foreignBankDetails[0]).toHaveProperty('correspondentBanks');
+            expect(result.supportOptions[0]).toHaveProperty('name');
+            expect(result.supportOptions[0]).toHaveProperty('value');
+        });
+    });
+});

--- a/src/services/api/public/donate/donate-api.ts
+++ b/src/services/api/public/donate/donate-api.ts
@@ -1,0 +1,51 @@
+import { API_ROUTES } from '../../../../const/common/api-routes/main-api';
+import {
+    PublicUahBankDetailsDto,
+    PublicForeignBankDetailsDto,
+    PublicSupportOptionsDto,
+    BankCurrency,
+    DonatePageData,
+} from '../../../../types/public/donate-page';
+import { axiosInstance } from '../../axios';
+
+// TODO:
+const TEMP_PUBLIC_ROUTES = {
+    BANK_DETAILS_UAH: 'api/public/donate/bank-details-uah', // TODO:
+    BANK_DETAILS_FOREIGN: 'api/public/donate/bank-details-foreign', // TODO:
+    SUPPORT_OPTIONS: 'api/public/donate/support-options', // TODO:
+};
+
+export const donatePageDataFetch = async (): Promise<DonatePageData> => {
+    // TODO:
+    const [
+        uahBankDetailsResponse,
+        usdForeignResponse,
+        eurForeignResponse,
+        uahSupportResponse,
+        usdSupportResponse,
+        eurSupportResponse,
+    ] = await Promise.all([
+        axiosInstance.get<PublicUahBankDetailsDto[]>(TEMP_PUBLIC_ROUTES.BANK_DETAILS_UAH),
+        axiosInstance.get<PublicForeignBankDetailsDto[]>(TEMP_PUBLIC_ROUTES.BANK_DETAILS_FOREIGN, {
+            params: { currency: BankCurrency.Usd },
+        }),
+        axiosInstance.get<PublicForeignBankDetailsDto[]>(TEMP_PUBLIC_ROUTES.BANK_DETAILS_FOREIGN, {
+            params: { currency: BankCurrency.Eur },
+        }),
+        axiosInstance.get<PublicSupportOptionsDto[]>(TEMP_PUBLIC_ROUTES.SUPPORT_OPTIONS, {
+            params: { currency: BankCurrency.Uah },
+        }),
+        axiosInstance.get<PublicSupportOptionsDto[]>(TEMP_PUBLIC_ROUTES.SUPPORT_OPTIONS, {
+            params: { currency: BankCurrency.Usd },
+        }),
+        axiosInstance.get<PublicSupportOptionsDto[]>(TEMP_PUBLIC_ROUTES.SUPPORT_OPTIONS, {
+            params: { currency: BankCurrency.Eur },
+        }),
+    ]);
+
+    return {
+        uahBankDetails: uahBankDetailsResponse.data,
+        foreignBankDetails: [...usdForeignResponse.data, ...eurForeignResponse.data],
+        supportOptions: [...uahSupportResponse.data, ...usdSupportResponse.data, ...eurSupportResponse.data],
+    };
+};

--- a/src/services/api/public/donate/donate-api.ts
+++ b/src/services/api/public/donate/donate-api.ts
@@ -1,22 +1,14 @@
 import { API_ROUTES } from '../../../../const/common/api-routes/main-api';
 import {
-    PublicUahBankDetailsDto,
-    PublicForeignBankDetailsDto,
-    PublicSupportOptionsDto,
-    BankCurrency,
+    PublishedUahBankDetailsDto,
+    PublishedForeignBankDetailsDto,
+    PublishedSupportOptionsDto,
+    Currency,
     DonatePageData,
 } from '../../../../types/public/donate-page';
 import { axiosInstance } from '../../axios';
 
-// TODO:
-const TEMP_PUBLIC_ROUTES = {
-    BANK_DETAILS_UAH: 'api/public/donate/bank-details-uah', // TODO:
-    BANK_DETAILS_FOREIGN: 'api/public/donate/bank-details-foreign', // TODO:
-    SUPPORT_OPTIONS: 'api/public/donate/support-options', // TODO:
-};
-
 export const donatePageDataFetch = async (): Promise<DonatePageData> => {
-    // TODO:
     const [
         uahBankDetailsResponse,
         usdForeignResponse,
@@ -25,21 +17,26 @@ export const donatePageDataFetch = async (): Promise<DonatePageData> => {
         usdSupportResponse,
         eurSupportResponse,
     ] = await Promise.all([
-        axiosInstance.get<PublicUahBankDetailsDto[]>(TEMP_PUBLIC_ROUTES.BANK_DETAILS_UAH),
-        axiosInstance.get<PublicForeignBankDetailsDto[]>(TEMP_PUBLIC_ROUTES.BANK_DETAILS_FOREIGN, {
-            params: { currency: BankCurrency.Usd },
+        axiosInstance.get<PublishedUahBankDetailsDto[]>(API_ROUTES.DONATE.PUBLIC.UAH_BANK_DETAILS),
+
+        axiosInstance.get<PublishedForeignBankDetailsDto[]>(API_ROUTES.DONATE.PUBLIC.FOREIGN_BANK_DETAILS, {
+            params: { currency: Currency.USD },
         }),
-        axiosInstance.get<PublicForeignBankDetailsDto[]>(TEMP_PUBLIC_ROUTES.BANK_DETAILS_FOREIGN, {
-            params: { currency: BankCurrency.Eur },
+
+        axiosInstance.get<PublishedForeignBankDetailsDto[]>(API_ROUTES.DONATE.PUBLIC.FOREIGN_BANK_DETAILS, {
+            params: { currency: Currency.EUR },
         }),
-        axiosInstance.get<PublicSupportOptionsDto[]>(TEMP_PUBLIC_ROUTES.SUPPORT_OPTIONS, {
-            params: { currency: BankCurrency.Uah },
+
+        axiosInstance.get<PublishedSupportOptionsDto[]>(API_ROUTES.DONATE.PUBLIC.SUPPORT_OPTIONS, {
+            params: { currency: Currency.UAH },
         }),
-        axiosInstance.get<PublicSupportOptionsDto[]>(TEMP_PUBLIC_ROUTES.SUPPORT_OPTIONS, {
-            params: { currency: BankCurrency.Usd },
+
+        axiosInstance.get<PublishedSupportOptionsDto[]>(API_ROUTES.DONATE.PUBLIC.SUPPORT_OPTIONS, {
+            params: { currency: Currency.USD },
         }),
-        axiosInstance.get<PublicSupportOptionsDto[]>(TEMP_PUBLIC_ROUTES.SUPPORT_OPTIONS, {
-            params: { currency: BankCurrency.Eur },
+
+        axiosInstance.get<PublishedSupportOptionsDto[]>(API_ROUTES.DONATE.PUBLIC.SUPPORT_OPTIONS, {
+            params: { currency: Currency.EUR },
         }),
     ]);
 

--- a/src/services/api/public/donate/donate-api.ts
+++ b/src/services/api/public/donate/donate-api.ts
@@ -17,13 +17,13 @@ export const donatePageDataFetch = async (): Promise<DonatePageData> => {
         usdSupportResponse,
         eurSupportResponse,
     ] = await Promise.all([
-        axiosInstance.get<PublishedUahBankDetailsDto[]>(API_ROUTES.DONATE.PUBLIC.UAH_BANK_DETAILS),
+        axiosInstance.get<PublishedUahBankDetailsDto[]>(API_ROUTES.DONATE.PUBLIC.BANK_DETAILS_UAH),
 
-        axiosInstance.get<PublishedForeignBankDetailsDto[]>(API_ROUTES.DONATE.PUBLIC.FOREIGN_BANK_DETAILS, {
+        axiosInstance.get<PublishedForeignBankDetailsDto[]>(API_ROUTES.DONATE.PUBLIC.BANK_DETAILS_FOREIGN, {
             params: { currency: Currency.USD },
         }),
 
-        axiosInstance.get<PublishedForeignBankDetailsDto[]>(API_ROUTES.DONATE.PUBLIC.FOREIGN_BANK_DETAILS, {
+        axiosInstance.get<PublishedForeignBankDetailsDto[]>(API_ROUTES.DONATE.PUBLIC.BANK_DETAILS_FOREIGN, {
             params: { currency: Currency.EUR },
         }),
 

--- a/src/types/public/donate-page.ts
+++ b/src/types/public/donate-page.ts
@@ -24,3 +24,52 @@ export interface TabItem {
 export enum PaymentSystem {
     WayForPay = 'WayForPay',
 }
+
+export enum BankCurrency {
+    Uah = 0,
+    Usd = 1,
+    Eur = 2,
+}
+
+export interface PublicUahBankDetailsDto {
+    id: number;
+    name: string; // TODO:
+    receiver: string; // TODO:
+    edrpou: string; // TODO:
+    iban: string; // TODO:
+    paymentPurpose: string; // TODO:
+}
+
+export interface PublicSupportOptionsDto {
+    id: number;
+    name: string; // TODO:
+    value: string; // TODO:
+    currency: BankCurrency; // TODO:
+}
+
+export interface PublicForeignBankDetailsDto {
+    id: number;
+    name: string; // TODO:
+    receiver: string; // TODO:
+    iban: string; // TODO:
+    swift: string; // TODO:
+    address: string; // TODO:
+    currency: BankCurrency;
+    correspondentBanks: PublicCorrespondentBankDetailsDto[]; // TODO: можливо цього не буде в public
+}
+
+// TODO:
+export interface PublicCorrespondentBankDetailsDto {
+    id: number;
+    name: string;
+    swift: string;
+    account: string;
+    iban?: string;
+    foreignBankDetailsId: number;
+}
+
+export interface DonatePageData {
+    uahBankDetails: PublicUahBankDetailsDto[];
+    foreignBankDetails: PublicForeignBankDetailsDto[];
+    supportOptions: PublicSupportOptionsDto[];
+}

--- a/src/types/public/donate-page.ts
+++ b/src/types/public/donate-page.ts
@@ -25,41 +25,23 @@ export enum PaymentSystem {
     WayForPay = 'WayForPay',
 }
 
-export enum BankCurrency {
-    Uah = 0,
-    Usd = 1,
-    Eur = 2,
-}
-
-export interface PublicUahBankDetailsDto {
+export interface PublishedUahBankDetailsDto {
     id: number;
-    name: string; // TODO:
-    receiver: string; // TODO:
-    edrpou: string; // TODO:
-    iban: string; // TODO:
-    paymentPurpose: string; // TODO:
+    name: string;
+    receiver: string;
+    edrpou: string;
+    iban: string;
+    paymentPurpose: string;
 }
 
-export interface PublicSupportOptionsDto {
+export interface PublishedSupportOptionsDto {
     id: number;
-    name: string; // TODO:
-    value: string; // TODO:
-    currency: BankCurrency; // TODO:
+    name: string;
+    value: string;
+    currency: Currency;
 }
 
-export interface PublicForeignBankDetailsDto {
-    id: number;
-    name: string; // TODO:
-    receiver: string; // TODO:
-    iban: string; // TODO:
-    swift: string; // TODO:
-    address: string; // TODO:
-    currency: BankCurrency;
-    correspondentBanks: PublicCorrespondentBankDetailsDto[]; // TODO: можливо цього не буде в public
-}
-
-// TODO:
-export interface PublicCorrespondentBankDetailsDto {
+export interface PublishedCorrespondentBankDetailsDto {
     id: number;
     name: string;
     swift: string;
@@ -68,8 +50,19 @@ export interface PublicCorrespondentBankDetailsDto {
     foreignBankDetailsId: number;
 }
 
+export interface PublishedForeignBankDetailsDto {
+    id: number;
+    name: string;
+    receiver: string;
+    iban: string;
+    swift: string;
+    address: string;
+    currency: Currency;
+    correspondentBanks: PublishedCorrespondentBankDetailsDto[];
+}
+
 export interface DonatePageData {
-    uahBankDetails: PublicUahBankDetailsDto[];
-    foreignBankDetails: PublicForeignBankDetailsDto[];
-    supportOptions: PublicSupportOptionsDto[];
+    uahBankDetails: PublishedUahBankDetailsDto[];
+    foreignBankDetails: PublishedForeignBankDetailsDto[];
+    supportOptions: PublishedSupportOptionsDto[];
 }


### PR DESCRIPTION
## Github ticker

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/837)

## Description

Added backend integration on the public donation page. Now, when you change the details on the admin panel, the public side changes too.

## How it looks
<img width="1395" height="980" alt="image" src="https://github.com/user-attachments/assets/3c0b22b2-1274-4d7f-afdb-70061517c115" />


## Summary of change

Added backend integration on the public donation page. Now, when you change the details on the admin panel, the public side changes too.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New donation API endpoints are available to retrieve bank transfer details and support resources:
    - UAH bank transfer details
    - Foreign bank transfer details
    - Support options and resources
  * These endpoints provide published/live information for donors to access bank details and support guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->