### PR TITLE
Fix/issue-426 On-fly validation of "Ім'я та прізвище" field doesn't work, error message isn't shown

### DIFF
--- a/src/const/admin/team.ts
+++ b/src/const/admin/team.ts
@@ -59,7 +59,7 @@ export const TEAM_MEMBER_VALIDATION = {
         max: 50,
         allowedCharsPattern: /^[A-Za-zА-Яа-яҐґЄєІіЇї''\-\s0-9]+$/,
         digitsPattern: /\d/,
-        getInvalidCharsError: () => 'Поле може містити лише літери, пробіли, ’ -.',
+        getInvalidCharsError: () => 'Поле може містити лише літери, пробіли, ’ -',
         getDigitsError: () => 'Поле не може містити цифри',
         getRequiredError: () => "Ім'я та прізвище обов'язкові",
         getMinError: () => `Не менше ${TEAM_MEMBER_VALIDATION.fullName.min} символів`,

--- a/src/const/admin/team.ts
+++ b/src/const/admin/team.ts
@@ -57,8 +57,10 @@ export const TEAM_MEMBER_VALIDATION = {
     fullName: {
         min: 2,
         max: 50,
-        pattern: /^[A-Za-zА-Яа-яҐґЄєІіЇї'’\-\s]+$/,
-        getPatternError: () => 'Поле може містити лише літери, пробіли, ’ -. Поле не може містити цифри',
+        allowedCharsPattern: /^[A-Za-zА-Яа-яҐґЄєІіЇї''\-\s0-9]+$/,
+        digitsPattern: /\d/,
+        getInvalidCharsError: () => 'Поле може містити лише літери, пробіли, ’ -.',
+        getDigitsError: () => 'Поле не може містити цифри',
         getRequiredError: () => "Ім'я та прізвище обов'язкові",
         getMinError: () => `Не менше ${TEAM_MEMBER_VALIDATION.fullName.min} символів`,
         getMaxError: () => `Не більше ${TEAM_MEMBER_VALIDATION.fullName.max} символів`,

--- a/src/hooks/admin/use-common-member-fields/useCommonMemberFields.ts
+++ b/src/hooks/admin/use-common-member-fields/useCommonMemberFields.ts
@@ -8,9 +8,9 @@ interface CommonFormState {
 }
 
 interface CommonErrorState {
-    fullName?: string;
+    fullName?: string[];
     description?: string;
-    [key: string]: string | undefined;
+    [key: string]: string | string[] | undefined;
 }
 
 interface UseCommonMemberFieldsParams<T extends CommonFormState, E extends CommonErrorState> {

--- a/src/pages/admin/team/components/common-member-fields/CommonMemberFields.test.tsx
+++ b/src/pages/admin/team/components/common-member-fields/CommonMemberFields.test.tsx
@@ -108,7 +108,7 @@ describe('CommonMemberFields', () => {
     it('shows validation errors when provided', () => {
         renderComponent({
             errors: {
-                fullName: 'Invalid full name',
+                fullName: ['Invalid full name'],
                 description: 'Description too short',
             },
         });

--- a/src/pages/admin/team/components/common-member-fields/CommonMemberFields.tsx
+++ b/src/pages/admin/team/components/common-member-fields/CommonMemberFields.tsx
@@ -23,9 +23,9 @@ export type CommonFields = {
 };
 
 export type CommonErrors = {
-    fullName?: string;
+    fullName?: string[];
     description?: string;
-    [key: string]: string | undefined;
+    [key: string]: string | string[] | undefined;
 };
 
 export const CommonMemberFields = <TFormData extends CommonFields, TErrorState extends CommonErrors>({
@@ -51,7 +51,13 @@ export const CommonMemberFields = <TFormData extends CommonFields, TErrorState e
                     maxLength={TEAM_MEMBER_VALIDATION.fullName.max}
                     disabled={isSubmitting || formDisabled}
                 />
-                {errors.fullName && <p className={styles.error}>{errors.fullName}</p>}
+                {errors.fullName &&
+                    Array.isArray(errors.fullName) &&
+                    errors.fullName.map((error, index) => (
+                        <p key={index} className={styles.error}>
+                            {error}
+                        </p>
+                    ))}
             </div>
 
             <div className={styles['form-group']}>

--- a/src/pages/admin/team/components/member-form/MemberForm.test.tsx
+++ b/src/pages/admin/team/components/member-form/MemberForm.test.tsx
@@ -63,7 +63,9 @@ jest.mock('../common-member-fields/CommonMemberFields', () => ({
                 disabled={isSubmitting || formDisabled}
             />
 
-            {errors?.fullName && <span>{errors.fullName}</span>}
+            {errors?.fullName &&
+                Array.isArray(errors.fullName) &&
+                errors.fullName.map((error: string, index: number) => <span key={index}>{error}</span>)}
             {errors?.description && <span>{errors.description}</span>}
         </div>
     ),
@@ -126,17 +128,18 @@ describe('MemberForm', () => {
         });
     });
 
-    it('shows validation errors on blur for invalid full name', () => {
+    it('shows multiple validation errors on blur for invalid full name', () => {
         const onSubmit = jest.fn();
         const ref = createRef<TeamMemberFormRef>();
 
         render(<MemberForm ref={ref} categories={categories} onSubmit={onSubmit} />);
 
         const fullNameInput = screen.getByLabelText(/Ім'я та Прізвище/);
-        fireEvent.change(fullNameInput, { target: { value: '123' } });
+        fireEvent.change(fullNameInput, { target: { value: 'John123@' } });
         fireEvent.blur(fullNameInput);
 
-        expect(screen.getByText(TEAM_MEMBER_VALIDATION.fullName.getPatternError())).toBeInTheDocument();
+        expect(screen.getByText(TEAM_MEMBER_VALIDATION.fullName.getDigitsError())).toBeInTheDocument();
+        expect(screen.getByText(TEAM_MEMBER_VALIDATION.fullName.getInvalidCharsError())).toBeInTheDocument();
     });
 
     it('submit: calls onSubmit for Draft when valid, but blocks Published without image/description', async () => {

--- a/src/pages/admin/team/components/member-form/MemberForm.tsx
+++ b/src/pages/admin/team/components/member-form/MemberForm.tsx
@@ -21,10 +21,10 @@ export interface TeamMemberFormValues {
 
 export interface TeamMemberFormErrorState {
     category?: string;
-    fullName?: string;
+    fullName?: string[];
     description?: string;
     image?: string;
-    [key: string]: string | undefined;
+    [key: string]: string | string[] | undefined;
 }
 
 export interface TeamMemberFormRef {

--- a/src/pages/admin/team/components/translate-member-form/TranslateMemberForm.tsx
+++ b/src/pages/admin/team/components/translate-member-form/TranslateMemberForm.tsx
@@ -15,7 +15,11 @@ export interface TranslateTeamMemberFormValues {
     fullName: string;
     description: string;
 }
-export type TranslateTeamMemberFormErrorState = Partial<Record<keyof TranslateTeamMemberFormValues, string>>;
+export interface TranslateTeamMemberFormErrorState {
+    fullName?: string[];
+    description?: string;
+    [key: string]: string | string[] | undefined;
+}
 export interface TranslateTeamMemberFormRef {
     submit: (status?: VisibilityStatus) => Promise<void>;
     isValid: () => boolean;

--- a/src/validation/admin/team-member-schema/team-member-schema.test.ts
+++ b/src/validation/admin/team-member-schema/team-member-schema.test.ts
@@ -5,7 +5,7 @@ describe('teamMemberValidationSchema', () => {
     const validFullName = 'John Doe';
     const invalidFullNameShort = 'J'.repeat(TEAM_MEMBER_VALIDATION.fullName.min - 1);
     const invalidFullNameLong = 'J'.repeat(TEAM_MEMBER_VALIDATION.fullName.max + 1);
-    const invalidFullNamePattern = 'John123';
+    const invalidFullNamePattern = 'John123#';
 
     const validDescription = 'This is a valid description';
     const invalidDescriptionShort = 'a'.repeat(TEAM_MEMBER_VALIDATION.description.min - 1);
@@ -23,27 +23,25 @@ describe('teamMemberValidationSchema', () => {
         });
 
         it('rejects empty fullName', () => {
-            expect(TEAM_MEMBER_VALIDATION_FUNCTIONS.validateFullName('', false)).toBe(
-                TEAM_MEMBER_VALIDATION.fullName.getRequiredError(),
-            );
+            const errors = TEAM_MEMBER_VALIDATION_FUNCTIONS.validateFullName('', false);
+            expect(errors).toEqual([TEAM_MEMBER_VALIDATION.fullName.getRequiredError()]);
         });
 
         it('rejects too short fullName', () => {
-            expect(TEAM_MEMBER_VALIDATION_FUNCTIONS.validateFullName(invalidFullNameShort, false)).toBe(
-                TEAM_MEMBER_VALIDATION.fullName.getMinError(),
-            );
+            const errors = TEAM_MEMBER_VALIDATION_FUNCTIONS.validateFullName(invalidFullNameShort, false);
+            expect(errors).toEqual([TEAM_MEMBER_VALIDATION.fullName.getMinError()]);
         });
 
         it('rejects too long fullName', () => {
-            expect(TEAM_MEMBER_VALIDATION_FUNCTIONS.validateFullName(invalidFullNameLong, false)).toBe(
-                TEAM_MEMBER_VALIDATION.fullName.getMaxError(),
-            );
+            const errors = TEAM_MEMBER_VALIDATION_FUNCTIONS.validateFullName(invalidFullNameLong, false);
+            expect(errors).toEqual([TEAM_MEMBER_VALIDATION.fullName.getMaxError()]);
         });
 
-        it('rejects fullName not matching pattern', () => {
-            expect(TEAM_MEMBER_VALIDATION_FUNCTIONS.validateFullName(invalidFullNamePattern, false)).toBe(
-                TEAM_MEMBER_VALIDATION.fullName.getPatternError(),
-            );
+        it('rejects fullName with digits and special characters', () => {
+            const errors = TEAM_MEMBER_VALIDATION_FUNCTIONS.validateFullName(invalidFullNamePattern, false);
+            expect(errors).toHaveLength(2);
+            expect(errors).toContain(TEAM_MEMBER_VALIDATION.fullName.getDigitsError());
+            expect(errors).toContain(TEAM_MEMBER_VALIDATION.fullName.getInvalidCharsError());
         });
     });
 

--- a/src/validation/admin/team-member-schema/team-member-schema.ts
+++ b/src/validation/admin/team-member-schema/team-member-schema.ts
@@ -11,7 +11,14 @@ export const teamMemberValidationSchema = Yup.object({
         .required(TEAM_MEMBER_VALIDATION.fullName.getRequiredError())
         .min(TEAM_MEMBER_VALIDATION.fullName.min, TEAM_MEMBER_VALIDATION.fullName.getMinError())
         .max(TEAM_MEMBER_VALIDATION.fullName.max, TEAM_MEMBER_VALIDATION.fullName.getMaxError())
-        .matches(TEAM_MEMBER_VALIDATION.fullName.pattern, TEAM_MEMBER_VALIDATION.fullName.getPatternError()),
+        .test('no-digits', TEAM_MEMBER_VALIDATION.fullName.getDigitsError(), (value) => {
+            if (!value) return true;
+            return !TEAM_MEMBER_VALIDATION.fullName.digitsPattern.test(value);
+        })
+        .test('allowed-chars', TEAM_MEMBER_VALIDATION.fullName.getInvalidCharsError(), (value) => {
+            if (!value) return true;
+            return TEAM_MEMBER_VALIDATION.fullName.allowedCharsPattern.test(value);
+        }),
 
     description: Yup.string()
         .min(TEAM_MEMBER_VALIDATION.description.min, TEAM_MEMBER_VALIDATION.description.getMinError())
@@ -51,13 +58,23 @@ export const teamMemberValidationSchema = Yup.object({
 });
 
 export const TEAM_MEMBER_VALIDATION_FUNCTIONS = {
-    validateFullName: (value: string, isPublishing: boolean): string | undefined => {
+    validateFullName: (value: string, isPublishing: boolean): string[] | undefined => {
         const context: TeamMemberValidationContext = { isPublishing };
+        const testTypes = ['no-digits', 'allowed-chars'];
         try {
             teamMemberValidationSchema.validateSyncAt('fullName', { fullName: value }, { context });
             return undefined;
         } catch (error: any) {
-            return error.message;
+            if (!testTypes.includes(error.type)) {
+                return [error.message];
+            }
+        }
+
+        try {
+            teamMemberValidationSchema.validateSyncAt('fullName', { fullName: value }, { context, abortEarly: false });
+            return undefined;
+        } catch (error: any) {
+            return error.inner.map((err: any) => err.message);
         }
     },
 


### PR DESCRIPTION
## Github ticker

* [Github](https://github.com/ita-social-projects/VictoryCenter-Back/issues/426)

## Description

Updated Team page validation and fixed related tests.
Fix test.

## How it looks

<img width="1171" height="929" alt="image" src="https://github.com/user-attachments/assets/16300778-957f-4aa7-9f2e-eeca89042ad1" />

## Summary of change

Fix Team page validation messages.

## How to recreate changes

1. Go to [admin panel]
2. Log in as an Admin
3. Go to "Команда" page

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Full name validation now reports separate, specific errors (invalid characters vs. digits) so users see clearer, actionable messages instead of one combined message.

* **Refactor**
  * Error handling updated to allow multiple error messages per field, improving how validation feedback is displayed across forms and edit flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->