### PR TITLE
Fix/issue-928: Add placeholder for correspondent bank name field in form(Fix bug)

### DIFF
--- a/src/pages/admin/donate/components/bank-details-currencies/bank-details-factory/BankDetailsFactory.ts
+++ b/src/pages/admin/donate/components/bank-details-currencies/bank-details-factory/BankDetailsFactory.ts
@@ -136,6 +136,7 @@ const correspondentBanksFields: GenericFormField<CorrespondentBankDetails>[] = [
         isTitle: true,
         validate: withNullCheck(BANK_DETAILS_VALIDATION_FUNCTIONS.validateName),
         isRequired: true,
+        placeholder: DONATE_TEXT.CORRESPONDENT_BANKS.NAME.PLACEHOLDER,
     },
     {
         name: 'swift',


### PR DESCRIPTION
## Github ticker

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/928)

## Description

Added the use of a placeholder for the name of the correspondent bank.
Now, instead of ‘Введіть назву’, it says ‘Введіть назву банку’.

## How it looks

<img width="830" height="902" alt="image" src="https://github.com/user-attachments/assets/5bff3f10-27c7-493b-a689-da68c0c57c94" />

## Summary of change

Added the use of a placeholder for the name of the correspondent bank.
Now, instead of ‘Введіть назву’, it says ‘Введіть назву банку’.

## How to recreate changes

1. Log in to the Admin panel.
2. Go to the “Donations” page and open USD or EUR tab.
3. Click "Додати реквізити" in the bottom of the page
4. Click "Додати банк" in "Кореспондентські банки" section
5. Pay attention to the hint for a new bank-correspondent title field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added placeholder text guidance to the correspondent bank name field in the admin section for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->