### PR TITLE
Reach text intorducing new key pluging

### DIFF
--- a/src/components/admin/rich-text-input/RichTextInput.tsx
+++ b/src/components/admin/rich-text-input/RichTextInput.tsx
@@ -8,7 +8,14 @@ import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary';
 import { $generateNodesFromDOM } from '@lexical/html';
 import { $getRoot, $insertNodes, LexicalEditor } from 'lexical';
 import styles from './RichTextInput.module.scss';
-import { MaxLengthPlugin, OnChangePlugin, FocusPlugin, ToolbarPlugin, InitialValuePlugin } from './plugins';
+import {
+    MaxLengthPlugin,
+    OnChangePlugin,
+    FocusPlugin,
+    ToolbarPlugin,
+    InitialValuePlugin,
+    EnterKeyPlugin,
+} from './plugins';
 
 export interface RichTextInputProps {
     value: string;
@@ -100,6 +107,7 @@ export const RichTextInput = ({
                 <MaxLengthPlugin maxLength={maxLength} onLengthChange={handleLengthChange} />
                 <FocusPlugin onFocus={onFocus} onBlur={onBlur} onFocusChange={handleFocusChange} />
                 <InitialValuePlugin value={value} />
+                <EnterKeyPlugin />
             </LexicalComposer>
             <output className={styles.counter}>
                 {currentLength}/{maxLength}

--- a/src/components/admin/rich-text-input/plugins/EnterKeyPlugin.test.tsx
+++ b/src/components/admin/rich-text-input/plugins/EnterKeyPlugin.test.tsx
@@ -1,0 +1,117 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { EnterKeyPlugin } from './EnterKeyPlugin';
+import { KEY_ENTER_COMMAND } from 'lexical';
+
+const mockRegisterCommand = jest.fn();
+const mockEditor = {
+    registerCommand: mockRegisterCommand,
+};
+
+jest.mock('@lexical/react/LexicalComposerContext', () => ({
+    useLexicalComposerContext: () => [mockEditor],
+}));
+
+describe('EnterKeyPlugin', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockRegisterCommand.mockReturnValue(jest.fn());
+    });
+
+    it('renders without crashing', () => {
+        const { container } = render(<EnterKeyPlugin />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('registers KEY_ENTER_COMMAND on mount', () => {
+        render(<EnterKeyPlugin />);
+
+        expect(mockRegisterCommand).toHaveBeenCalledWith(KEY_ENTER_COMMAND, expect.any(Function), expect.any(Number));
+    });
+
+    it('unregisters command on unmount', () => {
+        const unregister = jest.fn();
+        mockRegisterCommand.mockReturnValue(unregister);
+
+        const { unmount } = render(<EnterKeyPlugin />);
+
+        expect(unregister).not.toHaveBeenCalled();
+
+        unmount();
+
+        expect(unregister).toHaveBeenCalled();
+    });
+
+    describe('Enter key handling', () => {
+        it('returns false when event is null', () => {
+            render(<EnterKeyPlugin />);
+
+            const handler = mockRegisterCommand.mock.calls[0][1];
+            const mockSelection = { insertNodes: jest.fn() };
+
+            jest.spyOn(require('lexical'), '$getSelection').mockReturnValue(mockSelection);
+            jest.spyOn(require('lexical'), '$isRangeSelection').mockReturnValue(true);
+
+            const result = handler(null);
+
+            expect(result).toBe(false);
+        });
+
+        it('returns false when Shift+Enter is pressed', () => {
+            render(<EnterKeyPlugin />);
+
+            const handler = mockRegisterCommand.mock.calls[0][1];
+            const mockEvent = {
+                shiftKey: true,
+                preventDefault: jest.fn(),
+            };
+            const mockSelection = { insertNodes: jest.fn() };
+
+            jest.spyOn(require('lexical'), '$getSelection').mockReturnValue(mockSelection);
+            jest.spyOn(require('lexical'), '$isRangeSelection').mockReturnValue(true);
+
+            const result = handler(mockEvent);
+
+            expect(result).toBe(false);
+            expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+        });
+
+        it('prevents default and inserts line break when Enter is pressed', () => {
+            render(<EnterKeyPlugin />);
+
+            const handler = mockRegisterCommand.mock.calls[0][1];
+            const mockEvent = {
+                shiftKey: false,
+                preventDefault: jest.fn(),
+            };
+            const mockSelection = { insertNodes: jest.fn() };
+
+            jest.spyOn(require('lexical'), '$getSelection').mockReturnValue(mockSelection);
+            jest.spyOn(require('lexical'), '$isRangeSelection').mockReturnValue(true);
+
+            const result = handler(mockEvent);
+
+            expect(result).toBe(true);
+            expect(mockEvent.preventDefault).toHaveBeenCalled();
+            expect(mockSelection.insertNodes).toHaveBeenCalled();
+        });
+
+        it('returns false when selection is not a range selection', () => {
+            render(<EnterKeyPlugin />);
+
+            const handler = mockRegisterCommand.mock.calls[0][1];
+            const mockEvent = {
+                shiftKey: false,
+                preventDefault: jest.fn(),
+            };
+
+            jest.spyOn(require('lexical'), '$getSelection').mockReturnValue({});
+            jest.spyOn(require('lexical'), '$isRangeSelection').mockReturnValue(false);
+
+            const result = handler(mockEvent);
+
+            expect(result).toBe(false);
+            expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/components/admin/rich-text-input/plugins/EnterKeyPlugin.tsx
+++ b/src/components/admin/rich-text-input/plugins/EnterKeyPlugin.tsx
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { KEY_ENTER_COMMAND, COMMAND_PRIORITY_HIGH, $getSelection, $isRangeSelection } from 'lexical';
+import { $insertNodes, LineBreakNode } from 'lexical';
+
+export const EnterKeyPlugin = () => {
+    const [editor] = useLexicalComposerContext();
+
+    useEffect(() => {
+        const unregister = editor.registerCommand(
+            KEY_ENTER_COMMAND,
+            (event) => {
+                const selection = $getSelection();
+
+                if (!$isRangeSelection(selection)) {
+                    return false;
+                }
+
+                if (event === null) {
+                    return false;
+                }
+
+                // Prevent the default behavior only for Enter without Shift
+                // Let Shift+Enter work as default (it also inserts line breaks)
+                if (event.shiftKey) {
+                    return false;
+                }
+
+                event.preventDefault();
+
+                // Insert a line break node
+                selection.insertNodes([new LineBreakNode()]);
+
+                return true;
+            },
+            COMMAND_PRIORITY_HIGH,
+        );
+
+        return unregister;
+    }, [editor]);
+
+    return null;
+};

--- a/src/components/admin/rich-text-input/plugins/index.ts
+++ b/src/components/admin/rich-text-input/plugins/index.ts
@@ -3,3 +3,4 @@ export { OnChangePlugin } from './OnChangePlugin';
 export { InitialValuePlugin } from './InitialValuePlugin';
 export { FocusPlugin } from './FocusPlugin';
 export { ToolbarPlugin } from './ToolbarPlugin';
+export { EnterKeyPlugin } from './EnterKeyPlugin';


### PR DESCRIPTION
## JIRA or Github ticker

* [JIRA or Github ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)

## Description

<!--- Please decripe the main goal of this PR and why it was created --->

This PR adds new key pluging in order to apply same behaviour for `Enter` key as for `Shift+Enter` (default key combination for Lexical lib). This will insert <br> tag on pressing `Enter` key

## How it looks

<!--- Please provide iamges(screenshots or screen recording) of changes --->

https://github.com/user-attachments/assets/02009f6c-d776-497b-b6ac-660dcc183011


## Summary of change

<!--- Please specify what was changed --->

## How to recreate changes

<!--- Please provide short instruction step-by-step how to see changes that was implemented by this PR --->


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions
