### PR TITLE
Fix/issue-895: The pop-up 'Варіант підтримки видалено успішно' is not displayed

### DIFF
--- a/src/const/admin/donate.ts
+++ b/src/const/admin/donate.ts
@@ -97,7 +97,10 @@ export const DONATE_TEXT = {
         SUPPORT_OPTION: 'Введіть реквізити',
     },
     MESSAGE: {
-        SUPPORT_OPTION_PUBLISHED: 'Варіант підтримки успішно опубліковано',
+        SUPPORT_OPTIONS: {
+            PUBLISHED: 'Варіант підтримки успішно опубліковано',
+            DELETED: 'Варіант підтримки видалено успішно',
+        },
         CHANGES_SAVED: 'Зміни успішно опубліковано',
         CORRESPONDENT_BANKS: {
             DELETED: 'Банк-кореспондент видалено успішно',

--- a/src/pages/admin/donate/components/donate-page-content/DonatePageContent.tsx
+++ b/src/pages/admin/donate/components/donate-page-content/DonatePageContent.tsx
@@ -107,7 +107,7 @@ export const DonatePageContent = () => {
                 setIsSupportOptionsLoading(false);
             }
         },
-        [client],
+        [client, addToast],
     );
 
     // Bank Details handlers

--- a/src/pages/admin/donate/components/donate-page-content/DonatePageContent.tsx
+++ b/src/pages/admin/donate/components/donate-page-content/DonatePageContent.tsx
@@ -75,7 +75,7 @@ export const DonatePageContent = () => {
                 const newOption = await SupportOptionsApi.create(client, { name, value, currency: bankCurrency });
                 setSupportOptions((prev) => [...prev, newOption]);
 
-                addToast(DONATE_TEXT.MESSAGE.SUPPORT_OPTION_PUBLISHED, ToastType.Info);
+                addToast(DONATE_TEXT.MESSAGE.SUPPORT_OPTIONS.PUBLISHED, ToastType.Info);
             } finally {
                 setIsSupportOptionsLoading(false);
             }
@@ -102,6 +102,7 @@ export const DonatePageContent = () => {
             try {
                 await SupportOptionsApi.delete(client, id);
                 setSupportOptions((prev) => prev.filter((option) => option.id !== id));
+                addToast(DONATE_TEXT.MESSAGE.SUPPORT_OPTIONS.DELETED, ToastType.Info);
             } finally {
                 setIsSupportOptionsLoading(false);
             }


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/893)
* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/894)
* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/895)

## Description

The pop-up 'Варіант підтримки видалено успішно' is not displayed after deleting a way to support in donate tab on  admin panel

## How it looks

[Screencast from 2025-11-10 16-11-21.webm](https://github.com/user-attachments/assets/4f5d754c-41a5-4939-b7eb-6146e03f0a2f)

## Summary of change

Now the pop-up 'Варіант підтримки видалено успішно' is successfully displayed after deleting a way to support in donate tab on  admin panel

## How to recreate changes

1. Go to admin panel
2. Switch to donate tab
3. Select any currency at the top bar
4. Delete any way to support
5. Observe pop-up emerging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a toast notification when a support option is deleted.
  * Updated feedback for creating support options to use the new status wording.

* **Refactor**
  * Reorganized support option status messages into a clearer published/deleted structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->