### PR TITLE
Fix disabling "Add New" button in edit mode

### DIFF
--- a/src/pages/admin/donate/components/generic-details/GenericDetails.tsx
+++ b/src/pages/admin/donate/components/generic-details/GenericDetails.tsx
@@ -46,6 +46,15 @@ export function GenericDetails<T extends { id: number } & FieldValues>({
     const addformRef = useRef<GenericFormRef>(null);
     const [isAddFormVisible, setIsAddFormVisible] = useState(false);
     const [isItemsExpanded, setIsItemsExpanded] = useState(initialIsItemsExpanded);
+    const [editingItemId, setEditingItemId] = useState<number | null>(null);
+
+    const handleItemModeChange = (id: number, mode: GenericFormMode) => {
+        if (mode === GenericFormMode.Edit) {
+            setEditingItemId(id);
+        } else if (editingItemId === id) {
+            setEditingItemId(null);
+        }
+    };
 
     const updateItems = useCallback(
         (updater: React.SetStateAction<T[]>) => {
@@ -154,6 +163,7 @@ export function GenericDetails<T extends { id: number } & FieldValues>({
                                         onClose={handleClose}
                                         onDelete={() => handleItemDelete(item.id)}
                                         isChildForm={isChildForm}
+                                        onModeChange={(mode: GenericFormMode) => handleItemModeChange(item.id, mode)}
                                     >
                                         {(formProps) => <>{children && children(formProps)}</>}
                                     </FormComponent>
@@ -175,9 +185,10 @@ export function GenericDetails<T extends { id: number } & FieldValues>({
                     )}
                     {!showNotFound && (
                         <Button
-                            className={`generic-details btn-add-new ${isAddFormVisible ? 'disabled' : ''}`}
+                            className={`generic-details btn-add-new ${isAddFormVisible || editingItemId !== null ? 'disabled' : ''}`}
                             onClick={handleAdd}
                             buttonStyle="primary"
+                            disabled={isAddFormVisible || editingItemId !== null}
                         >
                             <div>{addNewText}</div>
                             <PlusIcon className="plus-icon" />

--- a/src/pages/admin/donate/components/generic-form/GenericForm.tsx
+++ b/src/pages/admin/donate/components/generic-form/GenericForm.tsx
@@ -373,7 +373,7 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
                                                         aria-label="edit-btn"
                                                         className={`edit-btn ${mode}`}
                                                         onClick={handleEditClick}
-                                                        disabled={true}
+                                                        disabled
                                                     />
                                                     <button
                                                         type="button"

--- a/src/pages/admin/donate/components/generic-form/GenericForm.tsx
+++ b/src/pages/admin/donate/components/generic-form/GenericForm.tsx
@@ -27,6 +27,7 @@ export interface GenericFormProps<T extends FieldValues> {
     onDelete?: (id: number) => void;
     isChildForm?: boolean;
     children?: (form: { formState: T; isItemsExpanded: boolean }) => React.ReactNode;
+    onModeChange?: (mode: GenericFormMode) => void;
 }
 
 export enum GenericFormMode {
@@ -62,6 +63,7 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
                 onDelete,
                 isChildForm = false,
                 children,
+                onModeChange,
             },
             ref,
         ) => {
@@ -83,6 +85,10 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
 
             const titleField = useMemo(() => fields.find((f) => f.isTitle), []);
             const titleFieldName = titleField?.name;
+
+            useEffect(() => {
+                onModeChange?.(mode);
+            }, [mode, onModeChange]);
 
             useEffect(() => {
                 const newState: FormState = { ...(initialData ?? ({} as FormState)) };
@@ -273,6 +279,7 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
                                         className={`edit-btn ${mode}`}
                                         aria-label="edit-btn"
                                         onClick={handleEditClick}
+                                        disabled={mode === GenericFormMode.Edit}
                                     />
                                     <button
                                         className={`delete-btn ${mode}`}
@@ -366,6 +373,7 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
                                                         aria-label="edit-btn"
                                                         className={`edit-btn ${mode}`}
                                                         onClick={handleEditClick}
+                                                        disabled={true}
                                                     />
                                                     <button
                                                         type="button"

--- a/src/pages/admin/donate/components/support-options/support-option-item/SupportOptionItem.test.tsx
+++ b/src/pages/admin/donate/components/support-options/support-option-item/SupportOptionItem.test.tsx
@@ -219,7 +219,7 @@ describe('SupportOptionItem', () => {
 
     it('calls onModeChange when mode changes', () => {
         const mockOnModeChange = jest.fn();
-        render(<SupportOptionItem data={defaultData} onModeChange={mockOnModeChange} />); // 1. Hook вызывается при первой загрузке
+        render(<SupportOptionItem data={defaultData} onModeChange={mockOnModeChange} />);
         expect(mockOnModeChange).toHaveBeenLastCalledWith(SupportOptionItemMode.View);
         mockOnModeChange.mockClear();
 

--- a/src/pages/admin/donate/components/support-options/support-option-item/SupportOptionItem.test.tsx
+++ b/src/pages/admin/donate/components/support-options/support-option-item/SupportOptionItem.test.tsx
@@ -216,4 +216,62 @@ describe('SupportOptionItem', () => {
 
         expect(screen.queryByTestId('confirmation-modal')).not.toBeInTheDocument();
     });
+
+    it('calls onModeChange when mode changes', () => {
+        const mockOnModeChange = jest.fn();
+        render(<SupportOptionItem data={defaultData} onModeChange={mockOnModeChange} />); // 1. Hook вызывается при первой загрузке
+        expect(mockOnModeChange).toHaveBeenLastCalledWith(SupportOptionItemMode.View);
+        mockOnModeChange.mockClear();
+
+        const editButton = screen.getByRole('button', { name: 'edit-btn' });
+        fireEvent.click(editButton);
+
+        expect(mockOnModeChange).toHaveBeenLastCalledWith(SupportOptionItemMode.Edit);
+        mockOnModeChange.mockClear();
+
+        const cancelButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL);
+        fireEvent.click(cancelButton);
+
+        expect(mockOnModeChange).toHaveBeenLastCalledWith(SupportOptionItemMode.View);
+    });
+
+    it('keeps modal open if onConfirm (delete) throws an error', async () => {
+        const mockOnDelete = jest.fn().mockRejectedValue(new Error('Delete failed'));
+        render(<SupportOptionItem data={defaultData} onDelete={mockOnDelete} />);
+
+        const deleteButton = screen.getByRole('button', { name: 'delete-btn' });
+        fireEvent.click(deleteButton);
+
+        const yesButton = await screen.findByText('Yes');
+        fireEvent.click(yesButton);
+
+        await waitFor(() => {
+            expect(mockOnDelete).toHaveBeenCalled();
+        });
+        expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument();
+    });
+
+    it('does not do anything if edit button is clicked while already in edit mode', () => {
+        const mockOnModeChange = jest.fn();
+        render(<SupportOptionItem data={defaultData} onModeChange={mockOnModeChange} />);
+
+        const editButton = screen.getByRole('button', { name: 'edit-btn' });
+        fireEvent.click(editButton);
+
+        mockOnModeChange.mockClear();
+
+        fireEvent.click(editButton);
+
+        expect(mockOnModeChange).not.toHaveBeenCalled();
+    });
+
+    it('shows validation errors for value field on blur', () => {
+        render(<SupportOptionItem initialMode={SupportOptionItemMode.Create} />);
+
+        const valueInput = screen.getByTestId('input-value');
+        fireEvent.change(valueInput, { target: { value: 'A' } });
+        fireEvent.blur(valueInput);
+
+        expect(screen.getByText('Value too short')).toBeInTheDocument();
+    });
 });

--- a/src/pages/admin/donate/components/support-options/support-option-item/SupportOptionItem.tsx
+++ b/src/pages/admin/donate/components/support-options/support-option-item/SupportOptionItem.tsx
@@ -25,9 +25,17 @@ export interface SupportOptionItemProps {
     onSave?: (name: string, value: string) => Promise<void>;
     onCancel?: () => void;
     onDelete?: () => Promise<void>;
+    onModeChange?: (mode: SupportOptionItemMode) => void;
 }
 
-export const SupportOptionItem = ({ data, initialMode, onSave, onCancel, onDelete }: SupportOptionItemProps) => {
+export const SupportOptionItem = ({
+    data,
+    initialMode,
+    onSave,
+    onCancel,
+    onDelete,
+    onModeChange,
+}: SupportOptionItemProps) => {
     const [mode, setMode] = useState<SupportOptionItemMode>(
         initialMode ?? (data ? SupportOptionItemMode.View : SupportOptionItemMode.Create),
     );
@@ -36,6 +44,10 @@ export const SupportOptionItem = ({ data, initialMode, onSave, onCancel, onDelet
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [modalConfig, setModalConfig] = useState<ModalConfig | null>(null);
     const [errors, setErrors] = useState<{ name?: string; value?: string }>({});
+
+    useEffect(() => {
+        onModeChange?.(mode);
+    }, [mode, onModeChange]);
 
     useEffect(() => {
         setName(data?.name ?? '');
@@ -132,7 +144,10 @@ export const SupportOptionItem = ({ data, initialMode, onSave, onCancel, onDelet
                         <button
                             aria-label="edit-btn"
                             className={`edit-btn ${editable ? 'edit' : ''}`}
-                            onClick={() => setMode(SupportOptionItemMode.Edit)}
+                            onClick={() => {
+                                if (editable) return;
+                                setMode(SupportOptionItemMode.Edit);
+                            }}
                             disabled={isSubmitting}
                         />
                         <button

--- a/src/pages/admin/donate/components/support-options/support-option-item/SupportOptionItem.tsx
+++ b/src/pages/admin/donate/components/support-options/support-option-item/SupportOptionItem.tsx
@@ -135,6 +135,11 @@ export const SupportOptionItem = ({
         }
     };
 
+    const handleEditClick = () => {
+        if (editable) return;
+        setMode(SupportOptionItemMode.Edit);
+    };
+
     return (
         <div className="support-option">
             <div className={`support-option-header ${editable ? 'editable' : ''}`}>
@@ -144,10 +149,7 @@ export const SupportOptionItem = ({
                         <button
                             aria-label="edit-btn"
                             className={`edit-btn ${editable ? 'edit' : ''}`}
-                            onClick={() => {
-                                if (editable) return;
-                                setMode(SupportOptionItemMode.Edit);
-                            }}
+                            onClick={handleEditClick}
                             disabled={isSubmitting}
                         />
                         <button

--- a/src/pages/admin/donate/components/support-options/support-options-form/SupportOptionsForm.test.tsx
+++ b/src/pages/admin/donate/components/support-options/support-options-form/SupportOptionsForm.test.tsx
@@ -221,26 +221,6 @@ describe('SupportOptionsForm', () => {
         expect(addButton).toBeDisabled();
     });
 
-    it('disables add new button when adding', () => {
-        render(
-            <SupportOptionsForm
-                supportOptions={mockSupportOptions}
-                isLoading={false}
-                onCreateOption={mockOnCreateOption}
-                onUpdateOption={mockOnUpdateOption}
-                onDeleteOption={mockOnDeleteOption}
-            />,
-        );
-
-        const addButton = screen.getByTestId('btn-add new');
-
-        expect(addButton).toBeEnabled();
-
-        fireEvent.click(addButton);
-        expect(addButton).toBeDisabled();
-        expect(addButton).toBeInTheDocument();
-    });
-
     it('shows loader when loading with no items', () => {
         render(
             <SupportOptionsForm

--- a/src/pages/admin/donate/components/support-options/support-options-form/SupportOptionsForm.test.tsx
+++ b/src/pages/admin/donate/components/support-options/support-options-form/SupportOptionsForm.test.tsx
@@ -1,17 +1,30 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { SupportOptionsForm } from './SupportOptionsForm';
 import { DONATE_TEXT } from '../../../../../../const/admin/donate';
 import { BankCurrency } from '../../../../../../types/admin/donate';
 
 jest.mock('../support-option-item/SupportOptionItem', () => ({
-    SupportOptionItem: ({ data, onSave, onDelete, onCancel }: any) => (
-        <div data-testid={`support-option-${data?.id || 'new'}`}>
-            <span>{data?.name || 'New Option'}</span>
-            <button onClick={() => onSave?.('Test', '123')}>Save</button>
-            {onDelete && <button onClick={onDelete}>Delete</button>}
-            {onCancel && <button onClick={onCancel}>Cancel</button>}
-        </div>
-    ),
+    ...jest.requireActual('../support-option-item/SupportOptionItem'),
+
+    SupportOptionItem: ({ data, onSave, onDelete, onCancel, onModeChange }: any) => {
+        const { SupportOptionItemMode } = jest.requireActual('../support-option-item/SupportOptionItem');
+
+        return (
+            <div data-testid={`support-option-${data?.id || 'new'}`}>
+                <span>{data?.name || 'New Option'}</span>
+                <button onClick={() => onSave?.('Test', '123')}>Save</button>
+                {onDelete && <button onClick={onDelete}>Delete</button>}
+                {onCancel && <button onClick={onCancel}>Cancel</button>}
+
+                {onModeChange && (
+                    <>
+                        <button onClick={() => onModeChange(SupportOptionItemMode.Edit)}>Simulate Edit</button>
+                        <button onClick={() => onModeChange(SupportOptionItemMode.View)}>Simulate View</button>
+                    </>
+                )}
+            </div>
+        );
+    },
 }));
 
 jest.mock('../../../../../../components/admin/button/Button', () => ({
@@ -267,5 +280,51 @@ describe('SupportOptionsForm', () => {
 
         expect(screen.queryByAltText('Завантаження...')).not.toBeInTheDocument();
         expect(screen.getByTestId('support-options-not-found')).toBeInTheDocument();
+    });
+
+    it('disables add new button when an item is in edit mode', () => {
+        render(
+            <SupportOptionsForm
+                supportOptions={mockSupportOptions}
+                isLoading={false}
+                onCreateOption={mockOnCreateOption}
+                onUpdateOption={mockOnUpdateOption}
+                onDeleteOption={mockOnDeleteOption}
+            />,
+        );
+
+        const addButton = screen.getByTestId('btn-add new');
+        expect(addButton).not.toBeDisabled();
+
+        const firstItem = screen.getByTestId('support-option-1');
+
+        const simulateEditButton = within(firstItem).getByText('Simulate Edit');
+        fireEvent.click(simulateEditButton);
+
+        expect(addButton).toBeDisabled();
+    });
+
+    it('re-enables add new button when an item exits edit mode', () => {
+        render(
+            <SupportOptionsForm
+                supportOptions={mockSupportOptions}
+                isLoading={false}
+                onCreateOption={mockOnCreateOption}
+                onUpdateOption={mockOnUpdateOption}
+                onDeleteOption={mockOnDeleteOption}
+            />,
+        );
+
+        const addButton = screen.getByTestId('btn-add new');
+
+        const firstItem = screen.getByTestId('support-option-1');
+        const simulateEditButton = within(firstItem).getByText('Simulate Edit');
+        const simulateViewButton = within(firstItem).getByText('Simulate View');
+
+        fireEvent.click(simulateEditButton);
+        expect(addButton).toBeDisabled();
+
+        fireEvent.click(simulateViewButton);
+        expect(addButton).not.toBeDisabled();
     });
 });

--- a/src/pages/admin/donate/components/support-options/support-options-form/SupportOptionsForm.tsx
+++ b/src/pages/admin/donate/components/support-options/support-options-form/SupportOptionsForm.tsx
@@ -4,7 +4,7 @@ import { SupportOptionsType } from '../../../../../../types/admin/donate';
 import { InlineLoader } from '../../../../../../components/common/inline-loader/InlineLoader';
 import { ReactComponent as PlusIcon } from '../../../../../../assets/icons/plus.svg';
 import './SupportOptionsForm.scss';
-import { SupportOptionItem } from '../support-option-item/SupportOptionItem';
+import { SupportOptionItem, SupportOptionItemMode } from '../support-option-item/SupportOptionItem';
 import NotFoundIcon from '../../../../../../assets/icons/not-found.svg';
 import { DONATE_TEXT } from '../../../../../../const/admin/donate';
 import { COMMON_TEXT_ADMIN } from '../../../../../../const/admin/common';
@@ -25,6 +25,15 @@ export const SupportOptionsForm = ({
     onDeleteOption,
 }: SupportOptionsFormProps) => {
     const [isAdding, setIsAdding] = useState(false);
+    const [editingItemId, setEditingItemId] = useState<number | null>(null);
+
+    const handleItemModeChange = (id: number, mode: SupportOptionItemMode) => {
+        if (mode === SupportOptionItemMode.Edit) {
+            setEditingItemId(id);
+        } else if (editingItemId === id) {
+            setEditingItemId(null);
+        }
+    };
 
     const handleSaveNewOption = async (name: string, value: string) => {
         await onCreateOption(name, value);
@@ -64,6 +73,7 @@ export const SupportOptionsForm = ({
                             data={item}
                             onSave={(name, value) => onUpdateOption(item.id, name, value)}
                             onDelete={() => onDeleteOption(item.id)}
+                            onModeChange={(mode) => handleItemModeChange(item.id, mode)}
                         />
                     ))}
 
@@ -76,7 +86,7 @@ export const SupportOptionsForm = ({
                             className="btn-add new"
                             onClick={() => setIsAdding(true)}
                             buttonStyle="primary"
-                            disabled={isLoading}
+                            disabled={isLoading || editingItemId !== null}
                         >
                             {DONATE_TEXT.SUPPORT_OPTIONS.ADD_NEW}
                             <PlusIcon className="plus-icon" />


### PR DESCRIPTION
##  Github

* [Github ticket](https://github.com/orgs/ita-social-projects/projects/64/views/1?filterQuery=%5BDonations%5D&pane=issue&itemId=138303373&issue=ita-social-projects%7CVictoryCenter-Back%7C896)

## Description

Fixes a bug where the "Add New" button in list components (like SupportOptionsForm and GenericDetails) remained enabled while a child item was in edit mode.

## How it looks

<img width="761" height="448" alt="изображение" src="https://github.com/user-attachments/assets/69df1752-5f59-4d80-aae3-1011f7321dc6" />


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-item edit tracking: items notify the parent when entering/exiting edit mode; nested forms reflect mode and adjust available actions.

* **Bug Fixes**
  * Prevents concurrent edits — adding new items is disabled while an item is being edited.
  * Edit clicks are ignored when already in edit mode to avoid redundant state changes.
  * Confirmation modal remains open if a delete fails.

* **Tests**
  * Added tests for mode transitions, field validation, delete error flow, and Add button enable/disable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->