### PR TITLE
Fix issue 611 The 'Додати в команду' window closes and the confirmation pop-up remains open after clicking the 'X' button

### DIFF
--- a/src/components/admin/category-bar/CategoryBar.test.tsx
+++ b/src/components/admin/category-bar/CategoryBar.test.tsx
@@ -272,5 +272,4 @@ describe('CategoryBar', () => {
 
         expect(scrollBySpy).toHaveBeenCalledWith({ left: 300, behavior: 'smooth' });
     });
-
 });

--- a/src/components/admin/category-bar/CategoryBar.test.tsx
+++ b/src/components/admin/category-bar/CategoryBar.test.tsx
@@ -210,4 +210,67 @@ describe('CategoryBar', () => {
             globalThis.ResizeObserver = originalResizeObserver;
         }
     });
+
+    it('scrolls left when left arrow button is clicked', () => {
+        const mockOnCategorySelect = jest.fn();
+        const { container } = render(
+            <CategoryBar
+                categories={mockCategories}
+                selectedCategory={null}
+                getCategoryKey={getCategoryKey}
+                getCategoryDisplayName={getCategoryDisplayName}
+                onCategorySelect={mockOnCategorySelect}
+                scrollAmount={200}
+            />,
+        );
+
+        const categoriesDiv = container.querySelector('.category-bar-categories') as HTMLDivElement;
+        const scrollBySpy = jest.fn();
+        categoriesDiv.scrollBy = scrollBySpy;
+
+        Object.defineProperty(categoriesDiv, 'scrollLeft', { value: 100, writable: true });
+        Object.defineProperty(categoriesDiv, 'scrollWidth', { value: 1000, writable: true });
+        Object.defineProperty(categoriesDiv, 'clientWidth', { value: 800, writable: true });
+
+        fireEvent.scroll(categoriesDiv);
+
+        const leftArrowButton = container.querySelector('.category-bar-arrow-left') as HTMLButtonElement;
+        expect(leftArrowButton).toBeInTheDocument();
+
+        fireEvent.click(leftArrowButton);
+
+        expect(scrollBySpy).toHaveBeenCalledWith({ left: -200, behavior: 'smooth' });
+    });
+
+    it('scrolls right when right arrow button is clicked', () => {
+        const mockOnCategorySelect = jest.fn();
+        const { container } = render(
+            <CategoryBar
+                categories={mockCategories}
+                selectedCategory={null}
+                getCategoryKey={getCategoryKey}
+                getCategoryDisplayName={getCategoryDisplayName}
+                onCategorySelect={mockOnCategorySelect}
+                scrollAmount={300}
+            />,
+        );
+
+        const categoriesDiv = container.querySelector('.category-bar-categories') as HTMLDivElement;
+        const scrollBySpy = jest.fn();
+        categoriesDiv.scrollBy = scrollBySpy;
+
+        Object.defineProperty(categoriesDiv, 'scrollLeft', { value: 100, writable: true });
+        Object.defineProperty(categoriesDiv, 'scrollWidth', { value: 1000, writable: true });
+        Object.defineProperty(categoriesDiv, 'clientWidth', { value: 800, writable: true });
+
+        fireEvent.scroll(categoriesDiv);
+
+        const rightArrowButton = container.querySelector('.category-bar-arrow-right') as HTMLButtonElement;
+        expect(rightArrowButton).toBeInTheDocument();
+
+        fireEvent.click(rightArrowButton);
+
+        expect(scrollBySpy).toHaveBeenCalledWith({ left: 300, behavior: 'smooth' });
+    });
+
 });

--- a/src/components/admin/generic-modal-wrapper/GenericModalWrapper.tsx
+++ b/src/components/admin/generic-modal-wrapper/GenericModalWrapper.tsx
@@ -64,11 +64,6 @@ export const GenericModalWrapper = <TFormValues, TFormRef>({
     renderForm,
     categories,
 }: GenericModalWrapperProps<TFormValues, TFormRef>) => {
-    const handleCancel = () => {
-        onCancelConfirmation();
-        onClose();
-    };
-
     return (
         <>
             <Modal isOpen={isOpen} onClose={onClose}>
@@ -108,8 +103,8 @@ export const GenericModalWrapper = <TFormValues, TFormRef>({
                 isButtonsDisabled={isSubmitting}
                 title={formConfirmTitle}
                 onConfirm={onConfirmAction}
-                onCancel={handleCancel}
-                onClose={onClose}
+                onCancel={onCancelConfirmation}
+                onClose={onCancelConfirmation}
                 confirmText={COMMON_TEXT_ADMIN.BUTTON.YES}
                 cancelText={COMMON_TEXT_ADMIN.BUTTON.NO}
             />

--- a/src/pages/admin/programs/components/programs-page-modals/program-modal/ProgramModal.test.tsx
+++ b/src/pages/admin/programs/components/programs-page-modals/program-modal/ProgramModal.test.tsx
@@ -361,7 +361,7 @@ describe('ProgramModal', () => {
             expect(getQuestionModal()).not.toBeInTheDocument();
             expect(mockedProgramsApi.addProgram).not.toHaveBeenCalled();
             expect(mockOnAddProgram).not.toHaveBeenCalled();
-            expect(mockOnClose).toHaveBeenCalled();
+            expect(mockOnClose).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
## JIRA or Github ticker

* [JIRA or Github ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)

## Description

Steps to reproduce

Go to 'Команда' > 'Основна команда' page
Click on 'Додати в команду' button
Enter the value 'Анастасія Ідзьо' in the 'Ім'я та Прізвище' field and the value 'Наглядова рада' in the 'Категорія' field
Click 'Зберегти як чернетку' button
Сlick 'X' button

## How it looks

<img width="599" height="828" alt="image" src="https://github.com/user-attachments/assets/5ca3209c-17f7-42eb-8424-1d1f9b791871" />

<img width="600" height="828" alt="image" src="https://github.com/user-attachments/assets/9706a442-6a3f-41cd-b995-9d6e7f501b14" />


## Summary of change

After clicking "X" button in confirmation pop-up values in fields in (description, name and ...) don't disappear

## How to recreate changes

<!--- Please provide short instruction step-by-step how to see changes that was implemented by this PR --->


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized form-confirmation modal behavior so cancel and close actions now follow the same, consistent flow; canceling a submission no longer triggers an unintended close.

* **Tests**
  * Updated modal tests to reflect the corrected cancel/close behavior.
  * Added tests covering horizontal scrolling for the category bar arrow controls (left/right offsets and smooth scrolling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->