### PR TITLE
Fix/issue-855: Fixed hover states not matching mock-ups at the admin-panel/donate page

### DIFF
--- a/src/components/admin/admin-navigation/AdminNavigation.scss
+++ b/src/components/admin/admin-navigation/AdminNavigation.scss
@@ -28,6 +28,11 @@
             text-decoration: none;
             position: relative;
             padding: 0.9375rem 0.625rem 0.9375rem 2.5rem;
+            transition: background-color 0.2s;
+
+            &:hover:not(.admin-pages-selected) {
+                background-color: colors.$blue-50;
+            }
         }
 
         &-selected {

--- a/src/components/admin/category-bar/CategoryBar.tsx
+++ b/src/components/admin/category-bar/CategoryBar.tsx
@@ -92,6 +92,7 @@ export const CategoryBar = <T,>({
             )}
             {showLeftArrow && (
                 <button
+                    title="Scroll Left"
                     className="category-bar-arrow category-bar-arrow-left"
                     onClick={() => handleScroll('left')}
                     type="button"
@@ -113,6 +114,7 @@ export const CategoryBar = <T,>({
             </div>
             {showRightArrow && (
                 <button
+                    title="Scroll Right"
                     className="category-bar-arrow category-bar-arrow-right"
                     onClick={() => handleScroll('right')}
                     type="button"

--- a/src/pages/admin/donate/components/donate-page-content/DonatePageContent.scss
+++ b/src/pages/admin/donate/components/donate-page-content/DonatePageContent.scss
@@ -66,7 +66,7 @@
 }
 
 .edit-btn {
-    cursor: default;
+    cursor: pointer;
     transition: opacity 0.2s ease;
     border: none;
     width: 1.5rem;
@@ -76,12 +76,9 @@
     &.edit {
         background: url('../../../../../assets/icons/edit-filled.svg');
     }
-
-    &.view {
-        cursor: pointer;
-        &:hover {
-            opacity: 0.7;
-        }
+    &:hover {
+        background: url('../../../../../assets/icons/edit-hover.svg');
+        transition: opacity 0.2s ease;
     }
 }
 

--- a/src/pages/admin/donate/components/donate-page-content/DonatePageContent.scss
+++ b/src/pages/admin/donate/components/donate-page-content/DonatePageContent.scss
@@ -67,7 +67,7 @@
 
 .edit-btn {
     cursor: default;
-    transition: opacity 0.2s ease;
+    transition: background-image 0.2s ease;
     border: none;
     width: 1.5rem;
     height: 1.5rem;
@@ -81,7 +81,6 @@
         cursor: pointer;
         &:hover {
             background: url('../../../../../assets/icons/edit-hover.svg');
-            transition: opacity 0.2s ease;
         }
     }
 }

--- a/src/pages/admin/donate/components/donate-page-content/DonatePageContent.scss
+++ b/src/pages/admin/donate/components/donate-page-content/DonatePageContent.scss
@@ -96,7 +96,7 @@
     font-size: 1.125rem;
 
     &:hover {
-        opacity: 0.7;
+        background: url('../../../../../assets/icons/delete-hover.svg') no-repeat;
     }
 
     width: 1.5rem;

--- a/src/pages/admin/donate/components/donate-page-content/DonatePageContent.scss
+++ b/src/pages/admin/donate/components/donate-page-content/DonatePageContent.scss
@@ -89,7 +89,7 @@
     display: flex;
     justify-self: flex-end;
     cursor: pointer;
-    transition: opacity 0.2s ease;
+    transition: background-image 0.2s ease;
     border: none;
     gap: 0.25rem;
     font-size: 1.125rem;

--- a/src/pages/admin/donate/components/donate-page-content/DonatePageContent.scss
+++ b/src/pages/admin/donate/components/donate-page-content/DonatePageContent.scss
@@ -66,7 +66,7 @@
 }
 
 .edit-btn {
-    cursor: pointer;
+    cursor: default;
     transition: opacity 0.2s ease;
     border: none;
     width: 1.5rem;
@@ -76,9 +76,13 @@
     &.edit {
         background: url('../../../../../assets/icons/edit-filled.svg');
     }
-    &:hover {
-        background: url('../../../../../assets/icons/edit-hover.svg');
-        transition: opacity 0.2s ease;
+
+    &.view {
+        cursor: pointer;
+        &:hover {
+            background: url('../../../../../assets/icons/edit-hover.svg');
+            transition: opacity 0.2s ease;
+        }
     }
 }
 

--- a/src/pages/admin/donate/components/generic-form/GenericForm.tsx
+++ b/src/pages/admin/donate/components/generic-form/GenericForm.tsx
@@ -168,29 +168,9 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
 
             const handleEditClick = (e: React.MouseEvent<HTMLButtonElement>) => {
                 e.preventDefault();
-                if (!isExpanded) {
-                    setIsExpanded(true);
-                    setMode(GenericFormMode.Edit);
-                } else if (mode === GenericFormMode.View) {
-                    setMode(GenericFormMode.Edit);
-                } else {
-                    // Exiting edit mode, check for unsaved changes
-                    if (isChanged()) {
-                        setModalConfig({
-                            title: COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE,
-                            onConfirm: () => {
-                                setFormState(initialFormState);
-                                setErrors({});
-                                setTouchedFields(new Set());
-                                setMode(GenericFormMode.View);
-                                setIsExpanded(false);
-                            },
-                        });
-                    } else {
-                        setMode(GenericFormMode.View);
-                        setIsExpanded(false);
-                    }
-                }
+                if (mode === GenericFormMode.Edit) return;
+                setMode((prev) => (prev === GenericFormMode.View ? GenericFormMode.Edit : GenericFormMode.View));
+                setIsExpanded(true);
             };
 
             const handleCreateCancel = () => {
@@ -213,7 +193,6 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
                             setErrors({});
                             setTouchedFields(new Set());
                             setMode(GenericFormMode.View);
-                            setIsExpanded(false);
                         },
                     });
                 } else {
@@ -221,13 +200,11 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
                     setErrors({});
                     setTouchedFields(new Set());
                     setMode(GenericFormMode.View);
-                    setIsExpanded(false);
                 }
             };
 
             const handleViewCancel = () => {
                 setIsExpanded(false);
-                setMode(GenericFormMode.View);
             };
 
             const handleCancel = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -322,6 +299,7 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
                                         className={`edit-btn ${mode}`}
                                         aria-label="edit-btn"
                                         onClick={handleEditClick}
+                                        disabled={mode === GenericFormMode.Edit}
                                     />
                                     <button
                                         className={`delete-btn ${mode}`}

--- a/src/pages/admin/donate/components/generic-form/GenericForm.tsx
+++ b/src/pages/admin/donate/components/generic-form/GenericForm.tsx
@@ -213,6 +213,7 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
                             setErrors({});
                             setTouchedFields(new Set());
                             setMode(GenericFormMode.View);
+                            setIsExpanded(false);
                         },
                     });
                 } else {
@@ -220,6 +221,7 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
                     setErrors({});
                     setTouchedFields(new Set());
                     setMode(GenericFormMode.View);
+                    setIsExpanded(false);
                 }
             };
 

--- a/src/pages/admin/donate/components/generic-form/GenericForm.tsx
+++ b/src/pages/admin/donate/components/generic-form/GenericForm.tsx
@@ -168,9 +168,29 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
 
             const handleEditClick = (e: React.MouseEvent<HTMLButtonElement>) => {
                 e.preventDefault();
-                if (mode === GenericFormMode.Edit) return;
-                setMode((prev) => (prev === GenericFormMode.View ? GenericFormMode.Edit : GenericFormMode.View));
-                setIsExpanded(true);
+                if (!isExpanded) {
+                    setIsExpanded(true);
+                    setMode(GenericFormMode.Edit);
+                } else if (mode === GenericFormMode.View) {
+                    setMode(GenericFormMode.Edit);
+                } else {
+                    // Exiting edit mode, check for unsaved changes
+                    if (isChanged()) {
+                        setModalConfig({
+                            title: COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE,
+                            onConfirm: () => {
+                                setFormState(initialFormState);
+                                setErrors({});
+                                setTouchedFields(new Set());
+                                setMode(GenericFormMode.View);
+                                setIsExpanded(false);
+                            },
+                        });
+                    } else {
+                        setMode(GenericFormMode.View);
+                        setIsExpanded(false);
+                    }
+                }
             };
 
             const handleCreateCancel = () => {
@@ -205,6 +225,7 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
 
             const handleViewCancel = () => {
                 setIsExpanded(false);
+                setMode(GenericFormMode.View);
             };
 
             const handleCancel = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -299,7 +320,6 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
                                         className={`edit-btn ${mode}`}
                                         aria-label="edit-btn"
                                         onClick={handleEditClick}
-                                        disabled={mode === GenericFormMode.Edit}
                                     />
                                     <button
                                         className={`delete-btn ${mode}`}

--- a/src/pages/admin/donate/components/support-options/support-option-item/SupportOptionItem.tsx
+++ b/src/pages/admin/donate/components/support-options/support-option-item/SupportOptionItem.tsx
@@ -155,7 +155,7 @@ export const SupportOptionItem = ({
                     <div className="support-option-header-actions">
                         <button
                             aria-label="edit-btn"
-                            className={`edit-btn ${editable ? 'edit' : ''}`}
+                            className={`edit-btn ${editable ? 'edit' : 'view'}`}
                             onClick={handleEditClick}
                             disabled={isSubmitting}
                         />


### PR DESCRIPTION
## Github ticker

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/855)

## Description

Corrected hover and active styles across the admin-panel/donate page interface, including updating the admin-page-link hover behavior in AdminNavigation, fixing the edit button styles and ensuring their hover state is applied consistently, and setting the correct hover image for the delete button

## How it looks


https://github.com/user-attachments/assets/0866ca01-4526-4ae3-8b6b-329cbff0633d


## Summary of change

Hover states are now working as intended across the admin-panel/donate page

## How to recreate changes

1. Log in to the Admin panel
2. Go to the “Donations” page
3. Hover over different active tabs/buttons



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced hover interactions for admin navigation links with a smooth background transition and a subtle blue hover state.
  * Updated edit and delete controls to use image-based hover visuals and adjusted their hover transitions for clearer feedback.
  * Adjusted view-mode styling so edit controls render consistently in view state.

* **Accessibility**
  * Added descriptive titles to category scroll arrow buttons for improved screen-reader support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->