### PR TITLE
Fix/issue-909: User can attempt to create a correspondent bank without a main bank

### DIFF
--- a/src/pages/admin/donate/components/donate-page-content/DonatePageContent.tsx
+++ b/src/pages/admin/donate/components/donate-page-content/DonatePageContent.tsx
@@ -246,6 +246,7 @@ export const DonatePageContent = () => {
                 primaryAddButton={true}
                 addNewText={DONATE_TEXT.CORRESPONDENT_BANKS.ADD_NEW}
                 isChildForm={true}
+                isDisabled={!formState.id}
                 onSubmit={(data) => handleCreateCorrespondentBank(formState.id, data)}
                 onUpdate={(id, data) => handleUpdateCorrespondentBank(formState.id, id, data)}
                 onDelete={(id) => handleDeleteCorrespondentBank(formState.id, id)}

--- a/src/pages/admin/donate/components/generic-details/GenericDetails.tsx
+++ b/src/pages/admin/donate/components/generic-details/GenericDetails.tsx
@@ -20,6 +20,7 @@ export interface GenericDetailsProps<T extends FieldValues> {
     notFoundText?: string;
     addNewText: string;
     isChildForm?: boolean;
+    isDisabled?: boolean;
     children?: (form: { formState: T; isItemsExpanded: boolean }) => React.ReactNode;
     onChangeItems?: React.Dispatch<React.SetStateAction<T[]>>;
     onSubmit?: (data: T) => Promise<void>;
@@ -37,6 +38,7 @@ export function GenericDetails<T extends { id: number } & FieldValues>({
     notFoundText,
     addNewText,
     isChildForm = false,
+    isDisabled = false,
     children,
     onChangeItems,
     onSubmit,
@@ -163,6 +165,7 @@ export function GenericDetails<T extends { id: number } & FieldValues>({
                                         onClose={handleClose}
                                         onDelete={() => handleItemDelete(item.id)}
                                         isChildForm={isChildForm}
+                                        isDisabled={isDisabled}
                                         onModeChange={(mode: GenericFormMode) => handleItemModeChange(item.id, mode)}
                                     >
                                         {(formProps) => <>{children && children(formProps)}</>}
@@ -179,6 +182,7 @@ export function GenericDetails<T extends { id: number } & FieldValues>({
                             onClose={handleClose}
                             initialMode={GenericFormMode.Create}
                             isChildForm={isChildForm}
+                            isDisabled={isDisabled}
                         >
                             {(formProps) => <>{children && children(formProps)}</>}
                         </FormComponent>

--- a/src/pages/admin/donate/components/generic-form/GenericForm.tsx
+++ b/src/pages/admin/donate/components/generic-form/GenericForm.tsx
@@ -26,6 +26,7 @@ export interface GenericFormProps<T extends FieldValues> {
     onClose: () => void;
     onDelete?: (id: number) => void;
     isChildForm?: boolean;
+    isDisabled?: boolean;
     children?: (form: { formState: T; isItemsExpanded: boolean }) => React.ReactNode;
     onModeChange?: (mode: GenericFormMode) => void;
 }
@@ -62,6 +63,7 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
                 onSubmit,
                 onDelete,
                 isChildForm = false,
+                isDisabled = false,
                 children,
                 onModeChange,
             },
@@ -277,7 +279,8 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
                 isSubmitting ||
                 hasEmptyRequiredFields ||
                 !isChanged() ||
-                Object.values(errors).some((e) => e !== undefined);
+                Object.values(errors).some((e) => e !== undefined) ||
+                isDisabled;
 
             return (
                 <div


### PR DESCRIPTION
## Github ticker

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/909)

## Description

Previously, user could submit a new correspondent bank without a main one, which resulted an 404 error

## How it looks

<img width="1455" height="1121" alt="image" src="https://github.com/user-attachments/assets/56082b54-4510-4cf8-81a2-c01eb6c5ba75" />


## Summary of change

Made changes to disable the submission of the correspondent bank form when the ID of the main bank is missing

## How to recreate changes

1. Log in to the Admin panel
2. Go to the “Donations” page
3. Switch currency to USD or EUR
4. Click the "Додати реквізити" button
5. Click the "Додати банк" button under the "Кореспондентські банки" button
6. Fill out the required fields of a correspondent bank
7. Try to submit the form of the correspondent bank

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Form interactions are now properly restricted until required conditions are met, preventing invalid submissions.
  * Correspondent bank forms are now disabled until initial data is established.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->