### PR TITLE
Feature/issue 1135 - Integrate localization for visitor Team Member page that retriving from Admin side

### DIFF
--- a/src/hooks/common/use-get-localization/useGetLocalization.test.ts
+++ b/src/hooks/common/use-get-localization/useGetLocalization.test.ts
@@ -1,0 +1,59 @@
+import { renderHook } from '@testing-library/react';
+import { useGetLocalization } from './useGetLocalization';
+import { useLocale } from '@/hooks/common/use-locale/useLocale';
+import { EntityLocalizationDto, TranslationStatus } from '@/types/common/language';
+
+jest.mock('@/hooks/common/use-locale/useLocale', () => ({
+    useLocale: jest.fn(),
+}));
+
+const mockUseLocale = useLocale as jest.Mock;
+
+type LocalizedDto<T extends object> = EntityLocalizationDto & Partial<T>;
+
+describe('useGetLocalization (uk default)', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    interface Fields {
+        fullName: string;
+        description: string;
+    }
+
+    const fallbackUk: Fields = {
+        fullName: 'Оригінальне імʼя',
+        description: 'Оригінальний опис',
+    };
+
+    const enLocalizations: LocalizedDto<Fields>[] = [
+        {
+            localizationInfoDto: { id: 1, code: 'en' },
+            translationStatus: TranslationStatus.Relevant,
+            fullName: 'English name',
+            description: 'English description',
+        },
+    ];
+
+    it('повертає fallback (uk), якщо поточна мова українська', () => {
+        mockUseLocale.mockReturnValue({ currentLanguage: 'uk' });
+
+        const { result } = renderHook(() => useGetLocalization(enLocalizations, fallbackUk));
+
+        expect(result.current).toEqual({
+            fullName: 'Оригінальне імʼя',
+            description: 'Оригінальний опис',
+        });
+    });
+
+    it('повертає англійський переклад, якщо мова en', () => {
+        mockUseLocale.mockReturnValue({ currentLanguage: 'en' });
+
+        const { result } = renderHook(() => useGetLocalization(enLocalizations, fallbackUk));
+
+        expect(result.current).toEqual({
+            fullName: 'English name',
+            description: 'English description',
+        });
+    });
+});

--- a/src/hooks/common/use-get-localization/useGetLocalization.ts
+++ b/src/hooks/common/use-get-localization/useGetLocalization.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { useLocale } from '@/hooks/common/use-locale/useLocale';
+import { EntityLocalizationDto } from '@/types/common/language';
+
+export const useGetLocalization = <T>(localizations: EntityLocalizationDto[] | undefined, fallback: T): T => {
+    const { currentLanguage } = useLocale();
+
+    return useMemo(() => {
+        const activeLoc = localizations?.find((loc) => loc.localizationInfoDto.code === currentLanguage);
+
+        return {
+            ...fallback,
+            ...activeLoc,
+        };
+    }, [currentLanguage, localizations, fallback]);
+};

--- a/src/hooks/common/use-get-localization/useGetLocalization.ts
+++ b/src/hooks/common/use-get-localization/useGetLocalization.ts
@@ -2,15 +2,28 @@ import { useMemo } from 'react';
 import { useLocale } from '@/hooks/common/use-locale/useLocale';
 import { EntityLocalizationDto } from '@/types/common/language';
 
-export const useGetLocalization = <T>(localizations: EntityLocalizationDto[] | undefined, fallback: T): T => {
+export const useGetLocalization = <T extends object>(
+    localizations: EntityLocalizationDto[] | undefined,
+    fallback: T,
+): T => {
     const { currentLanguage } = useLocale();
 
     return useMemo(() => {
         const activeLoc = localizations?.find((loc) => loc.localizationInfoDto.code === currentLanguage);
 
+        if (!activeLoc) {
+            return fallback;
+        }
+
+        const {
+            localizationInfoDto: _localizationInfoDto,
+            translationStatus: _translationStatus,
+            ...localizableFields
+        } = activeLoc;
+
         return {
             ...fallback,
-            ...activeLoc,
+            ...localizableFields,
         };
     }, [currentLanguage, localizations, fallback]);
 };

--- a/src/pages/public/team-page/team-member-card/TeamMemberCard.tsx
+++ b/src/pages/public/team-page/team-member-card/TeamMemberCard.tsx
@@ -1,8 +1,7 @@
 import { MemberCard } from '@/types/public/team-page';
 import { ReactComponent as DefaultTeamMemberIcon } from '@/assets/icons/team-member-blank.svg';
 import { useState, useEffect } from 'react';
-import { useLocale } from '@/hooks/common/use-locale/useLocale';
-import { TeamMemberLocalizableFields } from '@/types/admin/team-members';
+import { useGetLocalization } from '@/hooks/common/use-get-localization/useGetLocalization';
 
 interface TeamMemberProps {
     member: MemberCard;
@@ -10,22 +9,15 @@ interface TeamMemberProps {
 
 export const TeamMemberCard = ({ member }: TeamMemberProps) => {
     const [error, setError] = useState(false);
-    const { currentLanguage } = useLocale();
-    const [textFields, setTextFields] = useState<TeamMemberLocalizableFields>();
 
     useEffect(() => {
         setError(false);
     }, [member.photo]);
 
-    useEffect(() => {
-        const displayedLocalization = member.localizations?.find(
-            (loc) => loc.localizationInfoDto.code === currentLanguage,
-        );
-        setTextFields({
-            fullName: displayedLocalization?.fullName || member.name,
-            description: displayedLocalization?.description || member.role,
-        });
-    }, [currentLanguage, member]);
+    const translated = useGetLocalization(member.localizations, {
+        fullName: member.name,
+        description: member.role,
+    });
 
     return (
         <div className="team-member">
@@ -35,8 +27,8 @@ export const TeamMemberCard = ({ member }: TeamMemberProps) => {
                 <img src={member.photo} alt={member.name} className="member-photo" onError={() => setError(true)} />
             )}
             <div>
-                <p className="member-name">{textFields?.fullName}</p>
-                <p className="member-role">{textFields?.description}</p>
+                <p className="member-name">{translated.fullName}</p>
+                <p className="member-role">{translated.description}</p>
             </div>
         </div>
     );

--- a/src/pages/public/team-page/team-member-card/TeamMemberCard.tsx
+++ b/src/pages/public/team-page/team-member-card/TeamMemberCard.tsx
@@ -1,6 +1,8 @@
 import { MemberCard } from '@/types/public/team-page';
 import { ReactComponent as DefaultTeamMemberIcon } from '@/assets/icons/team-member-blank.svg';
 import { useState, useEffect } from 'react';
+import { useLocale } from '@/hooks/common/use-locale/useLocale';
+import { TeamMemberLocalizableFields } from '@/types/admin/team-members';
 
 interface TeamMemberProps {
     member: MemberCard;
@@ -8,10 +10,22 @@ interface TeamMemberProps {
 
 export const TeamMemberCard = ({ member }: TeamMemberProps) => {
     const [error, setError] = useState(false);
+    const { currentLanguage } = useLocale();
+    const [textFields, setTextFields] = useState<TeamMemberLocalizableFields>();
 
     useEffect(() => {
         setError(false);
     }, [member.photo]);
+
+    useEffect(() => {
+        const displayedLocalization = member.localizations?.find(
+            (loc) => loc.localizationInfoDto.code === currentLanguage,
+        );
+        setTextFields({
+            fullName: displayedLocalization?.fullName || member.name,
+            description: displayedLocalization?.description || member.role,
+        });
+    }, [currentLanguage, member]);
 
     return (
         <div className="team-member">
@@ -21,8 +35,8 @@ export const TeamMemberCard = ({ member }: TeamMemberProps) => {
                 <img src={member.photo} alt={member.name} className="member-photo" onError={() => setError(true)} />
             )}
             <div>
-                <p className="member-name">{member.name}</p>
-                <p className="member-role">{member.role}</p>
+                <p className="member-name">{textFields?.fullName}</p>
+                <p className="member-role">{textFields?.description}</p>
             </div>
         </div>
     );

--- a/src/pages/public/team-page/team-member-card/TeamMemberCard.tsx
+++ b/src/pages/public/team-page/team-member-card/TeamMemberCard.tsx
@@ -14,7 +14,7 @@ export const TeamMemberCard = ({ member }: TeamMemberProps) => {
         setError(false);
     }, [member.photo]);
 
-    const translated = useGetLocalization(member.localizations, {
+    const { fullName, description } = useGetLocalization(member.localizations, {
         fullName: member.name,
         description: member.role,
     });
@@ -27,8 +27,8 @@ export const TeamMemberCard = ({ member }: TeamMemberProps) => {
                 <img src={member.photo} alt={member.name} className="member-photo" onError={() => setError(true)} />
             )}
             <div>
-                <p className="member-name">{translated.fullName}</p>
-                <p className="member-role">{translated.description}</p>
+                <p className="member-name">{fullName}</p>
+                <p className="member-role">{description}</p>
             </div>
         </div>
     );

--- a/src/services/api/public/team/team-api.test.ts
+++ b/src/services/api/public/team/team-api.test.ts
@@ -19,13 +19,13 @@ describe('fetchTeamPageData', () => {
                 categoryName: 'Engineering',
                 description: 'Dev team',
                 teamMembers: [
-                    { id: 1, fullName: 'Alice', description: 'Frontend Dev' },
-                    { id: 2, fullName: 'Bob', description: null },
+                    { id: 1, fullName: 'Alice', description: 'Frontend Dev', localizations: [] },
+                    { id: 2, fullName: 'Bob', description: null, localizations: [] },
                 ],
             },
             {
                 categoryName: 'With no description',
-                teamMembers: [{ id: 3, fullName: 'John', description: 'Backend Dev' }],
+                teamMembers: [{ id: 3, fullName: 'John', description: 'Backend Dev', localizations: [] }],
             },
         ];
 
@@ -35,14 +35,14 @@ describe('fetchTeamPageData', () => {
                     title: 'Engineering',
                     description: 'Dev team',
                     members: [
-                        { id: 1, name: 'Alice', role: 'Frontend Dev', photo: null },
-                        { id: 2, name: 'Bob', role: '', photo: null },
+                        { id: 1, name: 'Alice', role: 'Frontend Dev', photo: null , localizations: []},
+                        { id: 2, name: 'Bob', role: '', photo: null, localizations: [] },
                     ],
                 },
                 {
                     title: 'With no description',
                     description: '',
-                    members: [{ id: 3, name: 'John', role: 'Backend Dev', photo: null }],
+                    members: [{ id: 3, name: 'John', role: 'Backend Dev', photo: null , localizations: []}],
                 },
             ],
         };
@@ -77,7 +77,7 @@ describe('fetchTeamPageData', () => {
                 {
                     title: 'Design',
                     description: 'Design team',
-                    members: [{ id: 5, name: 'John', role: 'Lead', photo: null }],
+                    members: [{ id: 5, name: 'John', role: 'Lead', photo: null , localizations: []}],
                 },
             ],
         };

--- a/src/services/api/public/team/team-api.test.ts
+++ b/src/services/api/public/team/team-api.test.ts
@@ -35,14 +35,14 @@ describe('fetchTeamPageData', () => {
                     title: 'Engineering',
                     description: 'Dev team',
                     members: [
-                        { id: 1, name: 'Alice', role: 'Frontend Dev', photo: null , localizations: []},
+                        { id: 1, name: 'Alice', role: 'Frontend Dev', photo: null, localizations: [] },
                         { id: 2, name: 'Bob', role: '', photo: null, localizations: [] },
                     ],
                 },
                 {
                     title: 'With no description',
                     description: '',
-                    members: [{ id: 3, name: 'John', role: 'Backend Dev', photo: null , localizations: []}],
+                    members: [{ id: 3, name: 'John', role: 'Backend Dev', photo: null, localizations: [] }],
                 },
             ],
         };
@@ -77,7 +77,7 @@ describe('fetchTeamPageData', () => {
                 {
                     title: 'Design',
                     description: 'Design team',
-                    members: [{ id: 5, name: 'John', role: 'Lead', photo: null , localizations: []}],
+                    members: [{ id: 5, name: 'John', role: 'Lead', photo: null, localizations: [] }],
                 },
             ],
         };

--- a/src/services/api/public/team/team-api.ts
+++ b/src/services/api/public/team/team-api.ts
@@ -23,6 +23,7 @@ const mapTeamMemberDtoToTeamMember = (dto: PublicTeamMemberDto): MemberCard => (
     name: dto.fullName,
     role: dto.description || '',
     photo: dto.image?.url ?? null,
+    localizations: dto.localizations || [],
 });
 
 const mapCategoryDtoToTeamCategory = (dto: PublicCategoryWithTeamMembersDto): TeamItem => {

--- a/src/types/public/team-page.ts
+++ b/src/types/public/team-page.ts
@@ -1,4 +1,4 @@
-import { TeamCategory } from '../admin/team-category';
+import { TeamMemberLocalizationDto } from '../admin/team-members';
 import { Image } from '../common/image';
 
 export interface MemberCard {
@@ -6,6 +6,7 @@ export interface MemberCard {
     name: string;
     role: string;
     photo: string | null;
+    localizations?: TeamMemberLocalizationDto[];
 }
 
 export type Member = {
@@ -14,7 +15,6 @@ export type Member = {
     fullName: string;
     description: string;
     status: string;
-    category: TeamCategory;
 };
 
 export interface TeamItem {
@@ -35,6 +35,7 @@ export interface PublicTeamMemberDto {
     fullName: string;
     description: string | null;
     image: Image | null;
+    localizations: TeamMemberLocalizationDto[];
 }
 
 export interface TeamPageData {


### PR DESCRIPTION
## Github ticker

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1135)

## Description

<!--- Please decripe the main goal of this PR and why it was created --->

## How it looks

<img width="1042" height="608" alt="image" src="https://github.com/user-attachments/assets/094d4d8a-1735-4f99-99e6-feb8ed10d742" />

## Summary of change

<!--- Please specify what was changed --->

## How to recreate changes

<!--- Please provide short instruction step-by-step how to see changes that was implemented by this PR --->


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a localization helper that detects the current language and merges language-specific content with fallback values so UI displays localized fields where available while preserving defaults.

* **Tests**
  * Added unit tests verifying behavior for different current languages, ensuring correct fallback and localized value selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->