### PR TITLE
Fix: sort bank details in donation components for consistent display order

### DIFF
--- a/src/pages/admin/donate/components/donate-page-content/DonatePageContent.tsx
+++ b/src/pages/admin/donate/components/donate-page-content/DonatePageContent.tsx
@@ -55,7 +55,7 @@ export const DonatePageContent = () => {
         SupportOptionsApi.getAll(client, bankCurrency)
             .then((data) => {
                 if (isAlive) {
-                    setSupportOptions(data);
+                    setSupportOptions(data.sort((a, b) => b.id - a.id));
                 }
             })
             .catch(() => {
@@ -95,7 +95,7 @@ export const DonatePageContent = () => {
             try {
                 const createData: CreateSupportOptionsDto = { name, value, currency: bankCurrency };
                 const newOption = await SupportOptionsApi.create(client, createData);
-                setSupportOptions((prev) => [...prev, newOption]);
+                setSupportOptions((prev) => [newOption, ...prev]);
 
                 addToast(DONATE_TEXT.MESSAGE.SUPPORT_OPTIONS.PUBLISHED, ToastType.Info);
             } finally {
@@ -273,7 +273,7 @@ export const DonatePageContent = () => {
             const existingItem = items.find((i) => i.id === parentId);
             const banksToShow = isParentCreating
                 ? []
-                : [...(existingItem?.correspondentBanks ?? [])].sort((a, b) => a.id - b.id);
+                : [...(existingItem?.correspondentBanks ?? [])].sort((a, b) => b.id - a.id);
 
             return (
                 <GenericDetails
@@ -322,7 +322,7 @@ export const DonatePageContent = () => {
                     {config && (
                         <GenericDetails
                             key={`bank-details-${selectedCategory}`}
-                            items={[...items].sort((a, b) => a.id - b.id)}
+                            items={[...items].sort((a, b) => b.id - a.id)}
                             isLoading={isLoading}
                             FormComponent={config.form}
                             notFoundText={DONATE_TEXT.BANK_DETAILS.NOT_FOUND}

--- a/src/pages/admin/donate/components/donate-page-content/DonatePageContent.tsx
+++ b/src/pages/admin/donate/components/donate-page-content/DonatePageContent.tsx
@@ -55,7 +55,7 @@ export const DonatePageContent = () => {
         SupportOptionsApi.getAll(client, bankCurrency)
             .then((data) => {
                 if (isAlive) {
-                    setSupportOptions(data.sort((a, b) => b.id - a.id));
+                    setSupportOptions(data.toSorted((a, b) => b.id - a.id));
                 }
             })
             .catch(() => {
@@ -273,7 +273,9 @@ export const DonatePageContent = () => {
             const existingItem = items.find((i) => i.id === parentId);
             const banksToShow = isParentCreating
                 ? []
-                : [...(existingItem?.correspondentBanks ?? [])].sort((a, b) => b.id - a.id);
+                : (existingItem?.correspondentBanks ?? []).toSorted(
+                      (a: CorrespondentBankDetailsDto, b: CorrespondentBankDetailsDto) => b.id - a.id,
+                  );
 
             return (
                 <GenericDetails
@@ -322,7 +324,7 @@ export const DonatePageContent = () => {
                     {config && (
                         <GenericDetails
                             key={`bank-details-${selectedCategory}`}
-                            items={[...items].sort((a, b) => b.id - a.id)}
+                            items={items.toSorted((a, b) => b.id - a.id)}
                             isLoading={isLoading}
                             FormComponent={config.form}
                             notFoundText={DONATE_TEXT.BANK_DETAILS.NOT_FOUND}

--- a/src/pages/public/donate-page/right-section/RightSection.tsx
+++ b/src/pages/public/donate-page/right-section/RightSection.tsx
@@ -73,7 +73,7 @@ export const RightSection = ({ donateData, error }: RightSectionProps) => {
         switch (activeTab) {
             case Currency.UAH:
                 return (
-                    <UkrainePaymentDetails bankDetails={[...donateData.uahBankDetails].sort((a, b) => b.id - a.id)} />
+                    <UkrainePaymentDetails bankDetails={donateData.uahBankDetails.toSorted((a, b) => b.id - a.id)} />
                 );
             case Currency.USD:
                 return (
@@ -81,7 +81,7 @@ export const RightSection = ({ donateData, error }: RightSectionProps) => {
                         currency={activeTab}
                         foreignBankDetails={donateData.foreignBankDetails
                             .filter((b) => b.currency === Currency.USD)
-                            .sort((a, b) => b.id - a.id)}
+                            .toSorted((a, b) => b.id - a.id)}
                     />
                 );
             case Currency.EUR:
@@ -90,7 +90,7 @@ export const RightSection = ({ donateData, error }: RightSectionProps) => {
                         currency={activeTab}
                         foreignBankDetails={donateData.foreignBankDetails
                             .filter((b) => b.currency === Currency.EUR)
-                            .sort((a, b) => b.id - a.id)}
+                            .toSorted((a, b) => b.id - a.id)}
                     />
                 );
         }
@@ -133,7 +133,7 @@ export const RightSection = ({ donateData, error }: RightSectionProps) => {
             <div className="donatePaymentDetails">
                 {paymentDetails()}
                 <AlternativeSupportWays
-                    supportOptions={[...(donateData?.supportOptions || [])].sort((a, b) => b.id - a.id)}
+                    supportOptions={(donateData?.supportOptions || []).toSorted((a, b) => b.id - a.id)}
                     currentCurrency={activeTab}
                 />
             </div>

--- a/src/pages/public/donate-page/right-section/RightSection.tsx
+++ b/src/pages/public/donate-page/right-section/RightSection.tsx
@@ -72,19 +72,25 @@ export const RightSection = ({ donateData, error }: RightSectionProps) => {
 
         switch (activeTab) {
             case Currency.UAH:
-                return <UkrainePaymentDetails bankDetails={donateData.uahBankDetails} />;
+                return (
+                    <UkrainePaymentDetails bankDetails={[...donateData.uahBankDetails].sort((a, b) => b.id - a.id)} />
+                );
             case Currency.USD:
                 return (
                     <AbroadPaymentDetails
                         currency={activeTab}
-                        foreignBankDetails={donateData.foreignBankDetails.filter((b) => b.currency === Currency.USD)}
+                        foreignBankDetails={donateData.foreignBankDetails
+                            .filter((b) => b.currency === Currency.USD)
+                            .sort((a, b) => b.id - a.id)}
                     />
                 );
             case Currency.EUR:
                 return (
                     <AbroadPaymentDetails
                         currency={activeTab}
-                        foreignBankDetails={donateData.foreignBankDetails.filter((b) => b.currency === Currency.EUR)}
+                        foreignBankDetails={donateData.foreignBankDetails
+                            .filter((b) => b.currency === Currency.EUR)
+                            .sort((a, b) => b.id - a.id)}
                     />
                 );
         }
@@ -126,7 +132,10 @@ export const RightSection = ({ donateData, error }: RightSectionProps) => {
             </div>
             <div className="donatePaymentDetails">
                 {paymentDetails()}
-                <AlternativeSupportWays supportOptions={donateData?.supportOptions || []} currentCurrency={activeTab} />
+                <AlternativeSupportWays
+                    supportOptions={[...(donateData?.supportOptions || [])].sort((a, b) => b.id - a.id)}
+                    currentCurrency={activeTab}
+                />
             </div>
         </div>
     );

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.tsx
@@ -19,7 +19,7 @@ export const AbroadPaymentDetails = ({ currency, foreignBankDetails }: AbroadPay
         return null;
     }
 
-    const sortedForeignBankDetails = [...foreignBankDetails].sort((a, b) => a.id - b.id);
+    const sortedForeignBankDetails = [...foreignBankDetails].sort((a, b) => b.id - a.id);
     const currencyString = currencyToString(currency) as AbroadCurrency;
     const title = t(`${currencyString}_PAYMENT_DETAILS_LABEL`);
     const ibanLabel = ABROAD_PAYMENT_DETAILS[`IBAN_${currencyString}_LABEL`];

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/AbroadPaymentDetails.tsx
@@ -19,7 +19,7 @@ export const AbroadPaymentDetails = ({ currency, foreignBankDetails }: AbroadPay
         return null;
     }
 
-    const sortedForeignBankDetails = [...foreignBankDetails].sort((a, b) => b.id - a.id);
+    const sortedForeignBankDetails = foreignBankDetails.toSorted((a, b) => b.id - a.id);
     const currencyString = currencyToString(currency) as AbroadCurrency;
     const title = t(`${currencyString}_PAYMENT_DETAILS_LABEL`);
     const ibanLabel = ABROAD_PAYMENT_DETAILS[`IBAN_${currencyString}_LABEL`];

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.tsx
@@ -13,7 +13,7 @@ export const CorrespondentBanksSection = ({
         return null;
     }
 
-    const sortedCorrespondentBanks = [...correspondentBanks].sort((a, b) => b.id - a.id);
+    const sortedCorrespondentBanks = correspondentBanks.toSorted((a, b) => b.id - a.id);
     const banks = sortedCorrespondentBanks.map((apiBank) => ({
         title: apiBank.name,
         fields: [

--- a/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.tsx
+++ b/src/pages/public/donate-page/right-section/abroad-payment-details/CorrespondentBanksSection.tsx
@@ -13,7 +13,7 @@ export const CorrespondentBanksSection = ({
         return null;
     }
 
-    const sortedCorrespondentBanks = [...correspondentBanks].sort((a, b) => a.id - b.id);
+    const sortedCorrespondentBanks = [...correspondentBanks].sort((a, b) => b.id - a.id);
     const banks = sortedCorrespondentBanks.map((apiBank) => ({
         title: apiBank.name,
         fields: [

--- a/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.test.tsx
+++ b/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.test.tsx
@@ -97,7 +97,7 @@ describe('UkrainePaymentDetails', () => {
 
         it('should render multiple banks with all details', () => {
             const bankDetails = createMultipleBanks(2);
-            const sortedBankDetails = [...bankDetails].sort((a, b) => b.id - a.id);
+            const sortedBankDetails = bankDetails.toSorted((a, b) => b.id - a.id);
 
             render(<UkrainePaymentDetails bankDetails={bankDetails} />);
 
@@ -109,7 +109,7 @@ describe('UkrainePaymentDetails', () => {
             expect(screen.getAllByText('IBAN (UAH)')).toHaveLength(2);
             expect(screen.getAllByText('Призначення платежу')).toHaveLength(2);
 
-            bankDetails.forEach((bank) => expectBankDataToBePresent(bank));
+            sortedBankDetails.forEach((bank) => expectBankDataToBePresent(bank));
             expectCopyButtonsWithCorrectData(sortedBankDetails);
         });
 
@@ -238,7 +238,7 @@ describe('UkrainePaymentDetails', () => {
 
         it('should handle 3 banks correctly', () => {
             const bankDetails = createMultipleBanks(3);
-            const sortedBankDetails = [...bankDetails].sort((a, b) => b.id - a.id);
+            const sortedBankDetails = bankDetails.toSorted((a, b) => b.id - a.id);
 
             render(<UkrainePaymentDetails bankDetails={bankDetails} />);
 

--- a/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.test.tsx
+++ b/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.test.tsx
@@ -97,6 +97,7 @@ describe('UkrainePaymentDetails', () => {
 
         it('should render multiple banks with all details', () => {
             const bankDetails = createMultipleBanks(2);
+            const sortedBankDetails = [...bankDetails].sort((a, b) => b.id - a.id);
 
             render(<UkrainePaymentDetails bankDetails={bankDetails} />);
 
@@ -109,7 +110,7 @@ describe('UkrainePaymentDetails', () => {
             expect(screen.getAllByText('Призначення платежу')).toHaveLength(2);
 
             bankDetails.forEach((bank) => expectBankDataToBePresent(bank));
-            expectCopyButtonsWithCorrectData(bankDetails);
+            expectCopyButtonsWithCorrectData(sortedBankDetails);
         });
 
         it('should apply separated class to non-first banks', () => {
@@ -237,11 +238,12 @@ describe('UkrainePaymentDetails', () => {
 
         it('should handle 3 banks correctly', () => {
             const bankDetails = createMultipleBanks(3);
+            const sortedBankDetails = [...bankDetails].sort((a, b) => b.id - a.id);
 
             render(<UkrainePaymentDetails bankDetails={bankDetails} />);
 
             expect(screen.getAllByText('Одержувач')).toHaveLength(3);
-            expectCopyButtonsWithCorrectData(bankDetails);
+            expectCopyButtonsWithCorrectData(sortedBankDetails);
 
             const separatedContainers = screen
                 .getByText('Реквізити для донатів в Україні')

--- a/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.tsx
+++ b/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.tsx
@@ -14,7 +14,7 @@ export const UkrainePaymentDetails = ({ bankDetails }: UkrainePaymentDetailsProp
         return null;
     }
 
-    const sortedBankDetails = [...bankDetails].sort((a, b) => a.id - b.id);
+    const sortedBankDetails = [...bankDetails].sort((a, b) => b.id - a.id);
 
     return (
         <div className="UkrainePaymentDetails">

--- a/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.tsx
+++ b/src/pages/public/donate-page/right-section/ukraine-payment-details/UkrainePaymentDetails.tsx
@@ -14,7 +14,7 @@ export const UkrainePaymentDetails = ({ bankDetails }: UkrainePaymentDetailsProp
         return null;
     }
 
-    const sortedBankDetails = [...bankDetails].sort((a, b) => b.id - a.id);
+    const sortedBankDetails = bankDetails.toSorted((a, b) => b.id - a.id);
 
     return (
         <div className="UkrainePaymentDetails">


### PR DESCRIPTION
## Github ticker

* [Github ticket](https://github.com/orgs/ita-social-projects/projects/64/views/18?sliceBy%5Bvalue%5D=L1ght1234&pane=issue&itemId=146254879&issue=ita-social-projects%7CVictoryCenter-Back%7C1070)

## Description

Fix: sort bank details in donation components for consistent display order

## How it looks

<img width="1429" height="816" alt="изображение" src="https://github.com/user-attachments/assets/79db3e87-2888-4d2d-bd7c-ba119f0c9897" />

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted sorting so support options, correspondent banks, and bank details display in descending order.
  * New support options are now inserted at the top of the list so recently added items appear first.
  * Rendering order updates ensure lists consistently show newest or highest-ID entries first for clearer UX.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->