### PR TITLE
Fix/issue-1218,1071 Fix Button State and View Mode in Bank-Correspondent

### DIFF
--- a/src/pages/admin/donate/components/donate-page-content/DonatePageContent.tsx
+++ b/src/pages/admin/donate/components/donate-page-content/DonatePageContent.tsx
@@ -373,6 +373,13 @@ export const DonatePageContent = () => {
                             onDelete={handleDeleteBankDetails}
                             isAddButtonDisabled={isChildEditing}
                             isParentAddFormVisible={isCorrespondentBankFormVisible}
+                            isPublishDisabled={isChildEditing || isCorrespondentBankFormVisible}
+                            onAddFormVisibilityChange={(isVisible) => {
+                                if (!isVisible) {
+                                    setIsChildEditing(false);
+                                    setIsCorrespondentBankFormVisible(false);
+                                }
+                            }}
                         >
                             {config.withCorrespondentBanks ? renderCorrespondentBanks : () => null}
                         </GenericDetails>

--- a/src/pages/admin/donate/components/generic-details/GenericDetails.test.tsx
+++ b/src/pages/admin/donate/components/generic-details/GenericDetails.test.tsx
@@ -341,4 +341,19 @@ describe('GenericDetails - Additional Coverage', () => {
             expect(onLocalDelete).toHaveBeenCalledWith(0);
         });
     });
+
+    it('add button after cancel in child edit mode', async () => {
+        render(
+            <GenericDetails
+                {...defaultProps}
+                items={[{ id: 1, name: 'Item 1' }]}
+                isChildForm={true}
+                FormComponent={MockFormWithModeChange}
+            />,
+        );
+        fireEvent.click(screen.getByText('Edit Item 1'));
+        expect(screen.getByText('Add New').closest('button')).toBeDisabled();
+        fireEvent.click(screen.getByText('View Item 1'));
+        expect(screen.getByText('Add New').closest('button')).not.toBeDisabled();
+    });
 });

--- a/src/pages/admin/donate/components/generic-details/GenericDetails.tsx
+++ b/src/pages/admin/donate/components/generic-details/GenericDetails.tsx
@@ -39,6 +39,7 @@ export interface GenericDetailsProps<T extends FieldValues> {
     onLocalSubmit?: (data: T) => void;
     onLocalUpdate?: (index: number, data: T) => void;
     onLocalDelete?: (index: number) => void;
+    isPublishDisabled?: boolean;
 }
 
 export function GenericDetails<T extends { id: number } & FieldValues>({
@@ -64,6 +65,7 @@ export function GenericDetails<T extends { id: number } & FieldValues>({
     onLocalSubmit,
     onLocalUpdate,
     onLocalDelete,
+    isPublishDisabled = false,
 }: Readonly<GenericDetailsProps<T>>) {
     const addformRef = useRef<GenericFormRef>(null);
     const [isAddFormVisible, setIsAddFormVisible] = useState(false);
@@ -206,7 +208,10 @@ export function GenericDetails<T extends { id: number } & FieldValues>({
                                         isChildForm={isChildForm}
                                         isParentCreating={isParentCreating}
                                         isDisabled={isDisabled}
-                                        onModeChange={(mode: GenericFormMode) => handleItemModeChange(item.id, mode)}
+                                        isPublishDisabled={isPublishDisabled}
+                                        onModeChange={(mode: GenericFormMode) =>
+                                            handleItemModeChange(item.id || index, mode)
+                                        }
                                     >
                                         {(formProps) => (
                                             <>
@@ -232,6 +237,7 @@ export function GenericDetails<T extends { id: number } & FieldValues>({
                             isChildForm={isChildForm}
                             isParentCreating={isParentCreating}
                             isDisabled={isDisabled}
+                            isPublishDisabled={isPublishDisabled}
                         >
                             {(formProps) => (
                                 <>

--- a/src/pages/admin/donate/components/generic-form/GenericForm.tsx
+++ b/src/pages/admin/donate/components/generic-form/GenericForm.tsx
@@ -38,6 +38,7 @@ export interface GenericFormProps<T extends FieldValues> {
     isParentCreating?: boolean;
     isDisabled?: boolean;
     onModeChange?: (mode: GenericFormMode) => void;
+    isPublishDisabled?: boolean;
 }
 
 export enum GenericFormMode {
@@ -80,6 +81,7 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
                 children,
                 isParentCreating = false,
                 onModeChange,
+                isPublishDisabled = false,
             },
             ref,
         ) => {
@@ -245,6 +247,7 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
                             setErrors({});
                             setTouchedFields(new Set());
                             setMode(GenericFormMode.View);
+                            if (isChildForm) setIsExpanded(false);
                         },
                     });
                 } else {
@@ -252,6 +255,7 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
                     setErrors({});
                     setTouchedFields(new Set());
                     setMode(GenericFormMode.View);
+                    if (isChildForm) setIsExpanded(false);
                 }
             };
 
@@ -335,7 +339,8 @@ export function createGenericForm<T extends { id?: number }>(fields: GenericForm
                 hasEmptyRequiredFields ||
                 !isChanged() ||
                 Object.values(errors).some((e) => e !== undefined) ||
-                (isDisabled && !isCorrespondentInParentCreation);
+                (isDisabled && !isCorrespondentInParentCreation) ||
+                (isPublishDisabled && !isChildForm);
 
             const handlePublishClick = () => {
                 if (isCorrespondentInParentCreation) {


### PR DESCRIPTION
## Github ticker

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1071)
* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1218)

## Description

Bug 1: The "Опублікувати" button for a new USD/EUR bank remained active while a bank-correspondent was unsaved or in edit/create mode.

Bug 2: After clicking "Відмінити" on a bank-correspondent in edit mode, the form was staying expanded showing all field details instead of collapsing back to show only the bank name.

## How it looks

https://github.com/user-attachments/assets/75ded7b4-59b2-45a6-8793-f84aa5eb6a5d

## How to recreate changes

- Go to Admin panel, open "Донати" page, USD/EUR tab
- Click Edit on any bank-correspondent and click "Відмінити" — form should collapse
- Click "Додати нові реквізити", fill fields, open bank-correspondent form — "Опублікувати" button should be disabled


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form editing experience by better managing state transitions, preventing concurrent edits when switching between edit and view modes in child forms.

* **Tests**
  * Added test coverage for edit mode transitions in child forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->