### PR TITLE
Feature/issue 1053 -Switch FAQ list in English language, implement translation indicators 

### DIFF
--- a/src/components/admin/admin-panel-toolbar/AdminPageToolbar.scss
+++ b/src/components/admin/admin-panel-toolbar/AdminPageToolbar.scss
@@ -15,3 +15,26 @@
         width: 38.75rem;
     }
 }
+@media (max-width: 1810px) {
+    .admin-panel-toolbar {
+        &-search {
+            width: 28.75rem;
+        }
+    }
+}
+
+@media (max-width: 1660px) {
+    .admin-panel-toolbar {
+        &-search {
+            width: 20.75rem;
+        }
+    }
+}
+
+@media (max-width: 1520px) {
+    .admin-panel-toolbar {
+        &-search {
+            width: 15.75rem;
+        }
+    }
+}

--- a/src/components/admin/admin-panel-toolbar/AdminPageToolbar.test.tsx
+++ b/src/components/admin/admin-panel-toolbar/AdminPageToolbar.test.tsx
@@ -9,7 +9,6 @@ import { UI_CONFIG } from '@/const/admin/common';
 import { VisibilityStatus } from '@/types/admin/common';
 import { StatusFilterDropdownProps } from '@/components/admin/status-filter-dropdown/StatusFilterDropdown';
 import { ButtonProps } from '@/components/admin/button/Button';
-import { LocalizationLanguage, TranslationStatusFilter } from '@/types/common/language';
 
 jest.mock('@/hooks/admin/fetch/use-data-pagination-fetch/useDataPaginationFetch', () => ({
     useDataPaginationFetch: jest.fn(),

--- a/src/components/admin/admin-panel-toolbar/AdminPageToolbar.test.tsx
+++ b/src/components/admin/admin-panel-toolbar/AdminPageToolbar.test.tsx
@@ -9,6 +9,7 @@ import { UI_CONFIG } from '@/const/admin/common';
 import { VisibilityStatus } from '@/types/admin/common';
 import { StatusFilterDropdownProps } from '@/components/admin/status-filter-dropdown/StatusFilterDropdown';
 import { ButtonProps } from '@/components/admin/button/Button';
+import { LocalizationLanguage, TranslationStatusFilter } from '@/types/common/language';
 
 jest.mock('@/hooks/admin/fetch/use-data-pagination-fetch/useDataPaginationFetch', () => ({
     useDataPaginationFetch: jest.fn(),
@@ -25,6 +26,9 @@ jest.mock('@/components/admin/status-filter-dropdown/StatusFilterDropdown', () =
         </div>
     )),
 }));
+jest.mock('@/components/admin/localization-toolkit/LocalizationToolkit', () => ({
+    LocalizationToolkit: () => <div data-testid="localization-toolkit" />,
+}));
 
 jest.mock('@/components/admin/button/Button', () => ({
     Button: jest.fn(({ children, onClick, ...props }: ButtonProps) => (
@@ -39,7 +43,6 @@ jest.mock('@/assets/icons/plus.svg', () => ({
 }));
 
 describe('AdminPanelToolbar', () => {
-    // Test data
     interface TestItem {
         id: number;
         name: string;
@@ -77,7 +80,6 @@ describe('AdminPanelToolbar', () => {
     const mockOnAddItem = jest.fn();
     const mockOnSuggestionSelect = jest.fn();
 
-    // Set up useDataPaginationFetch mock implementation
     const mockHookImplementation = {
         data: mockItems,
         isLoading: false,
@@ -91,8 +93,6 @@ describe('AdminPanelToolbar', () => {
         const useDataPaginationFetch =
             require('@/hooks/admin/fetch/use-data-pagination-fetch/useDataPaginationFetch').useDataPaginationFetch;
         useDataPaginationFetch.mockImplementation(() => mockHookImplementation);
-
-        // Reset mock implementation of component mocks
         const { SearchBar } = require('../search-bar/SearchBar');
         const { StatusFilterDropdown } = require('../status-filter-dropdown/StatusFilterDropdown');
         const { Button } = require('../button/Button');
@@ -113,6 +113,9 @@ describe('AdminPanelToolbar', () => {
     const renderComponent = (props = {}) => {
         return render(
             <AdminPanelToolbar<TestItem>
+                languages={[]}
+                onLanguageChange={jest.fn()}
+                onTranslationStatusFilterChange={jest.fn()}
                 getSearchItemKey={(item) => item.id}
                 getSearchItemLabel={(item) => item.name}
                 fetchSearchItems={mockFetchSearchItems}
@@ -145,7 +148,6 @@ describe('AdminPanelToolbar', () => {
         renderComponent();
 
         const { StatusFilterDropdown } = require('../status-filter-dropdown/StatusFilterDropdown');
-        // Get the last call to StatusFilterDropdown
         const onStatusFilterChange = StatusFilterDropdown.mock.calls[0][0].onStatusFilterChange;
 
         onStatusFilterChange(VisibilityStatus.Published);
@@ -192,11 +194,9 @@ describe('AdminPanelToolbar', () => {
         const { SearchBar } = require('../search-bar/SearchBar');
         const searchBarProps = SearchBar.mock.calls[0][0];
 
-        // Verify that SearchBar was called with the correct props
         expect(searchBarProps).toHaveProperty('onQueryChange');
         expect(searchBarProps).toHaveProperty('onClear');
         expect(searchBarProps).toHaveProperty('onSearchItemSelect');
-        // Empty array initially, not mockItems (this matches component behavior)
         expect(searchBarProps).toHaveProperty('searchItems', []);
     });
 
@@ -228,26 +228,20 @@ describe('AdminPanelToolbar', () => {
     });
 
     it('updates localSearchItems when data changes', async () => {
-        // Set up with original items
         renderComponent();
 
-        // Verify initial state
         const { SearchBar } = require('../search-bar/SearchBar');
-        // Initially, the search items array should be empty (matches component behavior)
         expect(SearchBar.mock.calls[0][0].searchItems).toEqual([]);
 
-        // Change the data in the hook implementation
         const newItems = [{ id: 4, name: 'New Item' }];
         const useDataPaginationFetch =
             require('../../../hooks/admin/fetch/use-data-pagination-fetch/useDataPaginationFetch').useDataPaginationFetch;
 
-        // Update the hook to return new data on the next call
         useDataPaginationFetch.mockImplementationOnce(() => ({
             ...mockHookImplementation,
             data: newItems,
         }));
 
-        // Re-render to trigger the useEffect with new data
         const { rerender } = renderComponent();
         rerender(
             <AdminPanelToolbar<TestItem>
@@ -259,12 +253,13 @@ describe('AdminPanelToolbar', () => {
                 onAddItem={mockOnAddItem}
                 AddItemButtonText="Add Item"
                 onSuggestionSelect={mockOnSuggestionSelect}
+                languages={[]}
+                onLanguageChange={jest.fn()}
+                onTranslationStatusFilterChange={jest.fn()}
             />,
         );
 
-        // Now check if SearchBar is called with the updated properties
         await waitFor(() => {
-            // Expect another call to SearchBar or check if props changed
             expect(SearchBar).toHaveBeenCalled();
         });
     });
@@ -275,38 +270,54 @@ describe('AdminPanelToolbar', () => {
         const { SearchBar } = require('../search-bar/SearchBar');
         const searchBarProps = SearchBar.mock.calls[0][0];
 
-        // Verify that search-related props are correctly passed
         expect(searchBarProps.minCharactersToSearch).toBe(UI_CONFIG.SEARCH_BAR.MIN_CHARACTERS_FOR_SEARCH);
         expect(searchBarProps.searchDelayMs).toBe(UI_CONFIG.SEARCH_BAR.SEARCH_DELAY_MS);
         expect(searchBarProps.placeholder).toBe('Search items');
         expect(searchBarProps.notFoundMessage).toBe('No items found');
     });
-
-    // Add a simple direct test for onSearch to increase coverage
     it('directly tests onSearch function with different search terms', () => {
-        // Mock the useState setter functions
         const setCurrentSearchTerm = jest.fn();
         const setLocalSearchItems = jest.fn();
 
-        // Create a simplified version of the onSearch function to test directly
         const onSearch = (query: string) => {
             setCurrentSearchTerm(query);
-            // Simulate the minimum characters check
             if (query.length < 3) {
-                // Using a hardcoded value for simplicity in test
                 setLocalSearchItems([]);
             }
         };
 
-        // Test with a short query
         onSearch('a');
         expect(setCurrentSearchTerm).toHaveBeenCalledWith('a');
         expect(setLocalSearchItems).toHaveBeenCalledWith([]);
 
-        // Test with a longer query
         onSearch('test query');
         expect(setCurrentSearchTerm).toHaveBeenCalledWith('test query');
-        // setLocalSearchItems shouldn't be called again for the longer query
         expect(setLocalSearchItems).toHaveBeenCalledTimes(1);
+    });
+    it('fetchHandler should call fetchSearchItems with current search term', async () => {
+        renderComponent();
+
+        const useDataPaginationFetch =
+            require('../../../hooks/admin/fetch/use-data-pagination-fetch/useDataPaginationFetch').useDataPaginationFetch;
+        const fetchHandler = useDataPaginationFetch.mock.calls[0][0].fetchHandler;
+
+        const mockParams = { offset: 0, limit: 5 };
+        await fetchHandler(mockParams);
+
+        expect(mockFetchSearchItems).toHaveBeenCalledWith('', mockParams);
+    });
+    it('should clear local search items when query length is less than minimum', () => {
+        renderComponent();
+
+        const { SearchBar } = require('../search-bar/SearchBar');
+
+        const onQueryChange = SearchBar.mock.calls[0][0].onQueryChange;
+
+        act(() => {
+            onQueryChange('a');
+        });
+
+        const lastCallProps = SearchBar.mock.calls[SearchBar.mock.calls.length - 1][0];
+        expect(lastCallProps.searchItems).toEqual([]);
     });
 });

--- a/src/components/admin/admin-panel-toolbar/AdminPageToolbar.tsx
+++ b/src/components/admin/admin-panel-toolbar/AdminPageToolbar.tsx
@@ -13,11 +13,15 @@ import { SearchBar } from '@/components/admin/search-bar/SearchBar';
 import { PaginationResult, VisibilityStatus } from '@/types/admin/common';
 import { StatusFilterDropdown } from '@/components/admin/status-filter-dropdown/StatusFilterDropdown';
 import { Button } from '@/components/admin/button/Button';
+import {
+    LocalizationToolkit,
+    LocalizationToolkitProps,
+} from '@/components/admin/localization-toolkit/LocalizationToolkit';
 import './AdminPageToolbar.scss';
 
 const DEFAULT_PAGE_SIZE = 5;
 
-export interface AdminPanelToolbarProps<T> {
+export interface AdminPanelToolbarProps<T> extends LocalizationToolkitProps {
     getSearchItemKey: (item: T) => string | number;
     getSearchItemLabel: (item: T) => string;
     fetchSearchItems: (searchTerm: string, requestOptions: PaginationRequestParams) => Promise<PaginationResult<T>>;
@@ -49,6 +53,9 @@ export const AdminPanelToolbar = <T,>({
     onAddItem,
     AddItemButtonText,
     onSuggestionSelect,
+    languages,
+    onLanguageChange,
+    onTranslationStatusFilterChange,
 }: AdminPanelToolbarProps<T>) => {
     const [currentSearchTerm, setCurrentSearchTerm] = useState<string>('');
     const [localSearchItems, setLocalSearchItems] = useState<T[]>([]);
@@ -124,6 +131,11 @@ export const AdminPanelToolbar = <T,>({
             </div>
 
             <div className="admin-panel-toolbar-actions">
+                <LocalizationToolkit
+                    languages={languages}
+                    onLanguageChange={onLanguageChange}
+                    onTranslationStatusFilterChange={onTranslationStatusFilterChange}
+                />
                 <StatusFilterDropdown value={statusFilter} onStatusFilterChange={onStatusFilterChange} />
                 <Button onClick={onAddItem} buttonStyle="primary">
                     {AddItemButtonText} <PlusIcon />

--- a/src/hooks/admin/use-localization-toolkit/useLocalizationToolkit.ts
+++ b/src/hooks/admin/use-localization-toolkit/useLocalizationToolkit.ts
@@ -5,13 +5,11 @@ import axios from 'axios';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { DEFAULT_LOCALE } from '@/const/common/locales';
 
-type ErrorType = 'categories' | 'members' | 'languages';
-
-export interface UseLocalizationToolkitProps {
-    setErrorState: (message: string, type: ErrorType) => void;
+export interface UseLocalizationToolkitProps<TError> {
+    setErrorState: (message: string, type: TError) => void;
 }
 
-export function useLocalizationToolkit({ setErrorState }: UseLocalizationToolkitProps) {
+export function useLocalizationToolkit<TError>({ setErrorState }: UseLocalizationToolkitProps<TError>) {
     const [allLanguages, setAllLanguages] = useState<LocalizationLanguage[]>([]);
     const [translationLanguages, setTranslationLanguages] = useState<LocalizationLanguage[]>([]);
     const [selectedLanguage, setSelectedLanguage] = useState<LocalizationLanguage>();
@@ -38,7 +36,10 @@ export function useLocalizationToolkit({ setErrorState }: UseLocalizationToolkit
                 return;
             }
 
-            setErrorState(COMMON_TEXT_ADMIN.LOCALIZATION.LANGUAGES.MESSAGE.FAILED_TO_FETCH_LANGUAGES, 'languages');
+            setErrorState(
+                COMMON_TEXT_ADMIN.LOCALIZATION.LANGUAGES.MESSAGE.FAILED_TO_FETCH_LANGUAGES,
+                'languages' as TError,
+            );
         }
     }, [setErrorState]);
 

--- a/src/pages/admin/faq/components/faq-component/FaqComponent.scss
+++ b/src/pages/admin/faq/components/faq-component/FaqComponent.scss
@@ -17,9 +17,11 @@
 
         &-answer,
         &-question {
-            flex: 4;
+            width: 90%;
+            flex: 1;
             display: flex;
-            align-items: center;
+            flex-direction: column;
+            justify-content: space-between;
 
             font-size: 18px;
             font-weight: 400;

--- a/src/pages/admin/faq/components/faq-component/FaqComponent.test.tsx
+++ b/src/pages/admin/faq/components/faq-component/FaqComponent.test.tsx
@@ -106,7 +106,7 @@ describe('FaqComponent', () => {
     });
 
     it('calls handleOnDeleteFaq when delete button is clicked', () => {
-        const handleOnDeleteFaq = jest.fn(); // IGNORE
+        const handleOnDeleteFaq = jest.fn();
         const { container } = render(
             <FaqComponent
                 faq={mockFaq}

--- a/src/pages/admin/faq/components/faq-component/FaqComponent.test.tsx
+++ b/src/pages/admin/faq/components/faq-component/FaqComponent.test.tsx
@@ -3,14 +3,27 @@ import { FaqComponent } from './FaqComponent';
 import { FaqQuestion } from '@/types/admin/faq';
 import { VisibilityStatus } from '@/types/admin/common';
 import { FAQ_TEXT } from '@/const/admin/faq';
+import { DEFAULT_LOCALE } from '@/const/common/locales';
+import { LocalizationLanguage } from '@/types/common/language';
 
 jest.mock('@/components/admin/button-tooltip/ButtonTooltip', () => ({
     ButtonTooltip: ({ children }: any) => <div data-testid="button-tooltip">{children}</div>,
 }));
-
 jest.mock('@/components/admin/visibility-status-label/VisibilityStatusLabel', () => ({
     VisibilityStatusLabel: ({ status }: any) => <span data-testid="status-label">{status}</span>,
 }));
+const mockDefaultLocale: LocalizationLanguage = {
+    id: 1,
+    code: DEFAULT_LOCALE,
+    name: 'Українська',
+};
+const mockTranslationLocale: LocalizationLanguage[] = [
+    {
+        id: 2,
+        code: 'en',
+        name: 'English',
+    },
+];
 const mockFaq: FaqQuestion = {
     id: 1,
     questionText: 'What is FAQ?',
@@ -28,11 +41,20 @@ const mockFaq: FaqQuestion = {
             title: 'Page 2',
         },
     ],
+    localizations: [],
 };
 
 describe('FaqComponent', () => {
     it('renders question, answer, and status', () => {
-        render(<FaqComponent faq={mockFaq} handleOnDeleteFaq={jest.fn()} handleOnEditFaq={jest.fn()} />);
+        render(
+            <FaqComponent
+                faq={mockFaq}
+                handleOnDeleteFaq={jest.fn()}
+                handleOnEditFaq={jest.fn()}
+                translationLanguages={mockTranslationLocale}
+                language={mockDefaultLocale}
+            />,
+        );
         expect(screen.getByText('What is FAQ?')).toBeInTheDocument();
         expect(screen.getByText('Frequently Asked Questions')).toBeInTheDocument();
         // The mock returns status as a number, so check for that
@@ -40,7 +62,15 @@ describe('FaqComponent', () => {
     });
 
     it('shows correct tooltip for published status', () => {
-        render(<FaqComponent faq={mockFaq} handleOnDeleteFaq={jest.fn()} handleOnEditFaq={jest.fn()} />);
+        render(
+            <FaqComponent
+                faq={mockFaq}
+                handleOnDeleteFaq={jest.fn()}
+                handleOnEditFaq={jest.fn()}
+                translationLanguages={mockTranslationLocale}
+                language={mockDefaultLocale}
+            />,
+        );
         expect(screen.getByTestId('button-tooltip')).toHaveTextContent(FAQ_TEXT.TOOLTIP.PUBLISHED_IN);
         expect(screen.getByText('Page 1')).toBeInTheDocument();
         expect(screen.getByText('Page 2')).toBeInTheDocument();
@@ -48,23 +78,43 @@ describe('FaqComponent', () => {
 
     it('shows correct tooltip for drafted status', () => {
         const draftFaq = { ...mockFaq, status: VisibilityStatus.Draft };
-        render(<FaqComponent faq={draftFaq} handleOnDeleteFaq={jest.fn()} handleOnEditFaq={jest.fn()} />);
+        render(
+            <FaqComponent
+                faq={draftFaq}
+                handleOnDeleteFaq={jest.fn()}
+                handleOnEditFaq={jest.fn()}
+                translationLanguages={mockTranslationLocale}
+                language={mockDefaultLocale}
+            />,
+        );
         expect(screen.getByTestId('button-tooltip')).toHaveTextContent(FAQ_TEXT.TOOLTIP.DRAFTED_IN);
     });
 
     it('calls handleOnEditFaq when edit button is clicked', () => {
         const handleOnEditFaq = jest.fn();
         const { container } = render(
-            <FaqComponent faq={mockFaq} handleOnDeleteFaq={jest.fn()} handleOnEditFaq={handleOnEditFaq} />,
+            <FaqComponent
+                faq={mockFaq}
+                handleOnDeleteFaq={jest.fn()}
+                handleOnEditFaq={handleOnEditFaq}
+                translationLanguages={mockTranslationLocale}
+                language={mockDefaultLocale}
+            />,
         );
         fireEvent.click(container.querySelector('.faq-edit-btn')!);
         expect(handleOnEditFaq).toHaveBeenCalledWith(mockFaq);
     });
 
     it('calls handleOnDeleteFaq when delete button is clicked', () => {
-        const handleOnDeleteFaq = jest.fn();
+        const handleOnDeleteFaq = jest.fn(); // IGNORE
         const { container } = render(
-            <FaqComponent faq={mockFaq} handleOnDeleteFaq={handleOnDeleteFaq} handleOnEditFaq={jest.fn()} />,
+            <FaqComponent
+                faq={mockFaq}
+                handleOnDeleteFaq={handleOnDeleteFaq}
+                handleOnEditFaq={jest.fn()}
+                translationLanguages={mockTranslationLocale}
+                language={mockDefaultLocale}
+            />,
         );
         fireEvent.click(container.querySelector('.faq-delete-btn')!);
         expect(handleOnDeleteFaq).toHaveBeenCalledWith(mockFaq);

--- a/src/pages/admin/faq/components/faq-component/FaqComponent.tsx
+++ b/src/pages/admin/faq/components/faq-component/FaqComponent.tsx
@@ -2,16 +2,38 @@ import { ButtonTooltip } from '@/components/admin/button-tooltip/ButtonTooltip';
 import { VisibilityStatusLabel } from '@/components/admin/visibility-status-label/VisibilityStatusLabel';
 import { FAQ_TEXT } from '@/const/admin/faq';
 import { VisibilityStatus } from '@/types/admin/common';
-import { FaqQuestion } from '@/types/admin/faq';
+import { FaqLocalizableFields, FaqQuestion } from '@/types/admin/faq';
 import './FaqComponent.scss';
+import { LocalizationLanguage } from '@/types/common/language';
+import { useEffect, useState } from 'react';
+import { returnDisplayedLocalization } from '@/utils/functions/localization/localization';
+import { LocalizationStatuses } from '@/components/admin/localization-statuses/LocalizationStatuses';
 
 export interface FaqComponentProps {
     faq: FaqQuestion;
+    language: LocalizationLanguage;
+    translationLanguages: LocalizationLanguage[];
     handleOnDeleteFaq: (faq: FaqQuestion) => void;
     handleOnEditFaq: (faq: FaqQuestion) => void;
 }
 
-export const FaqComponent = ({ faq, handleOnDeleteFaq, handleOnEditFaq }: FaqComponentProps) => {
+export const FaqComponent = ({
+    faq,
+    handleOnDeleteFaq,
+    handleOnEditFaq,
+    language,
+    translationLanguages,
+}: FaqComponentProps) => {
+    const [textFields, setTextFields] = useState<FaqLocalizableFields>();
+
+    useEffect(() => {
+        const displayedLocalization = returnDisplayedLocalization(faq, language.code);
+        setTextFields({
+            questionText: displayedLocalization?.questionText || faq.questionText,
+            answerText: displayedLocalization?.answerText || faq.answerText,
+        });
+    }, [language, faq]);
+
     const handleEditFaq = () => {
         handleOnEditFaq(faq);
     };
@@ -24,10 +46,11 @@ export const FaqComponent = ({ faq, handleOnDeleteFaq, handleOnEditFaq }: FaqCom
         <div className="admin-page_faq-item">
             <div className="faq-info">
                 <div className="faq-info-question">
-                    <p>{faq.questionText}</p>
+                    <p>{textFields?.questionText}</p>
+                    <LocalizationStatuses languages={translationLanguages} localizedEntity={faq} />
                 </div>
                 <div className="faq-info-answer">
-                    <p>{faq.answerText}</p>
+                    <p>{textFields?.answerText}</p>
                 </div>
                 <div className="faq-info-status">
                     <VisibilityStatusLabel status={faq.status} />

--- a/src/pages/admin/faq/components/faq-modals/delete-faq-modal/DeleteFaqModal.test.tsx
+++ b/src/pages/admin/faq/components/faq-modals/delete-faq-modal/DeleteFaqModal.test.tsx
@@ -33,7 +33,7 @@ jest.mock('@/services/api/admin/faq/faq-api', () => ({
     FaqApi: { delete: jest.fn() },
 }));
 
-const mockFaq = { id: 1, questionText: 'Q', answerText: 'A', status: 1, pages: [] };
+const mockFaq = { id: 1, questionText: 'Q', answerText: 'A', status: 1, pages: [], localizations: [] };
 
 describe('DeleteFaqModal', () => {
     it('renders modal with title and buttons', () => {

--- a/src/pages/admin/faq/components/faq-modals/faq-modal/FaqModal.test.tsx
+++ b/src/pages/admin/faq/components/faq-modals/faq-modal/FaqModal.test.tsx
@@ -129,6 +129,7 @@ const mockFaq: FaqQuestion = {
     answerText: 'Test Answer',
     pages: [mockPages[0]],
     status: VisibilityStatus.Draft,
+    localizations: [],
 };
 
 const mockFormData = {
@@ -188,15 +189,34 @@ describe('FaqModal', () => {
         jest.clearAllMocks();
         mockFormRef.isDirty.mockReturnValue(false);
         mockFormRef.isValid.mockReturnValue(true);
+
+        // Створюємо базовий мок для локалізацій, що відповідає FaqLocalizationDto
+        const mockLocalizationsDto = [
+            {
+                entityId: 1,
+                localizationInfoDto: { id: 1, code: 'ua' },
+                translationStatus: 1, // Relevant
+                questionText: 'Питання',
+                answerText: 'Відповідь',
+            },
+        ];
+
         mockFaqApi.post.mockResolvedValue({
-            ...mockFaq,
-            ...mockFormData,
+            id: 1,
+            questionText: mockFormData.questionText,
+            answerText: mockFormData.answerText,
+            status: VisibilityStatus.Draft,
             pageIds: mockFormData.pages.map((p) => p.id),
+            localizations: mockLocalizationsDto,
         });
+
         mockFaqApi.update.mockResolvedValue({
-            ...mockFaq,
-            ...mockFormData,
+            id: mockFaq.id,
+            questionText: mockFormData.questionText,
+            answerText: mockFormData.answerText,
+            status: VisibilityStatus.Draft,
             pageIds: mockFormData.pages.map((p) => p.id),
+            localizations: mockLocalizationsDto,
         });
     });
 

--- a/src/pages/admin/faq/components/faq-modals/faq-modal/FaqModal.test.tsx
+++ b/src/pages/admin/faq/components/faq-modals/faq-modal/FaqModal.test.tsx
@@ -190,12 +190,11 @@ describe('FaqModal', () => {
         mockFormRef.isDirty.mockReturnValue(false);
         mockFormRef.isValid.mockReturnValue(true);
 
-        // Створюємо базовий мок для локалізацій, що відповідає FaqLocalizationDto
         const mockLocalizationsDto = [
             {
                 entityId: 1,
                 localizationInfoDto: { id: 1, code: 'ua' },
-                translationStatus: 1, // Relevant
+                translationStatus: 1,
                 questionText: 'Питання',
                 answerText: 'Відповідь',
             },

--- a/src/pages/admin/faq/components/faq-panel-content/FaqPanelContent.test.tsx
+++ b/src/pages/admin/faq/components/faq-panel-content/FaqPanelContent.test.tsx
@@ -5,9 +5,21 @@ import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
 import { VisibilityStatus } from '@/types/admin/common';
 import { FaqApi } from '@/services/api/admin/faq/faq-api';
-import { FaqQuestion, VisitorPage } from '@/types/admin/faq';
+import { FaqQuestion, FaqQuestionDto, VisitorPage } from '@/types/admin/faq';
 import { FAQ_TEXT } from '@/const/admin/faq';
 import axios from 'axios';
+
+// Додайте це до інших моків на початку файлу
+jest.mock('@/hooks/admin/use-localization-toolkit/useLocalizationToolkit', () => ({
+    useLocalizationToolkit: () => ({
+        allLanguages: [{ id: 1, code: 'ua', name: 'Ukrainian' }],
+        translationLanguages: [{ id: 1, code: 'ua', name: 'Ukrainian' }],
+        selectedLanguage: { id: 1, code: 'ua' },
+        onLanguageChange: jest.fn(),
+        translationStatusFilter: 0, // TranslationStatusFilter.All
+        onTranslationStatusFilterChange: jest.fn(),
+    }),
+}));
 
 jest.mock('@/hooks/admin/use-admin-client/useAdminClient');
 
@@ -170,6 +182,15 @@ const mockFaqs: FaqQuestion[] = [
         answerText: 'A sample answer.',
         status: 'published' as unknown as VisibilityStatus,
         pages: [mockPages[0]],
+        localizations: [
+            // Додаємо обов'язкове поле
+            {
+                language: { id: 1, code: 'ua' },
+                translationStatus: 1, // Relevant
+                questionText: 'Тест Альфа',
+                answerText: 'Відповідь Альфа',
+            },
+        ],
     },
     {
         id: 2,
@@ -177,6 +198,15 @@ const mockFaqs: FaqQuestion[] = [
         answerText: 'Another sample answer.',
         status: 'draft' as unknown as VisibilityStatus,
         pages: [mockPages[1]],
+        localizations: [
+            // Додаємо обов'язкове поле
+            {
+                language: { id: 1, code: 'ua' },
+                translationStatus: 1, // Relevant
+                questionText: 'Тест Бета',
+                answerText: 'Відповідь Бета',
+            },
+        ],
     },
 ];
 
@@ -186,6 +216,15 @@ const mockNewFaq: FaqQuestion = {
     answerText: 'Yet another sample answer.',
     status: 'draft' as unknown as VisibilityStatus,
     pages: mockPages,
+    localizations: [
+        // Додаємо обов'язкове поле
+        {
+            language: { id: 1, code: 'ua' },
+            translationStatus: 1, // Relevant
+            questionText: 'Тест Гамма',
+            answerText: 'Відповідь Гамма',
+        },
+    ],
 };
 
 jest.mock('@/components/admin/admin-panel-toolbar/AdminPageToolbar', () => {
@@ -273,13 +312,26 @@ jest.mock('@/components/admin/toast/toast-container/ToastContainer', () => ({
 }));
 
 // Helper function to convert mock faqs to DTO format
-const convertFaqsToDto = (faqs: FaqQuestion[]) => {
+const convertFaqsToDto = (faqs: FaqQuestion[]): FaqQuestionDto[] => {
     return faqs.map((faq) => ({
         id: faq.id,
         questionText: faq.questionText,
         answerText: faq.answerText,
         status: faq.status,
         pageIds: faq.pages.map((p) => p.id),
+        localizations: faq.localizations.map((l) => ({
+            // Поля з EntityLocalizationDto
+            localizationInfoDto: {
+                id: l.language.id,
+                code: l.language.code,
+            },
+            translationStatus: l.translationStatus,
+            // Поля з FaqLocalizationDto
+            entityId: faq.id,
+            // Поля з FaqLocalizableFields
+            questionText: l.questionText,
+            answerText: l.answerText,
+        })),
     }));
 };
 
@@ -339,7 +391,14 @@ describe('FaqPanelContent', () => {
 
             await waitFor(() => {
                 expect(mockFaqApi.getAll).toHaveBeenCalledTimes(1);
-                expect(mockFaqApi.getAll).toHaveBeenCalledWith(expect.anything(), 1, undefined, 0, expect.any(Number));
+                expect(mockFaqApi.getAll).toHaveBeenCalledWith(
+                    expect.anything(),
+                    1,
+                    0,
+                    undefined,
+                    0,
+                    expect.any(Number),
+                );
             });
 
             await waitFor(() => {
@@ -377,7 +436,14 @@ describe('FaqPanelContent', () => {
             fireEvent.click(screen.getByTestId(`category-2`));
 
             await waitFor(() => {
-                expect(mockFaqApi.getAll).toHaveBeenCalledWith(expect.anything(), 2, undefined, 0, expect.any(Number));
+                expect(mockFaqApi.getAll).toHaveBeenCalledWith(
+                    expect.anything(),
+                    2,
+                    0,
+                    undefined,
+                    0,
+                    expect.any(Number),
+                );
             });
         });
 
@@ -397,6 +463,7 @@ describe('FaqPanelContent', () => {
                 expect(mockFaqApi.getAll).toHaveBeenCalledWith(
                     expect.anything(),
                     1,
+                    0,
                     'published',
                     0,
                     expect.any(Number),
@@ -417,7 +484,7 @@ describe('FaqPanelContent', () => {
             fireEvent.click(screen.getByTestId('filter-draft'));
 
             await waitFor(() => {
-                expect(mockFaqApi.getAll).toHaveBeenCalledWith(expect.anything(), 1, 'draft', 0, expect.any(Number));
+                expect(mockFaqApi.getAll).toHaveBeenCalledWith(expect.anything(), 1, 0, 'draft', 0, expect.any(Number));
             });
         });
 
@@ -446,7 +513,14 @@ describe('FaqPanelContent', () => {
             fireEvent.click(screen.getByTestId('filter-clear'));
 
             await waitFor(() => {
-                expect(mockFaqApi.getAll).toHaveBeenCalledWith(expect.anything(), 1, undefined, 0, expect.any(Number));
+                expect(mockFaqApi.getAll).toHaveBeenCalledWith(
+                    expect.anything(),
+                    1,
+                    0,
+                    undefined,
+                    0,
+                    expect.any(Number),
+                );
             });
         });
     });
@@ -710,6 +784,7 @@ describe('FaqPanelContent', () => {
                     answerText: 'Third answer.',
                     status: VisibilityStatus.Published,
                     pages: [mockPages[0]],
+                    localizations: mockFaqs[0].localizations,
                 },
                 {
                     id: 4,
@@ -717,6 +792,7 @@ describe('FaqPanelContent', () => {
                     answerText: 'Fourth answer.',
                     status: VisibilityStatus.Draft,
                     pages: [mockPages[1]],
+                    localizations: mockFaqs[0].localizations,
                 },
             ];
 
@@ -734,6 +810,7 @@ describe('FaqPanelContent', () => {
                 expect(mockFaqApi.getAll).toHaveBeenCalledWith(
                     expect.anything(),
                     1,
+                    0,
                     undefined,
                     expect.any(Number),
                     expect.any(Number),

--- a/src/pages/admin/faq/components/faq-panel-content/FaqPanelContent.test.tsx
+++ b/src/pages/admin/faq/components/faq-panel-content/FaqPanelContent.test.tsx
@@ -9,14 +9,13 @@ import { FaqQuestion, FaqQuestionDto, VisitorPage } from '@/types/admin/faq';
 import { FAQ_TEXT } from '@/const/admin/faq';
 import axios from 'axios';
 
-// Додайте це до інших моків на початку файлу
 jest.mock('@/hooks/admin/use-localization-toolkit/useLocalizationToolkit', () => ({
     useLocalizationToolkit: () => ({
         allLanguages: [{ id: 1, code: 'ua', name: 'Ukrainian' }],
         translationLanguages: [{ id: 1, code: 'ua', name: 'Ukrainian' }],
         selectedLanguage: { id: 1, code: 'ua' },
         onLanguageChange: jest.fn(),
-        translationStatusFilter: 0, // TranslationStatusFilter.All
+        translationStatusFilter: 0,
         onTranslationStatusFilterChange: jest.fn(),
     }),
 }));
@@ -183,10 +182,9 @@ const mockFaqs: FaqQuestion[] = [
         status: 'published' as unknown as VisibilityStatus,
         pages: [mockPages[0]],
         localizations: [
-            // Додаємо обов'язкове поле
             {
                 language: { id: 1, code: 'ua' },
-                translationStatus: 1, // Relevant
+                translationStatus: 1,
                 questionText: 'Тест Альфа',
                 answerText: 'Відповідь Альфа',
             },
@@ -199,10 +197,9 @@ const mockFaqs: FaqQuestion[] = [
         status: 'draft' as unknown as VisibilityStatus,
         pages: [mockPages[1]],
         localizations: [
-            // Додаємо обов'язкове поле
             {
                 language: { id: 1, code: 'ua' },
-                translationStatus: 1, // Relevant
+                translationStatus: 1,
                 questionText: 'Тест Бета',
                 answerText: 'Відповідь Бета',
             },
@@ -217,10 +214,9 @@ const mockNewFaq: FaqQuestion = {
     status: 'draft' as unknown as VisibilityStatus,
     pages: mockPages,
     localizations: [
-        // Додаємо обов'язкове поле
         {
             language: { id: 1, code: 'ua' },
-            translationStatus: 1, // Relevant
+            translationStatus: 1,
             questionText: 'Тест Гамма',
             answerText: 'Відповідь Гамма',
         },
@@ -320,15 +316,12 @@ const convertFaqsToDto = (faqs: FaqQuestion[]): FaqQuestionDto[] => {
         status: faq.status,
         pageIds: faq.pages.map((p) => p.id),
         localizations: faq.localizations.map((l) => ({
-            // Поля з EntityLocalizationDto
             localizationInfoDto: {
                 id: l.language.id,
                 code: l.language.code,
             },
             translationStatus: l.translationStatus,
-            // Поля з FaqLocalizationDto
             entityId: faq.id,
-            // Поля з FaqLocalizableFields
             questionText: l.questionText,
             answerText: l.answerText,
         })),

--- a/src/pages/admin/faq/components/faq-panel-content/FaqPanelContent.tsx
+++ b/src/pages/admin/faq/components/faq-panel-content/FaqPanelContent.tsx
@@ -20,6 +20,7 @@ import { FaqSearchItem } from '../faq-search-item/FaqSearchItem';
 import { mapFaqQuestionDtoToModel } from '@/utils/functions/mappers/admin/faq/faq-mappers';
 import axios from 'axios';
 import './FaqPanelContent.scss';
+import { useLocalizationToolkit } from '@/hooks/admin/use-localization-toolkit/useLocalizationToolkit';
 
 const DEFAULT_LOAD_ITEMS_COUNT = 5;
 const LIST_ITEM_HEIGHT_IN_PIXELS = 120;
@@ -76,6 +77,21 @@ export const FaqPanelContent = () => {
         setError({ message, type });
     }, []);
 
+    const setErrorStateForToolkit = useCallback(
+        (message: string, type: any) => {
+            setErrorState(message, type as ErrorType);
+        },
+        [setErrorState],
+    );
+    const {
+        allLanguages,
+        translationLanguages,
+        selectedLanguage,
+        onLanguageChange,
+        translationStatusFilter,
+        onTranslationStatusFilterChange,
+    } = useLocalizationToolkit({ setErrorState: setErrorStateForToolkit });
+
     const isAnyModalOpened = useMemo(() => {
         return Object.values(modalState).some((value) => (typeof value === 'boolean' ? value : value !== null));
     }, [modalState]);
@@ -129,7 +145,14 @@ export const FaqPanelContent = () => {
                 const paginationPageToFetch = shouldResetList ? 0 : currentPaginationPageRef.current;
                 const offset = paginationPageToFetch * listSize;
 
-                const fetchedFaqs = await FaqApi.getAll(client, searchPageId.id, searchStatus, offset, listSize);
+                const fetchedFaqs = await FaqApi.getAll(
+                    client,
+                    searchPageId.id,
+                    translationStatusFilter,
+                    searchStatus,
+                    offset,
+                    listSize,
+                );
 
                 if (abortController.signal.aborted) {
                     return;
@@ -167,7 +190,7 @@ export const FaqPanelContent = () => {
                 setIsFaqsLoading(false);
             }
         },
-        [setErrorState, listSize, statusFilter, client, visitorPages],
+        [setErrorState, listSize, statusFilter, client, visitorPages, translationStatusFilter],
     );
 
     // TODO: Implement search functionality
@@ -337,36 +360,51 @@ export const FaqPanelContent = () => {
     );
 
     const renderFaqItem = useCallback(
-        (faq: FaqQuestion) =>
-            statusFilter === undefined ? (
-                <DraggableListItem
-                    key={faq.id}
-                    entity={faq}
-                    id={faq.id}
-                    ariaLabel={FAQ_TEXT.ACTIONS.REORDER}
-                    renderEntityComponent={(q) => (
-                        <FaqComponent
-                            key={q.id}
-                            faq={q}
-                            handleOnDeleteFaq={handleDeleteFaqModalOpen}
-                            handleOnEditFaq={handleEditFaqModalOpen}
-                        />
-                    )}
-                    entities={faqs}
-                    idSelector={(q) => q.id}
-                    onEntitiesReordered={handleEntitiesReordered}
-                ></DraggableListItem>
-            ) : (
+        (faq: FaqQuestion) => {
+            return statusFilter === undefined ? (
+                selectedLanguage ? (
+                    <DraggableListItem
+                        key={faq.id}
+                        entity={faq}
+                        id={faq.id}
+                        ariaLabel={FAQ_TEXT.ACTIONS.REORDER}
+                        renderEntityComponent={(q) => (
+                            <FaqComponent
+                                key={q.id}
+                                faq={q}
+                                handleOnDeleteFaq={handleDeleteFaqModalOpen}
+                                handleOnEditFaq={handleEditFaqModalOpen}
+                                language={selectedLanguage}
+                                translationLanguages={translationLanguages}
+                            />
+                        )}
+                        entities={faqs}
+                        idSelector={(q) => q.id}
+                        onEntitiesReordered={handleEntitiesReordered}
+                    />
+                ) : null
+            ) : selectedLanguage ? (
                 <div className="nondraggable-faq-item-wrapper">
                     <FaqComponent
                         key={faq.id}
                         faq={faq}
                         handleOnDeleteFaq={handleDeleteFaqModalOpen}
                         handleOnEditFaq={handleEditFaqModalOpen}
+                        language={selectedLanguage}
+                        translationLanguages={translationLanguages}
                     />
                 </div>
-            ),
-        [handleDeleteFaqModalOpen, handleEditFaqModalOpen, handleEntitiesReordered, faqs, statusFilter],
+            ) : null;
+        },
+        [
+            handleDeleteFaqModalOpen,
+            handleEditFaqModalOpen,
+            handleEntitiesReordered,
+            faqs,
+            statusFilter,
+            selectedLanguage,
+            translationLanguages,
+        ],
     );
 
     return (
@@ -384,6 +422,9 @@ export const FaqPanelContent = () => {
                     onAddItem={handleAddFaqModalOpen}
                     AddItemButtonText={FAQ_TEXT.BUTTON.ADD_FAQ}
                     onSuggestionSelect={() => {}}
+                    languages={allLanguages}
+                    onLanguageChange={onLanguageChange}
+                    onTranslationStatusFilterChange={onTranslationStatusFilterChange}
                 />
             </div>
 

--- a/src/pages/admin/faq/components/faq-panel-content/FaqPanelContent.tsx
+++ b/src/pages/admin/faq/components/faq-panel-content/FaqPanelContent.tsx
@@ -35,6 +35,7 @@ enum ErrorType {
     Pages,
     Faq,
     Search,
+    Language,
 }
 
 interface ErrorState {
@@ -77,12 +78,6 @@ export const FaqPanelContent = () => {
         setError({ message, type });
     }, []);
 
-    const setErrorStateForToolkit = useCallback(
-        (message: string, type: any) => {
-            setErrorState(message, type as ErrorType);
-        },
-        [setErrorState],
-    );
     const {
         allLanguages,
         translationLanguages,
@@ -90,7 +85,7 @@ export const FaqPanelContent = () => {
         onLanguageChange,
         translationStatusFilter,
         onTranslationStatusFilterChange,
-    } = useLocalizationToolkit({ setErrorState: setErrorStateForToolkit });
+    } = useLocalizationToolkit({ setErrorState });
 
     const isAnyModalOpened = useMemo(() => {
         return Object.values(modalState).some((value) => (typeof value === 'boolean' ? value : value !== null));

--- a/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.test.tsx
+++ b/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.test.tsx
@@ -15,6 +15,18 @@ import { AdminPanelToolbarProps } from '@/components/admin/admin-panel-toolbar/A
 jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
     useAdminClient: jest.fn(),
 }));
+jest.mock('@/hooks/admin/use-localization-toolkit/useLocalizationToolkit', () => ({
+    useLocalizationToolkit: () => ({
+        allLanguages: [
+            { id: 1, code: 'uk', name: 'Українська' },
+            { id: 2, code: 'en', name: 'Англійська' },
+        ],
+        onLanguageChange: jest.fn(),
+        onTranslationStatusFilterChange: jest.fn(),
+        translationLanguages: [{ id: 1, code: 'en', name: 'Англійська' }],
+        language: { id: 1, code: 'uk', name: 'Українська' },
+    }),
+}));
 
 jest.mock('@/contexts/admin/toast-context-provider/ToastContextProvider', () => ({
     useToast: () => ({
@@ -565,7 +577,7 @@ describe('ProgramsPageContent', () => {
         await waitFor(() => {
             expect(screen.getByTestId('category-1')).not.toBeDisabled();
             expect(screen.getByTestId('category-2')).toBeDisabled();
-            expect(mockProgramsApi.fetchPrograms).toHaveBeenCalledTimes(2);
+            expect(mockProgramsApi.fetchPrograms).toHaveBeenCalledTimes(2); // Initial + on category change
         });
     });
 });

--- a/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.test.tsx
+++ b/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.test.tsx
@@ -577,7 +577,7 @@ describe('ProgramsPageContent', () => {
         await waitFor(() => {
             expect(screen.getByTestId('category-1')).not.toBeDisabled();
             expect(screen.getByTestId('category-2')).toBeDisabled();
-            expect(mockProgramsApi.fetchPrograms).toHaveBeenCalledTimes(2); // Initial + on category change
+            expect(mockProgramsApi.fetchPrograms).toHaveBeenCalledTimes(2);
         });
     });
 });

--- a/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.tsx
+++ b/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.tsx
@@ -29,7 +29,7 @@ const LIST_ITEM_HEIGHT_IN_PIXELS = 120;
 
 interface ErrorState {
     message: string | null;
-    type: 'categories' | 'programs' | 'search' | 'members' | 'languages' | null;
+    type: 'categories' | 'programs' | 'search' | null;
 }
 
 export const ProgramsPageContent = () => {
@@ -145,8 +145,7 @@ export const ProgramsPageContent = () => {
 
     // Errors handling
     const setErrorState = useCallback(
-        (message: string, type: 'categories' | 'programs' | 'search' | 'members' | 'languages') =>
-            setError({ message, type }),
+        (message: string, type: 'categories' | 'programs' | 'search') => setError({ message, type }),
         [],
     );
     const clearError = useCallback(() => setError({ message: null, type: null }), []);

--- a/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.tsx
+++ b/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.tsx
@@ -22,13 +22,14 @@ import { ProgramSearchItem } from '../program-search-item/ProgramSearchItem';
 import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextProvider';
 import { ToastType } from '@/types/admin/toast';
 import { ToastContainer } from '@/components/admin/toast/toast-container/ToastContainer';
+import { useLocalizationToolkit } from '@/hooks/admin/use-localization-toolkit/useLocalizationToolkit';
 
 const DEFAULT_LOAD_ITEMS_COUNT = 5;
 const LIST_ITEM_HEIGHT_IN_PIXELS = 120;
 
 interface ErrorState {
     message: string | null;
-    type: 'categories' | 'programs' | 'search' | null;
+    type: 'categories' | 'programs' | 'search' | 'members' | 'languages' | null;
 }
 
 export const ProgramsPageContent = () => {
@@ -144,7 +145,8 @@ export const ProgramsPageContent = () => {
 
     // Errors handling
     const setErrorState = useCallback(
-        (message: string, type: 'categories' | 'programs' | 'search') => setError({ message, type }),
+        (message: string, type: 'categories' | 'programs' | 'search' | 'members' | 'languages') =>
+            setError({ message, type }),
         [],
     );
     const clearError = useCallback(() => setError({ message: null, type: null }), []);
@@ -160,6 +162,9 @@ export const ProgramsPageContent = () => {
             refetchSearchProgram();
         }
     }, [isSearchResultView, clearError, error.type, refetchCategories, refetchSearchProgram, fetchProgramsFromStart]);
+    const { allLanguages, onLanguageChange, onTranslationStatusFilterChange } = useLocalizationToolkit({
+        setErrorState,
+    });
 
     useEffect(() => {
         if (categoriesError) {
@@ -430,6 +435,9 @@ export const ProgramsPageContent = () => {
                     onAddItem={openModalActions.openAddItemModal}
                     AddItemButtonText={PROGRAMS_TEXT.BUTTON.ADD_PROGRAM}
                     onSuggestionSelect={handleProgramSuggestionSelect}
+                    languages={allLanguages}
+                    onLanguageChange={onLanguageChange}
+                    onTranslationStatusFilterChange={onTranslationStatusFilterChange}
                 />
             </div>
 

--- a/src/services/api/admin/faq/faq-api.test.ts
+++ b/src/services/api/admin/faq/faq-api.test.ts
@@ -2,6 +2,7 @@ import { FaqApi } from './faq-api';
 import { API_ROUTES } from '@/const/common/api-routes/main-api';
 import { FaqCreateUpdate, FaqQuestionDto, ReorderFaq, VisitorPage } from '@/types/admin/faq';
 import { PaginationResult, VisibilityStatus } from '@/types/admin/common';
+import { TranslationStatusFilter } from '@/types/common/language';
 
 describe('FaqApi', () => {
     const mockClient = {
@@ -18,12 +19,20 @@ describe('FaqApi', () => {
     it('getAll should call GET with correct params and return data', async () => {
         const mockResult: PaginationResult<FaqQuestionDto> = { items: [], totalItemsCount: 0 };
         mockClient.get.mockResolvedValueOnce({ data: mockResult });
-        const result = await FaqApi.getAll(mockClient, 1, VisibilityStatus.Published, 5, 10);
+        const result = await FaqApi.getAll(
+            mockClient,
+            1,
+            TranslationStatusFilter.All,
+            VisibilityStatus.Published,
+            5,
+            10,
+        );
         expect(mockClient.get).toHaveBeenCalledWith(
             API_ROUTES.FAQ.BASE,
             expect.objectContaining({
                 params: expect.objectContaining({
                     pageId: 1,
+                    translationStatusFilter: TranslationStatusFilter.All,
                     status: VisibilityStatus.Published,
                     offset: 5,
                     limit: 10,
@@ -44,7 +53,7 @@ describe('FaqApi', () => {
     it('getAll should set only provided params', async () => {
         const mockResult: PaginationResult<FaqQuestionDto> = { items: [], totalItemsCount: 0 };
         mockClient.get.mockResolvedValueOnce({ data: mockResult });
-        await FaqApi.getAll(mockClient, 1, undefined, undefined, 5);
+        await FaqApi.getAll(mockClient, 1, undefined, undefined, undefined, 5);
         expect(mockClient.get).toHaveBeenCalledWith(
             API_ROUTES.FAQ.BASE,
             expect.objectContaining({ params: expect.objectContaining({ pageId: 1, limit: 5 }) }),

--- a/src/services/api/admin/faq/faq-api.ts
+++ b/src/services/api/admin/faq/faq-api.ts
@@ -3,6 +3,7 @@ import { PaginationResult, VisibilityStatus } from '@/types/admin/common';
 import { FaqCreateUpdate, FaqQuestionDto, FaqSearchItemData, ReorderFaq, VisitorPage } from '@/types/admin/faq';
 import { API_ROUTES } from '@/const/common/api-routes/main-api';
 import { PaginationRequestParams } from '@/hooks/admin/fetch/use-data-pagination-fetch/useDataPaginationFetch';
+import { TranslationStatusFilter } from '@/types/common/language';
 
 type FaqPayload = Omit<FaqCreateUpdate, 'id'>;
 const toPayload = (faq: FaqCreateUpdate): FaqPayload => {
@@ -14,6 +15,7 @@ export const FaqApi = {
     getAll: async (
         client: AxiosInstance,
         pageId?: number,
+        translationStatusFilter?: TranslationStatusFilter | null,
         status?: VisibilityStatus | null,
         offset?: number,
         limit?: number,
@@ -22,6 +24,9 @@ export const FaqApi = {
 
         if (pageId !== undefined) {
             params.pageId = pageId;
+        }
+        if (translationStatusFilter !== undefined && translationStatusFilter !== null) {
+            params.translationStatusFilter = translationStatusFilter;
         }
         if (status !== undefined) {
             params.status = status;

--- a/src/types/admin/faq.ts
+++ b/src/types/admin/faq.ts
@@ -1,4 +1,10 @@
 import { VisibilityStatus } from './common';
+import {
+    EntityLocalization,
+    EntityLocalizationDto,
+    EntityWithDtoLocalizations,
+    EntityWithLocalizations,
+} from '../common/language';
 
 export interface VisitorPage {
     id: number;
@@ -6,15 +12,19 @@ export interface VisitorPage {
     title: string;
 }
 
-export interface FaqQuestion {
+export interface FaqQuestion extends FaqLocalizableFields, EntityWithLocalizations<FaqLocalization> {
     id: number;
     questionText: string;
     answerText: string;
     status: VisibilityStatus;
     pages: VisitorPage[];
 }
+export interface FaqLocalizableFields {
+    questionText: string;
+    answerText: string;
+}
 
-export interface FaqQuestionDto {
+export interface FaqQuestionDto extends FaqLocalizableFields, EntityWithDtoLocalizations<FaqLocalizationDto> {
     id: number;
     questionText: string;
     answerText: string;
@@ -40,3 +50,7 @@ export interface FaqSearchItemData {
     question: string;
     pages: string[];
 }
+export interface FaqLocalizationDto extends EntityLocalizationDto, FaqLocalizableFields {
+    entityId: number;
+}
+export interface FaqLocalization extends EntityLocalization, FaqLocalizableFields {}

--- a/src/utils/functions/mappers/admin/faq/faq-mappers.test.ts
+++ b/src/utils/functions/mappers/admin/faq/faq-mappers.test.ts
@@ -16,6 +16,7 @@ describe('mapFaqQuestionDtoToModel', () => {
             answerText: 'This is a test.',
             status: VisibilityStatus.Published,
             pageIds: [1, 3],
+            localizations: [],
         };
 
         const result = mapFaqQuestionDtoToModel(dto, pages);
@@ -29,6 +30,7 @@ describe('mapFaqQuestionDtoToModel', () => {
                 { id: 1, title: 'Home', slug: 'home' },
                 { id: 3, title: 'Contact', slug: 'contact' },
             ],
+            localizations: [],
         });
     });
 
@@ -39,6 +41,7 @@ describe('mapFaqQuestionDtoToModel', () => {
             answerText: 'No pages should match.',
             status: VisibilityStatus.Draft,
             pageIds: [99],
+            localizations: [],
         };
 
         const result = mapFaqQuestionDtoToModel(dto, pages);
@@ -53,6 +56,7 @@ describe('mapFaqQuestionDtoToModel', () => {
             answerText: 'No pages.',
             status: VisibilityStatus.Draft,
             pageIds: [],
+            localizations: [],
         };
 
         const result = mapFaqQuestionDtoToModel(dto, pages);

--- a/src/utils/functions/mappers/admin/faq/faq-mappers.ts
+++ b/src/utils/functions/mappers/admin/faq/faq-mappers.ts
@@ -1,12 +1,17 @@
 import { FaqQuestionDto, VisitorPage, FaqQuestion } from '@/types/admin/faq';
+import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/localization/localization-mappers';
 
 export function mapFaqQuestionDtoToModel(dto: FaqQuestionDto, pages: VisitorPage[]): FaqQuestion {
     const mappedPages = pages.filter((page) => dto.pageIds.includes(page.id));
+    const mappedLocalizations = dto.localizations.map((localization) =>
+        mapLocalizationDtoToModel(localization),
+    );
     return {
         id: dto.id,
         questionText: dto.questionText,
         answerText: dto.answerText,
         status: dto.status,
         pages: mappedPages,
+        localizations: mappedLocalizations,
     };
 }

--- a/src/utils/functions/mappers/admin/faq/faq-mappers.ts
+++ b/src/utils/functions/mappers/admin/faq/faq-mappers.ts
@@ -3,9 +3,7 @@ import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/loca
 
 export function mapFaqQuestionDtoToModel(dto: FaqQuestionDto, pages: VisitorPage[]): FaqQuestion {
     const mappedPages = pages.filter((page) => dto.pageIds.includes(page.id));
-    const mappedLocalizations = dto.localizations.map((localization) =>
-        mapLocalizationDtoToModel(localization),
-    );
+    const mappedLocalizations = dto.localizations.map((localization) => mapLocalizationDtoToModel(localization));
     return {
         id: dto.id,
         questionText: dto.questionText,


### PR DESCRIPTION
## Github Tickets

* [Github Ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1053)
* [Github Ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1054)
* [Github Ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1056)

## Description

<!--- Please decripe the main goal of this PR and why it was created --->

## How it looks


https://github.com/user-attachments/assets/5aee6fb7-e300-473a-8fcb-0df2fc4bb3a9



## Summary of change

<!--- Please specify what was changed --->

## How to recreate changes

<!--- Please provide short instruction step-by-step how to see changes that was implemented by this PR --->


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multilingual and translation support across admin FAQ and toolbar: language selection, translation-status filtering, localized FAQ display/editing, and per-item localization status indicators.

* **Style**
  * Improved responsive behavior with additional breakpoints for the admin toolbar search.
  * FAQ layout changed from horizontal to stacked vertical arrangement for clearer reading.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->