### PR TITLE
Fix/issue-851: Wrong text when cancelling way of support creation in admin panel

### DIFF
--- a/src/const/admin/donate.ts
+++ b/src/const/admin/donate.ts
@@ -70,7 +70,6 @@ export const DONATE_TEXT = {
         VALUE: 'Реквізити',
     },
     QUESTION: {
-        CANCEL_EDIT: 'Зміни будуть втрачені. Бажаєте продовжити?',
         BANK_DETAILS: {
             ADD: 'Додати нові реквізити?',
             CANCEL_CREATE: 'Відмінити додавання реквізитів?',
@@ -83,6 +82,7 @@ export const DONATE_TEXT = {
         SUPPORT_OPTION: {
             ADD: 'Опублікувати новий варіант підтримки?',
             DELETE: 'Видалити варіант підтримки?',
+            CANCEL_CREATE: 'Відмінити додавання варіанту підтримки?',
         },
         CORRESPONDENT_BANKS: {
             DELETE: 'Видалити банк-кореспондент?',

--- a/src/pages/admin/donate/components/support-options/support-option-item/SupportOptionItem.tsx
+++ b/src/pages/admin/donate/components/support-options/support-option-item/SupportOptionItem.tsx
@@ -85,7 +85,7 @@ export const SupportOptionItem = ({ data, initialMode, onSave, onCancel, onDelet
                 title:
                     mode === SupportOptionItemMode.Edit
                         ? COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE
-                        : DONATE_TEXT.QUESTION.CANCEL_EDIT,
+                        : DONATE_TEXT.QUESTION.SUPPORT_OPTION.CANCEL_CREATE,
                 onConfirm: resetForm,
             });
         } else {


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/851)

## Description

When an Admin enters any data into the field "Введіть назву" or "Введіть реквізити" and clicks on the "Відмінити" button, the system displays pop-up which doesn't match mock-up and requirements.

## How it looks

<img width="614" height="220" alt="image" src="https://github.com/user-attachments/assets/8953882d-6d5f-4047-b588-790e4afb68b7" />

## Summary of change

Now pop-up shows 'Відмінити додавання варіанту підтримки?', **WHICH IS STILL DIFFERENT FROM THE USER STORY, BUT I BELIEVE IT HAS A TYPO.**

## How to recreate changes

1. Go to the admin panel
2. Open donate page 
3. Click on "Додати варіант підтримки"
4. Type something into the fields
5. Click on "Відмінити"

## CHECK LIST
- [ ]  Changes has light impact on users
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined confirmation prompts in the admin donation interface when managing support options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->