### PR TITLE
Fix/issue-1000: Fixed 'Додати нові реквізити' button being disabled after deleting bank in edit mode

### DIFF
--- a/src/pages/admin/donate/components/generic-details/GenericDetails.tsx
+++ b/src/pages/admin/donate/components/generic-details/GenericDetails.tsx
@@ -128,8 +128,10 @@ export function GenericDetails<T extends { id: number } & FieldValues>({
             } else if (onDelete && id !== null) {
                 await onDelete(id);
             }
+            setEditingItemId(null);
+            onEditingStateChange?.(false);
         },
-        [isParentCreating, onDelete, onLocalDelete],
+        [isParentCreating, onDelete, onLocalDelete, onEditingStateChange],
     );
 
     const showNotFound = !isLoading && !isAddFormVisible && items.length === 0;


### PR DESCRIPTION
## Github ticker

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1000)

## Description

This PR fixes issue when deleting bank (uah bank, foreign, corrspondent) during edit mode resulted Add button being not functional

## How it looks

Result: 

https://github.com/user-attachments/assets/af938229-22d9-456a-a250-9f9410000f30


## Summary of changes

1. Added edit state reset on item deletion

## How to recreate changes

1. Go to Admin page, then to Donate tab
2. Click Edit button for existing bank details
3. Click 'Delete' button while being in Edit mode
4. Pay attention to 'Додати нові реквізити' button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the editing state would not properly clear after deleting an item, ensuring a consistent user interface during item management operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->