### PR TITLE
Added snackbar after successful translation addition

### DIFF
--- a/src/const/admin/common.ts
+++ b/src/const/admin/common.ts
@@ -57,6 +57,8 @@ export const COMMON_TEXT_ADMIN = {
     MESSAGE: {
         SUCCESSFULLY_PUBLISHED: 'успішно опубліковано',
         FAIL_TO_PUBLISH_CHANGES: 'Не вдалося опублікувати зміни',
+        TRANSLATION_SAVED_SUCCESS: 'Переклад збережено успішно',
+        TRANSLATION_PUBLISHED_SUCCESS: 'Переклад опубліковано успішно',
     },
 
     BUTTON: {

--- a/src/pages/admin/team/components/team-page-content/TeamPageContent.test.tsx
+++ b/src/pages/admin/team/components/team-page-content/TeamPageContent.test.tsx
@@ -311,6 +311,22 @@ jest.mock('../team-page-modals/TeamPageModals', () => ({
                 Simulate Translate Member
             </button>
             <button
+                data-testid="simulate-translate-member-draft"
+                onClick={() => {
+                    onTranslateTeamMember({
+                        id: 1,
+                        fullName: 'Translated Member Draft',
+                        description: 'Draft description',
+                        status: 0,
+                        categoryId: 1,
+                        image: null,
+                        localizations: [],
+                    });
+                }}
+            >
+                Simulate Translate Draft
+            </button>
+            <button
                 data-testid="simulate-delete-member"
                 onClick={() => {
                     const memberToDelete = {
@@ -922,6 +938,33 @@ describe('TeamPageContent', () => {
 
                 await expectMemberNameToBe('Translated Member');
                 expect(mockCloseModalActions.closeTranslateItemModal).toHaveBeenCalled();
+                expect(mockAddToast).toHaveBeenCalled();
+            });
+
+            it('shows success toast when translated member is published', async () => {
+                renderTeamPageContent();
+
+                fireEvent.click(screen.getByTestId('simulate-translate-member'));
+
+                await waitFor(() => {
+                    expect(mockAddToast).toHaveBeenCalledWith(
+                        COMMON_TEXT_ADMIN.MESSAGE.TRANSLATION_PUBLISHED_SUCCESS,
+                        ToastType.Success,
+                    );
+                });
+            });
+
+            it('shows success toast when translated member is draft', async () => {
+                renderTeamPageContent();
+
+                fireEvent.click(screen.getByTestId('simulate-translate-member-draft'));
+
+                await waitFor(() => {
+                    expect(mockAddToast).toHaveBeenCalledWith(
+                        COMMON_TEXT_ADMIN.MESSAGE.TRANSLATION_SAVED_SUCCESS,
+                        ToastType.Success,
+                    );
+                });
             });
 
             // it('should edit member without image cache busting when no url present', async () => {

--- a/src/pages/admin/team/components/team-page-content/TeamPageContent.tsx
+++ b/src/pages/admin/team/components/team-page-content/TeamPageContent.tsx
@@ -403,8 +403,14 @@ export const TeamPageContent = () => {
                 prevMembers.map((member) => (member.id === updatedMember.id ? updatedMember : member)),
             );
             closeModalActions.closeTranslateItemModal();
+
+            if (updatedMember.status === VisibilityStatus.Published) {
+                addToast(COMMON_TEXT_ADMIN.MESSAGE.TRANSLATION_PUBLISHED_SUCCESS, ToastType.Success);
+            } else {
+                addToast(COMMON_TEXT_ADMIN.MESSAGE.TRANSLATION_SAVED_SUCCESS, ToastType.Success);
+            }
         },
-        [closeModalActions],
+        [closeModalActions, addToast],
     );
 
     const handleEditMember = useCallback(


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/576)

## Description

Added constants for snackbar of successfully added translation for team members.
Added snackbar after adding translation for team member.

## How it looks

For published members:
<img width="770" height="170" alt="image" src="https://github.com/user-attachments/assets/29e41302-f4bc-4cc7-8412-8a07e97062b3" />

For drafts:
<img width="737" height="154" alt="image" src="https://github.com/user-attachments/assets/18baf942-0bbb-4863-90bb-2bff25dda291" />

## Summary of change

Added a snackbar after adding translation for team member.

## How to recreate changes

1. Go to the Team page in the Admin Panel.
2. Click the <img width="48" height="48" alt="image" src="https://github.com/user-attachments/assets/2b41c881-7a8a-45d2-afdc-9a185fdfc0e6" /> button in the Team Member list view to open the corresponding modal window.
3. Enter valid data in all required fields for adding translation.
4. Click 'Зберегти переклад' button, confirm by pressing.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added distinct success notifications for team member translation actions: one when a translation is saved as draft and another when it is published (messages localized in Ukrainian).
* **Tests**
  * Added automated tests to verify the correct notifications and modal behavior for both saved-draft and published translation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->