### PR TITLE
Feature/issue 1277 - Implement Create and Edit localization for Team Category

### DIFF
--- a/src/const/admin/common.ts
+++ b/src/const/admin/common.ts
@@ -99,6 +99,7 @@ export const COMMON_TEXT_ADMIN = {
             ADD_CATEGORY: 'Додати категорію',
             EDIT_CATEGORY: 'Редагувати',
             DELETE_CATEGORY: 'Видалити',
+            ADD_TRANSLATION: 'Додати переклад',
         },
 
         FORM: {

--- a/src/const/admin/team.ts
+++ b/src/const/admin/team.ts
@@ -94,6 +94,11 @@ export const TEAM_CATEGORY_TEXT = {
             DESCRIPTION: 'Опис',
             CATEGORY: 'Категорія',
         },
+        MESSAGE: {
+            FAIL_TO_TRANSLATE_TEAM_CATEGORY: 'Виникла помилка під час додавання перекладу для категорії учасників',
+            FAIL_TO_UPDATE_TRANSLATION_FOR_TEAM_CATEGORY:
+                'Виникла помилка під час оновлення перекладу для категорії учасників',
+        },
     },
 };
 

--- a/src/const/common/api-routes/main-api.ts
+++ b/src/const/common/api-routes/main-api.ts
@@ -65,6 +65,9 @@ export const API_ROUTES = {
             LANGUAGE_ID: 'TeamMemberLocalizations/languageId',
         },
     },
+    TEAM_CATEGORY_LOCALIZATIONS: {
+        BASE: 'TeamCategoryLocalizations',
+    },
     PARTNERS: {
         BASE: 'Partners',
         BANNER: 'Partners/banner',

--- a/src/hooks/admin/use-modals-state/useModalsState.test.ts
+++ b/src/hooks/admin/use-modals-state/useModalsState.test.ts
@@ -340,6 +340,116 @@ describe('useModalsState', () => {
         expect(result.current.isAnyModalOpened).toBe(false);
     });
 
+    it('should open add section modal when no other modals are open', () => {
+        const { result } = renderHook(() => useModalsState<string>());
+
+        act(() => {
+            result.current.openModalActions.openAddSectionModal();
+        });
+
+        expect(result.current.modalState.isAddSectionModalOpen).toBe(true);
+        expect(result.current.isAnyModalOpened).toBe(true);
+    });
+
+    it('should not open add section modal when another modal is already open', () => {
+        const { result } = renderHook(() => useModalsState<string>());
+
+        act(() => {
+            result.current.openModalActions.openAddItemModal();
+        });
+
+        act(() => {
+            result.current.openModalActions.openAddSectionModal();
+        });
+
+        expect(result.current.modalState.isAddSectionModalOpen).toBe(false);
+        expect(result.current.modalState.isAddModalOpen).toBe(true);
+    });
+
+    it('should close add section modal', () => {
+        const { result } = renderHook(() => useModalsState<string>());
+
+        act(() => {
+            result.current.openModalActions.openAddSectionModal();
+        });
+
+        act(() => {
+            result.current.closeModalActions.closeAddSectionModal();
+        });
+
+        expect(result.current.modalState.isAddSectionModalOpen).toBe(false);
+        expect(result.current.isAnyModalOpened).toBe(false);
+    });
+
+    //Tranaslate category modal tests
+    it('should open translate category modal when no other modals are open', () => {
+        const { result } = renderHook(() => useModalsState<string>());
+
+        act(() => {
+            result.current.openModalActions.openTranslateCategoryModal();
+        });
+
+        expect(result.current.modalState.isCategoryToTranslate).toBe(true);
+        expect(result.current.isAnyModalOpened).toBe(true);
+    });
+    it('should not open translate category modal when another modal is already open', () => {
+        const { result } = renderHook(() => useModalsState<string>());
+
+        act(() => {
+            result.current.openModalActions.openAddItemModal();
+        });
+
+        act(() => {
+            result.current.openModalActions.openTranslateCategoryModal();
+        });
+
+        expect(result.current.modalState.isCategoryToTranslate).toBe(false);
+        expect(result.current.isAnyModalOpened).toBe(true);
+    });
+    it('should close translate category modal', () => {
+        const { result } = renderHook(() => useModalsState<string>());
+        act(() => {
+            result.current.openModalActions.openTranslateCategoryModal();
+        });
+
+        act(() => {
+            result.current.closeModalActions.closeTranslateCategoryModal();
+        });
+        expect(result.current.modalState.isCategoryToTranslate).toBe(false);
+        expect(result.current.isAnyModalOpened).toBe(false);
+    });
+    it('should open edit category translation modal when no other modals are open', () => {
+        const { result } = renderHook(() => useModalsState<string>());
+        act(() => {
+            result.current.openModalActions.openEditCategoryTranslationModal();
+        });
+
+        expect(result.current.modalState.isCategoryToEditTranslation).toBe(true);
+        expect(result.current.isAnyModalOpened).toBe(true);
+    });
+    it('should not open edit category translation modal when another modal is already open', () => {
+        const { result } = renderHook(() => useModalsState<string>());
+        act(() => {
+            result.current.openModalActions.openAddItemModal();
+        });
+        act(() => {
+            result.current.openModalActions.openEditCategoryTranslationModal();
+        });
+        expect(result.current.modalState.isCategoryToEditTranslation).toBe(false);
+        expect(result.current.isAnyModalOpened).toBe(true);
+    });
+    it('should close edit category translation modal', () => {
+        const { result } = renderHook(() => useModalsState<string>());
+        act(() => {
+            result.current.openModalActions.openEditCategoryTranslationModal();
+        });
+        act(() => {
+            result.current.closeModalActions.closeEditCategoryTranslationModal();
+        });
+        expect(result.current.modalState.isCategoryToEditTranslation).toBe(false);
+        expect(result.current.isAnyModalOpened).toBe(false);
+    });
+    //
     it('should correctly detect any modal opened - boolean values', () => {
         const { result } = renderHook(() => useModalsState<string>());
 

--- a/src/hooks/admin/use-modals-state/useModalsState.test.ts
+++ b/src/hooks/admin/use-modals-state/useModalsState.test.ts
@@ -15,6 +15,8 @@ describe('useModalsState', () => {
             isEditCategoryModalOpen: false,
             isDeleteCategoryModalOpen: false,
             isAddSectionModalOpen: false,
+            isCategoryToTranslate: false,
+            isCategoryToEditTranslation: false,
         });
         expect(result.current.isAnyModalOpened).toBe(false);
     });

--- a/src/hooks/admin/use-modals-state/useModalsState.test.ts
+++ b/src/hooks/admin/use-modals-state/useModalsState.test.ts
@@ -381,7 +381,6 @@ describe('useModalsState', () => {
         expect(result.current.isAnyModalOpened).toBe(false);
     });
 
-    //Tranaslate category modal tests
     it('should open translate category modal when no other modals are open', () => {
         const { result } = renderHook(() => useModalsState<string>());
 
@@ -449,7 +448,6 @@ describe('useModalsState', () => {
         expect(result.current.modalState.isCategoryToEditTranslation).toBe(false);
         expect(result.current.isAnyModalOpened).toBe(false);
     });
-    //
     it('should correctly detect any modal opened - boolean values', () => {
         const { result } = renderHook(() => useModalsState<string>());
 

--- a/src/hooks/admin/use-modals-state/useModalsState.ts
+++ b/src/hooks/admin/use-modals-state/useModalsState.ts
@@ -151,13 +151,13 @@ export const useModalsState = <TEntity>(): UseModalsStateResult<TEntity> => {
             openTranslateCategoryModal: () => {
                 setModalState((prev) => {
                     if (isAnyModalOpenedInState(prev)) return prev;
-                    return { ...prev, categoryToTranslate: true };
+                    return { ...prev, isCategoryToTranslate: true };
                 });
             },
             openEditCategoryTranslationModal: () => {
                 setModalState((prev) => {
                     if (isAnyModalOpenedInState(prev)) return prev;
-                    return { ...prev, categoryToEditTranslation: true };
+                    return { ...prev, isCategoryToEditTranslation: true };
                 });
             },
         };

--- a/src/hooks/admin/use-modals-state/useModalsState.ts
+++ b/src/hooks/admin/use-modals-state/useModalsState.ts
@@ -9,6 +9,8 @@ export interface BaseModalState<TEntity> {
     isAddCategoryModalOpen: boolean;
     isEditCategoryModalOpen: boolean;
     isDeleteCategoryModalOpen: boolean;
+    categoryToTranslate: boolean;
+    categoryToEditTranslation: boolean;
     isAddSectionModalOpen: boolean;
 }
 
@@ -22,6 +24,8 @@ export interface BaseCloseModalActions {
     closeEditTranslationModal: () => void;
     closeDeleteCategoryModal: () => void;
     closeAddSectionModal: () => void;
+    closeTranslateCategoryModal: () => void;
+    closeEditCategoryTranslationModal: () => void;
 }
 
 export interface BaseOpenModalActions<TEntity> {
@@ -33,6 +37,8 @@ export interface BaseOpenModalActions<TEntity> {
     openAddCategoryModal: () => void;
     openEditCategoryModal: () => void;
     openDeleteCategoryModal: () => void;
+    openTranslateCategoryModal: () => void;
+    openEditCategoryTranslationModal: () => void;
     openAddSectionModal: () => void;
 }
 
@@ -54,6 +60,8 @@ export const useModalsState = <TEntity>(): UseModalsStateResult<TEntity> => {
         isEditCategoryModalOpen: false,
         isDeleteCategoryModalOpen: false,
         isAddSectionModalOpen: false,
+        categoryToTranslate: false,
+        categoryToEditTranslation: false,
     });
 
     const isAnyModalOpened = useMemo(() => {
@@ -75,6 +83,8 @@ export const useModalsState = <TEntity>(): UseModalsStateResult<TEntity> => {
             closeEditTranslationModal: () => updateModalState({ itemToEditTranslation: null }),
             closeDeleteCategoryModal: () => updateModalState({ isDeleteCategoryModalOpen: false }),
             closeAddSectionModal: () => updateModalState({ isAddSectionModalOpen: false }),
+            closeTranslateCategoryModal: () => updateModalState({ categoryToTranslate: false }),
+            closeEditCategoryTranslationModal: () => updateModalState({ categoryToEditTranslation: false }),
         }),
         [updateModalState],
     );
@@ -136,6 +146,18 @@ export const useModalsState = <TEntity>(): UseModalsStateResult<TEntity> => {
                 setModalState((prev) => {
                     if (isAnyModalOpenedInState(prev)) return prev;
                     return { ...prev, isAddSectionModalOpen: true };
+                });
+            },
+            openTranslateCategoryModal: () => {
+                setModalState((prev) => {
+                    if (isAnyModalOpenedInState(prev)) return prev;
+                    return { ...prev, categoryToTranslate: true };
+                });
+            },
+            openEditCategoryTranslationModal: () => {
+                setModalState((prev) => {
+                    if (isAnyModalOpenedInState(prev)) return prev;
+                    return { ...prev, categoryToEditTranslation: true };
                 });
             },
         };

--- a/src/hooks/admin/use-modals-state/useModalsState.ts
+++ b/src/hooks/admin/use-modals-state/useModalsState.ts
@@ -9,8 +9,8 @@ export interface BaseModalState<TEntity> {
     isAddCategoryModalOpen: boolean;
     isEditCategoryModalOpen: boolean;
     isDeleteCategoryModalOpen: boolean;
-    categoryToTranslate: boolean;
-    categoryToEditTranslation: boolean;
+    isCategoryToTranslate: boolean;
+    isCategoryToEditTranslation: boolean;
     isAddSectionModalOpen: boolean;
 }
 
@@ -60,8 +60,8 @@ export const useModalsState = <TEntity>(): UseModalsStateResult<TEntity> => {
         isEditCategoryModalOpen: false,
         isDeleteCategoryModalOpen: false,
         isAddSectionModalOpen: false,
-        categoryToTranslate: false,
-        categoryToEditTranslation: false,
+        isCategoryToTranslate: false,
+        isCategoryToEditTranslation: false,
     });
 
     const isAnyModalOpened = useMemo(() => {
@@ -83,8 +83,8 @@ export const useModalsState = <TEntity>(): UseModalsStateResult<TEntity> => {
             closeEditTranslationModal: () => updateModalState({ itemToEditTranslation: null }),
             closeDeleteCategoryModal: () => updateModalState({ isDeleteCategoryModalOpen: false }),
             closeAddSectionModal: () => updateModalState({ isAddSectionModalOpen: false }),
-            closeTranslateCategoryModal: () => updateModalState({ categoryToTranslate: false }),
-            closeEditCategoryTranslationModal: () => updateModalState({ categoryToEditTranslation: false }),
+            closeTranslateCategoryModal: () => updateModalState({ isCategoryToTranslate: false }),
+            closeEditCategoryTranslationModal: () => updateModalState({ isCategoryToEditTranslation: false }),
         }),
         [updateModalState],
     );

--- a/src/hooks/admin/use-translate-team-category/useTranslateTeamCategory.test.ts
+++ b/src/hooks/admin/use-translate-team-category/useTranslateTeamCategory.test.ts
@@ -1,32 +1,32 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
-import { useTranslateTeamMember } from './useTranslateTeamMember';
-import { TeamMemberLocalizationsApi } from '@/services/api/admin/team/team-member-localizations/team-member-localizations-api';
+import { useTranslateTeamCategory } from './useTranslateTeamCategory';
+import { TeamCategoryLocalizationApi } from '@/services/api/admin/team/team-category-localizations/team-category-localizations-api';
 import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/localization/localization-mappers';
-import { TEAM_MEMBERS_TEXT } from '@/const/admin/team';
+import { TEAM_CATEGORY_TEXT } from '@/const/admin/team';
 import { LocalizationLanguage } from '@/types/common/language';
-import { TeamMember, TeamMemberLocalization } from '@/types/admin/team-members';
+import { TeamCategory, TeamCategoryLocalization } from '@/types/admin/team-category';
 import { ModalMode } from '@/types/admin/common';
 
-jest.mock('@/services/api/admin/team/team-member-localizations/team-member-localizations-api');
+jest.mock('@/services/api/admin/team/team-category-localizations/team-category-localizations-api');
 jest.mock('@/utils/functions/mappers/common/localization/localization-mappers');
 jest.mock('../use-admin-client/useAdminClient', () => ({
     useAdminClient: () => ({ post: jest.fn() }),
 }));
 
-const mockedCreate = TeamMemberLocalizationsApi.create as jest.MockedFunction<typeof TeamMemberLocalizationsApi.create>;
-
-const mockedUpdate = TeamMemberLocalizationsApi.update as jest.MockedFunction<typeof TeamMemberLocalizationsApi.update>;
-
+const mockedCreate = TeamCategoryLocalizationApi.create as jest.MockedFunction<
+    typeof TeamCategoryLocalizationApi.create
+>;
+const mockedUpdate = TeamCategoryLocalizationApi.update as jest.MockedFunction<
+    typeof TeamCategoryLocalizationApi.update
+>;
 const mockedMapper = mapLocalizationDtoToModel as jest.MockedFunction<typeof mapLocalizationDtoToModel>;
 
-const memberMock: TeamMember = {
+const teamCategoryMock: TeamCategory = {
     id: 1,
-    fullName: 'Original name',
-    description: 'Original description',
-    image: null,
-    status: 1 as any,
-    categoryId: 2,
+    name: 'Original category name',
+    description: 'Original category description',
     localizations: [],
+    teamMembersCount: 3,
 };
 
 const languageMock: LocalizationLanguage = {
@@ -36,8 +36,8 @@ const languageMock: LocalizationLanguage = {
 };
 
 const formValues = {
-    fullName: 'Translated name',
-    description: 'Translated description',
+    name: 'Translated category name',
+    description: 'Translated category description',
 };
 
 const localizationDtoMock = {
@@ -46,14 +46,14 @@ const localizationDtoMock = {
         id: 10,
         code: 'en',
     },
-    fullName: 'Translated name',
-    description: 'Translated description',
+    name: 'Translated category name',
+    description: 'Translated category description',
     translationStatus: 1,
 };
 
-const localizationModelMock: TeamMemberLocalization = {
-    fullName: 'Translated name',
-    description: 'Translated description',
+const localizationModelMock: TeamCategoryLocalization = {
+    name: 'Translated category name',
+    description: 'Translated category description',
     language: {
         id: 2,
         code: 'en',
@@ -61,15 +61,15 @@ const localizationModelMock: TeamMemberLocalization = {
     translationStatus: 1,
 };
 
-describe('useTranslateTeamMember', () => {
+describe('useTranslateTeamCategory', () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
     it('should initialize with default state', () => {
         const { result } = renderHook(() =>
-            useTranslateTeamMember({
-                member: memberMock,
+            useTranslateTeamCategory({
+                teamCategory: teamCategoryMock,
                 language: languageMock,
                 onSuccess: jest.fn(),
                 mode: ModalMode.Add,
@@ -80,15 +80,15 @@ describe('useTranslateTeamMember', () => {
         expect(result.current.error).toBe('');
     });
 
-    it('should translate member successfully', async () => {
+    it('should translate team category successfully', async () => {
         const onSuccess = jest.fn();
 
         mockedCreate.mockResolvedValue(localizationDtoMock as any);
         mockedMapper.mockReturnValue(localizationModelMock);
 
         const { result } = renderHook(() =>
-            useTranslateTeamMember({
-                member: memberMock,
+            useTranslateTeamCategory({
+                teamCategory: teamCategoryMock,
                 language: languageMock,
                 onSuccess,
                 mode: ModalMode.Add,
@@ -96,7 +96,7 @@ describe('useTranslateTeamMember', () => {
         );
 
         act(() => {
-            result.current.translateMember(formValues);
+            result.current.translateTeamCategory(formValues);
         });
 
         await waitFor(() => {
@@ -106,12 +106,12 @@ describe('useTranslateTeamMember', () => {
         expect(mockedCreate).toHaveBeenCalledWith(expect.anything(), {
             entityId: 1,
             languageId: 2,
-            fullName: formValues.fullName,
+            name: formValues.name,
             description: formValues.description,
         });
 
         expect(onSuccess).toHaveBeenCalledWith({
-            ...memberMock,
+            ...teamCategoryMock,
             localizations: [localizationModelMock],
         });
 
@@ -125,8 +125,8 @@ describe('useTranslateTeamMember', () => {
         mockedUpdate.mockResolvedValue(localizationDtoMock as any);
         mockedMapper.mockReturnValue(localizationModelMock);
 
-        const memberWithLocalization: TeamMember = {
-            ...memberMock,
+        const teamCategoryWithLocalization: TeamCategory = {
+            ...teamCategoryMock,
             localizations: [
                 {
                     ...localizationModelMock,
@@ -136,8 +136,8 @@ describe('useTranslateTeamMember', () => {
         };
 
         const { result } = renderHook(() =>
-            useTranslateTeamMember({
-                member: memberWithLocalization,
+            useTranslateTeamCategory({
+                teamCategory: teamCategoryWithLocalization,
                 language: languageMock,
                 onSuccess,
                 mode: ModalMode.Edit,
@@ -145,16 +145,16 @@ describe('useTranslateTeamMember', () => {
         );
 
         await act(async () => {
-            await result.current.translateMember(formValues);
+            await result.current.translateTeamCategory(formValues);
         });
 
-        expect(mockedUpdate).toHaveBeenCalledWith(expect.anything(), memberMock.id, languageMock.id, {
-            fullName: formValues.fullName,
+        expect(mockedUpdate).toHaveBeenCalledWith(expect.anything(), teamCategoryMock.id, languageMock.id, {
+            name: formValues.name,
             description: formValues.description,
         });
 
         expect(onSuccess).toHaveBeenCalledWith({
-            ...memberWithLocalization,
+            ...teamCategoryWithLocalization,
             localizations: [localizationModelMock],
         });
     });
@@ -165,8 +165,8 @@ describe('useTranslateTeamMember', () => {
         mockedCreate.mockRejectedValue(new Error('API error'));
 
         const { result } = renderHook(() =>
-            useTranslateTeamMember({
-                member: memberMock,
+            useTranslateTeamCategory({
+                teamCategory: teamCategoryMock,
                 language: languageMock,
                 onSuccess,
                 mode: ModalMode.Add,
@@ -175,14 +175,14 @@ describe('useTranslateTeamMember', () => {
 
         await act(async () => {
             try {
-                await result.current.translateMember(formValues);
+                await result.current.translateTeamCategory(formValues);
             } catch {
                 // Ignoring error for test
             }
         });
 
         await waitFor(() => {
-            expect(result.current.error).toBe(TEAM_MEMBERS_TEXT.FORM.MESSAGE.FAIL_TO_TRANSLATE_MEMBER);
+            expect(result.current.error).toBe(TEAM_CATEGORY_TEXT.FORM.MESSAGE.FAIL_TO_TRANSLATE_TEAM_CATEGORY);
         });
 
         expect(onSuccess).not.toHaveBeenCalled();
@@ -194,8 +194,8 @@ describe('useTranslateTeamMember', () => {
 
         mockedUpdate.mockRejectedValue(new Error('API error'));
 
-        const memberWithLocalization: TeamMember = {
-            ...memberMock,
+        const teamCategoryWithLocalization: TeamCategory = {
+            ...teamCategoryMock,
             localizations: [
                 {
                     ...localizationModelMock,
@@ -205,8 +205,8 @@ describe('useTranslateTeamMember', () => {
         };
 
         const { result } = renderHook(() =>
-            useTranslateTeamMember({
-                member: memberWithLocalization,
+            useTranslateTeamCategory({
+                teamCategory: teamCategoryWithLocalization,
                 language: languageMock,
                 onSuccess,
                 mode: ModalMode.Edit,
@@ -215,14 +215,16 @@ describe('useTranslateTeamMember', () => {
 
         await act(async () => {
             try {
-                await result.current.translateMember(formValues);
+                await result.current.translateTeamCategory(formValues);
             } catch {
                 // Ignoring error for test
             }
         });
 
         await waitFor(() => {
-            expect(result.current.error).toBe(TEAM_MEMBERS_TEXT.FORM.MESSAGE.FAIL_TO_UPDATE_TRANSLATION);
+            expect(result.current.error).toBe(
+                TEAM_CATEGORY_TEXT.FORM.MESSAGE.FAIL_TO_UPDATE_TRANSLATION_FOR_TEAM_CATEGORY,
+            );
         });
 
         expect(onSuccess).not.toHaveBeenCalled();
@@ -231,8 +233,8 @@ describe('useTranslateTeamMember', () => {
 
     it('should clear error', () => {
         const { result } = renderHook(() =>
-            useTranslateTeamMember({
-                member: memberMock,
+            useTranslateTeamCategory({
+                teamCategory: teamCategoryMock,
                 language: languageMock,
                 onSuccess: jest.fn(),
                 mode: ModalMode.Add,
@@ -246,12 +248,12 @@ describe('useTranslateTeamMember', () => {
         expect(result.current.error).toBe('');
     });
 
-    it('should do nothing if member is null', async () => {
+    it('should do nothing if teamCategory is null', async () => {
         const onSuccess = jest.fn();
 
         const { result } = renderHook(() =>
-            useTranslateTeamMember({
-                member: null,
+            useTranslateTeamCategory({
+                teamCategory: null,
                 language: languageMock,
                 onSuccess,
                 mode: ModalMode.Add,
@@ -259,7 +261,7 @@ describe('useTranslateTeamMember', () => {
         );
 
         await act(async () => {
-            await result.current.translateMember(formValues);
+            await result.current.translateTeamCategory(formValues);
         });
 
         expect(mockedCreate).not.toHaveBeenCalled();

--- a/src/hooks/admin/use-translate-team-category/useTranslateTeamCategory.ts
+++ b/src/hooks/admin/use-translate-team-category/useTranslateTeamCategory.ts
@@ -1,0 +1,97 @@
+import { ModalMode } from '@/types/admin/common';
+import { TeamCategory } from '@/types/admin/team-category';
+import { LocalizationLanguage } from '@/types/common/language';
+import { useAdminClient } from '../use-admin-client/useAdminClient';
+import { useState } from 'react';
+import { TeamCategoryLocalizationApi } from '@/services/api/admin/team/team-category-localizations/team-category-localizations-api';
+import { FaqLocalization } from '@/types/admin/faq';
+import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/localization/localization-mappers';
+import { TEAM_CATEGORY_TEXT } from '@/const/admin/team';
+import { TranslateTeamCategoryFormValues } from '@/pages/admin/team/components/translate-team-category-form/TranslateTeamCategoryForm';
+
+interface UseTranslateTeamCategoryParams {
+    teamCategory: TeamCategory | null;
+    language: LocalizationLanguage;
+    onSuccess: (updatedMember: TeamCategory) => void;
+    mode: ModalMode;
+}
+
+export const useTranslateTeamCategory = ({
+    teamCategory,
+    language,
+    onSuccess,
+    mode,
+}: UseTranslateTeamCategoryParams) => {
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [error, setError] = useState<string>('');
+
+    const client = useAdminClient();
+    const isEditMode = mode === ModalMode.Edit;
+
+    const translateTeamCategory = async (data: TranslateTeamCategoryFormValues) => {
+        if (!teamCategory) return;
+
+        try {
+            setIsSubmitting(true);
+            setError('');
+
+            if (isEditMode) {
+                const updatedLocalizationDto = await TeamCategoryLocalizationApi.update(
+                    client,
+                    teamCategory.id,
+                    language.id,
+                    {
+                        name: data.name,
+                        description: data.description,
+                    },
+                );
+
+                const updatedLocalization = mapLocalizationDtoToModel<typeof updatedLocalizationDto, FaqLocalization>(
+                    updatedLocalizationDto,
+                );
+
+                const updatedTeamCategory: TeamCategory = {
+                    ...teamCategory,
+                    localizations:
+                        teamCategory.localizations?.map((loc) =>
+                            loc.language.id === language.id ? updatedLocalization : loc,
+                        ) || [],
+                };
+                onSuccess(updatedTeamCategory);
+            } else {
+                const createdLocalizationDto = await TeamCategoryLocalizationApi.create(client, {
+                    entityId: teamCategory.id,
+                    languageId: language.id,
+                    name: data.name,
+                    description: data.description,
+                });
+
+                const createdLocalization = mapLocalizationDtoToModel<typeof createdLocalizationDto, FaqLocalization>(
+                    createdLocalizationDto,
+                );
+
+                const createdTeamCategory: TeamCategory = {
+                    ...teamCategory,
+                    localizations: [...(teamCategory.localizations || []), createdLocalization],
+                };
+                onSuccess(createdTeamCategory);
+            }
+        } catch (err) {
+            const errorMessage = isEditMode
+                ? TEAM_CATEGORY_TEXT.FORM.MESSAGE.FAIL_TO_UPDATE_TRANSLATION_FOR_TEAM_CATEGORY
+                : TEAM_CATEGORY_TEXT.FORM.MESSAGE.FAIL_TO_TRANSLATE_TEAM_CATEGORY;
+            setError(errorMessage);
+            throw err;
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+    const clearError = () => setError('');
+
+    return {
+        translateTeamCategory,
+        isSubmitting,
+        error,
+        clearError,
+    };
+};

--- a/src/hooks/admin/use-translate-team-category/useTranslateTeamCategory.ts
+++ b/src/hooks/admin/use-translate-team-category/useTranslateTeamCategory.ts
@@ -45,9 +45,10 @@ export const useTranslateTeamCategory = ({
                     },
                 );
 
-                const updatedLocalization = mapLocalizationDtoToModel<typeof updatedLocalizationDto, TeamCategoryLocalization>(
-                    updatedLocalizationDto,
-                );
+                const updatedLocalization = mapLocalizationDtoToModel<
+                    typeof updatedLocalizationDto,
+                    TeamCategoryLocalization
+                >(updatedLocalizationDto);
 
                 const updatedTeamCategory: TeamCategory = {
                     ...teamCategory,
@@ -65,9 +66,10 @@ export const useTranslateTeamCategory = ({
                     description: data.description,
                 });
 
-                const createdLocalization = mapLocalizationDtoToModel<typeof createdLocalizationDto, TeamCategoryLocalization>(
-                    createdLocalizationDto,
-                );
+                const createdLocalization = mapLocalizationDtoToModel<
+                    typeof createdLocalizationDto,
+                    TeamCategoryLocalization
+                >(createdLocalizationDto);
 
                 const createdTeamCategory: TeamCategory = {
                     ...teamCategory,

--- a/src/hooks/admin/use-translate-team-category/useTranslateTeamCategory.ts
+++ b/src/hooks/admin/use-translate-team-category/useTranslateTeamCategory.ts
@@ -1,10 +1,9 @@
 import { ModalMode } from '@/types/admin/common';
-import { TeamCategory } from '@/types/admin/team-category';
+import { TeamCategory, TeamCategoryLocalization } from '@/types/admin/team-category';
 import { LocalizationLanguage } from '@/types/common/language';
 import { useAdminClient } from '../use-admin-client/useAdminClient';
 import { useState } from 'react';
 import { TeamCategoryLocalizationApi } from '@/services/api/admin/team/team-category-localizations/team-category-localizations-api';
-import { FaqLocalization } from '@/types/admin/faq';
 import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/localization/localization-mappers';
 import { TEAM_CATEGORY_TEXT } from '@/const/admin/team';
 import { TranslateTeamCategoryFormValues } from '@/pages/admin/team/components/translate-team-category-form/TranslateTeamCategoryForm';
@@ -12,7 +11,7 @@ import { TranslateTeamCategoryFormValues } from '@/pages/admin/team/components/t
 interface UseTranslateTeamCategoryParams {
     teamCategory: TeamCategory | null;
     language: LocalizationLanguage;
-    onSuccess: (updatedMember: TeamCategory) => void;
+    onSuccess: (updatedTeamCategoryLocalization: TeamCategory) => void;
     mode: ModalMode;
 }
 
@@ -46,7 +45,7 @@ export const useTranslateTeamCategory = ({
                     },
                 );
 
-                const updatedLocalization = mapLocalizationDtoToModel<typeof updatedLocalizationDto, FaqLocalization>(
+                const updatedLocalization = mapLocalizationDtoToModel<typeof updatedLocalizationDto, TeamCategoryLocalization>(
                     updatedLocalizationDto,
                 );
 
@@ -66,7 +65,7 @@ export const useTranslateTeamCategory = ({
                     description: data.description,
                 });
 
-                const createdLocalization = mapLocalizationDtoToModel<typeof createdLocalizationDto, FaqLocalization>(
+                const createdLocalization = mapLocalizationDtoToModel<typeof createdLocalizationDto, TeamCategoryLocalization>(
                     createdLocalizationDto,
                 );
 

--- a/src/pages/admin/faq/components/faq-modals/translate-faq-modal/TranslateFaqModal.test.tsx
+++ b/src/pages/admin/faq/components/faq-modals/translate-faq-modal/TranslateFaqModal.test.tsx
@@ -9,10 +9,6 @@ import { ModalMode } from '@/types/admin/common';
 let mockFormIsValid = true;
 let mockFormIsDirty = true;
 
-jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
-    ConfirmationModal: (props: any) => require('@/utils/test-mocks/test-mocks').MockConfirmationModal(props),
-}));
-
 jest.mock('@/components/admin/localization-modal/LocalizationModal', () => ({
     LocalizationModal: (props: any) => require('@/utils/test-mocks/test-mocks').MockLocalizationModal(props),
 }));

--- a/src/pages/admin/programs/components/programs-page-modals/ProgramsPageModals.test.tsx
+++ b/src/pages/admin/programs/components/programs-page-modals/ProgramsPageModals.test.tsx
@@ -70,6 +70,8 @@ describe('ProgramsPageModals', () => {
         closeEditCategoryModal: jest.fn(),
         closeDeleteCategoryModal: jest.fn(),
         closeAddSectionModal: jest.fn(),
+        closeTranslateCategoryModal: jest.fn(),
+        closeEditCategoryTranslationModal: jest.fn(),
     };
 
     const createMockModalsState = (
@@ -85,6 +87,8 @@ describe('ProgramsPageModals', () => {
             isEditCategoryModalOpen: false,
             isDeleteCategoryModalOpen: false,
             isAddSectionModalOpen: false,
+            isCategoryToTranslate: false,
+            isCategoryToEditTranslation: false,
             ...overrides,
         },
         closeModalActions: mockCloseModalActions,
@@ -98,6 +102,8 @@ describe('ProgramsPageModals', () => {
             openEditCategoryModal: jest.fn(),
             openDeleteCategoryModal: jest.fn(),
             openAddSectionModal: jest.fn(),
+            openTranslateCategoryModal: jest.fn(),
+            openEditCategoryTranslationModal: jest.fn(),
         },
         isAnyModalOpened: false,
     });

--- a/src/pages/admin/team/components/team-page-content/TeamPageContent.test.tsx
+++ b/src/pages/admin/team/components/team-page-content/TeamPageContent.test.tsx
@@ -109,6 +109,8 @@ const mockModalState = {
     isAddCategoryModalOpen: false,
     isEditCategoryModalOpen: false,
     isDeleteCategoryModalOpen: false,
+    isCategoryToTranslate: false,
+    isCategoryToEditTranslation: false,
 };
 
 const mockOpenModalActions = {
@@ -120,6 +122,8 @@ const mockOpenModalActions = {
     openAddCategoryModal: jest.fn(),
     openEditCategoryModal: jest.fn(),
     openDeleteCategoryModal: jest.fn(),
+    openTranslateCategoryModal: jest.fn(),
+    openEditCategoryTranslationModal: jest.fn(),
 };
 
 const mockCloseModalActions = {
@@ -130,6 +134,8 @@ const mockCloseModalActions = {
     closeAddCategoryModal: jest.fn(),
     closeEditCategoryModal: jest.fn(),
     closeDeleteCategoryModal: jest.fn(),
+    closeTranslateCategoryModal: jest.fn(),
+    closeEditCategoryTranslationModal: jest.fn(),
 };
 
 jest.mock('@/hooks/admin/use-localization-toolkit/useLocalizationToolkit', () => ({

--- a/src/pages/admin/team/components/team-page-content/TeamPageContent.tsx
+++ b/src/pages/admin/team/components/team-page-content/TeamPageContent.tsx
@@ -87,9 +87,11 @@ export const TeamPageContent = () => {
                 openModalActions.openEditCategoryModal();
             } else if (id === 'delete') {
                 openModalActions.openDeleteCategoryModal();
+            } else if (id === 'addTranslation') {
+                openModalActions.openTranslateCategoryModal();
             }
         },
-        [openModalActions],
+        [openModalActions, selectedCategory],
     );
 
     const categoryBarContextMenuOptions: ContextMenuOption[] = useMemo(
@@ -97,6 +99,7 @@ export const TeamPageContent = () => {
             { id: 'add', name: COMMON_TEXT_ADMIN.CATEGORIES.BUTTON.ADD_CATEGORY },
             { id: 'edit', name: COMMON_TEXT_ADMIN.CATEGORIES.BUTTON.EDIT_CATEGORY },
             { id: 'delete', name: COMMON_TEXT_ADMIN.CATEGORIES.BUTTON.DELETE_CATEGORY },
+            { id: 'addTranslation', name: COMMON_TEXT_ADMIN.CATEGORIES.BUTTON.ADD_TRANSLATION },
         ],
         [],
     );
@@ -299,7 +302,6 @@ export const TeamPageContent = () => {
         },
         [isAnyModalOpened, openModalActions, englishLanguage],
     );
-
     const handleDeleteTeamMemberModalOpen = useCallback(
         (member: TeamMember) => {
             if (isAnyModalOpened) return;
@@ -498,6 +500,17 @@ export const TeamPageContent = () => {
         },
         [selectedCategory?.id],
     );
+    const handleTranslateCategory = useCallback(
+        (updatedCategory: TeamCategory) => {
+            setCategories((prevCategories) =>
+                prevCategories.map((category) => (category.id === updatedCategory.id ? updatedCategory : category)),
+            );
+            closeModalActions.closeTranslateItemModal();
+
+            addToast(COMMON_TEXT_ADMIN.MESSAGE.TRANSLATION_SAVED_SUCCESS, ToastType.Success);
+        },
+        [closeModalActions, addToast],
+    );
 
     const handleSearchItemSelect = useCallback(
         (member: TeamMember) => {
@@ -623,11 +636,12 @@ export const TeamPageContent = () => {
                 onAddTeamMember={handleAddMember}
                 onEditTeamMember={handleEditMember}
                 onTranslateTeamMember={handleTranslateMember}
+                onTranslateTeamCategory={handleTranslateCategory}
                 onDeleteTeamMember={handleDeleteMember}
                 onAddTeamCategory={handleAddCategory}
                 onEditTeamCategory={handleEditCategory}
-                onDeleteTeamCategory={handleDeleteCategory}
-            />
+                onDeleteTeamCategory={handleDeleteCategory} 
+                selectedCategory={selectedCategory}            />
             <ToastContainer />
         </div>
     );

--- a/src/pages/admin/team/components/team-page-content/TeamPageContent.tsx
+++ b/src/pages/admin/team/components/team-page-content/TeamPageContent.tsx
@@ -91,7 +91,7 @@ export const TeamPageContent = () => {
                 openModalActions.openTranslateCategoryModal();
             }
         },
-        [openModalActions, selectedCategory],
+        [openModalActions],
     );
 
     const categoryBarContextMenuOptions: ContextMenuOption[] = useMemo(

--- a/src/pages/admin/team/components/team-page-content/TeamPageContent.tsx
+++ b/src/pages/admin/team/components/team-page-content/TeamPageContent.tsx
@@ -505,7 +505,7 @@ export const TeamPageContent = () => {
             setCategories((prevCategories) =>
                 prevCategories.map((category) => (category.id === updatedCategory.id ? updatedCategory : category)),
             );
-            closeModalActions.closeTranslateItemModal();
+            closeModalActions.closeTranslateCategoryModal();
 
             addToast(COMMON_TEXT_ADMIN.MESSAGE.TRANSLATION_SAVED_SUCCESS, ToastType.Success);
         },
@@ -640,8 +640,9 @@ export const TeamPageContent = () => {
                 onDeleteTeamMember={handleDeleteMember}
                 onAddTeamCategory={handleAddCategory}
                 onEditTeamCategory={handleEditCategory}
-                onDeleteTeamCategory={handleDeleteCategory} 
-                selectedCategory={selectedCategory}            />
+                onDeleteTeamCategory={handleDeleteCategory}
+                selectedCategory={selectedCategory}
+            />
             <ToastContainer />
         </div>
     );

--- a/src/pages/admin/team/components/team-page-modals/TeamPageModals.test.tsx
+++ b/src/pages/admin/team/components/team-page-modals/TeamPageModals.test.tsx
@@ -693,7 +693,6 @@ describe('TeamPageModals', () => {
             });
             render(<TeamPageModals {...props} />);
 
-            // Team Member Modals
             const addTeamMemberModal = document.querySelectorAll('[data-testid="team-member-modal"]')[0];
             expect(addTeamMemberModal.querySelector('[data-testid="modal-is-open"]')).toHaveTextContent('true');
 
@@ -705,7 +704,6 @@ describe('TeamPageModals', () => {
                 'true',
             );
 
-            // Team Category Modals
             const addCategoryModal = document.querySelectorAll('[data-testid="team-category-modal"]')[0];
             expect(addCategoryModal.querySelector('[data-testid="category-modal-is-open"]')).toHaveTextContent('true');
 
@@ -725,11 +723,9 @@ describe('TeamPageModals', () => {
             });
             render(<TeamPageModals {...props} />);
 
-            // Edit modal should be closed when itemToEdit is null
             const editModal = document.querySelectorAll('[data-testid="team-member-modal"]')[1];
             expect(editModal.querySelector('[data-testid="modal-is-open"]')).toHaveTextContent('false');
 
-            // Delete modal should be closed when itemToDelete is null
             const deleteModal = document.querySelector('[data-testid="delete-team-member-modal"]');
             expect(deleteModal?.querySelector('[data-testid="delete-modal-is-open"]')).toHaveTextContent('false');
         });

--- a/src/pages/admin/team/components/team-page-modals/TeamPageModals.test.tsx
+++ b/src/pages/admin/team/components/team-page-modals/TeamPageModals.test.tsx
@@ -157,6 +157,8 @@ const createMockModalsStateControl = (
         itemToTranslate: null,
         itemToEditTranslation: null,
         isAddCategoryModalOpen: false,
+        isCategoryToEditTranslation: false,
+        isCategoryToTranslate: false,
         isEditCategoryModalOpen: false,
         isDeleteCategoryModalOpen: false,
         isAddSectionModalOpen: false,
@@ -172,6 +174,8 @@ const createMockModalsStateControl = (
         closeEditCategoryModal: jest.fn(),
         closeDeleteCategoryModal: jest.fn(),
         closeAddSectionModal: jest.fn(),
+        closeTranslateCategoryModal: jest.fn(),
+        closeEditCategoryTranslationModal: jest.fn(),
     },
     openModalActions: {
         openAddItemModal: jest.fn(),
@@ -183,6 +187,8 @@ const createMockModalsStateControl = (
         openEditCategoryModal: jest.fn(),
         openDeleteCategoryModal: jest.fn(),
         openAddSectionModal: jest.fn(),
+        openTranslateCategoryModal: jest.fn(),
+        openEditCategoryTranslationModal: jest.fn(),
     },
     isAnyModalOpened: false,
 });
@@ -206,6 +212,10 @@ const createDefaultProps = (
     onAddTeamCategory: jest.fn(),
     onEditTeamCategory: jest.fn(),
     onDeleteTeamCategory: jest.fn(),
+    selectedCategory: null,
+    onTranslateTeamCategory: function (translatedCategory: TeamCategory): void {
+        throw new Error('Function not implemented.');
+    }
 });
 
 describe('TeamPageModals', () => {

--- a/src/pages/admin/team/components/team-page-modals/TeamPageModals.test.tsx
+++ b/src/pages/admin/team/components/team-page-modals/TeamPageModals.test.tsx
@@ -118,6 +118,35 @@ jest.mock('../delete-team-category-modal/DeleteTeamCategoryModal', () => ({
     ),
 }));
 
+jest.mock('../translate-team-category-modal/TranslateTeamCategoryModal', () => ({
+    TranslateTeamCategoryModal: ({
+        isOpen,
+        onClose,
+        onTranslateCategory,
+        categoryToTranslate,
+        translatedLanguages,
+    }: any) => (
+        <div data-testid="translate-team-category-modal">
+            <span data-testid="translate-category-modal-is-open">{isOpen.toString()}</span>
+            {categoryToTranslate && (
+                <span data-testid="translate-category-modal-category">{categoryToTranslate.id}</span>
+            )}
+            <span data-testid="translate-category-modal-language">{translatedLanguages?.[0]?.code}</span>
+            <button data-testid="translate-category-modal-close-btn" onClick={onClose}>
+                Close
+            </button>
+            {onTranslateCategory && categoryToTranslate && (
+                <button
+                    data-testid="translate-category-modal-confirm-btn"
+                    onClick={() => onTranslateCategory(categoryToTranslate)}
+                >
+                    Translate Category
+                </button>
+            )}
+        </div>
+    ),
+}));
+
 const mockTeamMember: TeamMember = {
     id: 1,
     image: null,
@@ -213,9 +242,7 @@ const createDefaultProps = (
     onEditTeamCategory: jest.fn(),
     onDeleteTeamCategory: jest.fn(),
     selectedCategory: null,
-    onTranslateTeamCategory: function (translatedCategory: TeamCategory): void {
-        throw new Error('Function not implemented.');
-    }
+    onTranslateTeamCategory: jest.fn(),
 });
 
 describe('TeamPageModals', () => {
@@ -574,6 +601,82 @@ describe('TeamPageModals', () => {
                 deleteBtn.click();
 
                 expect(props.onDeleteTeamCategory).toHaveBeenCalledWith(1);
+            });
+        });
+
+        describe('Translate Team Category Modal', () => {
+            it('does not render translate category modal when selectedCategory is null', () => {
+                const props = createDefaultProps({ isCategoryToTranslate: true });
+                render(<TeamPageModals {...props} />);
+
+                expect(document.querySelector('[data-testid="translate-team-category-modal"]')).not.toBeInTheDocument();
+            });
+
+            it('renders translate category modal and handles close/confirm actions', () => {
+                const props = {
+                    ...createDefaultProps({ isCategoryToTranslate: true }),
+                    selectedCategory: mockTeamCategory,
+                };
+                render(<TeamPageModals {...props} />);
+
+                const modal = document.querySelector('[data-testid="translate-team-category-modal"]');
+                expect(modal).toBeInTheDocument();
+                expect(modal?.querySelector('[data-testid="translate-category-modal-is-open"]')).toHaveTextContent(
+                    'true',
+                );
+                expect(modal?.querySelector('[data-testid="translate-category-modal-category"]')).toHaveTextContent(
+                    mockTeamCategory.id.toString(),
+                );
+
+                const closeBtn = modal?.querySelector(
+                    '[data-testid="translate-category-modal-close-btn"]',
+                ) as HTMLElement;
+                closeBtn.click();
+                expect(props.modalsStateControl.closeModalActions.closeTranslateCategoryModal).toHaveBeenCalledTimes(1);
+
+                const confirmBtn = modal?.querySelector(
+                    '[data-testid="translate-category-modal-confirm-btn"]',
+                ) as HTMLElement;
+                confirmBtn.click();
+                expect(props.onTranslateTeamCategory).toHaveBeenCalledWith(mockTeamCategory);
+            });
+
+            it('does not render edit-translation category modal when selectedCategory is null', () => {
+                const props = createDefaultProps({ isCategoryToEditTranslation: true });
+                render(<TeamPageModals {...props} />);
+
+                expect(document.querySelector('[data-testid="translate-team-category-modal"]')).not.toBeInTheDocument();
+            });
+
+            it('renders edit-translation category modal and handles close/confirm actions', () => {
+                const props = {
+                    ...createDefaultProps({ isCategoryToEditTranslation: true }),
+                    selectedCategory: mockTeamCategory,
+                };
+                render(<TeamPageModals {...props} />);
+
+                const modal = document.querySelector('[data-testid="translate-team-category-modal"]');
+                expect(modal).toBeInTheDocument();
+                expect(modal?.querySelector('[data-testid="translate-category-modal-is-open"]')).toHaveTextContent(
+                    'true',
+                );
+                expect(modal?.querySelector('[data-testid="translate-category-modal-category"]')).toHaveTextContent(
+                    mockTeamCategory.id.toString(),
+                );
+
+                const closeBtn = modal?.querySelector(
+                    '[data-testid="translate-category-modal-close-btn"]',
+                ) as HTMLElement;
+                closeBtn.click();
+                expect(
+                    props.modalsStateControl.closeModalActions.closeEditCategoryTranslationModal,
+                ).toHaveBeenCalledTimes(1);
+
+                const confirmBtn = modal?.querySelector(
+                    '[data-testid="translate-category-modal-confirm-btn"]',
+                ) as HTMLElement;
+                confirmBtn.click();
+                expect(props.onTranslateTeamCategory).toHaveBeenCalledWith(mockTeamCategory);
             });
         });
     });

--- a/src/pages/admin/team/components/team-page-modals/TeamPageModals.tsx
+++ b/src/pages/admin/team/components/team-page-modals/TeamPageModals.tsx
@@ -8,14 +8,18 @@ import { TranslateTeamMemberModal } from '../translate-team-member-modal/Transla
 import { TeamCategoryModal } from '../team-category-modal/TeamCategoryModal';
 import { DeleteTeamCategoryModal } from '../delete-team-category-modal/DeleteTeamCategoryModal';
 import { LocalizationLanguage } from '@/types/common/language';
+import { TranslateTeamCategoryModal } from '../translate-team-category-modal/TranslateTeamCategoryModal';
+import { useState } from 'react';
 
 export interface TeamPageModalsProps {
     modalsStateControl: UseModalsStateResult<TeamMember>;
     categories: TeamCategory[];
+    selectedCategory: TeamCategory | null;
     translatedLanguages: LocalizationLanguage[];
     onAddTeamMember: (addedMember: TeamMember) => void;
     onEditTeamMember: (updatedMember: TeamMember) => void;
     onTranslateTeamMember: (translatedMember: TeamMember) => void;
+    onTranslateTeamCategory: (translatedCategory: TeamCategory) => void;
     onDeleteTeamMember: (member: TeamMember) => void;
     onAddTeamCategory: (newCategory: TeamCategory) => void;
     onEditTeamCategory: (updatedCategory: TeamCategory) => void;
@@ -25,9 +29,11 @@ export interface TeamPageModalsProps {
 export const TeamPageModals = ({
     modalsStateControl,
     categories,
+    selectedCategory,
     translatedLanguages,
     onAddTeamMember,
     onTranslateTeamMember,
+    onTranslateTeamCategory,
     onEditTeamMember,
     onDeleteTeamMember,
     onAddTeamCategory,
@@ -35,7 +41,6 @@ export const TeamPageModals = ({
     onDeleteTeamCategory,
 }: TeamPageModalsProps) => {
     const { modalState, closeModalActions } = modalsStateControl;
-
     return (
         <>
             {/* Team Member Modals */}
@@ -106,6 +111,28 @@ export const TeamPageModals = ({
                 onConfirm={onDeleteTeamCategory}
                 categories={categories}
             />
+
+            {modalState.categoryToTranslate && selectedCategory && (
+                <TranslateTeamCategoryModal
+                    isOpen={modalState.categoryToTranslate}
+                    onClose={closeModalActions.closeTranslateCategoryModal}
+                    onTranslateCategory={onTranslateTeamCategory}
+                    categoryToTranslate={selectedCategory}
+                    translatedLanguages={translatedLanguages}
+                    categories={categories}
+                />
+            )}
+
+            {modalState.categoryToEditTranslation && selectedCategory && (
+                <TranslateTeamCategoryModal
+                    isOpen={modalState.categoryToEditTranslation}
+                    onClose={closeModalActions.closeEditCategoryTranslationModal}
+                    onTranslateCategory={onTranslateTeamCategory}
+                    categoryToTranslate={selectedCategory}
+                    translatedLanguages={translatedLanguages}
+                    categories={categories}
+                />
+            )}
         </>
     );
 };

--- a/src/pages/admin/team/components/team-page-modals/TeamPageModals.tsx
+++ b/src/pages/admin/team/components/team-page-modals/TeamPageModals.tsx
@@ -9,7 +9,6 @@ import { TeamCategoryModal } from '../team-category-modal/TeamCategoryModal';
 import { DeleteTeamCategoryModal } from '../delete-team-category-modal/DeleteTeamCategoryModal';
 import { LocalizationLanguage } from '@/types/common/language';
 import { TranslateTeamCategoryModal } from '../translate-team-category-modal/TranslateTeamCategoryModal';
-import { useState } from 'react';
 
 export interface TeamPageModalsProps {
     modalsStateControl: UseModalsStateResult<TeamMember>;
@@ -112,9 +111,9 @@ export const TeamPageModals = ({
                 categories={categories}
             />
 
-            {modalState.categoryToTranslate && selectedCategory && (
+            {modalState.isCategoryToTranslate && selectedCategory && (
                 <TranslateTeamCategoryModal
-                    isOpen={modalState.categoryToTranslate}
+                    isOpen={modalState.isCategoryToTranslate}
                     onClose={closeModalActions.closeTranslateCategoryModal}
                     onTranslateCategory={onTranslateTeamCategory}
                     categoryToTranslate={selectedCategory}
@@ -123,9 +122,9 @@ export const TeamPageModals = ({
                 />
             )}
 
-            {modalState.categoryToEditTranslation && selectedCategory && (
+            {modalState.isCategoryToEditTranslation && selectedCategory && (
                 <TranslateTeamCategoryModal
-                    isOpen={modalState.categoryToEditTranslation}
+                    isOpen={modalState.isCategoryToEditTranslation}
                     onClose={closeModalActions.closeEditCategoryTranslationModal}
                     onTranslateCategory={onTranslateTeamCategory}
                     categoryToTranslate={selectedCategory}

--- a/src/pages/admin/team/components/translate-team-category-form/TranslateTeamCategoryForm.test.tsx
+++ b/src/pages/admin/team/components/translate-team-category-form/TranslateTeamCategoryForm.test.tsx
@@ -1,0 +1,274 @@
+import React, { createRef } from 'react';
+import { createEvent, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+    TranslateTeamCategoryForm,
+    TranslateTeamCategoryFormRef,
+    TranslateTeamCategoryFormValues,
+} from './TranslateTeamCategoryForm';
+import { TeamCategory } from '@/types/admin/team-category';
+import { VisibilityStatus } from '@/types/admin/common';
+import { TEAM_CATEGORY_VALIDATION_FUNCTIONS } from '@/validation/admin/team-category-schema/team-category-schema';
+
+jest.mock('@/validation/admin/team-category-schema/team-category-schema', () => ({
+    TEAM_CATEGORY_VALIDATION_FUNCTIONS: {
+        validateName: jest.fn(() => undefined),
+        validateDescription: jest.fn(() => undefined),
+    },
+}));
+
+jest.mock('@/components/admin/input-groups/single-select-input-group/SingleSelectInputGroup', () => ({
+    SingleSelectInputGroup: ({ options, value, onChange, disabled, getOptionId, getOptionName }: any) => (
+        <select
+            data-testid="category-select"
+            value={value ? String(getOptionId(value)) : ''}
+            onChange={(e) => {
+                if (!e.target.value) {
+                    onChange?.(null);
+                    return;
+                }
+                const selectedOption = options.find((option: any) => String(getOptionId(option)) === e.target.value);
+                onChange?.(selectedOption ?? null);
+            }}
+            disabled={disabled}
+        >
+            <option value="">Select category</option>
+            {options.map((option: any) => (
+                <option key={getOptionId(option)} value={String(getOptionId(option))}>
+                    {getOptionName(option)}
+                </option>
+            ))}
+        </select>
+    ),
+}));
+
+jest.mock('@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup', () => ({
+    InputWithCharacterLimitGroup: ({ value, onChange, onBlur, disabled, name, id, error }: any) => (
+        <div>
+            <input
+                data-testid={`input-${name ?? id}`}
+                value={value}
+                onChange={onChange}
+                onBlur={onBlur}
+                disabled={disabled}
+            />
+            {error && <span data-testid={`error-${name ?? id}`}>{error}</span>}
+        </div>
+    ),
+}));
+
+jest.mock(
+    '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup',
+    () => ({
+        TextAreaWithCharacterLimitGroup: ({ value, onChange, onBlur, disabled, name, id, error }: any) => (
+            <div>
+                <textarea
+                    data-testid={`textarea-${name ?? id}`}
+                    value={value}
+                    onChange={onChange}
+                    onBlur={onBlur}
+                    disabled={disabled}
+                />
+                {error && <span data-testid={`error-${name ?? id}`}>{error}</span>}
+            </div>
+        ),
+    }),
+);
+
+const mockCategories: TeamCategory[] = [
+    {
+        id: 1,
+        name: 'Category 1',
+        description: 'Description 1',
+        localizations: [],
+        teamMembersCount: 2,
+    },
+    {
+        id: 2,
+        name: 'Category 2',
+        description: 'Description 2',
+        localizations: [],
+        teamMembersCount: 1,
+    },
+];
+
+const validationMock = TEAM_CATEGORY_VALIDATION_FUNCTIONS as jest.Mocked<typeof TEAM_CATEGORY_VALIDATION_FUNCTIONS>;
+
+describe('TranslateTeamCategoryForm', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        validationMock.validateName.mockReturnValue(undefined);
+        validationMock.validateDescription.mockReturnValue(undefined);
+    });
+
+    const renderForm = (props: Partial<React.ComponentProps<typeof TranslateTeamCategoryForm>> = {}) => {
+        const ref = createRef<TranslateTeamCategoryFormRef>();
+        const defaultProps: React.ComponentProps<typeof TranslateTeamCategoryForm> = {
+            onSubmit: jest.fn(),
+            categories: mockCategories,
+        };
+
+        const view = render(<TranslateTeamCategoryForm ref={ref} {...defaultProps} {...props} />);
+
+        return {
+            ref,
+            onSubmit: props.onSubmit ?? defaultProps.onSubmit,
+            ...view,
+        };
+    };
+
+    it('renders category, name and description fields', () => {
+        renderForm();
+
+        expect(screen.getByTestId('category-select')).toBeInTheDocument();
+        expect(screen.getByTestId('input-name')).toBeInTheDocument();
+        expect(screen.getByTestId('textarea-description')).toBeInTheDocument();
+    });
+
+    it('fills fields from initialData', () => {
+        const initialData: TranslateTeamCategoryFormValues = {
+            name: 'Existing name',
+            description: 'Existing description',
+        };
+
+        renderForm({ initialData });
+
+        expect(screen.getByTestId('input-name')).toHaveValue('Existing name');
+        expect(screen.getByTestId('textarea-description')).toHaveValue('Existing description');
+    });
+
+    it('disables text inputs until category is selected', () => {
+        renderForm();
+
+        expect(screen.getByTestId('input-name')).toBeDisabled();
+        expect(screen.getByTestId('textarea-description')).toBeDisabled();
+
+        fireEvent.change(screen.getByTestId('category-select'), { target: { value: '1' } });
+
+        expect(screen.getByTestId('input-name')).toBeEnabled();
+        expect(screen.getByTestId('textarea-description')).toBeEnabled();
+    });
+
+    it('calls onCategoryChange with selected category and null on clear', () => {
+        const onCategoryChange = jest.fn();
+
+        renderForm({ onCategoryChange });
+
+        fireEvent.change(screen.getByTestId('category-select'), { target: { value: '2' } });
+        expect(onCategoryChange).toHaveBeenCalledWith(mockCategories[1]);
+
+        fireEvent.change(screen.getByTestId('category-select'), { target: { value: '' } });
+        expect(onCategoryChange).toHaveBeenLastCalledWith(null);
+    });
+
+    it('updates name and description values on change', () => {
+        renderForm();
+
+        fireEvent.change(screen.getByTestId('category-select'), { target: { value: '1' } });
+        fireEvent.change(screen.getByTestId('input-name'), { target: { value: 'Translated name' } });
+        fireEvent.change(screen.getByTestId('textarea-description'), {
+            target: { value: 'Translated description' },
+        });
+
+        expect(screen.getByTestId('input-name')).toHaveValue('Translated name');
+        expect(screen.getByTestId('textarea-description')).toHaveValue('Translated description');
+    });
+
+    it('validates name and description on blur', () => {
+        renderForm();
+
+        fireEvent.blur(screen.getByTestId('input-name'));
+        fireEvent.blur(screen.getByTestId('textarea-description'));
+
+        expect(validationMock.validateName).toHaveBeenCalled();
+        expect(validationMock.validateDescription).toHaveBeenCalled();
+    });
+
+    it('shows validation errors returned by validation functions', async () => {
+        validationMock.validateName.mockReturnValue('Name error');
+        validationMock.validateDescription.mockReturnValue('Description error');
+
+        renderForm();
+
+        fireEvent.blur(screen.getByTestId('input-name'));
+        fireEvent.blur(screen.getByTestId('textarea-description'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('error-name')).toHaveTextContent('Name error');
+            expect(screen.getByTestId('error-description')).toHaveTextContent('Description error');
+        });
+    });
+
+    it('calls onValidationChange from form manager updates', async () => {
+        const onValidationChange = jest.fn();
+
+        renderForm({ onValidationChange });
+
+        await waitFor(() => {
+            expect(onValidationChange).toHaveBeenCalledWith(true);
+        });
+    });
+
+    it('reports dirty state relative to initialData', async () => {
+        const onDirtyChange = jest.fn();
+        const initialData: TranslateTeamCategoryFormValues = {
+            name: 'Base name',
+            description: 'Base description',
+        };
+
+        renderForm({ initialData, onDirtyChange });
+
+        await waitFor(() => {
+            expect(onDirtyChange).toHaveBeenCalledWith(false);
+        });
+
+        fireEvent.change(screen.getByTestId('input-name'), { target: { value: 'Changed name' } });
+
+        await waitFor(() => {
+            expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+        });
+    });
+
+    it('submits data via ref.submit and forwards only form data to onSubmit', async () => {
+        const onSubmit = jest.fn();
+        const { ref } = renderForm({ onSubmit });
+
+        fireEvent.change(screen.getByTestId('category-select'), { target: { value: '1' } });
+        fireEvent.change(screen.getByTestId('input-name'), { target: { value: 'Final name' } });
+        fireEvent.change(screen.getByTestId('textarea-description'), {
+            target: { value: 'Final description' },
+        });
+
+        await ref.current?.submit(VisibilityStatus.Draft);
+
+        expect(onSubmit).toHaveBeenCalledWith({
+            name: 'Final name',
+            description: 'Final description',
+        });
+    });
+
+    it('exposes isValid and isDirty through ref', () => {
+        const { ref } = renderForm();
+
+        expect(ref.current?.isValid()).toBe(true);
+        expect(ref.current?.isDirty()).toBe(false);
+    });
+
+    it('disables category selector when formDisabled is true', () => {
+        renderForm({ formDisabled: true });
+
+        expect(screen.getByTestId('category-select')).toBeDisabled();
+    });
+
+    it('prevents default form submission behavior', () => {
+        const { container } = renderForm();
+        const form = container.querySelector('#translate-category-form') as HTMLFormElement;
+
+        const event = createEvent.submit(form);
+        event.preventDefault = jest.fn();
+
+        fireEvent(form, event);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+});

--- a/src/pages/admin/team/components/translate-team-category-form/TranslateTeamCategoryForm.tsx
+++ b/src/pages/admin/team/components/translate-team-category-form/TranslateTeamCategoryForm.tsx
@@ -80,12 +80,6 @@ export const TranslateTeamCategoryForm = forwardRef<TranslateTeamCategoryFormRef
             onDirtyChange?.(isDirty);
         }, [formState, initialData, onDirtyChange]);
 
-        useEffect(() => {
-            if (initialData) {
-                setFormState(initialData);
-            }
-        }, [initialData, setFormState]);
-
         const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
             setFormState((prev) => ({ ...prev, name: e.target.value }));
         };

--- a/src/pages/admin/team/components/translate-team-category-form/TranslateTeamCategoryForm.tsx
+++ b/src/pages/admin/team/components/translate-team-category-form/TranslateTeamCategoryForm.tsx
@@ -1,0 +1,160 @@
+import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
+import { SingleSelectInputGroup } from '@/components/admin/input-groups/single-select-input-group/SingleSelectInputGroup';
+import { TextAreaWithCharacterLimitGroup } from '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup';
+import { TEAM_CATEGORY_TEXT, TEAM_CATEGORY_VALIDATION } from '@/const/admin/team';
+import { useFormManager } from '@/hooks/admin/use-form-manager/useFormManager';
+import { VisibilityStatus } from '@/types/admin/common';
+import { TeamCategory } from '@/types/admin/team-category';
+import { TEAM_CATEGORY_VALIDATION_FUNCTIONS } from '@/validation/admin/team-category-schema/team-category-schema';
+import { forwardRef, useCallback, useEffect, useState } from 'react';
+
+export interface TranslateTeamCategoryFormValues {
+    name: string;
+    description: string;
+}
+
+export interface TranslateTeamCategoryFormErrorState {
+    name: string | undefined;
+    description: string | undefined | string[];
+    [key: string]: string | string[] | undefined;
+}
+
+export interface TranslateTeamCategoryFormRef {
+    submit: (status?: VisibilityStatus) => Promise<void>;
+    isValid: () => boolean;
+    isDirty: () => boolean;
+}
+
+export interface TranslateTeamCategoryFormProps {
+    onSubmit: (data: TranslateTeamCategoryFormValues, status?: VisibilityStatus) => void | Promise<void>;
+    categories: TeamCategory[];
+    initialData?: TranslateTeamCategoryFormValues | null;
+    formDisabled?: boolean;
+    onCategoryChange?: (category: TeamCategory | null) => void;
+    onValidationChange?: (isValid: boolean) => void;
+    onDirtyChange?: (isDirty: boolean) => void;
+}
+
+const DEFAULT_FORM_STATE: TranslateTeamCategoryFormValues = {
+    name: '',
+    description: '',
+};
+
+const validateForm = (
+    formState: TranslateTeamCategoryFormValues,
+    _isPublishing: boolean,
+): TranslateTeamCategoryFormErrorState => {
+    return {
+        name: TEAM_CATEGORY_VALIDATION_FUNCTIONS.validateName(formState.name),
+        description: TEAM_CATEGORY_VALIDATION_FUNCTIONS.validateDescription(formState.description),
+    };
+};
+export const TranslateTeamCategoryForm = forwardRef<TranslateTeamCategoryFormRef, TranslateTeamCategoryFormProps>(
+    (
+        {
+            initialData = null,
+            onSubmit,
+            categories,
+            formDisabled,
+            onCategoryChange,
+            onValidationChange,
+            onDirtyChange,
+        }: TranslateTeamCategoryFormProps,
+        ref,
+    ) => {
+        const { formState, setFormState, errors, setErrors, isSubmitting } = useFormManager<
+            TranslateTeamCategoryFormValues,
+            TranslateTeamCategoryFormErrorState
+        >({
+            defaultFormState: DEFAULT_FORM_STATE,
+            initialData,
+            validateForm,
+            onValidationChange,
+            ref,
+            onSubmit: (data, _status) => onSubmit(data),
+        });
+        const [selectedCategory, setSelectedCategory] = useState<TeamCategory | null>(null);
+
+        useEffect(() => {
+            const isDirty = JSON.stringify(formState) !== JSON.stringify(initialData);
+            onDirtyChange?.(isDirty);
+        }, [formState, initialData, onDirtyChange]);
+
+        useEffect(() => {
+            if (initialData) {
+                setFormState(initialData);
+            }
+        }, [initialData, setFormState]);
+
+        const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+            setFormState((prev) => ({ ...prev, name: e.target.value }));
+        };
+        const handleCategoryChange = (category: TeamCategory | null) => {
+            setSelectedCategory(category);
+            onCategoryChange?.(category);
+        };
+
+        const handleNameBlur = () => {
+            const error = TEAM_CATEGORY_VALIDATION_FUNCTIONS.validateName(formState.name);
+            setErrors((prev) => ({ ...prev, name: error }));
+        };
+
+        const handleDescriptionChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+            setFormState((prev) => ({ ...prev, description: e.target.value }));
+        };
+
+        const handleDescriptionBlur = () => {
+            const error = TEAM_CATEGORY_VALIDATION_FUNCTIONS.validateDescription(formState.description);
+            setErrors((prev) => ({ ...prev, description: error }));
+        };
+
+        return (
+            <form
+                onSubmit={(e) => e.preventDefault()}
+                className="team-category-modal-form"
+                id={'translate-category-form'}
+                noValidate
+            >
+                <SingleSelectInputGroup
+                    label={TEAM_CATEGORY_TEXT.FORM.LABEL.CATEGORY}
+                    isRequired
+                    options={categories}
+                    getOptionId={(c) => c.id}
+                    getOptionName={(c) => c.name}
+                    disabled={isSubmitting || formDisabled}
+                    onChange={handleCategoryChange}
+                    value={selectedCategory || undefined}
+                    placeholder="Оберіть категорію"
+                    id={'category-select'}
+                />
+
+                <InputWithCharacterLimitGroup
+                    label={TEAM_CATEGORY_TEXT.FORM.LABEL.NAME}
+                    error={errors.name}
+                    isRequired
+                    value={formState.name}
+                    onChange={handleNameChange}
+                    onBlur={handleNameBlur}
+                    disabled={isSubmitting || !selectedCategory}
+                    maxLength={TEAM_CATEGORY_VALIDATION.name.max}
+                    name={'name'}
+                    id={'name'}
+                />
+
+                <TextAreaWithCharacterLimitGroup
+                    label={TEAM_CATEGORY_TEXT.FORM.LABEL.DESCRIPTION}
+                    error={typeof errors.description === 'string' ? errors.description : undefined}
+                    value={formState.description}
+                    onChange={handleDescriptionChange}
+                    onBlur={handleDescriptionBlur}
+                    isRequired
+                    disabled={isSubmitting || !selectedCategory}
+                    rows={5}
+                    maxLength={TEAM_CATEGORY_VALIDATION.description.max}
+                    name={'description'}
+                    id={'description'}
+                />
+            </form>
+        );
+    },
+);

--- a/src/pages/admin/team/components/translate-team-category-form/TranslateTeamCategoryForm.tsx
+++ b/src/pages/admin/team/components/translate-team-category-form/TranslateTeamCategoryForm.tsx
@@ -6,7 +6,7 @@ import { useFormManager } from '@/hooks/admin/use-form-manager/useFormManager';
 import { VisibilityStatus } from '@/types/admin/common';
 import { TeamCategory } from '@/types/admin/team-category';
 import { TEAM_CATEGORY_VALIDATION_FUNCTIONS } from '@/validation/admin/team-category-schema/team-category-schema';
-import { forwardRef, useCallback, useEffect, useState } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 
 export interface TranslateTeamCategoryFormValues {
     name: string;

--- a/src/pages/admin/team/components/translate-team-category-modal/TranslateTeamCategoryModal.test.tsx
+++ b/src/pages/admin/team/components/translate-team-category-modal/TranslateTeamCategoryModal.test.tsx
@@ -1,0 +1,325 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { ModalMode } from '@/types/admin/common';
+import { TeamCategory } from '@/types/admin/team-category';
+import { TranslationStatus, LocalizationLanguage } from '@/types/common/language';
+import { useTranslateTeamCategory } from '@/hooks/admin/use-translate-team-category/useTranslateTeamCategory';
+import { TranslateTeamCategoryModal } from './TranslateTeamCategoryModal';
+
+let mockFormIsValid = true;
+let mockFormIsDirty = true;
+let mockAutoSelectCategoryIndex = 0;
+
+const mockTranslateTeamCategory = jest.fn();
+
+jest.mock('@/components/admin/localization-modal/LocalizationModal', () => ({
+    LocalizationModal: (props: unknown) => require('@/utils/test-mocks/test-mocks').MockLocalizationModal(props),
+}));
+
+jest.mock('@/components/admin/translation-controls/TranslationControls', () => ({
+    TranslationControls: ({ selectedLanguage, languages, onLanguageChange, isSubmitting }: any) => (
+        <div data-testid="translation-controls">
+            <span data-testid="selected-language">{selectedLanguage?.code ?? 'none'}</span>
+            <span data-testid="is-submitting">{String(isSubmitting)}</span>
+            <span data-testid="languages-count">{String(languages?.length ?? 0)}</span>
+            <button
+                data-testid="choose-last-language"
+                onClick={() => onLanguageChange?.(languages?.[languages.length - 1] ?? null)}
+            >
+                choose last language
+            </button>
+        </div>
+    ),
+}));
+
+jest.mock('../translate-team-category-form/TranslateTeamCategoryForm', () => {
+    const React = require('react');
+
+    return {
+        TranslateTeamCategoryForm: React.forwardRef(
+            (
+                {
+                    onSubmit,
+                    onValidationChange,
+                    onDirtyChange,
+                    onCategoryChange,
+                    categories,
+                    initialData,
+                    formDisabled,
+                }: any,
+                ref: React.Ref<any>,
+            ) => {
+                React.useImperativeHandle(ref, () => ({
+                    submit: () =>
+                        onSubmit({
+                            name: 'Translated category name',
+                            description: 'Translated category description',
+                        }),
+                    isValid: () => mockFormIsValid,
+                    isDirty: () => mockFormIsDirty,
+                }));
+
+                React.useEffect(() => {
+                    onValidationChange?.(true);
+                    onDirtyChange?.(mockFormIsDirty);
+
+                    const selectedCategory =
+                        mockAutoSelectCategoryIndex >= 0 ? (categories?.[mockAutoSelectCategoryIndex] ?? null) : null;
+                    onCategoryChange?.(selectedCategory);
+                }, [onValidationChange, onDirtyChange, onCategoryChange, categories]);
+
+                return (
+                    <div
+                        data-testid="translate-team-category-form"
+                        data-initial={initialData ? JSON.stringify(initialData) : 'null'}
+                        data-disabled={String(Boolean(formDisabled))}
+                        data-categories={String(categories?.length ?? 0)}
+                    />
+                );
+            },
+        ),
+    };
+});
+
+jest.mock('@/hooks/admin/use-translate-team-category/useTranslateTeamCategory', () => ({
+    useTranslateTeamCategory: jest.fn(() => ({
+        translateTeamCategory: mockTranslateTeamCategory,
+        isSubmitting: false,
+        error: '',
+        clearError: jest.fn(),
+    })),
+}));
+
+const mockUseTranslateTeamCategory = jest.mocked(useTranslateTeamCategory);
+
+const UK_LANGUAGE: LocalizationLanguage = {
+    id: 1,
+    code: 'uk',
+    name: 'Ukrainian',
+};
+
+const EN_LANGUAGE: LocalizationLanguage = {
+    id: 2,
+    code: 'en',
+    name: 'English',
+};
+
+const PL_LANGUAGE: LocalizationLanguage = {
+    id: 3,
+    code: 'pl',
+    name: 'Polish',
+};
+
+const CATEGORY_WITHOUT_LOCALIZATION: TeamCategory = {
+    id: 10,
+    name: 'Category 1',
+    description: 'Description 1',
+    teamMembersCount: 2,
+    localizations: [],
+};
+
+const CATEGORY_WITH_EN_LOCALIZATION: TeamCategory = {
+    id: 20,
+    name: 'Category 2',
+    description: 'Description 2',
+    teamMembersCount: 4,
+    localizations: [
+        {
+            name: 'Category EN',
+            description: 'Description EN',
+            language: {
+                id: EN_LANGUAGE.id,
+                code: EN_LANGUAGE.code,
+            },
+            translationStatus: TranslationStatus.Relevant,
+        },
+    ],
+};
+
+const CATEGORY_LIST: TeamCategory[] = [CATEGORY_WITHOUT_LOCALIZATION, CATEGORY_WITH_EN_LOCALIZATION];
+
+describe('TranslateTeamCategoryModal', () => {
+    const renderModal = (props: Partial<React.ComponentProps<typeof TranslateTeamCategoryModal>> = {}) => {
+        const defaultProps: React.ComponentProps<typeof TranslateTeamCategoryModal> = {
+            isOpen: true,
+            onClose: jest.fn(),
+            categoryToTranslate: CATEGORY_WITHOUT_LOCALIZATION,
+            onTranslateCategory: jest.fn(),
+            translatedLanguages: [UK_LANGUAGE, EN_LANGUAGE],
+            categories: CATEGORY_LIST,
+        };
+
+        return render(<TranslateTeamCategoryModal {...defaultProps} {...props} />);
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockFormIsValid = true;
+        mockFormIsDirty = true;
+        mockAutoSelectCategoryIndex = 0;
+
+        mockTranslateTeamCategory.mockResolvedValue(undefined);
+        mockUseTranslateTeamCategory.mockReturnValue({
+            translateTeamCategory: mockTranslateTeamCategory,
+            isSubmitting: false,
+            error: '',
+            clearError: jest.fn(),
+        });
+    });
+
+    it('returns null when categoryToTranslate is null', () => {
+        renderModal({ categoryToTranslate: null });
+
+        expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+    });
+
+    it('uses first non-default language as selected language by default', () => {
+        renderModal({ translatedLanguages: [UK_LANGUAGE, EN_LANGUAGE, PL_LANGUAGE] });
+
+        expect(screen.getByTestId('selected-language')).toHaveTextContent('en');
+    });
+
+    it('falls back to first language when only default locale exists', () => {
+        renderModal({ translatedLanguages: [UK_LANGUAGE] });
+
+        expect(screen.getByTestId('selected-language')).toHaveTextContent('uk');
+    });
+
+    it('uses null selected language when translatedLanguages is empty', () => {
+        renderModal({ translatedLanguages: [] });
+
+        expect(screen.getByTestId('selected-language')).toHaveTextContent('none');
+        expect(mockUseTranslateTeamCategory).toHaveBeenCalledWith(expect.objectContaining({ language: null }));
+    });
+
+    it('starts in add mode and changes to edit mode when selected category has localization for selected language', async () => {
+        mockAutoSelectCategoryIndex = 1;
+        renderModal({ translatedLanguages: [UK_LANGUAGE, EN_LANGUAGE] });
+
+        expect(mockUseTranslateTeamCategory).toHaveBeenCalledWith(expect.objectContaining({ mode: ModalMode.Add }));
+
+        await waitFor(() => {
+            expect(mockUseTranslateTeamCategory).toHaveBeenCalledWith(
+                expect.objectContaining({ mode: ModalMode.Edit }),
+            );
+        });
+        expect(screen.getByTestId('modal-title')).toHaveTextContent(
+            COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.UPDATE_TRANSLATION,
+        );
+    });
+
+    it('passes initialData to form in edit mode', async () => {
+        mockAutoSelectCategoryIndex = 1;
+        renderModal({ translatedLanguages: [UK_LANGUAGE, EN_LANGUAGE] });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('translate-team-category-form')).toHaveAttribute(
+                'data-initial',
+                JSON.stringify({
+                    name: 'Category EN',
+                    description: 'Description EN',
+                }),
+            );
+        });
+    });
+
+    it('submits translation and executes success callback flow', async () => {
+        const onTranslateCategory = jest.fn();
+        const onClose = jest.fn();
+
+        mockTranslateTeamCategory.mockImplementation(async () => {
+            const firstCallArgs = mockUseTranslateTeamCategory.mock.calls[0][0];
+            firstCallArgs.onSuccess(CATEGORY_WITH_EN_LOCALIZATION);
+        });
+
+        renderModal({ onTranslateCategory, onClose });
+
+        fireEvent.click(screen.getByTestId('save-localization-btn'));
+
+        await waitFor(() => {
+            expect(mockTranslateTeamCategory).toHaveBeenCalledWith({
+                name: 'Translated category name',
+                description: 'Translated category description',
+            });
+        });
+
+        expect(onTranslateCategory).toHaveBeenCalledWith(CATEGORY_WITH_EN_LOCALIZATION);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not submit when form is invalid', () => {
+        mockFormIsValid = false;
+        renderModal();
+
+        fireEvent.click(screen.getByTestId('save-localization-btn'));
+
+        expect(mockTranslateTeamCategory).not.toHaveBeenCalled();
+    });
+
+    it('shows confirmation modal when closing dirty form and closes immediately for clean form', () => {
+        const onClose = jest.fn();
+
+        mockFormIsDirty = true;
+        const { rerender } = render(
+            <TranslateTeamCategoryModal
+                isOpen={true}
+                onClose={onClose}
+                categoryToTranslate={CATEGORY_WITHOUT_LOCALIZATION}
+                onTranslateCategory={jest.fn()}
+                translatedLanguages={[UK_LANGUAGE, EN_LANGUAGE]}
+                categories={CATEGORY_LIST}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('modal'));
+        expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument();
+        expect(onClose).not.toHaveBeenCalled();
+
+        mockFormIsDirty = false;
+        rerender(
+            <TranslateTeamCategoryModal
+                isOpen={true}
+                onClose={onClose}
+                categoryToTranslate={CATEGORY_WITHOUT_LOCALIZATION}
+                onTranslateCategory={jest.fn()}
+                translatedLanguages={[UK_LANGUAGE, EN_LANGUAGE]}
+                categories={CATEGORY_LIST}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('modal'));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders error message and passes submitting state to controls and form', () => {
+        mockUseTranslateTeamCategory.mockReturnValue({
+            translateTeamCategory: mockTranslateTeamCategory,
+            isSubmitting: true,
+            error: 'Translation failed',
+            clearError: jest.fn(),
+        });
+
+        renderModal();
+
+        expect(screen.getByText('Translation failed')).toBeInTheDocument();
+        expect(screen.getByTestId('is-submitting')).toHaveTextContent('true');
+        expect(screen.getByTestId('translate-team-category-form')).toHaveAttribute('data-disabled', 'true');
+        expect(screen.getByTestId('save-localization-btn')).toBeDisabled();
+    });
+
+    it('changes language through translation controls and keeps add mode if localization is missing', async () => {
+        mockAutoSelectCategoryIndex = 0;
+        renderModal({ translatedLanguages: [UK_LANGUAGE, EN_LANGUAGE, PL_LANGUAGE] });
+
+        fireEvent.click(screen.getByTestId('choose-last-language'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('selected-language')).toHaveTextContent('pl');
+        });
+        expect(screen.getByTestId('modal-title')).toHaveTextContent(
+            COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION,
+        );
+    });
+});

--- a/src/pages/admin/team/components/translate-team-category-modal/TranslateTeamCategoryModal.tsx
+++ b/src/pages/admin/team/components/translate-team-category-modal/TranslateTeamCategoryModal.tsx
@@ -6,7 +6,7 @@ import { useTranslateTeamCategory } from '@/hooks/admin/use-translate-team-categ
 import { ModalMode } from '@/types/admin/common';
 import { TeamCategory } from '@/types/admin/team-category';
 import { LocalizationLanguage } from '@/types/common/language';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import {
     TranslateTeamCategoryForm,
     TranslateTeamCategoryFormRef,
@@ -38,7 +38,7 @@ export const TranslateTeamCategoryModal = ({
     const [language, setLanguage] = useState<LocalizationLanguage | null>(() => {
         if (!translatedLanguages?.length) return null;
         return translatedLanguages.find((l) => l.code !== DEFAULT_LOCALE) || translatedLanguages[0];
-   });
+    });
 
     const existingLocalization = useMemo(() => {
         if (!selectedCategory?.localizations || !language) return null;

--- a/src/pages/admin/team/components/translate-team-category-modal/TranslateTeamCategoryModal.tsx
+++ b/src/pages/admin/team/components/translate-team-category-modal/TranslateTeamCategoryModal.tsx
@@ -1,0 +1,122 @@
+import { LocalizationModal } from '@/components/admin/localization-modal/LocalizationModal';
+import { TranslationControls } from '@/components/admin/translation-controls/TranslationControls';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { DEFAULT_LOCALE } from '@/const/common/locales';
+import { useTranslateTeamCategory } from '@/hooks/admin/use-translate-team-category/useTranslateTeamCategory';
+import { ModalMode } from '@/types/admin/common';
+import { TeamCategory } from '@/types/admin/team-category';
+import { LocalizationLanguage } from '@/types/common/language';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+    TranslateTeamCategoryForm,
+    TranslateTeamCategoryFormRef,
+    TranslateTeamCategoryFormValues,
+} from '../translate-team-category-form/TranslateTeamCategoryForm';
+
+interface TranslateTeamCategoryModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    categoryToTranslate: TeamCategory | null;
+    onTranslateCategory: (category: TeamCategory) => void;
+    translatedLanguages: LocalizationLanguage[];
+    categories: TeamCategory[];
+}
+
+export const TranslateTeamCategoryModal = ({
+    isOpen,
+    onClose,
+    categoryToTranslate,
+    onTranslateCategory,
+    translatedLanguages,
+    categories,
+}: TranslateTeamCategoryModalProps) => {
+    const formRef = useRef<TranslateTeamCategoryFormRef>(null);
+    const [isFormValid, setIsFormValid] = useState(false);
+    const [isDirty, setIsDirty] = useState(false);
+    const [language, setLanguage] = useState<LocalizationLanguage | null>(translatedLanguages?.[0] ?? null);
+    const [selectedCategory, setSelectedCategory] = useState<TeamCategory | null>(null);
+
+    useEffect(() => {
+        if (translatedLanguages.length > 0 && !language) {
+            const defaultEnglish = translatedLanguages.find((l) => l.code !== DEFAULT_LOCALE) || translatedLanguages[0];
+            setLanguage(defaultEnglish);
+        }
+    }, [translatedLanguages, language]);
+
+    const existingLocalization = useMemo(() => {
+        if (!selectedCategory?.localizations || !language) return null;
+        return selectedCategory.localizations.find((loc) => loc.language.id === language.id);
+    }, [selectedCategory, language]);
+
+    const mode = existingLocalization ? ModalMode.Edit : ModalMode.Add;
+    const isEditMode = mode === ModalMode.Edit;
+
+    const initialData = useMemo<TranslateTeamCategoryFormValues | null>(() => {
+        if (!isEditMode || !existingLocalization) return null;
+
+        return {
+            name: existingLocalization.name,
+            description: existingLocalization.description,
+        };
+    }, [existingLocalization, isEditMode]);
+
+    const { translateTeamCategory, isSubmitting, error } = useTranslateTeamCategory({
+        teamCategory: selectedCategory,
+        language: language!,
+        onSuccess: (updatedTeamCategory) => {
+            onTranslateCategory(updatedTeamCategory);
+            onClose();
+        },
+        mode,
+    });
+
+    const handleSaveClick = () => {
+        if (!formRef.current?.isValid()) return;
+        formRef.current.submit();
+    };
+
+    const checkIsDirty = () => {
+        return formRef.current?.isDirty() ?? false;
+    };
+
+    const handleFormSubmit = async (data: TranslateTeamCategoryFormValues) => {
+        await translateTeamCategory(data);
+    };
+
+    if (!categoryToTranslate) return null;
+
+    const modalTitle = isEditMode
+        ? COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.UPDATE_TRANSLATION
+        : COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION;
+
+    return (
+        <LocalizationModal
+            isOpen={isOpen}
+            onClose={onClose}
+            title={modalTitle}
+            onSave={handleSaveClick}
+            isSubmitting={isSubmitting}
+            isFormValid={isFormValid}
+            checkIsDirty={checkIsDirty}
+            isDirty={isDirty}
+        >
+            <TranslationControls
+                selectedLanguage={language}
+                isSubmitting={isSubmitting}
+                languages={translatedLanguages}
+                onLanguageChange={setLanguage}
+            />
+            {error && <div className="translate-team-category-error">{error}</div>}
+            <TranslateTeamCategoryForm
+                ref={formRef}
+                categories={categories}
+                initialData={initialData}
+                onCategoryChange={setSelectedCategory}
+                onValidationChange={setIsFormValid}
+                onSubmit={handleFormSubmit}
+                formDisabled={isSubmitting}
+                onDirtyChange={setIsDirty}
+            />
+        </LocalizationModal>
+    );
+};

--- a/src/pages/admin/team/components/translate-team-category-modal/TranslateTeamCategoryModal.tsx
+++ b/src/pages/admin/team/components/translate-team-category-modal/TranslateTeamCategoryModal.tsx
@@ -33,15 +33,12 @@ export const TranslateTeamCategoryModal = ({
     const formRef = useRef<TranslateTeamCategoryFormRef>(null);
     const [isFormValid, setIsFormValid] = useState(false);
     const [isDirty, setIsDirty] = useState(false);
-    const [language, setLanguage] = useState<LocalizationLanguage | null>(translatedLanguages?.[0] ?? null);
     const [selectedCategory, setSelectedCategory] = useState<TeamCategory | null>(null);
 
-    useEffect(() => {
-        if (translatedLanguages.length > 0 && !language) {
-            const defaultEnglish = translatedLanguages.find((l) => l.code !== DEFAULT_LOCALE) || translatedLanguages[0];
-            setLanguage(defaultEnglish);
-        }
-    }, [translatedLanguages, language]);
+    const [language, setLanguage] = useState<LocalizationLanguage | null>(() => {
+        if (!translatedLanguages?.length) return null;
+        return translatedLanguages.find((l) => l.code !== DEFAULT_LOCALE) || translatedLanguages[0];
+   });
 
     const existingLocalization = useMemo(() => {
         if (!selectedCategory?.localizations || !language) return null;
@@ -62,7 +59,7 @@ export const TranslateTeamCategoryModal = ({
 
     const { translateTeamCategory, isSubmitting, error } = useTranslateTeamCategory({
         teamCategory: selectedCategory,
-        language: language!,
+        language: language as LocalizationLanguage,
         onSuccess: (updatedTeamCategory) => {
             onTranslateCategory(updatedTeamCategory);
             onClose();

--- a/src/services/api/admin/team/team-category-localizations/team-category-localizations-api.test.ts
+++ b/src/services/api/admin/team/team-category-localizations/team-category-localizations-api.test.ts
@@ -1,0 +1,94 @@
+import { TeamCategoryLocalizationApi } from './team-category-localizations-api';
+import { API_ROUTES } from '@/const/common/api-routes/main-api';
+import {
+    CreateTeamCategoryLocalizationDto,
+    TeamCategoryLocalizationDto,
+    UpdateTeamCategoryLocalizationDto,
+} from '@/types/admin/team-category';
+import { LocalizationInfo, TranslationStatus } from '@/types/common/language';
+
+describe('TeamCategoryLocalizationApi.create', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should call client.post with correct url and payload and return response data', async () => {
+        const mockClient = {
+            post: jest.fn(),
+        };
+
+        const payload: CreateTeamCategoryLocalizationDto = {
+            entityId: 1,
+            languageId: 2,
+            name: 'Category name',
+            description: 'Translated category description',
+        };
+
+        const mockResponseData: TeamCategoryLocalizationDto = {
+            entityId: 1,
+            name: 'Category name',
+            description: 'Translated category description',
+            localizationInfoDto: {
+                id: 2,
+                code: 'en',
+                name: 'English',
+            } as LocalizationInfo,
+            translationStatus: TranslationStatus.Relevant,
+        };
+
+        mockClient.post.mockResolvedValueOnce({
+            data: mockResponseData,
+        });
+
+        const result = await TeamCategoryLocalizationApi.create(mockClient as any, payload);
+
+        expect(mockClient.post).toHaveBeenCalledTimes(1);
+        expect(mockClient.post).toHaveBeenCalledWith(API_ROUTES.TEAM_CATEGORY_LOCALIZATIONS.BASE, payload);
+        expect(result).toEqual(mockResponseData);
+    });
+});
+
+describe('TeamCategoryLocalizationApi.update', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should call client.put with correct url and payload and return response data', async () => {
+        const mockClient = {
+            put: jest.fn(),
+        };
+
+        const entityId = 1;
+        const languageId = 2;
+
+        const payload: UpdateTeamCategoryLocalizationDto = {
+            name: 'Updated category name',
+            description: 'Updated category description',
+        };
+
+        const mockResponseData: TeamCategoryLocalizationDto = {
+            entityId,
+            name: 'Updated category name',
+            description: 'Updated category description',
+            localizationInfoDto: {
+                id: languageId,
+                code: 'en',
+                name: 'English',
+            } as LocalizationInfo,
+            translationStatus: TranslationStatus.Relevant,
+        };
+
+        mockClient.put.mockResolvedValueOnce({
+            data: mockResponseData,
+        });
+
+        const result = await TeamCategoryLocalizationApi.update(mockClient as any, entityId, languageId, payload);
+
+        expect(mockClient.put).toHaveBeenCalledTimes(1);
+        expect(mockClient.put).toHaveBeenCalledWith(
+            `${API_ROUTES.TEAM_CATEGORY_LOCALIZATIONS.BASE}/${entityId}/${languageId}`,
+            payload,
+        );
+        expect(result).toEqual(mockResponseData);
+    });
+});

--- a/src/services/api/admin/team/team-category-localizations/team-category-localizations-api.ts
+++ b/src/services/api/admin/team/team-category-localizations/team-category-localizations-api.ts
@@ -1,0 +1,33 @@
+import { API_ROUTES } from '@/const/common/api-routes/main-api';
+import {
+    CreateTeamCategoryLocalizationDto,
+    TeamCategoryLocalizationDto,
+    UpdateTeamCategoryLocalizationDto,
+} from '@/types/admin/team-category';
+import { AxiosInstance } from 'axios';
+
+export const TeamCategoryLocalizationApi = {
+    create: async (
+        client: AxiosInstance,
+        data: CreateTeamCategoryLocalizationDto,
+    ): Promise<TeamCategoryLocalizationDto> => {
+        const response = await client.post<TeamCategoryLocalizationDto>(
+            API_ROUTES.TEAM_CATEGORY_LOCALIZATIONS.BASE,
+            data,
+        );
+        return response.data;
+    },
+
+    update: async (
+        client: AxiosInstance,
+        entityId: number,
+        languageId: number,
+        data: UpdateTeamCategoryLocalizationDto,
+    ): Promise<TeamCategoryLocalizationDto> => {
+        const response = await client.put<TeamCategoryLocalizationDto>(
+            `${API_ROUTES.TEAM_CATEGORY_LOCALIZATIONS.BASE}/${entityId}/${languageId}`,
+            data,
+        );
+        return response.data;
+    },
+};

--- a/src/types/admin/team-category.ts
+++ b/src/types/admin/team-category.ts
@@ -31,6 +31,18 @@ export interface TeamCategoryLocalizableFields {
     description: string;
 }
 
+export interface CreateTeamCategoryLocalizationDto {
+    entityId: number;
+    languageId: number;
+    name: string;
+    description: string;
+}
+
+export interface UpdateTeamCategoryLocalizationDto {
+    name: string;
+    description: string;
+}
+
 export interface TeamCategoryLocalizationDto extends EntityLocalizationDto, TeamCategoryLocalizableFields {
     entityId: number;
 }


### PR DESCRIPTION
## Github tickets

* [Github ticket 1317](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1317)
* [Github ticket 1277](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1277)
* [Github ticket 1276](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1276)
* [Github ticket 1319](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1319)
* [Github ticket 1315](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1315)

## Description

<!--- Please decripe the main goal of this PR and why it was created --->

## How it looks


https://github.com/user-attachments/assets/1b9b7497-6f93-4d20-b5ef-d8de4ee85022



## Summary of change

<!--- Please specify what was changed --->

## How to recreate changes

<!--- Please provide short instruction step-by-step how to see changes that was implemented by this PR --->


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team category translation workflow: add/edit translations for names and descriptions via new modals, forms, and UI actions; language selection and success toasts included.

* **API**
  * New API group for team category localizations enabling create and update translation requests.

* **Tests**
  * Extensive unit tests added for hooks, forms, modals, and API create/update flows covering success, error, validation, and modal interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->