### PR TITLE
Remove Store link from Header and Footer

### DIFF
--- a/src/components/public/footer/Footer.test.tsx
+++ b/src/components/public/footer/Footer.test.tsx
@@ -50,7 +50,6 @@ describe('Footer', () => {
             'href',
             PUBLIC_ROUTES.REPORTS.FULL,
         );
-        expect(screen.getByRole('link', { name: footerUk['STORE'] })).toHaveAttribute('href', PUBLIC_ROUTES.MOCK.FULL);
         expect(screen.getByRole('link', { name: footerUk['HOW_TO_SUPPORT'] })).toHaveAttribute(
             'href',
             PUBLIC_ROUTES.MOCK.FULL,

--- a/src/components/public/footer/Footer.tsx
+++ b/src/components/public/footer/Footer.tsx
@@ -54,9 +54,6 @@ export const Footer = () => {
                     <span className="title">{t('MENU')}</span>
                     <Link to={PUBLIC_ROUTES.REPORTS.FULL}>{t('REPORTING')}</Link>
                     <Link to={PUBLIC_ROUTES.MOCK.FULL} className="disable">
-                        {t('STORE')}
-                    </Link>
-                    <Link to={PUBLIC_ROUTES.MOCK.FULL} className="disable">
                         {t('HOW_TO_SUPPORT')}
                     </Link>
                     <Link to={PUBLIC_ROUTES.MOCK.FULL} className="disable">

--- a/src/components/public/header/Header.test.tsx
+++ b/src/components/public/header/Header.test.tsx
@@ -126,7 +126,6 @@ describe('Header', () => {
             'href',
             PUBLIC_ROUTES.MOCK.FULL,
         );
-        expect(screen.getByRole('link', { name: headerUk['STORE'] })).toHaveAttribute('href', PUBLIC_ROUTES.MOCK.FULL);
         expect(screen.getByRole('link', { name: headerUk['STORIES_OF_VICTORIES'] })).toHaveAttribute(
             'href',
             PUBLIC_ROUTES.MOCK.FULL,

--- a/src/components/public/header/Header.tsx
+++ b/src/components/public/header/Header.tsx
@@ -56,10 +56,6 @@ export const Header = () => {
                             <Link to={PUBLIC_ROUTES.REPORTS.FULL}>{t('REPORTING')}</Link>
 
                             <Link to={PUBLIC_ROUTES.MOCK.FULL} className="disable">
-                                {t('STORE')}
-                            </Link>
-
-                            <Link to={PUBLIC_ROUTES.MOCK.FULL} className="disable">
                                 {t('STORIES_OF_VICTORIES')}
                             </Link>
 


### PR DESCRIPTION
## JIRA or Github ticker

https://github.com/ita-social-projects/VictoryCenter-Back/issues/1340

## Description

Remove Store link from Header and Footer

## How it looks
Header
Before
<img width="1804" height="82" alt="image" src="https://github.com/user-attachments/assets/6dbdeb73-258a-4f68-aeb3-706957dc7b9b" />

Now
<img width="1446" height="67" alt="image" src="https://github.com/user-attachments/assets/95d8d1f8-9bf1-4153-b0c5-0ca0debfc09e" />

Footer
Before
<img width="1465" height="443" alt="image" src="https://github.com/user-attachments/assets/a7b63d1a-9247-4617-95b2-385563725f93" />

Now
<img width="1171" height="349" alt="image" src="https://github.com/user-attachments/assets/69a55e0d-b234-4951-83a1-d081180c9d6d" />


## Summary of change

<!--- Please specify what was changed --->

## How to recreate changes

<!--- Please provide short instruction step-by-step how to see changes that was implemented by this PR --->


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions
