### PR TITLE
Fix/issue-1086 Program images are not displayed

### DIFF
--- a/src/components/public/program-card/ProgramCard.test.tsx
+++ b/src/components/public/program-card/ProgramCard.test.tsx
@@ -10,7 +10,7 @@ jest.mock('@/assets/icons/arrow-up-right.svg', () => ({
 describe('ProgramCard', () => {
     const program: PublishedProgramDto = {
         id: 1,
-        image: {
+        previewImage: {
             id: 1,
             url: 'mocked-image',
             mimeType: 'mocked-mime-type',

--- a/src/components/public/program-card/ProgramCard.tsx
+++ b/src/components/public/program-card/ProgramCard.tsx
@@ -11,7 +11,7 @@ export const ProgramCard = ({ program, className }: ProgramCardProps) => {
     const programCategories = program.categories.map((categorie) => categorie.name).join(', ');
     return (
         <div className={`card-block ${className}`}>
-            <img src={program.image?.url} alt={program.name} className="card-img" />
+            <img src={program.previewImage?.url} alt={program.name} className="card-img" />
             <div className="card-content">
                 <div className="subtitle-info">
                     <div className="subtitle-content">

--- a/src/services/api/public/programs/programs-api.test.ts
+++ b/src/services/api/public/programs/programs-api.test.ts
@@ -18,7 +18,7 @@ describe('programs-api', () => {
             const mockPrograms: PublishedProgramDto[] = [
                 {
                     id: 1,
-                    image: null,
+                    previewImage: null,
                     name: 'Program A',
                     description: 'Description A',
                     categories: [
@@ -28,7 +28,7 @@ describe('programs-api', () => {
                 },
                 {
                     id: 2,
-                    image: null,
+                    previewImage: null,
                     name: 'Program B',
                     description: 'Description B',
                     categories: [{ id: 1, name: 'Category 1' }], // duplicate

--- a/src/types/public/programs-page.ts
+++ b/src/types/public/programs-page.ts
@@ -7,7 +7,7 @@ export interface ProgramCategoryDto {
 
 export interface PublishedProgramDto {
     id: number;
-    image: Image | null;
+    previewImage: Image | null;
     name: string;
     description: string;
     categories: ProgramCategoryDto[];


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1086)
* [Back](https://github.com/ita-social-projects/VictoryCenter-Back/pull/1088)

## Description

Updated API field usage from Image to previewImage.
Updated PublishedProgramDto interface to use previewImage.
Fix test

## How it looks
/programs
<img width="1893" height="976" alt="image" src="https://github.com/user-attachments/assets/88cff88d-c1f6-413e-860f-eb04a3358dff" />

/about-us
<img width="1883" height="976" alt="image" src="https://github.com/user-attachments/assets/a1cf8da0-c817-4355-965e-8e7334c3d71b" />


## Summary of change

Fix incorrect program images display

## How to recreate changes

Go to the Programs page or About us page


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions
