### PR TITLE
Fix: added space under button "Додати нові реквізити"

### DIFF
--- a/src/pages/admin/donate/components/generic-details/GenericDetails.scss
+++ b/src/pages/admin/donate/components/generic-details/GenericDetails.scss
@@ -32,6 +32,17 @@
             }
         }
     }
+    &-footer {
+        width: 100%;
+        margin-top: 1rem;
+        
+        padding-bottom: 2.5rem; 
+        
+        .btn-add-new {
+            width: 100%;
+            margin-bottom: 0; 
+        }
+    }
     .child {
         .generic-details {
             &.header {

--- a/src/pages/admin/donate/components/generic-details/GenericDetails.tsx
+++ b/src/pages/admin/donate/components/generic-details/GenericDetails.tsx
@@ -216,7 +216,9 @@ export function GenericDetails<T extends { id: number } & FieldValues>({
                     {!isChildForm && !showNotFound && (
                         <div className="generic-details-footer">
                             <Button
-                                className={`generic-details btn-add-new ${isAddFormVisible || editingItemId !== null ? 'disabled' : ''}`}
+                                className={cn('generic-details btn-add-new', {
+                                    disabled: isAddFormVisible || editingItemId !== null,
+                                })}
                                 onClick={handleAdd}
                                 buttonStyle="primary"
                                 disabled={

--- a/src/pages/admin/donate/components/generic-details/GenericDetails.tsx
+++ b/src/pages/admin/donate/components/generic-details/GenericDetails.tsx
@@ -214,21 +214,23 @@ export function GenericDetails<T extends { id: number } & FieldValues>({
                         </FormComponent>
                     )}
                     {!isChildForm && !showNotFound && (
-                        <Button
-                            className={`generic-details btn-add-new ${isAddFormVisible || editingItemId !== null ? 'disabled' : ''}`}
-                            onClick={handleAdd}
-                            buttonStyle="primary"
-                            disabled={
-                                isDisabled ||
-                                isAddButtonDisabled ||
-                                isParentAddFormVisible ||
-                                isAddFormVisible ||
-                                editingItemId !== null
-                            }
-                        >
-                            <div>{addNewText}</div>
-                            <PlusIcon className="plus-icon" />
-                        </Button>
+                        <div className="generic-details-footer">
+                            <Button
+                                className={`generic-details btn-add-new ${isAddFormVisible || editingItemId !== null ? 'disabled' : ''}`}
+                                onClick={handleAdd}
+                                buttonStyle="primary"
+                                disabled={
+                                    isDisabled ||
+                                    isAddButtonDisabled ||
+                                    isParentAddFormVisible ||
+                                    isAddFormVisible ||
+                                    editingItemId !== null
+                                }
+                            >
+                                <div>{addNewText}</div>
+                                <PlusIcon className="plus-icon" />
+                            </Button>
+                        </div>
                     )}
                 </div>
             )}


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/orgs/ita-social-projects/projects/64/views/18?sliceBy%5Bvalue%5D=L1ght1234&pane=issue&itemId=134465828&issue=ita-social-projects%7CVictoryCenter-Back%7C681)

## Description

added space under button "Додати нові реквізити"

## How it looks
<img width="1309" height="385" alt="изображение" src="https://github.com/user-attachments/assets/e7f7f832-4db4-401d-81fb-25d9c52072d5" />

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added a new footer layout for generic detail views to improve visual hierarchy and spacing.
  * The action button now spans the full width in the footer and has adjusted margins/padding for clearer emphasis.
  * Visual behavior and disable logic remain unchanged; changes are purely layout and presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->