### PR TITLE
Feat/issue-1350: Reorder program sections

### DIFF
--- a/src/pages/admin/programs/components/program-form/ProgramForm.test.tsx
+++ b/src/pages/admin/programs/components/program-form/ProgramForm.test.tsx
@@ -12,6 +12,8 @@ import { PhotoInputGroupProps } from '@/components/admin/input-groups/photo-inpu
 import { ButtonProps } from '@/components/admin/button/Button';
 import { ProgramSection } from '@/types/common/program-sections';
 
+HTMLElement.prototype.scrollIntoView = jest.fn();
+
 jest.mock('@/validation/admin/program-schema/program-schema', () => ({
     PROGRAM_VALIDATION_FUNCTIONS: {
         validateName: jest.fn(),
@@ -790,22 +792,23 @@ describe('ProgramForm', () => {
             });
         });
 
-        it('moves section up when Move Up button is clicked', async () => {
-            const initialData = createInitialData({
+        let initialData: ReturnType<typeof createInitialData>;
+
+        beforeEach(() => {
+            initialData = createInitialData({
                 sections: [
                     { id: 101, template: 1, order: 0, contents: [] } as ProgramSection,
                     { id: 202, template: 1, order: 1, contents: [] } as ProgramSection,
                 ],
             });
+        });
 
+        it('moves section up when Move Up button is clicked', async () => {
             renderProgramForm({ initialData });
-
             await waitFor(() => {
                 expect(screen.getAllByTestId('program-section-form')).toHaveLength(2);
             });
-
             fireEvent.click(screen.getByTestId('move-up-section-202'));
-
             await waitFor(() => {
                 const sections = screen.getAllByTestId('program-section-form');
                 expect(sections[0]).toHaveAttribute('data-section-id', '202');
@@ -813,21 +816,11 @@ describe('ProgramForm', () => {
         });
 
         it('moves section down when Move Down button is clicked', async () => {
-            const initialData = createInitialData({
-                sections: [
-                    { id: 101, template: 1, order: 0, contents: [] } as ProgramSection,
-                    { id: 202, template: 1, order: 1, contents: [] } as ProgramSection,
-                ],
-            });
-
             renderProgramForm({ initialData });
-
             await waitFor(() => {
                 expect(screen.getAllByTestId('program-section-form')).toHaveLength(2);
             });
-
             fireEvent.click(screen.getByTestId('move-down-section-101'));
-
             await waitFor(() => {
                 const sections = screen.getAllByTestId('program-section-form');
                 expect(sections[1]).toHaveAttribute('data-section-id', '101');

--- a/src/pages/admin/programs/components/program-form/ProgramForm.test.tsx
+++ b/src/pages/admin/programs/components/program-form/ProgramForm.test.tsx
@@ -140,20 +140,28 @@ jest.mock('../program-section-form/ProgramSectionForm', () => ({
         onEditStateChange,
         onDelete,
         onRequestReplace,
+        onMoveUpSection,
+        onMoveDownSection,
+        isFirstSection,
+        isLastSection,
         isDisabled,
         isNewSection,
         isReplacingTemplate,
     }: any) => (
         <div
             data-testid="program-section-form"
+            data-section-id={section.id ?? section.template}
             data-section-template={String(section.template)}
             data-disabled={String(isDisabled)}
             data-is-new={String(isNewSection)}
             data-is-replacing={String(isReplacingTemplate)}
+            data-is-first={String(isFirstSection)}
+            data-is-last={String(isLastSection)}
         >
             <button type="button" data-testid={`save-section-${section.id ?? section.template}`} onClick={onSave}>
                 Save
             </button>
+
             <button
                 type="button"
                 data-testid={`cancel-section-${section.id ?? section.template}`}
@@ -168,6 +176,7 @@ jest.mock('../program-section-form/ProgramSectionForm', () => ({
             >
                 Cancel
             </button>
+
             <button
                 type="button"
                 data-testid={`change-section-${section.id ?? section.template}`}
@@ -175,6 +184,7 @@ jest.mock('../program-section-form/ProgramSectionForm', () => ({
             >
                 Change
             </button>
+
             <button
                 type="button"
                 data-testid={`edit-state-${section.id ?? section.template}`}
@@ -182,6 +192,7 @@ jest.mock('../program-section-form/ProgramSectionForm', () => ({
             >
                 Toggle Edit
             </button>
+
             <button
                 type="button"
                 data-testid={`delete-section-${section.id ?? section.template}`}
@@ -189,6 +200,7 @@ jest.mock('../program-section-form/ProgramSectionForm', () => ({
             >
                 Delete
             </button>
+
             <button
                 type="button"
                 data-testid={`replace-section-${section.id ?? section.template}`}
@@ -196,6 +208,26 @@ jest.mock('../program-section-form/ProgramSectionForm', () => ({
             >
                 Replace
             </button>
+
+            {!isFirstSection && (
+                <button
+                    type="button"
+                    data-testid={`move-up-section-${section.id ?? section.template}`}
+                    onClick={() => onMoveUpSection?.()}
+                >
+                    Move Up
+                </button>
+            )}
+
+            {!isLastSection && (
+                <button
+                    type="button"
+                    data-testid={`move-down-section-${section.id ?? section.template}`}
+                    onClick={() => onMoveDownSection?.()}
+                >
+                    Move Down
+                </button>
+            )}
         </div>
     ),
 }));
@@ -755,6 +787,68 @@ describe('ProgramForm', () => {
 
             await waitFor(() => {
                 expect(screen.queryByTestId('program-section-form')).not.toBeInTheDocument();
+            });
+        });
+
+        it('moves section up when Move Up button is clicked', async () => {
+            const initialData = createInitialData({
+                sections: [
+                    { id: 101, template: 1, order: 0, contents: [] } as ProgramSection,
+                    { id: 202, template: 1, order: 1, contents: [] } as ProgramSection,
+                ],
+            });
+
+            renderProgramForm({ initialData });
+
+            await waitFor(() => {
+                expect(screen.getAllByTestId('program-section-form')).toHaveLength(2);
+            });
+
+            fireEvent.click(screen.getByTestId('move-up-section-202'));
+
+            await waitFor(() => {
+                const sections = screen.getAllByTestId('program-section-form');
+                expect(sections[0]).toHaveAttribute('data-section-id', '202');
+            });
+        });
+
+        it('moves section down when Move Down button is clicked', async () => {
+            const initialData = createInitialData({
+                sections: [
+                    { id: 101, template: 1, order: 0, contents: [] } as ProgramSection,
+                    { id: 202, template: 1, order: 1, contents: [] } as ProgramSection,
+                ],
+            });
+
+            renderProgramForm({ initialData });
+
+            await waitFor(() => {
+                expect(screen.getAllByTestId('program-section-form')).toHaveLength(2);
+            });
+
+            fireEvent.click(screen.getByTestId('move-down-section-101'));
+
+            await waitFor(() => {
+                const sections = screen.getAllByTestId('program-section-form');
+                expect(sections[1]).toHaveAttribute('data-section-id', '101');
+            });
+        });
+
+        it('does nothing when section key is not found (covers idx === -1)', async () => {
+            const initialData = createInitialData({
+                sections: [{ id: 101, template: 1, order: 0, contents: [] } as ProgramSection],
+            });
+
+            renderProgramForm({ initialData });
+
+            await waitFor(() => {
+                expect(screen.getByTestId('program-section-form')).toBeInTheDocument();
+            });
+
+            fireEvent.click(screen.queryByTestId('move-up-section-101') || document.createElement('div'));
+
+            await waitFor(() => {
+                expect(screen.getAllByTestId('program-section-form')).toHaveLength(1);
             });
         });
     });

--- a/src/pages/admin/programs/components/program-form/ProgramForm.tsx
+++ b/src/pages/admin/programs/components/program-form/ProgramForm.tsx
@@ -312,7 +312,7 @@ export const ProgramForm = forwardRef<ProgramFormRef, ProgramFormProps>(
         const handleMoveUpSection = useCallback(
             (sectionKey: string) => {
                 const idx = sectionStatesRef.current.findIndex((s) => s.sectionKey === sectionKey);
-                if (idx === -1) return;
+                if (idx <= 0) return;
 
                 setFormState((prev) => {
                     const updatedSections = [...prev.sections];
@@ -339,7 +339,7 @@ export const ProgramForm = forwardRef<ProgramFormRef, ProgramFormProps>(
         const handleMoveDownSection = useCallback(
             (sectionKey: string) => {
                 const idx = sectionStatesRef.current.findIndex((s) => s.sectionKey === sectionKey);
-                if (idx === -1) return;
+                if (idx === -1 || idx >= sectionStatesRef.current.length - 1) return;
 
                 setFormState((prev) => {
                     const updatedSections = [...prev.sections];

--- a/src/pages/admin/programs/components/program-form/ProgramForm.tsx
+++ b/src/pages/admin/programs/components/program-form/ProgramForm.tsx
@@ -309,6 +309,46 @@ export const ProgramForm = forwardRef<ProgramFormRef, ProgramFormProps>(
             ],
         );
 
+        const handleMoveUpSection = useCallback(
+            (sectionKey: string) => {
+                const idx = sectionStatesRef.current.findIndex((s) => s.sectionKey === sectionKey);
+                if (idx === -1) return;
+
+                setFormState((prev) => {
+                    const updatedSections = [...prev.sections];
+                    [updatedSections[idx - 1], updatedSections[idx]] = [updatedSections[idx], updatedSections[idx - 1]];
+                    return { ...prev, sections: updatedSections };
+                });
+
+                setSectionStates((prev) => {
+                    const updated = [...prev];
+                    [updated[idx - 1], updated[idx]] = [updated[idx], updated[idx - 1]];
+                    return updated;
+                });
+            },
+            [setFormState],
+        );
+
+        const handleMoveDownSection = useCallback(
+            (sectionKey: string) => {
+                const idx = sectionStatesRef.current.findIndex((s) => s.sectionKey === sectionKey);
+                if (idx === -1) return;
+
+                setFormState((prev) => {
+                    const updatedSections = [...prev.sections];
+                    [updatedSections[idx + 1], updatedSections[idx]] = [updatedSections[idx], updatedSections[idx + 1]];
+                    return { ...prev, sections: updatedSections };
+                });
+
+                setSectionStates((prev) => {
+                    const updated = [...prev];
+                    [updated[idx + 1], updated[idx]] = [updated[idx], updated[idx + 1]];
+                    return updated;
+                });
+            },
+            [setFormState],
+        );
+
         const handleNameChange = useCallback(
             (e: React.ChangeEvent<HTMLTextAreaElement>) => {
                 setFormState((prev) => ({ ...prev, name: e.target.value }));
@@ -709,6 +749,10 @@ export const ProgramForm = forwardRef<ProgramFormRef, ProgramFormProps>(
                                             onDelete={() => handleDeleteSection(sectionKey)}
                                             isReplacingTemplate={sectionState.isReplacing}
                                             onRequestReplace={() => onReplaceSection?.(index)}
+                                            isFirstSection={index === 0}
+                                            isLastSection={index === formState.sections.length - 1}
+                                            onMoveUpSection={() => handleMoveUpSection(sectionKey)}
+                                            onMoveDownSection={() => handleMoveDownSection(sectionKey)}
                                         />
                                         <div className={styles['sections-divider']} />
                                     </React.Fragment>

--- a/src/pages/admin/programs/components/program-form/ProgramForm.tsx
+++ b/src/pages/admin/programs/components/program-form/ProgramForm.tsx
@@ -325,6 +325,13 @@ export const ProgramForm = forwardRef<ProgramFormRef, ProgramFormProps>(
                     [updated[idx - 1], updated[idx]] = [updated[idx], updated[idx - 1]];
                     return updated;
                 });
+
+                setTimeout(() => {
+                    document.querySelector(`[data-section-key="${sectionKey}"]`)?.scrollIntoView({
+                        behavior: 'smooth',
+                        block: 'start',
+                    });
+                }, 50);
             },
             [setFormState],
         );
@@ -345,6 +352,13 @@ export const ProgramForm = forwardRef<ProgramFormRef, ProgramFormProps>(
                     [updated[idx + 1], updated[idx]] = [updated[idx], updated[idx + 1]];
                     return updated;
                 });
+
+                setTimeout(() => {
+                    document.querySelector(`[data-section-key="${sectionKey}"]`)?.scrollIntoView({
+                        behavior: 'smooth',
+                        block: 'start',
+                    });
+                }, 50);
             },
             [setFormState],
         );
@@ -733,27 +747,29 @@ export const ProgramForm = forwardRef<ProgramFormRef, ProgramFormProps>(
                                 const { sectionKey } = sectionState;
                                 return (
                                     <React.Fragment key={sectionKey}>
-                                        <ProgramSectionForm
-                                            section={section}
-                                            onSave={() => handleSaveSection(sectionKey)}
-                                            onCancel={(options) => handleCancelSection(sectionKey, options)}
-                                            onSectionChange={(updatedSection) =>
-                                                handleSectionChange(sectionKey, updatedSection)
-                                            }
-                                            isDisabled={isSubmitting || isFormDisabled}
-                                            isNewSection={sectionState.isNew}
-                                            isSectionValid={sectionValidity[index] ?? false}
-                                            onEditStateChange={(isEditing) =>
-                                                handleSectionEditStateChange(sectionKey, isEditing)
-                                            }
-                                            onDelete={() => handleDeleteSection(sectionKey)}
-                                            isReplacingTemplate={sectionState.isReplacing}
-                                            onRequestReplace={() => onReplaceSection?.(index)}
-                                            isFirstSection={index === 0}
-                                            isLastSection={index === formState.sections.length - 1}
-                                            onMoveUpSection={() => handleMoveUpSection(sectionKey)}
-                                            onMoveDownSection={() => handleMoveDownSection(sectionKey)}
-                                        />
+                                        <div data-section-key={sectionKey}>
+                                            <ProgramSectionForm
+                                                section={section}
+                                                onSave={() => handleSaveSection(sectionKey)}
+                                                onCancel={(options) => handleCancelSection(sectionKey, options)}
+                                                onSectionChange={(updatedSection) =>
+                                                    handleSectionChange(sectionKey, updatedSection)
+                                                }
+                                                isDisabled={isSubmitting || isFormDisabled}
+                                                isNewSection={sectionState.isNew}
+                                                isSectionValid={sectionValidity[index] ?? false}
+                                                onEditStateChange={(isEditing) =>
+                                                    handleSectionEditStateChange(sectionKey, isEditing)
+                                                }
+                                                onDelete={() => handleDeleteSection(sectionKey)}
+                                                isReplacingTemplate={sectionState.isReplacing}
+                                                onRequestReplace={() => onReplaceSection?.(index)}
+                                                isFirstSection={index === 0}
+                                                isLastSection={index === formState.sections.length - 1}
+                                                onMoveUpSection={() => handleMoveUpSection(sectionKey)}
+                                                onMoveDownSection={() => handleMoveDownSection(sectionKey)}
+                                            />
+                                        </div>
                                         <div className={styles['sections-divider']} />
                                     </React.Fragment>
                                 );

--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.module.scss
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.module.scss
@@ -8,13 +8,18 @@
         opacity: 1;
         visibility: visible;
     }
+
+    &:hover .order-controls {
+        opacity: 1;
+        visibility: visible;
+    }
 }
 
 .actions-section {
     display: flex;
-    justify-content: end;
+    justify-content: space-between;
     height: 100px;
-    padding: 30px 30px 0 0;
+    padding: 30px 30px 0 30px;
 }
 
 .hover-buttons {
@@ -86,12 +91,48 @@
     }
 }
 
+.order-controls {
+    display: flex;
+    flex-direction: column;
+    opacity: 0;
+    visibility: hidden;
+    transition:
+        opacity 0.2s ease,
+        visibility 0.2s ease;
+}
+
+.up-button {
+    background-image: url('~@/assets/icons/chevron-up.svg');
+
+    &:hover,
+    &:active {
+        background-image: url('~@/assets/icons/chevron-up.svg');
+    }
+
+    &:hover {
+        opacity: 0.6;
+    }
+}
+
+.down-button {
+    background-image: url('~@/assets/icons/chevron-down.svg');
+
+    &:hover,
+    &:active {
+        background-image: url('~@/assets/icons/chevron-down.svg');
+    }
+
+    &:hover {
+        opacity: 0.6;
+    }
+}
+
 .content {
     width: 100%;
     display: flex;
     flex-direction: column;
 
-    > div {
+    >div {
         width: 100%;
     }
 }

--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.test.tsx
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.test.tsx
@@ -129,6 +129,10 @@ describe('ProgramSectionForm', () => {
             onSectionChange: jest.fn(),
             isNewSection: false,
             isSectionValid: false,
+            isFirstSection: false,
+            isLastSection: false,
+            onMoveUpSection: jest.fn(),
+            onMoveDownSection: jest.fn(),
         } as ProgramSectionFormProps;
     });
 
@@ -613,5 +617,61 @@ describe('ProgramSectionForm', () => {
         fireEvent.click(screen.getByLabelText('Replace section'));
 
         expect(onRequestReplace).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onMoveUpSection when Move Up button is clicked', () => {
+        const onMoveUpSection = jest.fn();
+
+        renderForm({
+            isFirstSection: false,
+            isLastSection: false,
+            onMoveUpSection,
+        });
+
+        fireEvent.click(screen.getByLabelText('Move up section'));
+
+        expect(onMoveUpSection).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onMoveDownSection when Move Down button is clicked', () => {
+        const onMoveDownSection = jest.fn();
+
+        renderForm({
+            isFirstSection: false,
+            isLastSection: false,
+            onMoveDownSection,
+        });
+
+        fireEvent.click(screen.getByLabelText('Move down section'));
+
+        expect(onMoveDownSection).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render Move Up button when section is first', () => {
+        renderForm({
+            isFirstSection: true,
+            isLastSection: false,
+        });
+
+        expect(screen.queryByLabelText('Move up section')).not.toBeInTheDocument();
+    });
+
+    it('does not render Move Down button when section is last', () => {
+        renderForm({
+            isFirstSection: false,
+            isLastSection: true,
+        });
+
+        expect(screen.queryByLabelText('Move down section')).not.toBeInTheDocument();
+    });
+
+    it('does not render move buttons when section is both first and last', () => {
+        renderForm({
+            isFirstSection: true,
+            isLastSection: true,
+        });
+
+        expect(screen.queryByLabelText('Move up section')).not.toBeInTheDocument();
+        expect(screen.queryByLabelText('Move down section')).not.toBeInTheDocument();
     });
 });

--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
@@ -468,8 +468,20 @@ export const ProgramSectionForm = ({
 
     return (
         <div className={styles.container}>
-            <div className={styles['actions-section']}>
-                {sectionMode === ProgramSectionMode.View && (
+            {sectionMode === ProgramSectionMode.View && (
+                <div className={styles['actions-section']}>
+                    <div className={styles['order-controls']}>
+                        <button
+                            type="button"
+                            className={`${styles['icon-button']} ${styles['up-button']}`}
+                            aria-label="Move up section"
+                        />
+                        <button
+                            type="button"
+                            className={`${styles['icon-button']} ${styles['down-button']}`}
+                            aria-label="Move down section"
+                        />
+                    </div>
                     <div className={styles['hover-buttons']}>
                         <button
                             type="button"
@@ -490,8 +502,8 @@ export const ProgramSectionForm = ({
                             aria-label="Replace section"
                         />
                     </div>
-                )}
-            </div>
+                </div>
+            )}
             <div className={styles.content}>
                 {editableSection || (
                     <p className={styles['template-info']}>

--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
@@ -24,6 +24,10 @@ export interface ProgramSectionFormProps {
     onDelete?: () => void;
     isReplacingTemplate?: boolean;
     onRequestReplace?: () => void;
+    isFirstSection?: boolean;
+    isLastSection?: boolean;
+    onMoveUpSection?: () => void;
+    onMoveDownSection?: () => void;
 }
 
 export interface SectionCancelOptions {
@@ -86,6 +90,10 @@ export const ProgramSectionForm = ({
     onDelete,
     isReplacingTemplate = false,
     onRequestReplace,
+    isFirstSection,
+    isLastSection,
+    onMoveDownSection,
+    onMoveUpSection,
 }: ProgramSectionFormProps) => {
     const [localSection, setLocalSection] = useState<ProgramSection>(section);
     const [originalSection, setOriginalSection] = useState<ProgramSection>(section);
@@ -466,21 +474,49 @@ export const ProgramSectionForm = ({
         },
     });
 
+    const isSingleSection = isLastSection && isFirstSection;
+
     return (
         <div className={styles.container}>
             {sectionMode === ProgramSectionMode.View && (
                 <div className={styles['actions-section']}>
                     <div className={styles['order-controls']}>
-                        <button
-                            type="button"
-                            className={`${styles['icon-button']} ${styles['up-button']}`}
-                            aria-label="Move up section"
-                        />
-                        <button
-                            type="button"
-                            className={`${styles['icon-button']} ${styles['down-button']}`}
-                            aria-label="Move down section"
-                        />
+                        {!isSingleSection && (
+                            <>
+                                {isFirstSection && (
+                                    <button
+                                        type="button"
+                                        onClick={onMoveDownSection}
+                                        className={`${styles['icon-button']} ${styles['down-button']}`}
+                                        aria-label="Move down section"
+                                    />
+                                )}
+                                {isLastSection && (
+                                    <button
+                                        type="button"
+                                        onClick={onMoveUpSection}
+                                        className={`${styles['icon-button']} ${styles['up-button']}`}
+                                        aria-label="Move up section"
+                                    />
+                                )}
+                                {!isLastSection && !isFirstSection && (
+                                    <>
+                                        <button
+                                            type="button"
+                                            onClick={onMoveUpSection}
+                                            className={`${styles['icon-button']} ${styles['up-button']}`}
+                                            aria-label="Move up section"
+                                        />
+                                        <button
+                                            type="button"
+                                            onClick={onMoveDownSection}
+                                            className={`${styles['icon-button']} ${styles['down-button']}`}
+                                            aria-label="Move down section"
+                                        />
+                                    </>
+                                )}
+                            </>
+                        )}
                     </div>
                     <div className={styles['hover-buttons']}>
                         <button

--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
@@ -474,49 +474,29 @@ export const ProgramSectionForm = ({
         },
     });
 
-    const isSingleSection = isLastSection && isFirstSection;
-
     return (
         <div className={styles.container}>
             {sectionMode === ProgramSectionMode.View && (
                 <div className={styles['actions-section']}>
                     <div className={styles['order-controls']}>
-                        {!isSingleSection && (
-                            <>
-                                {isFirstSection && (
-                                    <button
-                                        type="button"
-                                        onClick={onMoveDownSection}
-                                        className={`${styles['icon-button']} ${styles['down-button']}`}
-                                        aria-label="Move down section"
-                                    />
-                                )}
-                                {isLastSection && (
-                                    <button
-                                        type="button"
-                                        onClick={onMoveUpSection}
-                                        className={`${styles['icon-button']} ${styles['up-button']}`}
-                                        aria-label="Move up section"
-                                    />
-                                )}
-                                {!isLastSection && !isFirstSection && (
-                                    <>
-                                        <button
-                                            type="button"
-                                            onClick={onMoveUpSection}
-                                            className={`${styles['icon-button']} ${styles['up-button']}`}
-                                            aria-label="Move up section"
-                                        />
-                                        <button
-                                            type="button"
-                                            onClick={onMoveDownSection}
-                                            className={`${styles['icon-button']} ${styles['down-button']}`}
-                                            aria-label="Move down section"
-                                        />
-                                    </>
-                                )}
-                            </>
-                        )}
+                        <div className={styles['order-controls']}>
+                            {!isFirstSection && (
+                                <button
+                                    type="button"
+                                    onClick={onMoveUpSection}
+                                    className={`${styles['icon-button']} ${styles['up-button']}`}
+                                    aria-label="Move up section"
+                                />
+                            )}
+                            {!isLastSection && (
+                                <button
+                                    type="button"
+                                    onClick={onMoveDownSection}
+                                    className={`${styles['icon-button']} ${styles['down-button']}`}
+                                    aria-label="Move down section"
+                                />
+                            )}
+                        </div>
                     </div>
                     <div className={styles['hover-buttons']}>
                         <button

--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
@@ -24,10 +24,10 @@ export interface ProgramSectionFormProps {
     onDelete?: () => void;
     isReplacingTemplate?: boolean;
     onRequestReplace?: () => void;
-    isFirstSection?: boolean;
-    isLastSection?: boolean;
-    onMoveUpSection?: () => void;
-    onMoveDownSection?: () => void;
+    isFirstSection: boolean;
+    isLastSection: boolean;
+    onMoveUpSection: () => void;
+    onMoveDownSection: () => void;
 }
 
 export interface SectionCancelOptions {
@@ -90,8 +90,8 @@ export const ProgramSectionForm = ({
     onDelete,
     isReplacingTemplate = false,
     onRequestReplace,
-    isFirstSection,
-    isLastSection,
+    isFirstSection = false,
+    isLastSection = false,
     onMoveDownSection,
     onMoveUpSection,
 }: ProgramSectionFormProps) => {


### PR DESCRIPTION
## Github ticker

[Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1350)

## Description

This PR implements the ability for Admins to reorder sections within a single program using Up and Down arrow controls. Sections can be moved up or down in the list, and the system updates the order values sequentially.

## How it looks

https://github.com/user-attachments/assets/2461a36e-9c2f-4135-9ac9-975cf55a4c17

## Summary of change

1. Added isFirstSection and isLastSection props to ProgramSectionForm to control the display of move buttons.
2. Implemented handleMoveUpSection and handleMoveDownSection callbacks in ProgramForm.
3. Scroll logic ensures the moved section is visible after the action.
4. Updated unit tests to cover the new functionality.

## How to recreate changes

1. Open a single program page (existing or newly created).
2. Ensure there are at least 2 sections in the program.
3. Click Up/Down arrows on sections to reorder them.
4. Observe that:
    Sections move correctly in the list.
    Smooth scroll brings the active section into view.
7. “Зберегти як чернетку” and “Опублікувати” buttons are enabled.
8. Save or publish the program and confirm that the section order persists.

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [x]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add ability to reorder program sections with Move Up / Move Down controls; moved section becomes focusable and scrolls into view.
  * Move controls are hidden at boundaries (first/last) and shown on hover.

* **Tests**
  * Add tests for moving sections up/down and for no-op when a move target is unavailable.

* **Style**
  * Add styles for hover-visible order controls and up/down buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->