### PR TITLE
Fix/issue 868: Filter Status doesn't clean up automatically after an Admin choose found profile using the Search field

### DIFF
--- a/src/components/admin/admin-panel-toolbar/AdminPageToolbar.test.tsx
+++ b/src/components/admin/admin-panel-toolbar/AdminPageToolbar.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'; // Додано act
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import {
     SearchItemContentRef,
     SearchItemContentRenderProps,

--- a/src/components/admin/admin-panel-toolbar/AdminPageToolbar.test.tsx
+++ b/src/components/admin/admin-panel-toolbar/AdminPageToolbar.test.tsx
@@ -103,18 +103,11 @@ describe('AdminPanelToolbar', () => {
                 Status Filter Mock
             </div>
         ));
-        Button.mockImplementation(
-            ({
-                children,
-                onClick,
-                buttonStyle,
-                ...props
-            }: ButtonProps) => (
-                <button data-testid="add-item-button" onClick={onClick} {...props}>
-                    {children}
-                </button>
-            ),
-        );
+        Button.mockImplementation(({ children, onClick, buttonStyle, ...props }: ButtonProps) => (
+            <button data-testid="add-item-button" onClick={onClick} {...props}>
+                {children}
+            </button>
+        ));
     });
 
     const renderComponent = (props = {}) => {

--- a/src/components/admin/admin-panel-toolbar/AdminPageToolbar.test.tsx
+++ b/src/components/admin/admin-panel-toolbar/AdminPageToolbar.test.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'; // Додано act
 import {
     SearchItemContentRef,
     SearchItemContentRenderProps,
 } from '../search-bar/search-item-wrapper/SearchItemWrapper';
 import { AdminPanelToolbar } from './AdminPageToolbar';
 import { UI_CONFIG } from '../../../const/admin/common';
+import { VisibilityStatus } from '../../../types/admin/common';
+import { StatusFilterDropdownProps } from '../status-filter-dropdown/StatusFilterDropdown';
+import { ButtonProps } from '../button/Button';
 
 jest.mock('../../../hooks/admin/fetch/use-data-pagination-fetch/useDataPaginationFetch', () => ({
     useDataPaginationFetch: jest.fn(),
@@ -16,11 +19,15 @@ jest.mock('../search-bar/SearchBar', () => ({
 }));
 
 jest.mock('../status-filter-dropdown/StatusFilterDropdown', () => ({
-    StatusFilterDropdown: jest.fn(() => <div data-testid="status-filter-dropdown">Status Filter Mock</div>),
+    StatusFilterDropdown: jest.fn(({ value }: StatusFilterDropdownProps) => (
+        <div data-testid="status-filter-dropdown" data-value={value}>
+            Status Filter Mock
+        </div>
+    )),
 }));
 
 jest.mock('../button/Button', () => ({
-    Button: jest.fn(({ children, onClick, ...props }) => (
+    Button: jest.fn(({ children, onClick, ...props }: ButtonProps) => (
         <button data-testid="add-item-button" onClick={onClick} {...props}>
             {children}
         </button>
@@ -91,19 +98,18 @@ describe('AdminPanelToolbar', () => {
         const { Button } = require('../button/Button');
 
         SearchBar.mockImplementation(() => <div data-testid="search-bar">Search Bar Mock</div>);
-        StatusFilterDropdown.mockImplementation(() => (
-            <div data-testid="status-filter-dropdown">Status Filter Mock</div>
+        StatusFilterDropdown.mockImplementation(({ value }: StatusFilterDropdownProps) => (
+            <div data-testid="status-filter-dropdown" data-value={value}>
+                Status Filter Mock
+            </div>
         ));
         Button.mockImplementation(
             ({
                 children,
                 onClick,
+                buttonStyle,
                 ...props
-            }: {
-                children: React.ReactNode;
-                onClick: () => void;
-                [key: string]: any;
-            }) => (
+            }: ButtonProps) => (
                 <button data-testid="add-item-button" onClick={onClick} {...props}>
                     {children}
                 </button>
@@ -122,6 +128,7 @@ describe('AdminPanelToolbar', () => {
                 searchPageSize={5}
                 suggestionsNotFoundMessage="No items found"
                 onSearchClear={mockOnSearchClear}
+                statusFilter={undefined}
                 onStatusFilterChange={mockOnStatusFilterChange}
                 onAddItem={mockOnAddItem}
                 AddItemButtonText="Add Item"
@@ -148,10 +155,19 @@ describe('AdminPanelToolbar', () => {
         // Get the last call to StatusFilterDropdown
         const onStatusFilterChange = StatusFilterDropdown.mock.calls[0][0].onStatusFilterChange;
 
-        // Trigger the filter change with value 1 (Published)
-        onStatusFilterChange(1);
+        onStatusFilterChange(VisibilityStatus.Published);
 
-        expect(mockOnStatusFilterChange).toHaveBeenCalledWith(1);
+        expect(mockOnStatusFilterChange).toHaveBeenCalledWith(VisibilityStatus.Published);
+    });
+
+    it('passes statusFilter value correctly to StatusFilterDropdown', () => {
+        const testStatus = VisibilityStatus.Draft;
+        renderComponent({ statusFilter: testStatus });
+
+        const { StatusFilterDropdown } = require('../status-filter-dropdown/StatusFilterDropdown');
+        const lastCallProps = StatusFilterDropdown.mock.calls[StatusFilterDropdown.mock.calls.length - 1][0];
+
+        expect(lastCallProps.value).toBe(testStatus);
     });
 
     it('calls onAddItem when add button is clicked', () => {
@@ -197,8 +213,9 @@ describe('AdminPanelToolbar', () => {
         const { SearchBar } = require('../search-bar/SearchBar');
         const onSearchItemSelect = SearchBar.mock.calls[0][0].onSearchItemSelect;
 
-        // Call the onSearchItemSelect function with a mock item
-        onSearchItemSelect(mockItems[0]);
+        act(() => {
+            onSearchItemSelect(mockItems[0]);
+        });
 
         expect(mockOnSuggestionSelect).toHaveBeenCalledWith(1);
         expect(mockHookImplementation.resetList).toHaveBeenCalledTimes(1);
@@ -206,12 +223,12 @@ describe('AdminPanelToolbar', () => {
 
     it('calls onSearchClear when clear button is clicked', () => {
         renderComponent();
-
         const { SearchBar } = require('../search-bar/SearchBar');
         const onClear = SearchBar.mock.calls[0][0].onClear;
 
-        // Call the onClear function
-        onClear();
+        act(() => {
+            onClear();
+        });
 
         expect(mockOnSearchClear).toHaveBeenCalledTimes(1);
         expect(mockHookImplementation.resetList).toHaveBeenCalledTimes(1);
@@ -223,7 +240,7 @@ describe('AdminPanelToolbar', () => {
 
         // Verify initial state
         const { SearchBar } = require('../search-bar/SearchBar');
-        // Initially the search items array should be empty (matches component behavior)
+        // Initially, the search items array should be empty (matches component behavior)
         expect(SearchBar.mock.calls[0][0].searchItems).toEqual([]);
 
         // Change the data in the hook implementation
@@ -244,6 +261,7 @@ describe('AdminPanelToolbar', () => {
                 getSearchItemKey={(item) => item.id}
                 getSearchItemLabel={(item) => item.name}
                 fetchSearchItems={mockFetchSearchItems}
+                statusFilter={undefined}
                 onStatusFilterChange={mockOnStatusFilterChange}
                 onAddItem={mockOnAddItem}
                 AddItemButtonText="Add Item"
@@ -287,12 +305,12 @@ describe('AdminPanelToolbar', () => {
             }
         };
 
-        // Test with short query
+        // Test with a short query
         onSearch('a');
         expect(setCurrentSearchTerm).toHaveBeenCalledWith('a');
         expect(setLocalSearchItems).toHaveBeenCalledWith([]);
 
-        // Test with longer query
+        // Test with a longer query
         onSearch('test query');
         expect(setCurrentSearchTerm).toHaveBeenCalledWith('test query');
         // setLocalSearchItems shouldn't be called again for the longer query

--- a/src/components/admin/admin-panel-toolbar/AdminPageToolbar.tsx
+++ b/src/components/admin/admin-panel-toolbar/AdminPageToolbar.tsx
@@ -28,6 +28,7 @@ export interface AdminPanelToolbarProps<T> {
     searchPageSize?: number;
     suggestionsNotFoundMessage?: string;
     onSearchClear?: () => void;
+    statusFilter: VisibilityStatus | undefined;
     onStatusFilterChange: (statusFilter: VisibilityStatus | undefined) => void;
     onAddItem: () => void;
     AddItemButtonText: string;
@@ -43,6 +44,7 @@ export const AdminPanelToolbar = <T,>({
     searchPageSize = DEFAULT_PAGE_SIZE,
     suggestionsNotFoundMessage = COMMON_TEXT_ADMIN.LIST.NOT_FOUND,
     onSearchClear,
+    statusFilter,
     onStatusFilterChange,
     onAddItem,
     AddItemButtonText,
@@ -122,7 +124,7 @@ export const AdminPanelToolbar = <T,>({
             </div>
 
             <div className="admin-panel-toolbar-actions">
-                <StatusFilterDropdown onStatusFilterChange={onStatusFilterChange} />
+                <StatusFilterDropdown value={statusFilter} onStatusFilterChange={onStatusFilterChange} />
                 <Button onClick={onAddItem} buttonStyle="primary">
                     {AddItemButtonText} <PlusIcon />
                 </Button>

--- a/src/components/admin/status-filter-dropdown/StatusFilterDropdown.test.tsx
+++ b/src/components/admin/status-filter-dropdown/StatusFilterDropdown.test.tsx
@@ -1,23 +1,26 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { StatusFilterDropdown } from './StatusFilterDropdown';
 import { VisibilityStatus } from '../../../types/admin/common';
-import { SelectProps } from '../../common/select/Select';
+import { SelectOptionProps, SelectProps } from '../../common/select/Select';
 import { COMMON_TEXT_ADMIN } from '../../../const/admin/common';
 
 jest.mock('../../common/select/Select', () => {
-    const MockOption = ({ value, name, ...props }: any) => (
-        <option value={value === undefined ? 'undefined' : value} {...props}>
-            {name}
-        </option>
+    const MockOption = ({ value, name }: SelectOptionProps<any>) => (
+        <option value={value === undefined ? 'undefined' : value}>{name}</option>
     );
 
-    const MockSelect = ({ children, onValueChange, ...props }: SelectProps<any>) => {
+    const MockSelect = ({ children, onValueChange, value, ...props }: SelectProps<any>) => {
         const handleChange = (e: any) => {
-            const value = e.target.value === 'undefined' ? undefined : e.target.value;
-            onValueChange(value);
+            const val = e.target.value === 'undefined' ? undefined : e.target.value;
+            onValueChange(val);
         };
         return (
-            <select onChange={handleChange} data-testid="status-filter" {...props}>
+            <select
+                onChange={handleChange}
+                data-testid="status-filter"
+                value={value === undefined ? 'undefined' : value}
+                {...props}
+            >
                 {children}
             </select>
         );
@@ -35,13 +38,13 @@ describe('StatusFilterDropdown', () => {
     });
 
     it('renders the select with data-testid', () => {
-        render(<StatusFilterDropdown onStatusFilterChange={mockOnStatusFilterChange} />);
+        render(<StatusFilterDropdown value={undefined} onStatusFilterChange={mockOnStatusFilterChange} />);
         const select = screen.getByTestId('status-filter');
         expect(select).toBeInTheDocument();
     });
 
     it('renders all status options from COMMON_TEXT_ADMIN.FILTER.STATUS', () => {
-        render(<StatusFilterDropdown onStatusFilterChange={mockOnStatusFilterChange} />);
+        render(<StatusFilterDropdown value={undefined} onStatusFilterChange={mockOnStatusFilterChange} />);
         const options = screen.getAllByRole('option');
         const expectedValues = Object.values(COMMON_TEXT_ADMIN.FILTER.STATUS);
         expect(options).toHaveLength(expectedValues.length);
@@ -52,7 +55,7 @@ describe('StatusFilterDropdown', () => {
     });
 
     it('calls onStatusFilterChange with correct value when changed', () => {
-        render(<StatusFilterDropdown onStatusFilterChange={mockOnStatusFilterChange} />);
+        render(<StatusFilterDropdown value={undefined} onStatusFilterChange={mockOnStatusFilterChange} />);
         const select = screen.getByTestId('status-filter');
 
         fireEvent.change(select, { target: { value: String(VisibilityStatus.Published) } });
@@ -61,12 +64,29 @@ describe('StatusFilterDropdown', () => {
         expect(mockOnStatusFilterChange).toHaveBeenCalledWith(String(VisibilityStatus.Published));
     });
 
-    it('calls onStatusFilterChange with undefined when "undefined" is selected', () => {
-        render(<StatusFilterDropdown onStatusFilterChange={mockOnStatusFilterChange} />);
+    it('calls onStatusFilterChange with undefined when "undefined" (default option) is selected', () => {
+        render(
+            <StatusFilterDropdown value={VisibilityStatus.Published} onStatusFilterChange={mockOnStatusFilterChange} />,
+        );
         const select = screen.getByTestId('status-filter');
 
         fireEvent.change(select, { target: { value: 'undefined' } });
 
         expect(mockOnStatusFilterChange).toHaveBeenCalledWith(undefined);
+    });
+
+    it('updates the selected option when the value prop changes', () => {
+        const { rerender } = render(
+            <StatusFilterDropdown value={undefined} onStatusFilterChange={mockOnStatusFilterChange} />,
+        );
+        const select = screen.getByTestId('status-filter') as HTMLSelectElement;
+
+        expect(select.value).toBe('undefined');
+
+        rerender(
+            <StatusFilterDropdown value={VisibilityStatus.Published} onStatusFilterChange={mockOnStatusFilterChange} />,
+        );
+
+        expect(select.value).toBe(String(VisibilityStatus.Published));
     });
 });

--- a/src/components/admin/status-filter-dropdown/StatusFilterDropdown.tsx
+++ b/src/components/admin/status-filter-dropdown/StatusFilterDropdown.tsx
@@ -3,15 +3,16 @@ import { VisibilityStatus } from '../../../types/admin/common';
 import { COMMON_TEXT_ADMIN } from '../../../const/admin/common';
 import { mapLabelToStatus } from '../../../utils/functions/mappers/common/status-mappers';
 
-interface StatusFilterDropdownProps {
+export interface StatusFilterDropdownProps {
+    value: VisibilityStatus | undefined;
     onStatusFilterChange: (statusFilter: VisibilityStatus | undefined) => void;
 }
 
-export const StatusFilterDropdown = ({ onStatusFilterChange }: StatusFilterDropdownProps) => {
+export const StatusFilterDropdown = ({ value, onStatusFilterChange }: StatusFilterDropdownProps) => {
     return (
-        <Select<VisibilityStatus | undefined> onValueChange={onStatusFilterChange}>
-            {Object.entries(COMMON_TEXT_ADMIN.FILTER.STATUS).map(([, value], index) => (
-                <Select.Option key={index} value={mapLabelToStatus(value)} name={value} />
+        <Select<VisibilityStatus | undefined> onValueChange={onStatusFilterChange} value={value}>
+            {Object.entries(COMMON_TEXT_ADMIN.FILTER.STATUS).map(([, label], index) => (
+                <Select.Option key={index} value={mapLabelToStatus(label)} name={label} />
             ))}
         </Select>
     );

--- a/src/components/admin/status-filter-dropdown/StatusFilterDropdown.tsx
+++ b/src/components/admin/status-filter-dropdown/StatusFilterDropdown.tsx
@@ -8,11 +8,16 @@ export interface StatusFilterDropdownProps {
     onStatusFilterChange: (statusFilter: VisibilityStatus | undefined) => void;
 }
 
+const STATUS_OPTIONS = Object.values(COMMON_TEXT_ADMIN.FILTER.STATUS).map((label) => ({
+    value: mapLabelToStatus(label),
+    name: label,
+}));
+
 export const StatusFilterDropdown = ({ value, onStatusFilterChange }: StatusFilterDropdownProps) => {
     return (
         <Select<VisibilityStatus | undefined> onValueChange={onStatusFilterChange} value={value}>
-            {Object.entries(COMMON_TEXT_ADMIN.FILTER.STATUS).map(([, label], index) => (
-                <Select.Option key={index} value={mapLabelToStatus(label)} name={label} />
+            {STATUS_OPTIONS.map((option) => (
+                <Select.Option key={String(option.value)} value={option.value} name={option.name} />
             ))}
         </Select>
     );

--- a/src/components/common/select/Select.test.tsx
+++ b/src/components/common/select/Select.test.tsx
@@ -220,7 +220,9 @@ describe('Select Component', () => {
 
         fireEvent.click(selectButton);
 
-        const selectedOption = screen.getByRole('button', { name: 'Option 1' });
+        const buttons = screen.getAllByRole('button', { name: 'Option 1' });
+        const selectedOption = buttons.find((btn) => !btn.classList.contains('select-head'));
+
         expect(selectedOption).toHaveClass('select-options-selected');
     });
 
@@ -230,17 +232,21 @@ describe('Select Component', () => {
 
         fireEvent.click(selectButton);
 
-        const selectedOption = screen.getByRole('button', { name: 'Option 1' });
+        const buttons = screen.getAllByRole('button', { name: 'Option 1' });
+        const selectedOption = buttons.find((btn) => !btn.classList.contains('select-head'));
+
         expect(selectedOption).not.toHaveClass('select-options-selected');
     });
 
     it('has correct default value for isAutocomplete prop', () => {
-        const { container } = render(<Select {...defaultProps} value="option1" />); // isAutocomplete defaults to false
+        const { container } = render(<Select {...defaultProps} value="option1" />);
         const selectButton = container.querySelector('.select-head') as HTMLElement;
 
         fireEvent.click(selectButton);
 
-        const selectedOption = screen.getByRole('button', { name: 'Option 1' });
+        const buttons = screen.getAllByRole('button', { name: 'Option 1' });
+        const selectedOption = buttons.find((btn) => !btn.classList.contains('select-head'));
+
         expect(selectedOption).toHaveClass('select-options-selected');
     });
 
@@ -424,9 +430,9 @@ describe('Select Component', () => {
         fireEvent.click(selectButton);
 
         const options = screen.getAllByRole('button');
-        const optionButtons = options.filter(btn => btn !== selectButton);
+        const optionButtons = options.filter((btn) => btn !== selectButton);
 
-        optionButtons.forEach(option => {
+        optionButtons.forEach((option) => {
             expect(option).toHaveClass('custom-option');
         });
     });

--- a/src/components/common/select/Select.test.tsx
+++ b/src/components/common/select/Select.test.tsx
@@ -24,17 +24,6 @@ describe('Select Component', () => {
         onValueChange: jest.fn(),
     };
 
-    const getSelectButton = () => screen.getByRole('button', { name: COMMON_TEXT_ADMIN.STATUS.DEFAULT });
-
-    const renderSelectWithContainer = (props = defaultProps) => {
-        const { container } = render(<Select {...props} />);
-        return {
-            container,
-            selectContainer: container.firstChild as HTMLElement,
-            selectButton: getSelectButton(),
-        };
-    };
-
     beforeEach(() => {
         jest.clearAllMocks();
     });
@@ -68,8 +57,10 @@ describe('Select Component', () => {
         expect(ref.current).toHaveClass('select');
     });
 
-    it('opens select when clicked', () => {
-        const { selectButton, selectContainer } = renderSelectWithContainer();
+    it('opens select when button is clicked', () => {
+        const { container } = render(<Select {...defaultProps} />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
+        const selectContainer = container.firstChild as HTMLElement;
 
         fireEvent.click(selectButton);
 
@@ -78,8 +69,10 @@ describe('Select Component', () => {
         expect(icon).toBeInTheDocument();
     });
 
-    it('closes select when clicked again', () => {
-        const { selectButton, selectContainer } = renderSelectWithContainer();
+    it('closes select when button is clicked again', () => {
+        const { container } = render(<Select {...defaultProps} />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
+        const selectContainer = container.firstChild as HTMLElement;
 
         fireEvent.click(selectButton);
         expect(selectContainer).toHaveClass('select-opened');
@@ -90,7 +83,9 @@ describe('Select Component', () => {
     });
 
     it('opens select when Space or Enter is pressed', () => {
-        const { selectButton, selectContainer } = renderSelectWithContainer();
+        const { container } = render(<Select {...defaultProps} />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
+        const selectContainer = container.firstChild as HTMLElement;
 
         fireEvent.keyDown(selectButton, { key: ' ', code: 'Space', charCode: 32 });
         expect(selectContainer).toHaveClass('select-opened');
@@ -104,7 +99,9 @@ describe('Select Component', () => {
     });
 
     it('does not open select when a non-Space/Enter key is pressed', () => {
-        const { selectButton, selectContainer } = renderSelectWithContainer();
+        const { container } = render(<Select {...defaultProps} />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
+        const selectContainer = container.firstChild as HTMLElement;
 
         fireEvent.keyDown(selectButton, { key: 'a', code: 'KeyA', charCode: 65 });
         expect(selectContainer).toHaveClass('select-closed');
@@ -112,7 +109,9 @@ describe('Select Component', () => {
     });
 
     it('closes select when Space or Enter is pressed again', () => {
-        const { selectButton, selectContainer } = renderSelectWithContainer();
+        const { container } = render(<Select {...defaultProps} />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
+        const selectContainer = container.firstChild as HTMLElement;
 
         fireEvent.keyDown(selectButton, { key: ' ', code: 'Space', charCode: 32 });
         expect(selectContainer).toHaveClass('select-opened');
@@ -130,7 +129,9 @@ describe('Select Component', () => {
     });
 
     it('does not close select when a non-Space/Enter key is pressed', () => {
-        const { selectButton, selectContainer } = renderSelectWithContainer();
+        const { container } = render(<Select {...defaultProps} />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
+        const selectContainer = container.firstChild as HTMLElement;
 
         fireEvent.click(selectButton);
         expect(selectContainer).toHaveClass('select-opened');
@@ -142,7 +143,9 @@ describe('Select Component', () => {
     });
 
     it('toggles select state multiple times', () => {
-        const { selectButton, selectContainer } = renderSelectWithContainer();
+        const { container } = render(<Select {...defaultProps} />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
+        const selectContainer = container.firstChild as HTMLElement;
 
         expect(selectContainer).toHaveClass('select-closed');
 
@@ -157,8 +160,8 @@ describe('Select Component', () => {
     });
 
     it('renders all options when opened', () => {
-        render(<Select {...defaultProps} />);
-        const selectButton = getSelectButton();
+        const { container } = render(<Select {...defaultProps} />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
 
         fireEvent.click(selectButton);
 
@@ -169,8 +172,8 @@ describe('Select Component', () => {
 
     it('calls onValueChange when option is selected', () => {
         const mockOnValueChange = jest.fn();
-        render(<Select {...defaultProps} onValueChange={mockOnValueChange} />);
-        const selectButton = getSelectButton();
+        const { container } = render(<Select {...defaultProps} onValueChange={mockOnValueChange} />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
 
         fireEvent.click(selectButton);
 
@@ -182,64 +185,63 @@ describe('Select Component', () => {
     });
 
     it('updates displayed value when option is selected', () => {
-        const { container } = render(<Select {...defaultProps} />);
-        const selectButton = getSelectButton();
-        fireEvent.click(selectButton);
+        const mockOnValueChange = jest.fn();
+        const { container, rerender } = render(<Select {...defaultProps} onValueChange={mockOnValueChange} />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
 
+        fireEvent.click(selectButton);
         const option = screen.getByRole('button', { name: 'Option 1' });
         fireEvent.click(option);
+
+        expect(mockOnValueChange).toHaveBeenCalledWith('option1');
+
+        // Rerender with the new value to simulate parent component updating
+        rerender(<Select {...defaultProps} value="option1" onValueChange={mockOnValueChange} />);
 
         expect(screen.getByText('Option 1')).toBeInTheDocument();
         expect(screen.queryByText(COMMON_TEXT_ADMIN.STATUS.DEFAULT)).not.toBeInTheDocument();
     });
 
     it('changes text color when value is selected', () => {
-        const { container } = render(<Select {...defaultProps} />);
-        const selectButton = getSelectButton();
+        const { container, rerender } = render(<Select {...defaultProps} />);
         const span = container.querySelector('span');
 
         expect(span).toHaveClass('empty');
 
-        fireEvent.click(selectButton);
-
-        const option = screen.getByText('Option 1');
-        fireEvent.click(option);
+        // Rerender with value prop
+        rerender(<Select {...defaultProps} value="option1" />);
 
         expect(span).toHaveClass('not-empty');
     });
 
     it('applies selected class to options when not in autocomplete mode', () => {
-        const { container } = render(<Select {...defaultProps} isAutocomplete={false} />);
-        const selectButton = getSelectButton();
+        const { container } = render(<Select {...defaultProps} value="option1" isAutocomplete={false} />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
 
         fireEvent.click(selectButton);
-        const selectOptions = container.querySelector('.select-options') as HTMLElement;
-        fireEvent.click(selectOptions.querySelectorAll('button')[0]);
 
-        // Re-open to check the class
-        fireEvent.click(selectButton);
-
-        const selectedOption = (container.querySelector('.select-options') as HTMLElement).querySelector(
-            '.select-options-selected',
-        ) as HTMLElement;
+        const selectedOption = screen.getByRole('button', { name: 'Option 1' });
         expect(selectedOption).toHaveClass('select-options-selected');
     });
 
     it('does not apply selected class in autocomplete mode', () => {
-        const { container } = render(<Select {...defaultProps} isAutocomplete={true} />);
-        const selectButton = getSelectButton();
+        const { container } = render(<Select {...defaultProps} value="option1" isAutocomplete={true} />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
 
         fireEvent.click(selectButton);
-        const selectOptions = container.querySelector('.select-options') as HTMLElement;
-        fireEvent.click(selectOptions.querySelectorAll('button')[0]);
 
-        // Re-open to check the class
+        const selectedOption = screen.getByRole('button', { name: 'Option 1' });
+        expect(selectedOption).not.toHaveClass('select-options-selected');
+    });
+
+    it('has correct default value for isAutocomplete prop', () => {
+        const { container } = render(<Select {...defaultProps} value="option1" />); // isAutocomplete defaults to false
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
+
         fireEvent.click(selectButton);
 
-        const selectedOption = (container.querySelector('.select-options') as HTMLElement).querySelector(
-            '.select-options-selected',
-        );
-        expect(selectedOption).not.toBeInTheDocument();
+        const selectedOption = screen.getByRole('button', { name: 'Option 1' });
+        expect(selectedOption).toHaveClass('select-options-selected');
     });
 
     it('handles numeric values', () => {
@@ -247,14 +249,18 @@ describe('Select Component', () => {
         const numericProps: SelectProps<number> = {
             children: [<Select.Option key="1" value={1} name="One" />, <Select.Option key="2" value={2} name="Two" />],
             onValueChange: mockOnValueChange,
+            value: 1,
         };
-        render(<Select {...numericProps} />);
-        const selectButton = getSelectButton();
-        fireEvent.click(selectButton);
-        const option = screen.getByRole('button', { name: 'One' });
-        fireEvent.click(option);
-        expect(mockOnValueChange).toHaveBeenCalledWith(1);
+        const { container } = render(<Select {...numericProps} />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
+
         expect(screen.getByText('One')).toBeInTheDocument();
+
+        fireEvent.click(selectButton);
+        const option = screen.getByRole('button', { name: 'Two' });
+        fireEvent.click(option);
+
+        expect(mockOnValueChange).toHaveBeenCalledWith(2);
     });
 
     it('handles boolean values', () => {
@@ -265,15 +271,18 @@ describe('Select Component', () => {
                 <Select.Option key="2" value={false} name="False" />,
             ],
             onValueChange: mockOnValueChange,
+            value: true,
         };
-        render(<Select {...booleanProps} />);
+        const { container } = render(<Select {...booleanProps} />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
 
-        fireEvent.click(getSelectButton());
-        fireEvent.click(screen.getByRole('button', { name: 'True' }));
-
-        expect(mockOnValueChange).toHaveBeenCalledWith(true);
         expect(screen.getByText('True')).toBeInTheDocument();
         expect(screen.queryByText('true')).not.toBeInTheDocument();
+
+        fireEvent.click(selectButton);
+        fireEvent.click(screen.getByRole('button', { name: 'False' }));
+
+        expect(mockOnValueChange).toHaveBeenCalledWith(false);
     });
 
     it('handles empty children array', () => {
@@ -283,7 +292,7 @@ describe('Select Component', () => {
         };
 
         const { container } = render(<Select {...emptyProps} />);
-        const selectButton = getSelectButton();
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
 
         fireEvent.click(selectButton);
 
@@ -302,8 +311,8 @@ describe('Select Component', () => {
             onValueChange: jest.fn(),
         };
 
-        render(<Select {...mixedProps} />);
-        const selectButton = getSelectButton();
+        const { container } = render(<Select {...mixedProps} />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
 
         fireEvent.click(selectButton);
 
@@ -315,14 +324,15 @@ describe('Select Component', () => {
 
     it('handles option selection with multiple clicks', () => {
         const mockOnValueChange = jest.fn();
-        render(<Select {...defaultProps} onValueChange={mockOnValueChange} />);
+        const { container } = render(<Select {...defaultProps} onValueChange={mockOnValueChange} />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
 
         // First selection
-        fireEvent.click(getSelectButton());
+        fireEvent.click(selectButton);
         fireEvent.click(screen.getByRole('button', { name: 'Option 1' }));
 
         // Second selection
-        fireEvent.click(screen.getByRole('button', { name: 'Option 1' }));
+        fireEvent.click(selectButton);
         fireEvent.click(screen.getByRole('button', { name: 'Option 2' }));
 
         expect(mockOnValueChange).toHaveBeenCalledTimes(2);
@@ -332,24 +342,31 @@ describe('Select Component', () => {
 
     it('handles complete user interaction flow', () => {
         const mockOnValueChange = jest.fn();
-        const { container } = render(<Select {...defaultProps} onValueChange={mockOnValueChange} />);
+        const { container, rerender } = render(<Select {...defaultProps} onValueChange={mockOnValueChange} />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
         const selectContainer = container.firstChild as HTMLElement;
 
         expect(selectContainer).toHaveClass('select-closed');
         expect(screen.getByText(COMMON_TEXT_ADMIN.STATUS.DEFAULT)).toBeInTheDocument();
 
         // Open and select Option 1
-        fireEvent.click(getSelectButton());
+        fireEvent.click(selectButton);
         expect(selectContainer).toHaveClass('select-opened');
         fireEvent.click(screen.getByRole('button', { name: 'Option 1' }));
         expect(mockOnValueChange).toHaveBeenCalledWith('option1');
-        expect(screen.getByText('Option 1')).toBeInTheDocument();
         expect(selectContainer).toHaveClass('select-closed');
 
+        // Rerender with new value
+        rerender(<Select {...defaultProps} value="option1" onValueChange={mockOnValueChange} />);
+        expect(screen.getByText('Option 1')).toBeInTheDocument();
+
         // Open and select Option 2
-        fireEvent.click(screen.getByRole('button', { name: 'Option 1' }));
+        fireEvent.click(selectButton);
         fireEvent.click(screen.getByRole('button', { name: 'Option 2' }));
         expect(mockOnValueChange).toHaveBeenCalledWith('option2');
+
+        // Rerender with new value
+        rerender(<Select {...defaultProps} value="option2" onValueChange={mockOnValueChange} />);
         expect(screen.getByText('Option 2')).toBeInTheDocument();
     });
 
@@ -363,13 +380,12 @@ describe('Select Component', () => {
 
     it('provides access to container element through ref', () => {
         const ref = React.createRef<HTMLDivElement>();
-        render(<Select {...defaultProps} selectContainerRef={ref} />);
+        const { container } = render(<Select {...defaultProps} selectContainerRef={ref} />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
 
         expect(ref.current).toBeTruthy();
         expect(ref.current?.tagName).toBe('DIV');
 
-        // Click the button inside the ref container
-        const selectButton = getSelectButton();
         fireEvent.click(selectButton);
         expect(ref.current).toHaveClass('select-opened');
     });
@@ -392,5 +408,38 @@ describe('Select Component', () => {
         render(<Select {...defaultProps} value="nonexistent-option" onValueChange={mockOnValueChange} />);
 
         expect(screen.getByText(COMMON_TEXT_ADMIN.STATUS.DEFAULT)).toBeInTheDocument();
+    });
+
+    it('applies custom headClassName to select button', () => {
+        const { container } = render(<Select {...defaultProps} headClassName="custom-head" />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
+
+        expect(selectButton).toHaveClass('custom-head');
+    });
+
+    it('applies custom optionClassName to option buttons', () => {
+        const { container } = render(<Select {...defaultProps} optionClassName="custom-option" />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
+
+        fireEvent.click(selectButton);
+
+        const options = screen.getAllByRole('button');
+        const optionButtons = options.filter(btn => btn !== selectButton);
+
+        optionButtons.forEach(option => {
+            expect(option).toHaveClass('custom-option');
+        });
+    });
+
+    it('closes select automatically after option selection', () => {
+        const { container } = render(<Select {...defaultProps} />);
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
+        const selectContainer = container.firstChild as HTMLElement;
+
+        fireEvent.click(selectButton);
+        expect(selectContainer).toHaveClass('select-opened');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Option 1' }));
+        expect(selectContainer).toHaveClass('select-closed');
     });
 });

--- a/src/components/common/select/Select.tsx
+++ b/src/components/common/select/Select.tsx
@@ -34,12 +34,10 @@ export const Select = <TValue,>({
 
     const [isOpen, setIsOpen] = useState(false);
 
-    // Контроль стану ззовні - обчислюємо selectedOption на основі value prop
     const selectedOption = options.find((opt) => opt.props.value === value);
-    const displayLabel = selectedOption
-        ? selectedOption.props.name
-        : (placeholder ?? COMMON_TEXT_ADMIN.STATUS.DEFAULT);
     const hasValue = value !== null && value !== undefined;
+    const displayLabel =
+        hasValue && selectedOption ? selectedOption.props.name : (placeholder ?? COMMON_TEXT_ADMIN.STATUS.DEFAULT);
 
     const handleOpenSelect = () => {
         setIsOpen(!isOpen);

--- a/src/components/common/select/Select.tsx
+++ b/src/components/common/select/Select.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useState, useEffect } from 'react';
+import React, { RefObject, useState } from 'react';
 import { COMMON_TEXT_ADMIN } from '../../../const/admin/common';
 import { ReactComponent as ArrowDown } from '../../../assets/icons/chevron-down.svg';
 import { ReactComponent as ArrowUp } from '../../../assets/icons/chevron-up.svg';
@@ -33,31 +33,26 @@ export const Select = <TValue,>({
     }) as React.ReactElement<SelectOptionProps<TValue>>[];
 
     const [isOpen, setIsOpen] = useState(false);
-    const [selectedValue, setSelectedValue] = useState<TValue | null>(null);
-    const [selectedName, setSelectedName] = useState<string | null>(null);
 
-    useEffect(() => {
-        if (value !== undefined) {
-            const selectedOption = options.find((opt) => opt.props.value === value);
-            setSelectedValue(value);
-            setSelectedName(selectedOption ? selectedOption.props.name : null);
-        }
-    }, [value, options]);
+    // Контроль стану ззовні - обчислюємо selectedOption на основі value prop
+    const selectedOption = options.find((opt) => opt.props.value === value);
+    const displayLabel = selectedOption
+        ? selectedOption.props.name
+        : (placeholder ?? COMMON_TEXT_ADMIN.STATUS.DEFAULT);
+    const hasValue = value !== null && value !== undefined;
 
     const handleOpenSelect = () => {
         setIsOpen(!isOpen);
     };
 
-    const handleSelect = (value: TValue, name: string) => {
-        setSelectedValue(value);
-        setSelectedName(name);
-        onValueChange(value);
+    const handleSelect = (newValue: TValue) => {
+        onValueChange(newValue);
         setIsOpen(false);
     };
 
-    const handleOptionClick = (e: React.MouseEvent, value: TValue, name: string) => {
+    const handleOptionClick = (e: React.MouseEvent, val: TValue) => {
         e.stopPropagation();
-        handleSelect(value, name);
+        handleSelect(val);
     };
 
     return (
@@ -81,10 +76,10 @@ export const Select = <TValue,>({
             >
                 <span
                     className={classNames('empty', {
-                        'not-empty': selectedValue !== null && selectedValue !== undefined,
+                        'not-empty': hasValue,
                     })}
                 >
-                    {selectedName ?? placeholder ?? COMMON_TEXT_ADMIN.STATUS.DEFAULT}
+                    {displayLabel}
                 </span>
                 {isOpen ? <ArrowUp /> : <ArrowDown />}
             </button>
@@ -96,9 +91,9 @@ export const Select = <TValue,>({
                             <button
                                 key={`${name}-${index}`}
                                 className={classNames(optionClassName, {
-                                    'select-options-selected': !isAutocomplete && selectedValue === optValue,
+                                    'select-options-selected': !isAutocomplete && value === optValue,
                                 })}
-                                onClick={(e) => handleOptionClick(e, optValue, name)}
+                                onClick={(e) => handleOptionClick(e, optValue)}
                             >
                                 <span>{name}</span>
                             </button>

--- a/src/pages/admin/faq/components/faq-panel-content/FaqPanelContent.tsx
+++ b/src/pages/admin/faq/components/faq-panel-content/FaqPanelContent.tsx
@@ -379,6 +379,7 @@ export const FaqPanelContent = () => {
                     renderSearchItemComponent={FaqSearchItem}
                     placeholder={FAQ_TEXT.PLACEHOLDER.SEARCH_FAQ}
                     onSearchClear={() => {}}
+                    statusFilter={statusFilter}
                     onStatusFilterChange={onStatusFilterChange}
                     onAddItem={handleAddFaqModalOpen}
                     AddItemButtonText={FAQ_TEXT.BUTTON.ADD_FAQ}

--- a/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.tsx
+++ b/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.tsx
@@ -220,6 +220,7 @@ export const ProgramsPageContent = () => {
         (programId: string | number) => {
             setIsSearchResultView(true);
             setSearchProgramId(typeof programId === 'string' ? parseInt(programId, 10) : programId);
+            setStatusFilter(undefined);
             resetProgramsList();
         },
         [resetProgramsList],
@@ -409,6 +410,7 @@ export const ProgramsPageContent = () => {
                     renderSearchItemComponent={ProgramSearchItem}
                     placeholder={PROGRAMS_TEXT.PLACEHOLDER.SEARCH_PROGRAMS}
                     onSearchClear={handleSearchClear}
+                    statusFilter={statusFilter}
                     onStatusFilterChange={onStatusFilterChange}
                     onAddItem={openModalActions.openAddItemModal}
                     AddItemButtonText={PROGRAMS_TEXT.BUTTON.ADD_PROGRAM}

--- a/src/pages/admin/team/components/team-page-content/TeamPageContent.tsx
+++ b/src/pages/admin/team/components/team-page-content/TeamPageContent.tsx
@@ -484,6 +484,7 @@ export const TeamPageContent = () => {
                 <TeamPageToolbar
                     onSearchQueryChange={handleSearchQueryByName}
                     onStatusFilterChange={onStatusFilterChange}
+                    statusFilter={statusFilter}
                     onAddMember={openModalActions.openAddItemModal}
                     searchItems={searchSuggestions}
                     isSearchLoading={isSearchLoading}

--- a/src/pages/admin/team/components/team-page-toolbar/TeamPageToolbar.test.tsx
+++ b/src/pages/admin/team/components/team-page-toolbar/TeamPageToolbar.test.tsx
@@ -210,7 +210,6 @@ describe('TeamPageToolbar', () => {
     it('renders with statusFilter prop value', () => {
         renderToolbar({ statusFilter: VisibilityStatus.Published });
 
-        // Verify the component renders without errors when statusFilter is provided
         expect(screen.getByTestId('team-page-toolbar')).toBeInTheDocument();
     });
 

--- a/src/pages/admin/team/components/team-page-toolbar/TeamPageToolbar.test.tsx
+++ b/src/pages/admin/team/components/team-page-toolbar/TeamPageToolbar.test.tsx
@@ -13,6 +13,7 @@ const DEFAULT_PROPS: React.ComponentProps<typeof TeamPageToolbar> = {
     onSearchQueryChange: jest.fn(),
     onStatusFilterChange: jest.fn(),
     onAddMember: jest.fn(),
+    statusFilter: undefined,
     searchItems: [],
     isSearchLoading: false,
     searchHasMore: false,
@@ -204,5 +205,22 @@ describe('TeamPageToolbar', () => {
         rerender(<TeamPageToolbar {...{ ...DEFAULT_PROPS, categories: CATS_2, searchItems: ITEM_JANE }} />);
 
         expect(screen.getByTestId('team-member-item')).toHaveTextContent('Jane Roe - 2');
+    });
+
+    it('renders with statusFilter prop value', () => {
+        renderToolbar({ statusFilter: VisibilityStatus.Published });
+
+        // Verify the component renders without errors when statusFilter is provided
+        expect(screen.getByTestId('team-page-toolbar')).toBeInTheDocument();
+    });
+
+    it('passes statusFilter to StatusFilterDropdown', () => {
+        const { rerender } = renderToolbar({ statusFilter: undefined });
+
+        expect(screen.getByTestId('team-page-toolbar')).toBeInTheDocument();
+
+        rerender(<TeamPageToolbar {...{ ...DEFAULT_PROPS, statusFilter: VisibilityStatus.Draft }} />);
+
+        expect(screen.getByTestId('team-page-toolbar')).toBeInTheDocument();
     });
 });

--- a/src/pages/admin/team/components/team-page-toolbar/TeamPageToolbar.test.tsx
+++ b/src/pages/admin/team/components/team-page-toolbar/TeamPageToolbar.test.tsx
@@ -138,18 +138,27 @@ describe('TeamPageToolbar', () => {
         const onStatusFilterChange = jest.fn();
         renderToolbar({ onStatusFilterChange });
 
-        const statusSelect = screen.getByRole('button', { name: COMMON_TEXT_ADMIN.STATUS.DEFAULT });
+        const statusSelect = screen.getByRole('button', { name: /Статус/i });
+
         fireEvent.click(statusSelect);
 
-        fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.FILTER.STATUS.ALL));
+        const optionAll = screen.getByRole('button', { name: COMMON_TEXT_ADMIN.FILTER.STATUS.ALL });
+        fireEvent.click(optionAll);
+
         expect(onStatusFilterChange).toHaveBeenCalledWith(undefined);
 
         fireEvent.click(statusSelect);
-        fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.FILTER.STATUS.PUBLISHED));
+
+        const optionPublished = screen.getByRole('button', { name: COMMON_TEXT_ADMIN.FILTER.STATUS.PUBLISHED });
+        fireEvent.click(optionPublished);
+
         expect(onStatusFilterChange).toHaveBeenCalledWith(VisibilityStatus.Published);
 
         fireEvent.click(statusSelect);
-        fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.FILTER.STATUS.DRAFT));
+
+        const optionDraft = screen.getByRole('button', { name: COMMON_TEXT_ADMIN.FILTER.STATUS.DRAFT });
+        fireEvent.click(optionDraft);
+
         expect(onStatusFilterChange).toHaveBeenCalledWith(VisibilityStatus.Draft);
     });
 

--- a/src/pages/admin/team/components/team-page-toolbar/TeamPageToolbar.tsx
+++ b/src/pages/admin/team/components/team-page-toolbar/TeamPageToolbar.tsx
@@ -19,6 +19,7 @@ export interface TeamPageToolbarProps {
     onSearchQueryChange: (query: string) => void;
     onStatusFilterChange: (status: VisibilityStatus | undefined) => void;
     onAddMember: () => void;
+    statusFilter: VisibilityStatus | undefined;
     searchItems: TeamMember[];
     isSearchLoading: boolean;
     searchHasMore: boolean;
@@ -40,8 +41,10 @@ const createItemRenderer = (categories: TeamCategory[]) =>
 export const TeamPageToolbar = ({
     onSearchQueryChange,
     onStatusFilterChange,
+
     onAddMember,
     searchItems,
+    statusFilter,
     isSearchLoading,
     searchHasMore,
     onSearchLoadMore,
@@ -72,7 +75,7 @@ export const TeamPageToolbar = ({
                 />
             </div>
             <div className="toolbar-actions">
-                <StatusFilterDropdown onStatusFilterChange={onStatusFilterChange} />
+                <StatusFilterDropdown value={statusFilter} onStatusFilterChange={onStatusFilterChange} />
                 <Button onClick={onAddMember} buttonStyle="primary">
                     {TEAM_MEMBERS_TEXT.BUTTON.ADD_MEMBER}
                     <PlusIcon />

--- a/src/pages/admin/team/components/team-page-toolbar/TeamPageToolbar.tsx
+++ b/src/pages/admin/team/components/team-page-toolbar/TeamPageToolbar.tsx
@@ -41,7 +41,6 @@ const createItemRenderer = (categories: TeamCategory[]) =>
 export const TeamPageToolbar = ({
     onSearchQueryChange,
     onStatusFilterChange,
-
     onAddMember,
     searchItems,
     statusFilter,

--- a/src/services/api/admin/programs/programs-api.ts
+++ b/src/services/api/admin/programs/programs-api.ts
@@ -95,14 +95,12 @@ export const ProgramsApi = {
         limit: number = 5,
         signal?: AbortSignal,
     ): Promise<PaginationResult<ProgramSearchItemData>> => {
-        const params = {
-            SearchQuery: searchTerm,
-            offset: offset,
-            limit: limit,
-        };
-
         const response = await client.get<PaginationResult<Program>>(`${API_ROUTES.PROGRAMS.SEARCH}`, {
-            params,
+            params: {
+                SearchQuery: searchTerm,
+                offset: offset,
+                limit: limit,
+            },
             signal,
         });
 

--- a/src/types/admin/team-members.ts
+++ b/src/types/admin/team-members.ts
@@ -10,17 +10,6 @@ export type TeamMember = {
     categoryId: number;
 };
 
-export interface TeamMemberDto {
-    id: number;
-    fullName: string;
-    categoryId: number;
-    priority: number;
-    status: number;
-    description: string;
-    image: Image;
-    email: string;
-}
-
 export interface TeamMemberCreateUpdateRequest {
     id: number | null;
     fullName: string;


### PR DESCRIPTION
## Github ticker

* [868](https://github.com/ita-social-projects/VictoryCenter-Back/issues/868)

## Description

Fix of problem when Filter Status doesn't clean up automatically after an Admin choose found profile using the Search field.

## How it looks

Before selecting search suggestion:
<img width="1920" height="907" alt="image" src="https://github.com/user-attachments/assets/8f461a56-d8b7-4d85-ab78-86aa5111d8ed" />

After clicking the suggestion:
<img width="1920" height="903" alt="image" src="https://github.com/user-attachments/assets/f958c0cc-913d-4e08-abde-0b4e0826ba2b" />

## Summary of change
- Add statusFilter prop to TeamPageToolbar, AdminPanelToolbar and StatusFilterDropdown to make filter value controllable from upper level
- Improve Select component and fix tests
- Remove unused TeamMemberDto

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin panel now displays and maintains the current visibility status filter across toolbars and pages.

* **Bug Fixes**
  * Status filter dropdown now correctly reflects the selected filter value when the page reloads or navigation occurs.
  * Select component now properly syncs with parent state updates without delay.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->