### PR TITLE
Feat/issue-733: Text input validation for Template Frame 633435

### DIFF
--- a/src/components/common/program-section-templates/single-title-quintuple-description/SingleTitleQuintupleDescription.test.tsx
+++ b/src/components/common/program-section-templates/single-title-quintuple-description/SingleTitleQuintupleDescription.test.tsx
@@ -41,6 +41,13 @@ jest.mock('@/const/admin/programs', () => ({
     },
 }));
 
+jest.mock('@/validation/admin/program-schema/program-schema', () => ({
+    PROGRAM_SECTION_VALIDATION_FUNCTIONS: {
+        validateSectionTitle: jest.fn(() => undefined),
+        validateSectionDescription: jest.fn(() => undefined),
+    },
+}));
+
 const setup = (props: React.ComponentProps<typeof SingleTitleQuintupleDescription> = {}) => {
     mockDescProps.mockClear();
     return render(<SingleTitleQuintupleDescription {...props} />);
@@ -50,7 +57,7 @@ const getRoot = (container: HTMLElement) => container.firstElementChild as HTMLE
 const getPreviewTexts = (container: HTMLElement) =>
     Array.from(container.querySelectorAll('p')).map((p) => p.textContent);
 
-const getDescCallIds = () => mockDescProps.mock.calls.map((call: any[]) => call[0]?.id);
+const getDescCallIds = () => mockDescProps.mock.calls.slice(0, 5).map((call: any[]) => call[0]?.id);
 
 describe('SingleTitleQuintupleDescription', () => {
     describe('Preview', () => {

--- a/src/components/common/program-section-templates/single-title-quintuple-description/SingleTitleQuintupleDescription.tsx
+++ b/src/components/common/program-section-templates/single-title-quintuple-description/SingleTitleQuintupleDescription.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames';
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState, useEffect } from 'react';
 import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
 import { TextAreaWithCharacterLimitGroup } from '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup';
 import { PROGRAMS_TEXT, SINGLE_TITLE_QUINTUPLE_DESCRIPTION_CONFIG } from '@/const/admin/programs';
@@ -8,6 +8,7 @@ import { ContentType } from '@/types/common/programs';
 import { getProgramSectionTemplateMaxLength } from '@/utils/functions/program-section-template-validation/programSectionTemplateValidation';
 import baseStyles from './SingleTitleQuintupleDescription.module.scss';
 import previewStyles from './SingleTitleQuintupleDescription-preview.module.scss';
+import { PROGRAM_SECTION_VALIDATION_FUNCTIONS } from '@/validation/admin/program-schema/program-schema';
 
 export interface SingleTitleQuintupleDescriptionProps {
     title?: string;
@@ -16,6 +17,7 @@ export interface SingleTitleQuintupleDescriptionProps {
     onTitleChange?: (value: string) => void;
     onDescriptionsChange?: (index: number, value: string) => void;
     className?: string;
+    validationResetKey?: number;
 }
 
 const DESCRIPTION_LAYOUT = {
@@ -31,6 +33,7 @@ export const SingleTitleQuintupleDescription = ({
     onTitleChange,
     onDescriptionsChange,
     className,
+    validationResetKey,
 }: SingleTitleQuintupleDescriptionProps) => {
     const descriptionsCount = SINGLE_TITLE_QUINTUPLE_DESCRIPTION_CONFIG.descriptionsCount;
 
@@ -59,6 +62,44 @@ export const SingleTitleQuintupleDescription = ({
         className,
     );
 
+    const [errors, setErrors] = useState<{
+        title?: string;
+        descriptions: Record<number, string | undefined>;
+    }>({
+        title: undefined,
+        descriptions: {},
+    });
+
+    useEffect(() => {
+        setErrors({
+            title: undefined,
+            descriptions: {},
+        });
+    }, [validationResetKey]);
+
+    const handleTitleBlur = useCallback(() => {
+        const error = PROGRAM_SECTION_VALIDATION_FUNCTIONS.validateSectionTitle(title, true, TEMPLATE);
+        setErrors((prev) => ({ ...prev, title: error }));
+    }, [title]);
+
+    const handleDescriptionBlur = useCallback(
+        (index: number) => {
+            const error = PROGRAM_SECTION_VALIDATION_FUNCTIONS.validateSectionDescription(
+                normalizedDescriptions[index],
+                true,
+                TEMPLATE,
+            );
+            setErrors((prev) => ({
+                ...prev,
+                descriptions: {
+                    ...prev.descriptions,
+                    [index]: error,
+                },
+            }));
+        },
+        [normalizedDescriptions],
+    );
+
     return (
         <div className={rootClassName}>
             {mode === ProgramSectionMode.Edit || mode === ProgramSectionMode.View ? (
@@ -74,6 +115,8 @@ export const SingleTitleQuintupleDescription = ({
                             onChange={(e) => onTitleChange?.(e.target.value)}
                             maxLength={titleMaxLength}
                             placeholder={PROGRAMS_TEXT.SECTION.FORM.TITLE.PLACEHOLDER}
+                            error={errors.title}
+                            onBlur={handleTitleBlur}
                         />
                     </div>
 
@@ -89,6 +132,8 @@ export const SingleTitleQuintupleDescription = ({
                                 onChange={(e) => onDescriptionsChange?.(index, e.target.value)}
                                 maxLength={descriptionMaxLength}
                                 rows={4}
+                                error={errors.descriptions[index]}
+                                onBlur={() => handleDescriptionBlur(index)}
                             />
                         </div>
                     ))}


### PR DESCRIPTION
## Github ticker

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/733)

## Description

The main goal of this PR to show a real-time field-level validation on blur for [Frame 633435](https://www.figma.com/design/mZTSCb4NVC31facfhy6Gu1/Victory-Center-Admin-Panel?node-id=6200-9040&t=OCFCSGXqIMyzWyUd-4), so users are informed about errors (empty fields, insufficient character count) as soon as they leave a field.

## How it looks


https://github.com/user-attachments/assets/142cb031-ab31-4f9a-8e68-66243d91f19c


## Summary of change

Changes:

1. Added errors state to track validation errors for title and each description independently
2. Added handleTitleBlur and handleDescriptionBlur handlers that run validation on field blur and update error state
3. Added validationResetKey prop - when it changes, all errors are cleared

## How to recreate changes

1. Open any program in the admin panel and navigate to the section editor.
2. Add a new section with the SingleTitleQuintupleDescription template or choose to edit an existing one.
3. Leave the title or description fields empty and click away - an error should appear below the input field.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time validation with error feedback for title and description fields in program section templates
  * Validation triggers when users leave input fields
  * Error messages display inline to guide users during data entry
  * Added validation reset capability for form management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->