### PR TITLE
Fix/issue-809: Wrong amounts of donations in the widget WayForPay in UAH

### DIFF
--- a/scripts/start-in-dev-over-https.mjs
+++ b/scripts/start-in-dev-over-https.mjs
@@ -10,9 +10,7 @@ import { getCerts } from 'https-localhost/certs.js';
         // Safety check to ensure we're in the project directory
         const packageJsonPath = path.join(process.cwd(), 'package.json');
         await fs.access(packageJsonPath).catch(() => {
-            throw new Error(
-                'package.json not found. Please run this script from the project root.'
-            );
+            throw new Error('package.json not found. Please run this script from the project root.');
         });
         await fs.rm(certDir, { recursive: true, force: true });
         await fs.mkdir(certDir, { recursive: true });

--- a/src/const/public/donate-page.ts
+++ b/src/const/public/donate-page.ts
@@ -1,9 +1,23 @@
+import { Currency } from '../../types/public/donate-page';
+
 export const PAGE_TITLE = 'МИ ВДЯЧНІ | ЗА КОЖЕН ДОНАТ';
 
-export const DONATION_SIZE = {
-    10: '+10 ',
-    50: '+50 ',
-    100: '+100 ',
+export const DONATION_AMOUNTS = {
+    [Currency.UAH]: {
+        small: 100,
+        medium: 200,
+        large: 500,
+    },
+    [Currency.USD]: {
+        small: 10,
+        medium: 50,
+        large: 100,
+    },
+    [Currency.EUR]: {
+        small: 10,
+        medium: 50,
+        large: 100,
+    },
 };
 
 export const DONATE_SECTION = {

--- a/src/pages/public/donate-page/donate-section/DonateSection.test.tsx
+++ b/src/pages/public/donate-page/donate-section/DonateSection.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { DonateSection } from './DonateSection';
 import { Currency } from '../../../../types/public/donate-page';
+import { DONATION_AMOUNTS } from '../../../../const/public/donate-page';
 
 describe('DonateSection', () => {
     it('renders input, currency selector, and quick amount buttons', () => {
@@ -30,13 +31,18 @@ describe('DonateSection', () => {
     it('increments donation amount with quick buttons', () => {
         render(<DonateSection />);
         const input = screen.getByPlaceholderText('0');
-        const [btn10, btn50, btn100] = screen.getAllByRole('button', { name: /\+/ });
-        fireEvent.click(btn10);
-        expect(input).toHaveValue('10');
-        fireEvent.click(btn50);
-        expect(input).toHaveValue('60');
-        fireEvent.click(btn100);
-        expect(input).toHaveValue('160');
+        const [btnSmall, btnMedium, btnLarge] = screen.getAllByRole('button', { name: /\+/ });
+
+        const uahSmall = DONATION_AMOUNTS[Currency.UAH].small;
+        const uahMedium = DONATION_AMOUNTS[Currency.UAH].medium;
+        const uahLarge = DONATION_AMOUNTS[Currency.UAH].large;
+
+        fireEvent.click(btnSmall);
+        expect(input).toHaveValue(`${uahSmall}`);
+        fireEvent.click(btnMedium);
+        expect(input).toHaveValue(`${uahSmall + uahMedium}`);
+        fireEvent.click(btnLarge);
+        expect(input).toHaveValue(`${uahSmall + uahMedium + uahLarge}`);
     });
 
     it('changes currency', () => {
@@ -46,6 +52,29 @@ describe('DonateSection', () => {
         expect(select).toHaveValue(`${Currency.USD}`);
         fireEvent.change(select, { target: { value: Currency.EUR } });
         expect(select).toHaveValue(`${Currency.EUR}`);
+    });
+
+    it('updates quick button amounts when currency changes', () => {
+        render(<DonateSection />);
+        const input = screen.getByPlaceholderText('0');
+        const select = screen.getByRole('combobox');
+        const [btnSmall, btnMedium, btnLarge] = screen.getAllByRole('button', { name: /\+/ });
+
+        fireEvent.change(select, { target: { value: Currency.USD } });
+        const usdSmall = DONATION_AMOUNTS[Currency.USD].small;
+        const usdMedium = DONATION_AMOUNTS[Currency.USD].medium;
+
+        fireEvent.click(btnSmall);
+        expect(input).toHaveValue(`${usdSmall}`);
+        fireEvent.click(btnMedium);
+        expect(input).toHaveValue(`${usdSmall + usdMedium}`);
+
+        fireEvent.change(select, { target: { value: Currency.EUR } });
+        const eurLarge = DONATION_AMOUNTS[Currency.EUR].large;
+
+        fireEvent.change(input, { target: { value: '0' } });
+        fireEvent.click(btnLarge);
+        expect(input).toHaveValue(`${eurLarge}`);
     });
 
     it('shows correct submit button label for one-time and subscription tabs', () => {

--- a/src/pages/public/donate-page/donate-section/DonateSection.tsx
+++ b/src/pages/public/donate-page/donate-section/DonateSection.tsx
@@ -1,6 +1,6 @@
 import './DonateSection.scss';
 import React, { useState } from 'react';
-import { DONATE_SECTION, DONATION_SIZE } from '../../../../const/public/donate-page';
+import { DONATE_SECTION, DONATION_AMOUNTS } from '../../../../const/public/donate-page';
 import { DonateTab, PaymentSystem, Currency } from '../../../../types/public/donate-page';
 import { API_ROUTES } from '../../../../const/common/api-routes/main-api';
 import { getEnvVariable } from '../../../../utils/functions/get-env-variable/get-env-variable';
@@ -86,16 +86,28 @@ export const DonateSection = () => {
                 </div>
             </div>
             <div className="fastDonateOptionsSection">
-                <button className="donateFastOptionButton" onClick={() => handleQuickAmountChange(10)} type="button">
-                    <span className="donateFastValueText">{DONATION_SIZE[10]}</span>
+                <button
+                    className="donateFastOptionButton"
+                    onClick={() => handleQuickAmountChange(DONATION_AMOUNTS[currency].small)}
+                    type="button"
+                >
+                    <span className="donateFastValueText">+{DONATION_AMOUNTS[currency].small} </span>
                     {currencyString}
                 </button>
-                <button className="donateFastOptionButton" onClick={() => handleQuickAmountChange(50)} type="button">
-                    <span className="donateFastValueText">{DONATION_SIZE[50]}</span>
+                <button
+                    className="donateFastOptionButton"
+                    onClick={() => handleQuickAmountChange(DONATION_AMOUNTS[currency].medium)}
+                    type="button"
+                >
+                    <span className="donateFastValueText">+{DONATION_AMOUNTS[currency].medium} </span>
                     {currencyString}
                 </button>
-                <button className="donateFastOptionButton" onClick={() => handleQuickAmountChange(100)} type="button">
-                    <span className="donateFastValueText">{DONATION_SIZE[100]}</span>
+                <button
+                    className="donateFastOptionButton"
+                    onClick={() => handleQuickAmountChange(DONATION_AMOUNTS[currency].large)}
+                    type="button"
+                >
+                    <span className="donateFastValueText">+{DONATION_AMOUNTS[currency].large} </span>
                     {currencyString}
                 </button>
             </div>


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/809)

## Description

While comparing amounts of donations in the widget WayForPay at UAH tab and [mock-up](https://www.figma.com/design/dvuyDlhKvOxYw6ijnr76J0/VC-Website-Design?node-id=4280-18985&t=TxTuPj7C2XdQlsI5-0) there are different values

## How it looks

<img width="471" height="378" alt="image" src="https://github.com/user-attachments/assets/02562b4b-2f2b-4900-911e-41d184afb9a7" />
<img width="471" height="378" alt="image" src="https://github.com/user-attachments/assets/e2b20d8b-81fd-4e81-8e4a-e56e3674a5e2" />
<img width="471" height="378" alt="image" src="https://github.com/user-attachments/assets/2777a6c9-e42d-4201-982b-89273517b595" />

## Summary of change

Fixed the approach so that now each currency has its own quick add amounts

## How to recreate changes

Go to [local](https://localhost:3000/donate) or [staging](https://historycode.online/donate) donate page

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has medium impact on users
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor refactor to internal script formatting with no impact to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->