### PR TITLE
Fix/issue-822: Removed PDF dowload button

### DIFF
--- a/src/const/public/donate-page.ts
+++ b/src/const/public/donate-page.ts
@@ -101,7 +101,6 @@ export const ALTERNATIVE_SUPPORT_WAYS = {
     PAY_PAL_EMAIL_LABEL: 'victorycenterua@gmail.com',
     MONOBANK_JAR_LABEL: 'Monobank баночка',
     MONOBANK_JAR_LINK_LABEL: 'https://send.monobank.ua/jar/2JGG2F8rHQ',
-    DOWNLOAD_PAYMENT_DETAILS_BUTTON_LABEL: 'Завантажити реквізити PDF',
 };
 
 export const CORRESPONDENT_BANKS = {

--- a/src/pages/public/donate-page/right-section/alternative-support-ways/AlternativeSupportWays.scss
+++ b/src/pages/public/donate-page/right-section/alternative-support-ways/AlternativeSupportWays.scss
@@ -26,7 +26,7 @@
         color: colors.$blue-900;
     }
 
-    .labelContainer {
+    .labelContainer:not(:last-child) {
         padding-bottom: 1.5rem;
     }
 
@@ -34,32 +34,5 @@
         padding-top: 0.125rem;
         display: flex;
         gap: 0.5rem;
-    }
-
-    .buttonsContainer {
-        display: flex;
-        flex-direction: row;
-        gap: 0.5rem;
-
-        .downloadPaymentDetailsButton {
-            display: flex;
-            flex-direction: row;
-            justify-content: center;
-            align-items: center;
-            gap: 0.5rem;
-            font-family: fonts.$mulish-regular-font;
-            font-weight: 400;
-            font-size: 1rem;
-            background-color: white;
-            width: 19.75rem;
-            height: 2.5rem;
-            cursor: pointer;
-        }
-
-        .shareButton {
-            background-color: white;
-            cursor: pointer;
-            display: none;
-        }
     }
 }

--- a/src/pages/public/donate-page/right-section/alternative-support-ways/AlternativeSupportWays.test.tsx
+++ b/src/pages/public/donate-page/right-section/alternative-support-ways/AlternativeSupportWays.test.tsx
@@ -3,14 +3,6 @@ import '@testing-library/jest-dom';
 import { AlternativeSupportWays } from './AlternativeSupportWays';
 import { PublishedSupportOptionsDto, Currency } from '../../../../../types/public/donate-page';
 
-jest.mock('../../../../../assets/icons/arrow-up-right.svg', () => ({
-    ReactComponent: (props: any) => <svg {...props} data-testid="arrow-up-right-icon" />,
-}));
-
-jest.mock('../../../../../assets/icons/forward.svg', () => ({
-    ReactComponent: (props: any) => <svg {...props} data-testid="forward-icon" />,
-}));
-
 jest.mock('../../copy-text-button/CopyTextButton', () => ({
     CopyTextButton: ({ textToCopy }: { textToCopy: string }) => (
         <button data-testid="copy-button" data-copy-text={textToCopy}>
@@ -22,7 +14,6 @@ jest.mock('../../copy-text-button/CopyTextButton', () => ({
 jest.mock('../../../../../const/public/donate-page', () => ({
     ALTERNATIVE_SUPPORT_WAYS: {
         ALTERNATIVE_SUPPORT_WAYS_LABEL: 'Інші варіанти підтримки',
-        DOWNLOAD_PAYMENT_DETAILS_BUTTON_LABEL: 'Завантажити реквізити',
     },
 }));
 
@@ -54,12 +45,8 @@ describe('AlternativeSupportWays', () => {
             expect(screen.getByText('api@paypal.com')).toBeInTheDocument();
             expect(screen.getByTestId('copy-button')).toHaveAttribute('data-copy-text', 'api@paypal.com');
 
-            expect(screen.getByText('Завантажити реквізити')).toBeInTheDocument();
-            expect(screen.getByTestId('arrow-up-right-icon')).toBeInTheDocument();
-            expect(screen.getByTestId('forward-icon')).toBeInTheDocument();
-
             const allButtons = screen.getAllByRole('button');
-            expect(allButtons).toHaveLength(3);
+            expect(allButtons).toHaveLength(1);
         });
 
         it('renders multiple support options for current currency', () => {
@@ -87,7 +74,7 @@ describe('AlternativeSupportWays', () => {
             expect(screen.getByText('usd@stripe.com')).toBeInTheDocument();
 
             const allButtons = screen.getAllByRole('button');
-            expect(allButtons).toHaveLength(4);
+            expect(allButtons).toHaveLength(2);
         });
 
         it('filters options by current currency correctly', () => {
@@ -149,22 +136,7 @@ describe('AlternativeSupportWays', () => {
             expect(screen.queryByText('Option 3')).not.toBeInTheDocument();
 
             const allButtons = screen.getAllByRole('button');
-            expect(allButtons).toHaveLength(4);
-        });
-
-        it('renders download and share buttons with correct icons', () => {
-            const supportOptions = [createMockSupportOption()];
-
-            render(<AlternativeSupportWays supportOptions={supportOptions} currentCurrency={Currency.UAH} />);
-
-            const downloadButton = screen.getByText('Завантажити реквізити').closest('button');
-            expect(downloadButton).toHaveClass('downloadPaymentDetailsButton');
-
-            const shareButton = screen.getByTestId('forward-icon').closest('button');
-            expect(shareButton).toHaveClass('shareButton');
-
-            expect(screen.getByTestId('arrow-up-right-icon')).toBeInTheDocument();
-            expect(screen.getByTestId('forward-icon')).toBeInTheDocument();
+            expect(allButtons).toHaveLength(2);
         });
     });
 

--- a/src/pages/public/donate-page/right-section/alternative-support-ways/AlternativeSupportWays.tsx
+++ b/src/pages/public/donate-page/right-section/alternative-support-ways/AlternativeSupportWays.tsx
@@ -1,7 +1,5 @@
 import './AlternativeSupportWays.scss';
 import { CopyTextButton } from '../../copy-text-button/CopyTextButton';
-import { ReactComponent as ArrowUpRight } from '../../../../../assets/icons/arrow-up-right.svg';
-import { ReactComponent as ShareForwardArrow } from '../../../../../assets/icons/forward.svg';
 import { ALTERNATIVE_SUPPORT_WAYS } from '../../../../../const/public/donate-page';
 import { PublishedSupportOptionsDto, Currency } from '../../../../../types/public/donate-page';
 
@@ -30,16 +28,6 @@ export const AlternativeSupportWays = ({ supportOptions, currentCurrency }: Alte
                     </div>
                 </div>
             ))}
-
-            <div className="buttonsContainer">
-                <button className="downloadPaymentDetailsButton">
-                    {ALTERNATIVE_SUPPORT_WAYS.DOWNLOAD_PAYMENT_DETAILS_BUTTON_LABEL}
-                    <ArrowUpRight />
-                </button>
-                <button className="shareButton">
-                    <ShareForwardArrow />
-                </button>
-            </div>
         </div>
     );
 };


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/822)

## Description

There mustn't be any button to download PDF with bank details displays under published ways to support

## How it looks

<img width="1920" height="899" alt="image" src="https://github.com/user-attachments/assets/4d48486d-5ae4-4fde-b8d3-466e4936118c" />

## Summary of change

- Removed download PDF with bank details button for donate page
- Fixed style sheets
- Updated unit tests

## How to recreate changes

1. Go to https://historycode.online/donate
2. Scroll down to the end of published ways to support section
3. There is no PDF  download button
