### PR TITLE
Fix/issue-937: Account filed don`t visible on visitor page if it null

### DIFF
--- a/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.test.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.test.tsx
@@ -80,6 +80,18 @@ describe('CorrespondentBanksSection', () => {
             expectBankFields(['SWIFT: TEST123', 'Account: 123456789'], 2);
         });
 
+        it('renders correspondent banks without Account when not provided', () => {
+            const mockBanks = [createMockCorrespondentBank({ account: undefined })];
+            renderAndExpectBasics(mockBanks, 'Test Bank USD');
+            expectBankFields(['SWIFT: TEST123', 'IBAN: US29NWBK60161331926819'], 2);
+        });
+
+        it('renders correspondent banks with empty Account when provided but empty', () => {
+            const mockBanks = [createMockCorrespondentBank({ account: '' })];
+            render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
+            expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
+            expectBankFields(['SWIFT: TEST123', 'IBAN: US29NWBK60161331926819'], 2);
+        });
         it('renders multiple correspondent banks', () => {
             const mockBanks = [
                 createMockCorrespondentBank({ name: 'Bank 1', swift: 'BANK1' }),
@@ -106,13 +118,13 @@ describe('CorrespondentBanksSection', () => {
                 createMockCorrespondentBank({
                     name: '',
                     swift: '',
-                    account: '',
+                    account: null as any,
                     foreignIban: null as any,
                 }),
             ];
 
             renderAndExpectBasics(mockBanks, '');
-            expectBankFields(['SWIFT:', 'Account:'], 2);
+            expectBankFields(['SWIFT:'], 1);
         });
 
         it('handles banks with null IBAN value', () => {
@@ -121,6 +133,18 @@ describe('CorrespondentBanksSection', () => {
             render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
             expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
             expectBankFields(['SWIFT: TEST123', 'Account: 123456789'], 2);
+        });
+        it('handles banks with null Account value', () => {
+            const mockBanks = [createMockCorrespondentBank({ account: null as any })];
+            render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
+            expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
+            expectBankFields(['SWIFT: TEST123', 'IBAN: US29NWBK60161331926819'], 2);
+        });
+        it('handles banks with both Account and IBAN as null', () => {
+            const mockBanks = [createMockCorrespondentBank({ account: null as any, foreignIban: null as any })];
+            render(<CorrespondentBanksSection correspondentBanks={mockBanks} />);
+            expect(screen.getByText('Кореспондентські банки')).toBeInTheDocument();
+            expectBankFields(['SWIFT: TEST123'], 1);
         });
     });
 

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.tsx
@@ -15,7 +15,6 @@ export const CorrespondentBanksSection = ({
         title: apiBank.name,
         fields: [
             { label: ABROAD_PAYMENT_DETAILS.SWIFT_LABEL, value: apiBank.swift },
-            //{ label: ABROAD_PAYMENT_DETAILS.ACCOUNT_LABEL, value: apiBank.account },
             ...(apiBank.account ? [{ label: ABROAD_PAYMENT_DETAILS.ACCOUNT_LABEL, value: apiBank.account }] : []),
             ...(apiBank.foreignIban ? [{ label: ABROAD_PAYMENT_DETAILS.IBAN_LABEL, value: apiBank.foreignIban }] : []),
         ],

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.tsx
@@ -15,7 +15,8 @@ export const CorrespondentBanksSection = ({
         title: apiBank.name,
         fields: [
             { label: ABROAD_PAYMENT_DETAILS.SWIFT_LABEL, value: apiBank.swift },
-            { label: ABROAD_PAYMENT_DETAILS.ACCOUNT_LABEL, value: apiBank.account },
+            //{ label: ABROAD_PAYMENT_DETAILS.ACCOUNT_LABEL, value: apiBank.account },
+            ...(apiBank.account ? [{ label: ABROAD_PAYMENT_DETAILS.ACCOUNT_LABEL, value: apiBank.account }] : []),
             ...(apiBank.foreignIban ? [{ label: ABROAD_PAYMENT_DETAILS.IBAN_LABEL, value: apiBank.foreignIban }] : []),
         ],
     }));


### PR DESCRIPTION
##Github Ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/937)

## Description

<!--- Please decripe the main goal of this PR and why it was created --->

## How it looks

<img width="1617" height="903" alt="image" src="https://github.com/user-attachments/assets/d7f73bcf-991b-4f9b-bce2-9d0197241527" />

## Summary of change

When account filed is null, it don`t visible on visitor page. Also i cover this changes by unit tests.

## How to recreate changes

<!--- Please provide short instruction step-by-step how to see changes that was implemented by this PR --->


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions
