### PR TITLE
Feature/issue 1272 - Add Translation indicators for TeamCategory 

### DIFF
--- a/src/components/admin/category-bar/CategoryBar.tsx
+++ b/src/components/admin/category-bar/CategoryBar.tsx
@@ -20,6 +20,7 @@ export interface CategoryBarProps<T> {
     contextMenuOptions?: ContextMenuOption[];
     onContextMenuOptionSelected?: (id: string) => void;
     scrollAmount?: number;
+    renderCategoryExtra?: (item: T) => React.ReactNode;
 }
 
 export const CategoryBar = <T,>({
@@ -32,6 +33,7 @@ export const CategoryBar = <T,>({
     contextMenuOptions = [],
     onContextMenuOptionSelected,
     scrollAmount = 400,
+    renderCategoryExtra,
 }: CategoryBarProps<T>) => {
     const categoriesContainerRef = useRef<HTMLDivElement>(null);
     const [showLeftArrow, setShowLeftArrow] = useState(false);
@@ -109,6 +111,7 @@ export const CategoryBar = <T,>({
                         getCategoryKey={getCategoryKey}
                         getCategoryDisplayName={getCategoryDisplayName}
                         onSelect={onCategorySelect}
+                        renderExtra={renderCategoryExtra}
                     />
                 ))}
             </div>

--- a/src/components/admin/category-button/CategoryButton.scss
+++ b/src/components/admin/category-button/CategoryButton.scss
@@ -1,5 +1,8 @@
 @use '@/assets/sass/variables/colors';
 
+.category-extra {
+    margin-left: 0.9375rem;
+}
 .category-bar-button {
     display: flex;
     align-items: center;

--- a/src/components/admin/category-button/CategoryButton.tsx
+++ b/src/components/admin/category-button/CategoryButton.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, ReactNode } from 'react';
 import classNames from 'classnames';
 import './CategoryButton.scss';
 
@@ -8,6 +8,7 @@ export interface CategoryButtonProps<T> {
     getCategoryKey: (item: T) => string | number;
     getCategoryDisplayName: (item: T) => string;
     onSelect: (category: T) => void;
+    renderExtra?: (category: T) => ReactNode;
 }
 
 function CategoryButtonInner<T>({
@@ -16,20 +17,25 @@ function CategoryButtonInner<T>({
     getCategoryKey,
     getCategoryDisplayName,
     onSelect,
+    renderExtra,
 }: Readonly<CategoryButtonProps<T>>) {
     const key = getCategoryKey(category);
     const name = getCategoryDisplayName(category);
     const isSelected = !!selectedCategory && key === getCategoryKey(selectedCategory);
 
     return (
-        <button
-            onClick={() => onSelect(category)}
-            className={classNames('category-bar-button', {
-                'category-bar-button-selected': isSelected,
-            })}
-        >
-            {name}
-        </button>
+        <div className="category-bar-button-container">
+            {renderExtra && <div className="category-extra">{renderExtra(category)}</div>}
+            <button
+                type="button"
+                onClick={() => onSelect(category)}
+                className={classNames('category-bar-button', {
+                    'category-bar-button-selected': isSelected,
+                })}
+            >
+                {name}
+            </button>
+        </div>
     );
 }
 

--- a/src/components/admin/category-button/CategoryButton.tsx
+++ b/src/components/admin/category-button/CategoryButton.tsx
@@ -1,5 +1,5 @@
 import { memo, ReactNode } from 'react';
-import classNames from 'classnames';
+import cn from 'classnames';
 import './CategoryButton.scss';
 
 export interface CategoryButtonProps<T> {
@@ -29,7 +29,7 @@ function CategoryButtonInner<T>({
             <button
                 type="button"
                 onClick={() => onSelect(category)}
-                className={classNames('category-bar-button', {
+                className={cn('category-bar-button', {
                     'category-bar-button-selected': isSelected,
                 })}
             >

--- a/src/components/admin/search-bar/team-member-search-item/TeamMemberSearchItem.test.tsx
+++ b/src/components/admin/search-bar/team-member-search-item/TeamMemberSearchItem.test.tsx
@@ -12,6 +12,7 @@ describe('TeamMemberSearchItem', () => {
             id: 1,
             name: 'Category A',
             description: '',
+            localizations: [],
             teamMembersCount: 1,
         },
     ];

--- a/src/pages/admin/team/components/delete-team-category-modal/DeleteTeamCategoryModal.test.tsx
+++ b/src/pages/admin/team/components/delete-team-category-modal/DeleteTeamCategoryModal.test.tsx
@@ -99,13 +99,13 @@ jest.mock('@/components/admin/hint-box/HintBox', () => ({
 const mockCategoriesEmpty: TeamCategory[] = [];
 
 const mockCategoriesWithMembers: TeamCategory[] = [
-    { id: 1, name: 'Category 1', description: 'Description 1', teamMembersCount: 5 },
-    { id: 2, name: 'Category 2', description: 'Description 2', teamMembersCount: 3 },
+    { id: 1, name: 'Category 1', description: 'Description 1', localizations: [], teamMembersCount: 5 },
+    { id: 2, name: 'Category 2', description: 'Description 2', localizations: [], teamMembersCount: 3 },
 ];
 
 const mockCategoriesNoMembers: TeamCategory[] = [
-    { id: 10, name: 'Empty Category 1', description: 'Description 1', teamMembersCount: 0 },
-    { id: 20, name: 'Empty Category 2', description: 'Description 2', teamMembersCount: 0 },
+    { id: 10, name: 'Empty Category 1', description: 'Description 1', localizations: [], teamMembersCount: 0 },
+    { id: 20, name: 'Empty Category 2', description: 'Description 2', localizations: [], teamMembersCount: 0 },
 ];
 
 const mockClient = {

--- a/src/pages/admin/team/components/member-form/MemberForm.test.tsx
+++ b/src/pages/admin/team/components/member-form/MemberForm.test.tsx
@@ -100,8 +100,8 @@ jest.mock('@/components/admin/image-input/ImageInput', () => ({
 }));
 
 const categories: TeamCategory[] = [
-    { id: 1, name: 'Coaches', description: '', teamMembersCount: 0 },
-    { id: 2, name: 'Volunteers', description: '', teamMembersCount: 0 },
+    { id: 1, name: 'Coaches', description: '', localizations: [], teamMembersCount: 0 },
+    { id: 2, name: 'Volunteers', description: '', localizations: [], teamMembersCount: 0 },
 ];
 
 describe('MemberForm', () => {

--- a/src/pages/admin/team/components/team-category-modal/TeamCategoryModal.test.tsx
+++ b/src/pages/admin/team/components/team-category-modal/TeamCategoryModal.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { TeamCategoryModal } from './TeamCategoryModal';
 import { ModalMode } from '@/types/admin/common';
-import { TeamCategory } from '@/types/admin/team-category';
+import { TeamCategory, TeamCategoryDto } from '@/types/admin/team-category';
 import { TeamCategoriesApi } from '@/services/api/admin/team/team-categories/team-categories-api';
 import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
 import { TEAM_CATEGORY_VALIDATION_FUNCTIONS } from '@/validation/admin/team-category-schema/team-category-schema';
@@ -185,8 +185,8 @@ jest.mock('@/components/admin/input-groups/single-select-input-group/SingleSelec
 }));
 
 const mockCategories: TeamCategory[] = [
-    { id: 1, name: 'Category 1', description: 'Description 1', teamMembersCount: 5 },
-    { id: 2, name: 'Category 2', description: 'Description 2', teamMembersCount: 3 },
+    { id: 1, name: 'Category 1', description: 'Description 1', localizations: [], teamMembersCount: 5 },
+    { id: 2, name: 'Category 2', description: 'Description 2', localizations: [], teamMembersCount: 3 },
 ];
 
 const mockClient = {
@@ -196,17 +196,19 @@ const mockClient = {
     delete: jest.fn(),
 };
 
-const mockCreatedCategory: TeamCategory = {
+const mockCreatedCategory: TeamCategoryDto = {
     id: 3,
     name: 'New Category',
     description: 'New Description',
+    localizations: [],
     teamMembersCount: 0,
 };
 
-const mockUpdatedCategory: TeamCategory = {
+const mockUpdatedCategory: TeamCategoryDto = {
     id: 1,
     name: 'Updated Category',
     description: 'Updated Description',
+    localizations: [],
     teamMembersCount: 5,
 };
 
@@ -533,8 +535,8 @@ describe('TeamCategoryModal', () => {
         });
 
         it('prevents closing modal when submitting', async () => {
-            let resolvePromise: (value: TeamCategory) => void;
-            const slowPromise = new Promise<TeamCategory>((resolve) => {
+            let resolvePromise: (value: TeamCategoryDto) => void;
+            const slowPromise = new Promise<TeamCategoryDto>((resolve) => {
                 resolvePromise = resolve;
             });
             getMockedApi().create.mockReturnValue(slowPromise);

--- a/src/pages/admin/team/components/team-category-modal/TeamCategoryModal.tsx
+++ b/src/pages/admin/team/components/team-category-modal/TeamCategoryModal.tsx
@@ -14,6 +14,7 @@ import './TeamCategoryModal.scss';
 import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
 import { TextAreaWithCharacterLimitGroup } from '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup';
 import { ModalMode } from '@/types/admin/common';
+import { mapTeamCategoryDtoToTeamCategory } from '@/utils/functions/mappers/admin/team-category/team-category-mappers';
 
 interface TeamCategoryFormValues {
     name: string;
@@ -139,10 +140,12 @@ export const TeamCategoryModal = (props: TeamCategoryModalProps) => {
 
                 if (mode === ModalMode.Add) {
                     const newCategory = await TeamCategoriesApi.create(client, categoryData);
-                    props.onAddCategory(newCategory);
+                    const mappedCategory = mapTeamCategoryDtoToTeamCategory(newCategory);
+                    props.onAddCategory(mappedCategory);
                 } else {
                     const updatedCategory = await TeamCategoriesApi.update(client, categoryData);
-                    props.onEditCategory(updatedCategory);
+                    const mappedCategory = mapTeamCategoryDtoToTeamCategory(updatedCategory);
+                    props.onEditCategory(mappedCategory);
                 }
 
                 onClose();

--- a/src/pages/admin/team/components/team-member-modal/TeamMemberModal.test.tsx
+++ b/src/pages/admin/team/components/team-member-modal/TeamMemberModal.test.tsx
@@ -143,7 +143,9 @@ const mockClient = {
     delete: jest.fn(),
 } as unknown as jest.Mocked<AxiosInstance>;
 
-const mockCategories: TeamCategory[] = [{ id: 1, name: 'Cat 1', description: '', teamMembersCount: 0 }];
+const mockCategories: TeamCategory[] = [
+    { id: 1, name: 'Cat 1', description: '', localizations: [], teamMembersCount: 0 },
+];
 
 const baseMember: TeamMember = {
     id: 10,

--- a/src/pages/admin/team/components/team-page-content/TeamPageContent.test.tsx
+++ b/src/pages/admin/team/components/team-page-content/TeamPageContent.test.tsx
@@ -9,7 +9,7 @@ import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
 import { TeamMembersApi } from '@/services/api/admin/team/team-members/team-members-api';
 import { TeamMember } from '@/types/admin/team-members';
 import { VisibilityStatus } from '@/types/admin/common';
-import { TeamCategory } from '@/types/admin/team-category';
+import { TeamCategory, TeamCategoryDto } from '@/types/admin/team-category';
 import { ToastType } from '@/types/admin/toast';
 import { LocalizationLanguage, TranslationStatus } from '@/types/common/language';
 
@@ -391,9 +391,9 @@ const mockLanguages: LocalizationLanguage[] = [
     { id: 2, code: 'en', name: 'Англійська' },
 ];
 
-const mockCategories: TeamCategory[] = [
-    { id: 1, name: 'Category A', description: 'desc', teamMembersCount: 2 },
-    { id: 2, name: 'Category B', description: 'desc', teamMembersCount: 1 },
+const mockCategories: TeamCategoryDto[] = [
+    { id: 1, name: 'Category A', description: 'desc', localizations: [], teamMembersCount: 2 },
+    { id: 2, name: 'Category B', description: 'desc', localizations: [], teamMembersCount: 1 },
 ];
 
 const mockMembers: TeamMember[] = [
@@ -619,7 +619,7 @@ describe('TeamPageContent', () => {
                 resolveFirstCall = resolve;
             });
 
-            mockTeamCategoriesApi.getAll.mockImplementationOnce(() => firstCallPromise as Promise<TeamCategory[]>);
+            mockTeamCategoriesApi.getAll.mockImplementationOnce(() => firstCallPromise as Promise<TeamCategoryDto[]>);
 
             renderTeamPageContent();
 
@@ -756,7 +756,7 @@ describe('TeamPageContent', () => {
 
     describe('Empty categories handling', () => {
         it('should handle empty categories list without setting selected category', async () => {
-            mockTeamCategoriesApi.getAll.mockResolvedValueOnce([] as TeamCategory[]);
+            mockTeamCategoriesApi.getAll.mockResolvedValueOnce([] as TeamCategoryDto[]);
 
             renderTeamPageContent();
 
@@ -771,7 +771,7 @@ describe('TeamPageContent', () => {
 
     describe('Members fetching with null category', () => {
         it('should not fetch members when selectedCategory is null', async () => {
-            mockTeamCategoriesApi.getAll.mockResolvedValueOnce([] as TeamCategory[]);
+            mockTeamCategoriesApi.getAll.mockResolvedValueOnce([] as TeamCategoryDto[]);
 
             renderTeamPageContent();
 

--- a/src/pages/admin/team/components/team-page-content/TeamPageContent.tsx
+++ b/src/pages/admin/team/components/team-page-content/TeamPageContent.tsx
@@ -23,6 +23,9 @@ import { useTeamMemberSearch } from '@/hooks/admin/team/useTeamMemberSearch';
 import { updateCategoryMemberCounts } from '@/utils/functions/update-category-member-counts/update-category-member-counts';
 import { useLocalizationToolkit } from '@/hooks/admin/use-localization-toolkit/useLocalizationToolkit';
 import { mapEntityWithLocalizations } from '@/utils/functions/mappers/common/localization/localization-mappers';
+import { mapTeamCategoryDtoToTeamCategory } from '@/utils/functions/mappers/admin/team-category/team-category-mappers';
+import { LocalizationStatuses } from '@/components/admin/localization-statuses/LocalizationStatuses';
+import { returnDisplayedLocalization } from '@/utils/functions/localization/localization';
 
 const DEFAULT_LOAD_ITEMS_COUNT = 5;
 const LIST_ITEM_HEIGHT_IN_PIXELS = 120;
@@ -143,10 +146,11 @@ export const TeamPageContent = () => {
             clearError();
 
             const fetchedCategories = await TeamCategoriesApi.getAll(client);
-            setCategories(fetchedCategories);
+            const mappedCategories = fetchedCategories.map((category) => mapTeamCategoryDtoToTeamCategory(category));
+            setCategories(mappedCategories);
 
-            if (fetchedCategories.length > 0) {
-                setSelectedCategory((prevSelected: TeamCategory | null) => prevSelected ?? fetchedCategories[0]);
+            if (mappedCategories.length > 0) {
+                setSelectedCategory((prevSelected: TeamCategory | null) => prevSelected ?? mappedCategories[0]);
             }
         } catch (error: any) {
             if (axios.isCancel?.(error) || error.name === 'CanceledError' || error.name === 'AbortError') {
@@ -512,6 +516,14 @@ export const TeamPageContent = () => {
         if (!wasSelected) fetchMembers(true);
     }, [selectedSearchMember, resetMembersState, fetchMembers]);
 
+    const getCategoryName = useCallback(
+        (category: TeamCategory) => {
+            const localization = returnDisplayedLocalization(category, selectedLanguage?.code || '');
+            return localization?.name || category.name;
+        },
+        [selectedLanguage?.code],
+    );
+
     const renderMemberItem = useCallback(
         (member: TeamMember) => (
             <DraggableListItem
@@ -576,10 +588,13 @@ export const TeamPageContent = () => {
                     selectedCategory={selectedCategory}
                     displayContextMenuButton={true}
                     onCategorySelect={handleCategorySelect}
-                    getCategoryDisplayName={(category) => category.name}
+                    getCategoryDisplayName={getCategoryName}
                     getCategoryKey={(category) => category.id}
                     contextMenuOptions={categoryBarContextMenuOptions}
                     onContextMenuOptionSelected={onContextMenuOptionSelected}
+                    renderCategoryExtra={(category) => (
+                        <LocalizationStatuses languages={translationLanguages} localizedEntity={category} />
+                    )}
                 />
 
                 {error.message && (

--- a/src/pages/admin/team/components/team-page-modals/TeamPageModals.test.tsx
+++ b/src/pages/admin/team/components/team-page-modals/TeamPageModals.test.tsx
@@ -133,6 +133,7 @@ const mockTeamCategory: TeamCategory = {
     id: 1,
     name: 'Test Category',
     description: 'Test category description',
+    localizations: [],
     teamMembersCount: 5,
 };
 
@@ -142,6 +143,7 @@ const mockCategories: TeamCategory[] = [
         id: 2,
         name: 'Another Category',
         description: 'Another test category',
+        localizations: [],
         teamMembersCount: 3,
     },
 ];

--- a/src/services/api/admin/team/team-categories/team-categories-api.test.ts
+++ b/src/services/api/admin/team/team-categories/team-categories-api.test.ts
@@ -1,5 +1,5 @@
 import { API_ROUTES } from '@/const/common/api-routes/main-api';
-import { TeamCategory, TeamCategoryCreateUpdate } from '@/types/admin/team-category';
+import { TeamCategory, TeamCategoryCreateUpdate, TeamCategoryDto } from '@/types/admin/team-category';
 import { TeamCategoriesApi } from './team-categories-api';
 
 describe('TeamCategoriesApi', () => {
@@ -15,9 +15,9 @@ describe('TeamCategoriesApi', () => {
     });
 
     it('getAll should call GET and return data', async () => {
-        const mockCategories: TeamCategory[] = [
-            { id: 1, name: 'Category 1', description: 'Description 1', teamMembersCount: 1 },
-            { id: 2, name: 'Category 2', description: 'Description 2', teamMembersCount: 2 },
+        const mockCategories: TeamCategoryDto[] = [
+            { id: 1, name: 'Category 1', description: 'Description 1', localizations: [], teamMembersCount: 1 },
+            { id: 2, name: 'Category 2', description: 'Description 2', localizations: [], teamMembersCount: 2 },
         ];
         mockClient.get.mockResolvedValueOnce({ data: mockCategories });
         const result = await TeamCategoriesApi.getAll(mockClient);
@@ -31,7 +31,7 @@ describe('TeamCategoriesApi', () => {
             name: 'New Category',
             description: 'New Description',
         };
-        const createdCategory: TeamCategory = { ...newCategory, id: 3, teamMembersCount: 0 };
+        const createdCategory: TeamCategoryDto = { ...newCategory, id: 3, teamMembersCount: 0, localizations: [] };
         mockClient.post.mockResolvedValueOnce({ data: createdCategory });
         const result = await TeamCategoriesApi.create(mockClient, newCategory);
         expect(mockClient.post).toHaveBeenCalledWith(
@@ -47,9 +47,10 @@ describe('TeamCategoriesApi', () => {
             name: 'Updated Category',
             description: 'Updated Description',
         };
-        const returnedCategory: TeamCategory = {
+        const returnedCategory: TeamCategoryDto = {
             ...(updatedCategory as Omit<TeamCategory, 'teamMembersCount'>),
             teamMembersCount: 5,
+            localizations: [],
         };
         mockClient.put.mockResolvedValueOnce({ data: returnedCategory });
         const result = await TeamCategoriesApi.update(mockClient, updatedCategory);

--- a/src/services/api/admin/team/team-categories/team-categories-api.ts
+++ b/src/services/api/admin/team/team-categories/team-categories-api.ts
@@ -1,6 +1,6 @@
 import { AxiosInstance } from 'axios';
 import { API_ROUTES } from '@/const/common/api-routes/main-api';
-import { TeamCategory, TeamCategoryCreateUpdate } from '@/types/admin/team-category';
+import { TeamCategoryDto, TeamCategoryCreateUpdate } from '@/types/admin/team-category';
 
 type TeamCategoryPayload = Omit<TeamCategoryCreateUpdate, 'id'>;
 const toPayload = (category: TeamCategoryCreateUpdate): TeamCategoryPayload => {
@@ -9,17 +9,17 @@ const toPayload = (category: TeamCategoryCreateUpdate): TeamCategoryPayload => {
 };
 
 export const TeamCategoriesApi = {
-    getAll: async (client: AxiosInstance): Promise<TeamCategory[]> => {
-        const response = await client.get<TeamCategory[]>(API_ROUTES.TEAM_CATEGORIES.BASE);
+    getAll: async (client: AxiosInstance): Promise<TeamCategoryDto[]> => {
+        const response = await client.get<TeamCategoryDto[]>(API_ROUTES.TEAM_CATEGORIES.BASE);
         return response.data;
     },
 
-    create: async (client: AxiosInstance, category: TeamCategoryCreateUpdate): Promise<TeamCategory> => {
-        const response = await client.post<TeamCategory>(API_ROUTES.TEAM_CATEGORIES.BASE, toPayload(category));
+    create: async (client: AxiosInstance, category: TeamCategoryCreateUpdate): Promise<TeamCategoryDto> => {
+        const response = await client.post<TeamCategoryDto>(API_ROUTES.TEAM_CATEGORIES.BASE, toPayload(category));
         return response.data;
     },
 
-    update: async (client: AxiosInstance, category: TeamCategoryCreateUpdate): Promise<TeamCategory> => {
+    update: async (client: AxiosInstance, category: TeamCategoryCreateUpdate): Promise<TeamCategoryDto> => {
         if (category.id == null) {
             throw new Error('TeamCategoriesApi.update: category.id is required');
         }

--- a/src/types/admin/team-category.ts
+++ b/src/types/admin/team-category.ts
@@ -1,4 +1,19 @@
-export interface TeamCategory {
+import {
+    EntityLocalization,
+    EntityLocalizationDto,
+    EntityWithDtoLocalizations,
+    EntityWithLocalizations,
+} from '../common/language';
+
+export interface TeamCategoryDto
+    extends TeamCategoryLocalizableFields,
+        EntityWithDtoLocalizations<TeamCategoryLocalizationDto> {
+    id: number;
+    name: string;
+    description: string;
+    teamMembersCount: number;
+}
+export interface TeamCategory extends TeamCategoryLocalizableFields, EntityWithLocalizations<TeamCategoryLocalization> {
     id: number;
     name: string;
     description: string;
@@ -10,3 +25,14 @@ export interface TeamCategoryCreateUpdate {
     name: string;
     description: string;
 }
+
+export interface TeamCategoryLocalizableFields {
+    name: string;
+    description: string;
+}
+
+export interface TeamCategoryLocalizationDto extends EntityLocalizationDto, TeamCategoryLocalizableFields {
+    entityId: number;
+}
+
+export interface TeamCategoryLocalization extends EntityLocalization, TeamCategoryLocalizableFields {}

--- a/src/utils/functions/mappers/admin/team-category/team-category-mappers.test.ts
+++ b/src/utils/functions/mappers/admin/team-category/team-category-mappers.test.ts
@@ -1,0 +1,47 @@
+import { TeamCategoryDto } from '@/types/admin/team-category';
+import { TranslationStatus } from '@/types/common/language';
+import { mapTeamCategoryDtoToTeamCategory } from './team-category-mappers';
+
+describe('mapTeamCategoryDtoToModel', () => {
+    it('should correctly map all fields from DTO to Model', () => {
+        const mockDto: TeamCategoryDto = {
+            id: 1,
+            name: 'Розробники',
+            description: 'Опис для розробників українською',
+            teamMembersCount: 10,
+            localizations: [
+                {
+                    entityId: 1,
+                    name: 'Engineering',
+                    localizationInfoDto: {
+                        id: 1,
+                        code: 'en',
+                    },
+                    translationStatus: TranslationStatus.Relevant,
+                    description: 'New description for category',
+                },
+            ],
+        };
+
+        const result = mapTeamCategoryDtoToTeamCategory(mockDto);
+
+        expect(result.id).toBe(mockDto.id);
+        expect(result.name).toBe(mockDto.name);
+        expect(result.description).toBe(mockDto.description);
+        expect(result.teamMembersCount).toBe(mockDto.teamMembersCount);
+        expect(result.localizations).toHaveLength(1);
+    });
+    it('should handle empty localizations array', () => {
+        const mockDto: TeamCategoryDto = {
+            id: 21,
+            name: 'Empty',
+            description: 'No localizations',
+            teamMembersCount: 0,
+            localizations: [],
+        };
+
+        const result = mapTeamCategoryDtoToTeamCategory(mockDto);
+
+        expect(result.localizations).toEqual([]);
+    });
+});

--- a/src/utils/functions/mappers/admin/team-category/team-category-mappers.ts
+++ b/src/utils/functions/mappers/admin/team-category/team-category-mappers.ts
@@ -1,0 +1,14 @@
+import { TeamCategory, TeamCategoryDto } from '@/types/admin/team-category';
+import { mapLocalizationDtoToModel } from '../../common/localization/localization-mappers';
+
+export const mapTeamCategoryDtoToTeamCategory = (dto: TeamCategoryDto): TeamCategory => {
+    const mappedLocalizations = dto.localizations.map((localization) => mapLocalizationDtoToModel(localization));
+
+    return {
+        id: dto.id,
+        name: dto.name,
+        description: dto.description,
+        teamMembersCount: dto.teamMembersCount,
+        localizations: mappedLocalizations,
+    };
+};

--- a/src/utils/functions/update-category-member-counts/update-category-member-counts.test.ts
+++ b/src/utils/functions/update-category-member-counts/update-category-member-counts.test.ts
@@ -4,9 +4,9 @@ import { TeamMember } from '@/types/admin/team-members';
 
 describe('updateCategoryMemberCounts', () => {
     const mockCategories: TeamCategory[] = [
-        { id: 1, name: 'Category 1', description: 'Description 1', teamMembersCount: 5 },
-        { id: 2, name: 'Category 2', description: 'Description 2', teamMembersCount: 3 },
-        { id: 3, name: 'Category 3', description: 'Description 3', teamMembersCount: 7 },
+        { id: 1, name: 'Category 1', description: 'Description 1', localizations: [], teamMembersCount: 5 },
+        { id: 2, name: 'Category 2', description: 'Description 2', localizations: [], teamMembersCount: 3 },
+        { id: 3, name: 'Category 3', description: 'Description 3', localizations: [], teamMembersCount: 7 },
     ];
 
     const mockMember: TeamMember = {


### PR DESCRIPTION
## GitHub Tickets

* [Github ticket 1272](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1272)

## Description

<!--- Please decripe the main goal of this PR and why it was created --->

## How it looks

<img width="1122" height="547" alt="image" src="https://github.com/user-attachments/assets/8dddd704-53d2-436a-8044-31aaa1074373" />

## Summary of change

<!--- Please specify what was changed --->

## How to recreate changes

<!--- Please provide short instruction step-by-step how to see changes that was implemented by this PR --->


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customize category items by rendering extra content per category.
  * Show localization status indicators for team categories (translation progress per language).

* **Improvements**
  * Category list now displays localized names with fallback to defaults for missing translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->