### PR TITLE
Fix/issue-1149 The location of the Clean-up icon doesn't match mock-up

### DIFF
--- a/src/components/admin/textarea-with-character-limit/TextAreaWithCharacterLimit.scss
+++ b/src/components/admin/textarea-with-character-limit/TextAreaWithCharacterLimit.scss
@@ -7,7 +7,6 @@
     &__wrapper {
         display: flex;
         position: relative;
-        padding: 0.625rem;
         background: white;
         border: 1px solid colors.$grey-700;
         border-radius: 8px;
@@ -38,6 +37,7 @@
         font-weight: 400;
         line-height: 1.75rem;
         letter-spacing: -0.0225rem;
+        padding: 10px 40px 10px 14px;
 
         &::placeholder {
             color: colors.$grey-700;
@@ -50,8 +50,8 @@
 
     &__clear-button {
         position: absolute;
-        top: 0.75rem;
-        right: 0.75rem;
+        top: 8px;
+        right: 8px;
         border: none;
         width: 1.5rem;
         height: 1.5rem;

--- a/src/components/admin/textarea-with-character-limit/TextAreaWithCharacterLimit.scss
+++ b/src/components/admin/textarea-with-character-limit/TextAreaWithCharacterLimit.scss
@@ -37,7 +37,7 @@
         font-weight: 400;
         line-height: 1.75rem;
         letter-spacing: -0.0225rem;
-        padding: 10px 40px 10px 14px;
+        padding: 0.625rem 2.5rem 0.625rem 0.875rem;
 
         &::placeholder {
             color: colors.$grey-700;
@@ -50,8 +50,8 @@
 
     &__clear-button {
         position: absolute;
-        top: 8px;
-        right: 8px;
+        top: 0.5rem;
+        right: 0.875rem;
         border: none;
         width: 1.5rem;
         height: 1.5rem;

--- a/src/components/admin/textarea-with-character-limit/TextAreaWithCharacterLimit.scss
+++ b/src/components/admin/textarea-with-character-limit/TextAreaWithCharacterLimit.scss
@@ -50,7 +50,7 @@
 
     &__clear-button {
         position: absolute;
-        bottom: 0.75rem;
+        top: 0.75rem;
         right: 0.75rem;
         border: none;
         width: 1.5rem;


### PR DESCRIPTION
## Github ticker

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1149)

## Description

Fixed Clean-up icon position to match design 

## How it looks

<img width="1857" height="952" alt="image" src="https://github.com/user-attachments/assets/e45c7b44-5842-4ba7-8fb7-c58bc490d8bf" />

## Summary of change

Updated TextAreaWithCharacterLimit styles.

## How to recreate changes

- Go to the Admin Panel

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved layout and spacing for the textarea with character limit: inner padding adjusted for cleaner text alignment and visual balance.
  * Clear-button repositioned to the top-right for easier access and a less cluttered input area, enhancing usability when editing longer text.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->