### PR TITLE
Fix/issue-887: Corrected bank list order in Visitor and Admin panels

### DIFF
--- a/src/pages/admin/donate/components/donate-page-content/DonatePageContent.tsx
+++ b/src/pages/admin/donate/components/donate-page-content/DonatePageContent.tsx
@@ -238,25 +238,30 @@ export const DonatePageContent = () => {
     );
 
     const renderCorrespondentBanks = useCallback(
-        ({ formState, isItemsExpanded }: any) => (
-            <GenericDetails
-                key={`corr-${selectedCategory}-${formState.id}`}
-                title={DONATE_TEXT.CORRESPONDENT_BANKS.TITLE}
-                items={items.find((i) => i.id === formState.id)?.correspondentBanks ?? []}
-                isLoading={false}
-                FormComponent={config?.correspondentForm!}
-                initialIsItemsExpanded={isItemsExpanded}
-                primaryAddButton={true}
-                addNewText={DONATE_TEXT.CORRESPONDENT_BANKS.ADD_NEW}
-                isChildForm={true}
-                isDisabled={!formState.id}
-                onSubmit={(data) => handleCreateCorrespondentBank(formState.id, data)}
-                onUpdate={(id, data) => handleUpdateCorrespondentBank(formState.id, id, data)}
-                onDelete={(id) => handleDeleteCorrespondentBank(formState.id, id)}
-                onEditingStateChange={setIsChildEditing}
-                onAddFormVisibilityChange={setIsCorrespondentBankFormVisible}
-            />
-        ),
+        ({ formState, isItemsExpanded }: any) => {
+            const correspondentBanks = items.find((i) => i.id === formState.id)?.correspondentBanks ?? [];
+            const sortedCorrespondentBanks = [...correspondentBanks].sort((a, b) => a.id - b.id);
+
+            return (
+                <GenericDetails
+                    key={`corr-${selectedCategory}-${formState.id}`}
+                    title={DONATE_TEXT.CORRESPONDENT_BANKS.TITLE}
+                    items={sortedCorrespondentBanks}
+                    isLoading={false}
+                    FormComponent={config?.correspondentForm!}
+                    initialIsItemsExpanded={isItemsExpanded}
+                    primaryAddButton={true}
+                    addNewText={DONATE_TEXT.CORRESPONDENT_BANKS.ADD_NEW}
+                    isChildForm={true}
+                    isDisabled={!formState.id}
+                    onSubmit={(data) => handleCreateCorrespondentBank(formState.id, data)}
+                    onUpdate={(id, data) => handleUpdateCorrespondentBank(formState.id, id, data)}
+                    onDelete={(id) => handleDeleteCorrespondentBank(formState.id, id)}
+                    onEditingStateChange={setIsChildEditing}
+                    onAddFormVisibilityChange={setIsCorrespondentBankFormVisible}
+                />
+            );
+        },
         [
             selectedCategory,
             items,

--- a/src/pages/admin/donate/components/donate-page-content/DonatePageContent.tsx
+++ b/src/pages/admin/donate/components/donate-page-content/DonatePageContent.tsx
@@ -288,7 +288,7 @@ export const DonatePageContent = () => {
                     {config && (
                         <GenericDetails
                             key={`bank-details-${selectedCategory}`}
-                            items={items}
+                            items={[...items].sort((a, b) => a.id - b.id)}
                             isLoading={isLoading}
                             FormComponent={config.form}
                             notFoundText={DONATE_TEXT.BANK_DETAILS.NOT_FOUND}

--- a/src/pages/admin/donate/components/generic-form/GenericForm.scss
+++ b/src/pages/admin/donate/components/generic-form/GenericForm.scss
@@ -113,7 +113,7 @@
         }
 
         .body {
-            flex-direction: column-reverse;
+            flex-direction: column;
         }
 
         .generic-form {

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.tsx
@@ -17,13 +17,14 @@ export const AbroadPaymentDetails = ({ currency, foreignBankDetails }: AbroadPay
         return null;
     }
 
+    const sortedForeignBankDetails = [...foreignBankDetails].sort((a, b) => a.id - b.id);
     const currencyString = currencyToString(currency) as AbroadCurrency;
     const title = ABROAD_PAYMENT_DETAILS[`${currencyString}_PAYMENT_DETAILS_LABEL`];
     const ibanLabel = ABROAD_PAYMENT_DETAILS[`IBAN_${currencyString}_LABEL`];
 
     return (
         <div className="abroadPaymentDetails">
-            {foreignBankDetails.map((bank, index) => (
+            {sortedForeignBankDetails.map((bank, index) => (
                 <div key={bank.id} className={`bankGroup ${index > 0 ? 'separated' : ''}`}>
                     <PaymentDetailsSection
                         title={index === 0 ? title : ''}

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.tsx
@@ -11,7 +11,8 @@ export const CorrespondentBanksSection = ({
         return null;
     }
 
-    const banks = correspondentBanks.map((apiBank) => ({
+    const sortedCorrespondentBanks = [...correspondentBanks].sort((a, b) => a.id - b.id);
+    const banks = sortedCorrespondentBanks.map((apiBank) => ({
         title: apiBank.name,
         fields: [
             { label: ABROAD_PAYMENT_DETAILS.SWIFT_LABEL, value: apiBank.swift },

--- a/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.tsx
+++ b/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.tsx
@@ -12,10 +12,12 @@ export const UkrainePaymentDetails = ({ bankDetails }: UkrainePaymentDetailsProp
         return null;
     }
 
+    const sortedBankDetails = [...bankDetails].sort((a, b) => a.id - b.id);
+
     return (
         <div className="UkrainePaymentDetails">
             <h2>{UKRAINE_PAYMENT_DETAILS.UKRAINE_PAYMENT_DETAILS_LABEL}</h2>
-            {bankDetails.map((bank, index) => (
+            {sortedBankDetails.map((bank, index) => (
                 <div key={bank.id} className={`paymentDetails ${index > 0 ? 'separated' : ''}`}>
                     <div className="paymentLabel">
                         <h3>{PAYMENT_DETAILS_COMMON.RECIPIENT_LABEL}</h3>


### PR DESCRIPTION
## Github ticker

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/887)

## Description

This PR fixes the inconsistent ordering of published correspondent bank details across the Visitor interface and the Admin panel for USD, EUR, and UAH tabs.
To resolve this, the update introduces consistent sorting by id for all bank lists (UAH banks, foreign banks, correspondent banks) and removes layout styles that inverted the visual order

## How it looks

Example for UahBankDetails

Visitor donate page:
<img width="672" height="1112" alt="image" src="https://github.com/user-attachments/assets/c32f2dd0-ecae-4d6a-a99b-8aff3541352c" />

Admin donate page:
<img width="656" height="807" alt="image" src="https://github.com/user-attachments/assets/dbb0659e-fbcd-454a-a16d-18316347d934" />


## Summary of changes

1. Added sorting by id for correspondent banks on both Visitor and Admin pages
2. Implemented sorting for UAH banks and foreign banks to align all currencies
3. Removed column-reverse from GenericForm.scss, which previously caused inverted display order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correspondent bank details now display in a consistent, predictable order.

* **Style**
  * Updated form layout ordering for improved visual alignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->