### PR TITLE
Fix display Edit and Delete icons in Donation Page

### DIFF
--- a/src/pages/admin/donate/components/generic-details/GenericDetails.scss
+++ b/src/pages/admin/donate/components/generic-details/GenericDetails.scss
@@ -54,22 +54,8 @@
                 }
             }
 
-            .form-name-actions {
-                display: none;
-            }
-
             .btn-add {
                 width: 100%;
-            }
-        }
-    }
-
-    .edit {
-        .child {
-            .generic-details-item {
-                .form-name-actions {
-                    display: flex;
-                }
             }
         }
     }

--- a/src/pages/admin/donate/components/generic-form/GenericForm.scss
+++ b/src/pages/admin/donate/components/generic-form/GenericForm.scss
@@ -107,8 +107,8 @@
         }
         
         .form-name-actions {
-            display: flex;         // <-- ДОБАВЛЕНО
-            flex-direction: row;   // <-- ДОБАВЛЕНО
+            display: flex;
+            flex-direction: row;
             gap: 0.5rem;
         }
 

--- a/src/pages/admin/donate/components/generic-form/GenericForm.scss
+++ b/src/pages/admin/donate/components/generic-form/GenericForm.scss
@@ -98,7 +98,7 @@
         .form-head-container {
             display: flex;
             flex-direction: row;
-            justify-content: space-between
+            justify-content: space-between;
         }
 
         .form-name {
@@ -129,13 +129,6 @@
 
             .form-field-content {
                 flex: 1;
-            }
-
-            .title-actions {
-                display: flex;
-                flex-direction: row;
-                gap: 0.5rem;
-                flex-shrink: 0;
             }
         }
     }

--- a/src/pages/admin/donate/components/generic-form/GenericForm.scss
+++ b/src/pages/admin/donate/components/generic-form/GenericForm.scss
@@ -98,15 +98,18 @@
         .form-head-container {
             display: flex;
             flex-direction: row;
+            justify-content: space-between
         }
 
         .form-name {
             font-size: 1.5rem;
             font-weight: 600;
-
-            &-actions {
-                gap: 0.5rem;
-            }
+        }
+        
+        .form-name-actions {
+            display: flex;         // <-- ДОБАВЛЕНО
+            flex-direction: row;   // <-- ДОБАВЛЕНО
+            gap: 0.5rem;
         }
 
         .body {

--- a/src/pages/admin/donate/components/generic-form/GenericForm.tsx
+++ b/src/pages/admin/donate/components/generic-form/GenericForm.tsx
@@ -301,13 +301,13 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
                                     {isChildForm && (
                                         <div className="form-name-actions">
                                             <button
-                                                className="edit-btn"
+                                                className={`edit-btn ${mode}`}
                                                 aria-label="edit-btn"
                                                 type="button"
                                                 onClick={handleEditClick}
                                             ></button>
                                             <button
-                                                className={`delete-btn delete-btn-icon ${isDeleting ? 'pressed' : ''}`}
+                                                className={`delete-btn delete-btn-icon ${mode} ${isDeleting ? 'pressed' : ''}`}
                                                 aria-label="delete-btn"
                                                 type="button"
                                                 onClick={handleDeleteClick}
@@ -358,23 +358,6 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
                                                     <span className="error">{errors[f.name]}</span>
                                                 )}
                                             </div>
-
-                                            {isChildForm && isTitleField && mode === GenericFormMode.Edit && (
-                                                <div className={`title-actions`}>
-                                                    <button
-                                                        type="button"
-                                                        aria-label="edit-btn"
-                                                        className={`edit-btn ${mode}`}
-                                                        onClick={handleEditClick}
-                                                    />
-                                                    <button
-                                                        type="button"
-                                                        aria-label="delete-btn"
-                                                        className={`delete-btn delete-btn-icon ${isDeleting ? 'pressed' : ''}`}
-                                                        onClick={handleDeleteClick}
-                                                    />
-                                                </div>
-                                            )}
                                         </div>
                                     );
                                 })}


### PR DESCRIPTION
## Github

* [Github ticket](https://github.com/orgs/ita-social-projects/projects/64/views/1?pane=issue&itemId=137024687&issue=ita-social-projects%7CVictoryCenter-Back%7C842)

## How it looks

<img width="815" height="499" alt="изображение" src="https://github.com/user-attachments/assets/65436d48-401a-46e9-95de-34c4419e3cc8" />

## Summary of change

Removed overriding CSS rules in GenericDetails.scss that incorrectly set display: none on .form-name-actions. These styles were preventing child form buttons from appearing unless the parent form was in edit mode.


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved form layout with better horizontal spacing and balanced header alignment.
  * Form action controls are now visible and consistently positioned.
  * Button styling updated to reflect current form mode and state for clearer visual feedback.
  * Streamlined interface by removing duplicate action controls and simplifying action grouping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->