### PR TITLE
Change start-in-dev-over-https.mjs script to use craco

### DIFF
--- a/scripts/start-in-dev-over-https.mjs
+++ b/scripts/start-in-dev-over-https.mjs
@@ -28,7 +28,7 @@ import { getCerts } from 'https-localhost/certs.js';
         process.env.SSL_KEY_FILE = keyPath;
         process.env.SSL_CRT_FILE = certPath;
 
-        // Forwarding arguments to react-scripts start
+        // Forwarding arguments to craco start
         const args = ['start', ...process.argv.slice(2)];
         const child = spawn('craco', args, {
             stdio: 'inherit',

--- a/scripts/start-in-dev-over-https.mjs
+++ b/scripts/start-in-dev-over-https.mjs
@@ -30,7 +30,7 @@ import { getCerts } from 'https-localhost/certs.js';
 
         // Forwarding arguments to react-scripts start
         const args = ['start', ...process.argv.slice(2)];
-        const child = spawn('react-scripts', args, {
+        const child = spawn('craco', args, {
             stdio: 'inherit',
             shell: process.platform === 'win32',
         });


### PR DESCRIPTION
Fix webpack aliases not resolving when running with HTTPS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the development server launcher to use craco start in development, while preserving existing startup behaviors: argument forwarding, environment and HTTPS certificate setup, child process handling, and signal/exit forwarding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->