### PR TITLE
Fix/issue 995: While add new corresponding bank button add new details should be disabled

### DIFF
--- a/src/pages/admin/donate/components/donate-page-content/DonatePageContent.tsx
+++ b/src/pages/admin/donate/components/donate-page-content/DonatePageContent.tsx
@@ -26,6 +26,7 @@ export const DonatePageContent = () => {
     const [supportOptions, setSupportOptions] = useState<SupportOptionsType[]>([]);
     const [isSupportOptionsLoading, setIsSupportOptionsLoading] = useState(false);
 
+    const [isCorrespondentBankFormVisible, setIsCorrespondentBankFormVisible] = useState(false);
     useEffect(() => {
         let isAlive = true;
         const bankCurrency = mapCurrencyToBankCurrency(selectedCategory);
@@ -249,6 +250,7 @@ export const DonatePageContent = () => {
                 onSubmit={(data) => handleCreateCorrespondentBank(formState.id, data)}
                 onUpdate={(id, data) => handleUpdateCorrespondentBank(formState.id, id, data)}
                 onDelete={(id) => handleDeleteCorrespondentBank(formState.id, id)}
+                onAddFormVisibilityChange={setIsCorrespondentBankFormVisible}
             />
         ),
         [
@@ -284,6 +286,7 @@ export const DonatePageContent = () => {
                             onSubmit={handleCreateBankDetails}
                             onUpdate={handleUpdateBankDetails}
                             onDelete={handleDeleteBankDetails}
+                            isParentAddFormVisible={isCorrespondentBankFormVisible}
                         >
                             {config.withCorrespondentBanks ? renderCorrespondentBanks : () => null}
                         </GenericDetails>

--- a/src/pages/admin/donate/components/donate-page-content/DonatePageContent.tsx
+++ b/src/pages/admin/donate/components/donate-page-content/DonatePageContent.tsx
@@ -282,7 +282,7 @@ export const DonatePageContent = () => {
                             isLoading={isLoading}
                             FormComponent={config.form}
                             notFoundText={DONATE_TEXT.BANK_DETAILS.NOT_FOUND}
-                            addNewText={DONATE_TEXT.BANK_DETAILS.ADD_FIRST}
+                            addNewText={DONATE_TEXT.BANK_DETAILS.ADD_NEW}
                             onSubmit={handleCreateBankDetails}
                             onUpdate={handleUpdateBankDetails}
                             onDelete={handleDeleteBankDetails}

--- a/src/pages/admin/donate/components/generic-details/GenericDetails.tsx
+++ b/src/pages/admin/donate/components/generic-details/GenericDetails.tsx
@@ -25,6 +25,8 @@ export interface GenericDetailsProps<T extends FieldValues> {
     onSubmit?: (data: T) => Promise<void>;
     onUpdate?: (id: number, data: T) => Promise<void>;
     onDelete?: (id: number) => Promise<void>;
+    onAddFormVisibilityChange?: (isVisible: boolean) => void;
+    isParentAddFormVisible?: boolean;
 }
 
 export function GenericDetails<T extends { id: number } & FieldValues>({
@@ -42,6 +44,8 @@ export function GenericDetails<T extends { id: number } & FieldValues>({
     onSubmit,
     onUpdate,
     onDelete,
+    onAddFormVisibilityChange,
+    isParentAddFormVisible = false,
 }: GenericDetailsProps<T>) {
     const addformRef = useRef<GenericFormRef>(null);
     const [isAddFormVisible, setIsAddFormVisible] = useState(false);
@@ -65,10 +69,12 @@ export function GenericDetails<T extends { id: number } & FieldValues>({
 
     const handleAdd = () => {
         setIsAddFormVisible(true);
+        onAddFormVisibilityChange?.(true);
     };
 
     const handleClose = () => {
         setIsAddFormVisible(false);
+        onAddFormVisibilityChange?.(false);
     };
 
     const handleSubmit = useCallback(
@@ -76,17 +82,20 @@ export function GenericDetails<T extends { id: number } & FieldValues>({
             if (onSubmit) {
                 await onSubmit(data);
                 setIsAddFormVisible(false);
+                onAddFormVisibilityChange?.(false);
             } else if (isChildForm) {
                 onChangeItems?.((prevItems) => [...prevItems, data]);
                 setIsAddFormVisible(false);
+                onAddFormVisibilityChange?.(false);
             } else {
                 const newItemWithId = { ...data, id: data.id || Date.now() };
 
                 onChangeItems?.((prevItems) => [...prevItems, newItemWithId]);
                 setIsAddFormVisible(false);
+                onAddFormVisibilityChange?.(false);
             }
         },
-        [onSubmit, isChildForm, onChangeItems],
+        [onSubmit, isChildForm, onChangeItems, onAddFormVisibilityChange],
     );
 
     const handleItemUpdate = useCallback(
@@ -188,7 +197,7 @@ export function GenericDetails<T extends { id: number } & FieldValues>({
                             className={`generic-details btn-add-new ${isAddFormVisible || editingItemId !== null ? 'disabled' : ''}`}
                             onClick={handleAdd}
                             buttonStyle="primary"
-                            disabled={isAddFormVisible || editingItemId !== null}
+                            disabled={isAddFormVisible || editingItemId !== null || isParentAddFormVisible}
                         >
                             <div>{addNewText}</div>
                             <PlusIcon className="plus-icon" />


### PR DESCRIPTION
##GitHub Ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/955)

## Description

<!--- Please decripe the main goal of this PR and why it was created --->

## How it looks

<img width="1039" height="717" alt="Screenshot 2025-12-03 235306" src="https://github.com/user-attachments/assets/177c2f94-c0fa-4ed5-970a-9d14d590974d" />


## Summary of change
At first I change namin on main add button from "Додати реквізити" to "Додати нові реквізити" and when we add new corresponding bank button "Додати нові реквізити" become disabled.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed issue where multiple form panels could open simultaneously when adding correspondent bank and bank details.

* **Improvements**
  * Enhanced form state management to prevent conflicting form operations in the donations administration interface.
  * Updated text labels for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->