### PR TITLE
Fix/issue-849: Fix display "Додати варіант" button as disabled during creation

### DIFF
--- a/src/pages/admin/donate/components/support-options/support-options-form/SupportOptionsForm.test.tsx
+++ b/src/pages/admin/donate/components/support-options/support-options-form/SupportOptionsForm.test.tsx
@@ -208,7 +208,7 @@ describe('SupportOptionsForm', () => {
         expect(addButton).toBeDisabled();
     });
 
-    it('hides add new button when adding', () => {
+    it('disables add new button when adding', () => {
         render(
             <SupportOptionsForm
                 supportOptions={mockSupportOptions}
@@ -219,8 +219,13 @@ describe('SupportOptionsForm', () => {
             />,
         );
 
-        fireEvent.click(screen.getByTestId('btn-add new'));
-        expect(screen.queryByTestId('btn-add new')).not.toBeInTheDocument();
+        const addButton = screen.getByTestId('btn-add new');
+
+        expect(addButton).toBeEnabled();
+
+        fireEvent.click(addButton);
+        expect(addButton).toBeDisabled();
+        expect(addButton).toBeInTheDocument();
     });
 
     it('shows loader when loading with no items', () => {

--- a/src/pages/admin/donate/components/support-options/support-options-form/SupportOptionsForm.tsx
+++ b/src/pages/admin/donate/components/support-options/support-options-form/SupportOptionsForm.tsx
@@ -71,17 +71,15 @@ export const SupportOptionsForm = ({
                         <SupportOptionItem key="new" onSave={handleSaveNewOption} onCancel={() => setIsAdding(false)} />
                     )}
 
-                    {!isAdding && (
-                        <Button
-                            className="btn-add new"
-                            onClick={() => setIsAdding(true)}
-                            buttonStyle="primary"
-                            disabled={isLoading}
-                        >
-                            {DONATE_TEXT.SUPPORT_OPTIONS.ADD_NEW}
-                            <PlusIcon className="plus-icon" />
-                        </Button>
-                    )}
+                    <Button
+                        className="btn-add new"
+                        onClick={() => setIsAdding(true)}
+                        buttonStyle="primary"
+                        disabled={isLoading || isAdding}
+                    >
+                        {DONATE_TEXT.SUPPORT_OPTIONS.ADD_NEW}
+                        <PlusIcon className="plus-icon" />
+                    </Button>
                 </div>
             )}
         </div>


### PR DESCRIPTION
## Github ticker

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/849)

## Description

Bug fix: "Додати варіант" button visibility during support option creation

Fixed issue where the "Додати варіант +" button was hidden when creating a new support option. According to mockup requirements, the button should remain visible but disabled during creation.

## How it looks

<img width="1490" height="688" alt="image" src="https://github.com/user-attachments/assets/b7d6e393-c0f3-4af3-ad4d-4591136a889e" />


## Summary of change

Fixed "Додати варіант +" button to remain visible but disabled during support option creation, instead of hiding completely. Updated button rendering logic in SupportOptionsForm.tsx and corresponding test assertions.

## How to recreate changes

1. Login as Admin
2. Navigate to "Донати" page
3. Click on the button "Додати варіант підтримки" and observe all displayed buttons in the form to add a way to support (in UAH, USD, EUR tabs)

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Add New button to remain visible but disabled while processing, preventing accidental duplicate submissions and providing clearer feedback to users during the adding operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->