### PR TITLE
Feature/issue-1427: Add Public View Option for Template 633433 + Refactor ProgramSectionForm

### DIFF
--- a/src/components/public/detailed-program-section/DetailedProgramSection.test.tsx
+++ b/src/components/public/detailed-program-section/DetailedProgramSection.test.tsx
@@ -51,6 +51,7 @@ describe('DetailedProgramSection', () => {
                 title: 'Test Title',
                 description: 'Test Description',
                 images: [],
+                descriptionAuthorPairs: [],
             },
             mode: ProgramSectionMode.Published,
         });
@@ -82,6 +83,7 @@ describe('DetailedProgramSection', () => {
                 title: '',
                 description: 'Test Description',
                 images: [],
+                descriptionAuthorPairs: [],
             },
             mode: ProgramSectionMode.Published,
         });
@@ -112,6 +114,7 @@ describe('DetailedProgramSection', () => {
                 title: 'Test Title',
                 description: '',
                 images: [],
+                descriptionAuthorPairs: [],
             },
             mode: ProgramSectionMode.Published,
         });
@@ -171,6 +174,7 @@ describe('DetailedProgramSection', () => {
                     { id: 12, url: 'img2.jpg', mimeType: 'image/jpeg' },
                     { id: 10, url: 'img3.jpg', mimeType: 'image/jpeg' },
                 ],
+                descriptionAuthorPairs: [],
             },
             mode: ProgramSectionMode.Published,
         });
@@ -203,6 +207,7 @@ describe('DetailedProgramSection', () => {
                 title: 'Title',
                 description: 'Desc',
                 images: [null],
+                descriptionAuthorPairs: [],
             },
             mode: ProgramSectionMode.Published,
         });
@@ -224,6 +229,80 @@ describe('DetailedProgramSection', () => {
                 title: '',
                 description: '',
                 images: [],
+                descriptionAuthorPairs: [],
+            },
+            mode: ProgramSectionMode.Published,
+        });
+    });
+
+    it('extracts description-author pairs by group index and passes them sorted', () => {
+        const section: ProgramSection = {
+            id: 1,
+            template: ProgramSectionTemplate.SingleTitleDescriptionAuthorPairs,
+            contents: [
+                {
+                    id: 1,
+                    contentType: ContentType.Description,
+                    description: 'Desc 2',
+                    order: 5,
+                    groupIndex: 2,
+                    title: null,
+                    image: null,
+                },
+                {
+                    id: 2,
+                    contentType: ContentType.Author,
+                    author: 'Author 2',
+                    order: 6,
+                    groupIndex: 2,
+                    title: null,
+                    description: null,
+                    image: null,
+                },
+                {
+                    id: 3,
+                    contentType: ContentType.Author,
+                    author: 'Author 1',
+                    order: 3,
+                    groupIndex: 1,
+                    title: null,
+                    description: null,
+                    image: null,
+                },
+                {
+                    id: 4,
+                    contentType: ContentType.Description,
+                    description: null,
+                    order: 2,
+                    groupIndex: 1,
+                    title: null,
+                    image: null,
+                },
+                {
+                    id: 5,
+                    contentType: ContentType.Description,
+                    description: 'Ignored no group',
+                    order: 7,
+                    groupIndex: null,
+                    title: null,
+                    image: null,
+                },
+            ],
+            order: 0,
+        };
+
+        render(<DetailedProgramSection section={section} />);
+
+        expect(mockRenderProgramSection).toHaveBeenCalledWith({
+            templateId: ProgramSectionTemplate.SingleTitleDescriptionAuthorPairs,
+            data: {
+                title: '',
+                description: 'Desc 2',
+                images: [],
+                descriptionAuthorPairs: [
+                    { description: '', author: 'Author 1' },
+                    { description: 'Desc 2', author: 'Author 2' },
+                ],
             },
             mode: ProgramSectionMode.Published,
         });

--- a/src/components/public/detailed-program-section/DetailedProgramSection.tsx
+++ b/src/components/public/detailed-program-section/DetailedProgramSection.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ProgramSection, ProgramSectionContent, ProgramSectionMode } from '@/types/common/program-sections';
 import { ContentType } from '@/types/common/programs';
 import { renderProgramSection } from '@/utils/functions/render-program-section';
+import { getDescriptionAuthorPairsByGroup } from '@/utils/functions/mappers/public/program/get-grouped-program-section-content-pairs';
 import styles from './DetailedProgramSection.module.scss';
 
 export interface DetailedProgramSectionProps {
@@ -16,6 +17,11 @@ export const DetailedProgramSection: React.FC<DetailedProgramSectionProps> = ({ 
     const titleContent = getContentByType(section.contents, ContentType.Title);
     const descriptionContent = getContentByType(section.contents, ContentType.Description);
 
+    const descriptionAuthorPairs = getDescriptionAuthorPairsByGroup(section.contents).map((pair) => ({
+        description: pair.description,
+        author: pair.author,
+    }));
+
     const imageContents = section.contents
         .filter((c) => c.contentType === ContentType.Image)
         .sort((a, b) => a.order - b.order)
@@ -27,6 +33,7 @@ export const DetailedProgramSection: React.FC<DetailedProgramSectionProps> = ({ 
             title: titleContent?.title || '',
             description: descriptionContent?.description || '',
             images: imageContents,
+            descriptionAuthorPairs,
         },
         mode: ProgramSectionMode.Published,
     });

--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.test.tsx
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.test.tsx
@@ -456,7 +456,7 @@ describe('ProgramSectionForm', () => {
             expect(onSectionChange).not.toHaveBeenCalled();
         });
 
-        it('adds a pair (groupIndex is pairs.length) and schedules focus on next textarea id', () => {
+        it('adds a pair after normalizing grouped indexes and schedules focus on next textarea id', () => {
             jest.useFakeTimers();
 
             const section = makePairsSection([
@@ -494,6 +494,23 @@ describe('ProgramSectionForm', () => {
             expect((newDesc as any)?.description).toBe('');
             expect(newAuth?.groupIndex).toBe(2);
             expect((newAuth as any)?.author).toBe('');
+
+            const descGroups = updated.contents
+                .filter((c: any) => c.contentType === ContentType.Description)
+                .map((c: any) => c.groupIndex)
+                .filter((g: any) => g !== null && g !== undefined)
+                .sort((a: number, b: number) => a - b);
+
+            const authorGroups = updated.contents
+                .filter((c: any) => c.contentType === ContentType.Author)
+                .map((c: any) => c.groupIndex)
+                .filter((g: any) => g !== null && g !== undefined)
+                .sort((a: number, b: number) => a - b);
+
+            expect(descGroups).toEqual([0, 1, 2]);
+            expect(authorGroups).toEqual([0, 1, 2]);
+            expect((getContentByGroupAndType(updated, 1, ContentType.Description) as any)?.description).toBe('D2');
+            expect((getContentByGroupAndType(updated, 1, ContentType.Author) as any)?.author).toBe('A2');
 
             expect(focusMock).toHaveBeenCalledTimes(1);
 

--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
@@ -344,20 +344,25 @@ export const ProgramSectionForm = ({
         const prev = localSectionRef.current;
         if (prev.template !== ProgramSectionTemplate.SingleTitleDescriptionAuthorPairs) return;
 
-        const pairs = getDescriptionAuthorPairsByGroup(prev.contents);
+        const normalizedContents = normalizeGroupedContentsGroupIndexes(prev.contents, [
+            ContentType.Description,
+            ContentType.Author,
+        ]);
+
+        const pairs = getDescriptionAuthorPairsByGroup(normalizedContents);
         const maxGroupCount = getProgramSectionTemplateMaxGroupCount(prev.template);
         if (pairs.length >= maxGroupCount) return;
 
         const nextGroupIndex = pairs.length;
 
-        const maxOrder = prev.contents.length ? Math.max(...prev.contents.map((c) => c.order)) : -1;
+        const maxOrder = normalizedContents.length ? Math.max(...normalizedContents.map((c) => c.order)) : -1;
         const descriptionOrder = maxOrder + 1;
         const authorOrder = maxOrder + 2;
 
         const newSection: ProgramSection = {
             ...prev,
             contents: [
-                ...prev.contents,
+                ...normalizedContents,
                 {
                     contentType: ContentType.Description,
                     order: descriptionOrder,

--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
@@ -15,6 +15,7 @@ import {
     getProgramSectionTemplateMaxGroupCount,
     normalizeGroupedContentsGroupIndexes,
 } from '@/utils/functions/program-section-template-validation/programSectionTemplateValidation';
+import { getDescriptionAuthorPairsByGroup } from '@/utils/functions/mappers/public/program/get-grouped-program-section-content-pairs';
 
 export interface ProgramSectionFormProps {
     section: ProgramSection;
@@ -46,38 +47,6 @@ const getDescriptionsInOrder = (contents: ProgramSectionContent[]) => {
     return contents.filter((c) => c.contentType === ContentType.Description).sort((a, b) => a.order - b.order);
 };
 
-const getDescriptionAuthorPairs = (contents: ProgramSectionContent[]) => {
-    const map = new Map<number, { description: string; author: string }>();
-
-    for (const content of contents) {
-        if (content.groupIndex === null || content.groupIndex === undefined) continue;
-
-        const groupIndex = content.groupIndex;
-
-        if (!map.has(groupIndex)) {
-            map.set(groupIndex, { description: '', author: '' });
-        }
-
-        const entry = map.get(groupIndex)!;
-
-        if (content.contentType === ContentType.Description) {
-            entry.description = (content as any).description || '';
-        }
-
-        if (content.contentType === ContentType.Author) {
-            entry.author = (content as any).author || '';
-        }
-    }
-
-    return Array.from(map.entries())
-        .sort((a, b) => a[0] - b[0])
-        .map(([groupIndex, value]) => ({
-            groupIndex,
-            description: value.description,
-            author: value.author,
-        }));
-};
-
 const ensureTitleContentAndOnePair = (section: ProgramSection): ProgramSection => {
     if (section.template !== ProgramSectionTemplate.SingleTitleDescriptionAuthorPairs) return section;
 
@@ -101,7 +70,7 @@ const ensureTitleContentAndOnePair = (section: ProgramSection): ProgramSection =
         hasChanges = true;
     }
 
-    const pairs = getDescriptionAuthorPairs(updatedContents);
+    const pairs = getDescriptionAuthorPairsByGroup(updatedContents);
     if (pairs.length > 0) {
         return hasChanges ? { ...section, contents: updatedContents } : section;
     }
@@ -203,7 +172,7 @@ export const ProgramSectionForm = ({
     const isDescriptionAuthorPairsTemplate =
         section.template === ProgramSectionTemplate.SingleTitleDescriptionAuthorPairs;
 
-    const orderedPairs = getDescriptionAuthorPairs(localSection.contents);
+    const orderedPairs = getDescriptionAuthorPairsByGroup(localSection.contents);
 
     const descriptionAuthorPairs = orderedPairs.map((p) => ({
         description: p.description,
@@ -334,7 +303,7 @@ export const ProgramSectionForm = ({
     const handlePairFieldChange = useCallback(
         (index: number, value: string, field: ContentType.Description | ContentType.Author) => {
             const prev = localSectionRef.current;
-            const pairs = getDescriptionAuthorPairs(prev.contents);
+            const pairs = getDescriptionAuthorPairsByGroup(prev.contents);
             const target = pairs[index];
             if (!target) return;
 
@@ -375,7 +344,7 @@ export const ProgramSectionForm = ({
         const prev = localSectionRef.current;
         if (prev.template !== ProgramSectionTemplate.SingleTitleDescriptionAuthorPairs) return;
 
-        const pairs = getDescriptionAuthorPairs(prev.contents);
+        const pairs = getDescriptionAuthorPairsByGroup(prev.contents);
         const maxGroupCount = getProgramSectionTemplateMaxGroupCount(prev.template);
         if (pairs.length >= maxGroupCount) return;
 
@@ -420,7 +389,7 @@ export const ProgramSectionForm = ({
             const prev = localSectionRef.current;
             if (prev.template !== ProgramSectionTemplate.SingleTitleDescriptionAuthorPairs) return;
 
-            const pairs = getDescriptionAuthorPairs(prev.contents);
+            const pairs = getDescriptionAuthorPairsByGroup(prev.contents);
             if (pairs.length <= 1) return;
 
             const target = pairs[index];

--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
@@ -377,9 +377,8 @@ export const ProgramSectionForm = ({
         setLocalSection(newSection);
         emitSectionChange(newSection);
 
-        const nextIndex = pairs.length;
         setTimeout(() => {
-            const element = document.getElementById(`pair-description-${nextIndex}`) as HTMLTextAreaElement | null;
+            const element = document.getElementById(`pair-description-${nextGroupIndex}`) as HTMLTextAreaElement | null;
             element?.focus();
         }, 0);
     }, [emitSectionChange]);

--- a/src/utils/functions/mappers/public/program/get-grouped-program-section-content-pairs.test.ts
+++ b/src/utils/functions/mappers/public/program/get-grouped-program-section-content-pairs.test.ts
@@ -1,0 +1,107 @@
+import { ProgramSectionContent } from '@/types/common/program-sections';
+import { ContentType } from '@/types/common/programs';
+import {
+    getDescriptionAuthorPairsByGroup,
+    getGroupedProgramSectionTextPairs,
+} from './get-grouped-program-section-content-pairs';
+
+const makeContent = (overrides: Partial<ProgramSectionContent>): ProgramSectionContent =>
+    ({
+        contentType: ContentType.Description,
+        order: 0,
+        title: null,
+        description: null,
+        author: null,
+        image: null,
+        ...overrides,
+    }) as ProgramSectionContent;
+
+describe('get-grouped-program-section-content-pairs', () => {
+    describe('getGroupedProgramSectionTextPairs', () => {
+        it('returns an empty array when there are no grouped items', () => {
+            const contents: ProgramSectionContent[] = [
+                makeContent({ contentType: ContentType.Description, groupIndex: null, description: 'D' }),
+                makeContent({ contentType: ContentType.Author, groupIndex: undefined, author: 'A' }),
+            ];
+
+            const result = getGroupedProgramSectionTextPairs(contents, ContentType.Description, ContentType.Author);
+
+            expect(result).toEqual([]);
+        });
+
+        it('groups by groupIndex, sorts groups, and fills missing values with empty strings', () => {
+            const contents: ProgramSectionContent[] = [
+                makeContent({ contentType: ContentType.Description, groupIndex: 2, description: 'Desc 2' }),
+                makeContent({ contentType: ContentType.Author, groupIndex: 2, author: 'Author 2' }),
+                makeContent({ contentType: ContentType.Author, groupIndex: 1, author: 'Author 1' }),
+                makeContent({ contentType: ContentType.Description, groupIndex: 1, description: null }),
+                makeContent({ contentType: ContentType.Description, groupIndex: null, description: 'Ignored' }),
+            ];
+
+            const result = getGroupedProgramSectionTextPairs(contents, ContentType.Description, ContentType.Author);
+
+            expect(result).toEqual([
+                { groupIndex: 1, left: '', right: 'Author 1' },
+                { groupIndex: 2, left: 'Desc 2', right: 'Author 2' },
+            ]);
+        });
+
+        it('reads title values when Title is requested as leftType', () => {
+            const contents: ProgramSectionContent[] = [
+                makeContent({ contentType: ContentType.Title, groupIndex: 0, title: 'TITLE' }),
+                makeContent({ contentType: ContentType.Description, groupIndex: 0, description: 'DESC' }),
+            ];
+
+            const result = getGroupedProgramSectionTextPairs(contents, ContentType.Title, ContentType.Description);
+
+            expect(result).toEqual([{ groupIndex: 0, left: 'TITLE', right: 'DESC' }]);
+        });
+
+        it('falls back to empty string for null title and null author values', () => {
+            const contents: ProgramSectionContent[] = [
+                makeContent({ contentType: ContentType.Title, groupIndex: 0, title: null }),
+                makeContent({ contentType: ContentType.Author, groupIndex: 0, author: null }),
+            ];
+
+            const result = getGroupedProgramSectionTextPairs(contents, ContentType.Title, ContentType.Author);
+
+            expect(result).toEqual([{ groupIndex: 0, left: '', right: '' }]);
+        });
+
+        it('returns empty string for unknown text content type (default switch branch)', () => {
+            const unknownType = 999 as ContentType;
+
+            const contents: ProgramSectionContent[] = [
+                makeContent({
+                    contentType: unknownType,
+                    groupIndex: 0,
+                    title: 'TITLE',
+                    description: 'DESC',
+                    author: 'AUTHOR',
+                } as any),
+            ];
+
+            const result = getGroupedProgramSectionTextPairs(contents, unknownType, ContentType.Description);
+
+            expect(result).toEqual([{ groupIndex: 0, left: '', right: '' }]);
+        });
+    });
+
+    describe('getDescriptionAuthorPairsByGroup', () => {
+        it('maps grouped text pairs into description-author shape', () => {
+            const contents: ProgramSectionContent[] = [
+                makeContent({ contentType: ContentType.Description, groupIndex: 1, description: 'D1' }),
+                makeContent({ contentType: ContentType.Author, groupIndex: 1, author: 'A1' }),
+                makeContent({ contentType: ContentType.Description, groupIndex: 0, description: 'D0' }),
+                makeContent({ contentType: ContentType.Author, groupIndex: 0, author: 'A0' }),
+            ];
+
+            const result = getDescriptionAuthorPairsByGroup(contents);
+
+            expect(result).toEqual([
+                { groupIndex: 0, description: 'D0', author: 'A0' },
+                { groupIndex: 1, description: 'D1', author: 'A1' },
+            ]);
+        });
+    });
+});

--- a/src/utils/functions/mappers/public/program/get-grouped-program-section-content-pairs.test.ts
+++ b/src/utils/functions/mappers/public/program/get-grouped-program-section-content-pairs.test.ts
@@ -2,7 +2,7 @@ import { ProgramSectionContent } from '@/types/common/program-sections';
 import { ContentType } from '@/types/common/programs';
 import {
     getDescriptionAuthorPairsByGroup,
-    getGroupedProgramSectionTextPairs,
+    getGroupedProgramSectionValuesByGroup,
 } from './get-grouped-program-section-content-pairs';
 
 const makeContent = (overrides: Partial<ProgramSectionContent>): ProgramSectionContent =>
@@ -17,19 +17,85 @@ const makeContent = (overrides: Partial<ProgramSectionContent>): ProgramSectionC
     }) as ProgramSectionContent;
 
 describe('get-grouped-program-section-content-pairs', () => {
-    describe('getGroupedProgramSectionTextPairs', () => {
-        it('returns an empty array when there are no grouped items', () => {
+    describe('getGroupedProgramSectionValuesByGroup', () => {
+        it('supports 4 content types per group and keeps sorted group order', () => {
+            const unknownType = 999 as ContentType;
+            const contents: ProgramSectionContent[] = [
+                makeContent({ contentType: ContentType.Author, groupIndex: 2, author: 'A2' }),
+                makeContent({ contentType: ContentType.Title, groupIndex: 2, title: 'T2' }),
+                makeContent({ contentType: ContentType.Description, groupIndex: 2, description: 'D2' }),
+                makeContent({ contentType: unknownType, groupIndex: 2 } as any),
+                makeContent({ contentType: ContentType.Title, groupIndex: 0, title: 'T0' }),
+                makeContent({ contentType: ContentType.Description, groupIndex: 0, description: 'D0' }),
+                makeContent({ contentType: ContentType.Author, groupIndex: 0, author: null }),
+                makeContent({ contentType: unknownType, groupIndex: 0 } as any),
+            ];
+
+            const result = getGroupedProgramSectionValuesByGroup(contents, [
+                ContentType.Title,
+                ContentType.Description,
+                ContentType.Author,
+                unknownType,
+            ]);
+
+            expect(result).toEqual([
+                {
+                    groupIndex: 0,
+                    byType: {
+                        [ContentType.Title]: 'T0',
+                        [ContentType.Description]: 'D0',
+                        [ContentType.Author]: '',
+                        [unknownType]: '',
+                    },
+                },
+                {
+                    groupIndex: 2,
+                    byType: {
+                        [ContentType.Title]: 'T2',
+                        [ContentType.Description]: 'D2',
+                        [ContentType.Author]: 'A2',
+                        [unknownType]: '',
+                    },
+                },
+            ]);
+        });
+
+        it('returns empty array when requested types are empty', () => {
+            const contents: ProgramSectionContent[] = [
+                makeContent({ contentType: ContentType.Title, groupIndex: 0, title: 'T0' }),
+            ];
+
+            const result = getGroupedProgramSectionValuesByGroup(contents, []);
+
+            expect(result).toEqual([]);
+        });
+
+        it('does not create group when a group contains only unrequested content types', () => {
+            const contents: ProgramSectionContent[] = [
+                makeContent({ contentType: ContentType.Title, groupIndex: 0, title: 'T0' }),
+                makeContent({ contentType: ContentType.Author, groupIndex: 1, author: 'A1' }),
+            ];
+
+            const result = getGroupedProgramSectionValuesByGroup(contents, [ContentType.Description]);
+
+            expect(result).toEqual([]);
+        });
+
+        it('returns an empty array when there are no grouped items for requested types', () => {
             const contents: ProgramSectionContent[] = [
                 makeContent({ contentType: ContentType.Description, groupIndex: null, description: 'D' }),
                 makeContent({ contentType: ContentType.Author, groupIndex: undefined, author: 'A' }),
             ];
 
-            const result = getGroupedProgramSectionTextPairs(contents, ContentType.Description, ContentType.Author);
+            const result = getGroupedProgramSectionValuesByGroup(contents, [
+                ContentType.Description,
+                ContentType.Author,
+            ]);
 
             expect(result).toEqual([]);
         });
 
-        it('groups by groupIndex, sorts groups, and fills missing values with empty strings', () => {
+        it('fills missing values with empty strings for requested types', () => {
             const contents: ProgramSectionContent[] = [
                 makeContent({ contentType: ContentType.Description, groupIndex: 2, description: 'Desc 2' }),
                 makeContent({ contentType: ContentType.Author, groupIndex: 2, author: 'Author 2' }),
@@ -38,23 +104,49 @@ describe('get-grouped-program-section-content-pairs', () => {
                 makeContent({ contentType: ContentType.Description, groupIndex: null, description: 'Ignored' }),
             ];
 
-            const result = getGroupedProgramSectionTextPairs(contents, ContentType.Description, ContentType.Author);
+            const result = getGroupedProgramSectionValuesByGroup(contents, [
+                ContentType.Description,
+                ContentType.Author,
+            ]);
 
             expect(result).toEqual([
-                { groupIndex: 1, left: '', right: 'Author 1' },
-                { groupIndex: 2, left: 'Desc 2', right: 'Author 2' },
+                {
+                    groupIndex: 1,
+                    byType: {
+                        [ContentType.Description]: '',
+                        [ContentType.Author]: 'Author 1',
+                    },
+                },
+                {
+                    groupIndex: 2,
+                    byType: {
+                        [ContentType.Description]: 'Desc 2',
+                        [ContentType.Author]: 'Author 2',
+                    },
+                },
             ]);
         });
 
-        it('reads title values when Title is requested as leftType', () => {
+        it('reads title and description values for requested types', () => {
             const contents: ProgramSectionContent[] = [
                 makeContent({ contentType: ContentType.Title, groupIndex: 0, title: 'TITLE' }),
                 makeContent({ contentType: ContentType.Description, groupIndex: 0, description: 'DESC' }),
             ];
 
-            const result = getGroupedProgramSectionTextPairs(contents, ContentType.Title, ContentType.Description);
+            const result = getGroupedProgramSectionValuesByGroup(contents, [
+                ContentType.Title,
+                ContentType.Description,
+            ]);
 
-            expect(result).toEqual([{ groupIndex: 0, left: 'TITLE', right: 'DESC' }]);
+            expect(result).toEqual([
+                {
+                    groupIndex: 0,
+                    byType: {
+                        [ContentType.Title]: 'TITLE',
+                        [ContentType.Description]: 'DESC',
+                    },
+                },
+            ]);
         });
 
         it('falls back to empty string for null title and null author values', () => {
@@ -63,9 +155,17 @@ describe('get-grouped-program-section-content-pairs', () => {
                 makeContent({ contentType: ContentType.Author, groupIndex: 0, author: null }),
             ];
 
-            const result = getGroupedProgramSectionTextPairs(contents, ContentType.Title, ContentType.Author);
+            const result = getGroupedProgramSectionValuesByGroup(contents, [ContentType.Title, ContentType.Author]);
 
-            expect(result).toEqual([{ groupIndex: 0, left: '', right: '' }]);
+            expect(result).toEqual([
+                {
+                    groupIndex: 0,
+                    byType: {
+                        [ContentType.Title]: '',
+                        [ContentType.Author]: '',
+                    },
+                },
+            ]);
         });
 
         it('returns empty string for unknown text content type (default switch branch)', () => {
@@ -81,9 +181,17 @@ describe('get-grouped-program-section-content-pairs', () => {
                 } as any),
             ];
 
-            const result = getGroupedProgramSectionTextPairs(contents, unknownType, ContentType.Description);
+            const result = getGroupedProgramSectionValuesByGroup(contents, [unknownType, ContentType.Description]);
 
-            expect(result).toEqual([{ groupIndex: 0, left: '', right: '' }]);
+            expect(result).toEqual([
+                {
+                    groupIndex: 0,
+                    byType: {
+                        [unknownType]: '',
+                        [ContentType.Description]: '',
+                    },
+                },
+            ]);
         });
     });
 

--- a/src/utils/functions/mappers/public/program/get-grouped-program-section-content-pairs.ts
+++ b/src/utils/functions/mappers/public/program/get-grouped-program-section-content-pairs.ts
@@ -33,7 +33,7 @@ export const getGroupedProgramSectionValuesByGroup = (
     if (requestedTypes.length === 0) return [];
 
     const requestedTypesSet = new Set<ContentType>(requestedTypes);
-    const map = new Map<number, Partial<Record<ContentType, string>>>();
+    const groupValuesByTypeMap = new Map<number, Partial<Record<ContentType, string>>>();
 
     for (const content of contents) {
         if (
@@ -46,21 +46,21 @@ export const getGroupedProgramSectionValuesByGroup = (
 
         const groupIndex = content.groupIndex;
 
-        let entry = map.get(groupIndex);
+        let entry = groupValuesByTypeMap.get(groupIndex);
 
         if (!entry) {
             const initial: Partial<Record<ContentType, string>> = {};
             for (const type of requestedTypes) {
                 initial[type] = '';
             }
-            map.set(groupIndex, initial);
+            groupValuesByTypeMap.set(groupIndex, initial);
             entry = initial;
         }
 
         entry[content.contentType] = getContentTextValueByType(content);
     }
 
-    return Array.from(map.entries())
+    return Array.from(groupValuesByTypeMap.entries())
         .sort((a, b) => a[0] - b[0])
         .map(([groupIndex, byType]) => ({
             groupIndex,

--- a/src/utils/functions/mappers/public/program/get-grouped-program-section-content-pairs.ts
+++ b/src/utils/functions/mappers/public/program/get-grouped-program-section-content-pairs.ts
@@ -1,0 +1,71 @@
+import { ProgramSectionContent } from '@/types/common/program-sections';
+import { ContentType } from '@/types/common/programs';
+
+export interface GroupedProgramSectionTextPair {
+    groupIndex: number;
+    left: string;
+    right: string;
+}
+
+export interface DescriptionAuthorPairGroup {
+    groupIndex: number;
+    description: string;
+    author: string;
+}
+
+const getContentTextValueByType = (content: ProgramSectionContent, type: ContentType): string => {
+    switch (type) {
+        case ContentType.Title:
+            return content.title || '';
+        case ContentType.Description:
+            return content.description || '';
+        case ContentType.Author:
+            return content.author || '';
+        default:
+            return '';
+    }
+};
+
+export const getGroupedProgramSectionTextPairs = (
+    contents: ProgramSectionContent[],
+    leftType: ContentType,
+    rightType: ContentType,
+): GroupedProgramSectionTextPair[] => {
+    const map = new Map<number, { left: string; right: string }>();
+
+    for (const content of contents) {
+        if (content.groupIndex === null || content.groupIndex === undefined) continue;
+
+        const groupIndex = content.groupIndex;
+
+        if (!map.has(groupIndex)) {
+            map.set(groupIndex, { left: '', right: '' });
+        }
+
+        const entry = map.get(groupIndex)!;
+
+        if (content.contentType === leftType) {
+            entry.left = getContentTextValueByType(content, leftType);
+        }
+
+        if (content.contentType === rightType) {
+            entry.right = getContentTextValueByType(content, rightType);
+        }
+    }
+
+    return Array.from(map.entries())
+        .sort((a, b) => a[0] - b[0])
+        .map(([groupIndex, value]) => ({
+            groupIndex,
+            left: value.left,
+            right: value.right,
+        }));
+};
+
+export const getDescriptionAuthorPairsByGroup = (contents: ProgramSectionContent[]): DescriptionAuthorPairGroup[] => {
+    return getGroupedProgramSectionTextPairs(contents, ContentType.Description, ContentType.Author).map((pair) => ({
+        groupIndex: pair.groupIndex,
+        description: pair.left,
+        author: pair.right,
+    }));
+};

--- a/src/utils/functions/mappers/public/program/get-grouped-program-section-content-pairs.ts
+++ b/src/utils/functions/mappers/public/program/get-grouped-program-section-content-pairs.ts
@@ -1,10 +1,9 @@
 import { ProgramSectionContent } from '@/types/common/program-sections';
 import { ContentType } from '@/types/common/programs';
 
-export interface GroupedProgramSectionTextPair {
+export interface GroupedProgramSectionValuesByType {
     groupIndex: number;
-    left: string;
-    right: string;
+    byType: Partial<Record<ContentType, string>>;
 }
 
 export interface DescriptionAuthorPairGroup {
@@ -13,59 +12,68 @@ export interface DescriptionAuthorPairGroup {
     author: string;
 }
 
-const getContentTextValueByType = (content: ProgramSectionContent, type: ContentType): string => {
-    switch (type) {
+const getContentTextValueByType = (content: ProgramSectionContent): string => {
+    switch (content.contentType) {
         case ContentType.Title:
-            return content.title || '';
+            return content.title ?? '';
         case ContentType.Description:
-            return content.description || '';
+            return content.description ?? '';
         case ContentType.Author:
-            return content.author || '';
+            return content.author ?? '';
         default:
             return '';
     }
 };
 
-export const getGroupedProgramSectionTextPairs = (
+export const getGroupedProgramSectionValuesByGroup = (
     contents: ProgramSectionContent[],
-    leftType: ContentType,
-    rightType: ContentType,
-): GroupedProgramSectionTextPair[] => {
-    const map = new Map<number, { left: string; right: string }>();
+    types: ContentType[],
+): GroupedProgramSectionValuesByType[] => {
+    const requestedTypes = Array.from(new Set(types));
+    if (requestedTypes.length === 0) return [];
+
+    const requestedTypesSet = new Set<ContentType>(requestedTypes);
+    const map = new Map<number, Partial<Record<ContentType, string>>>();
 
     for (const content of contents) {
-        if (content.groupIndex === null || content.groupIndex === undefined) continue;
+        if (
+            content.groupIndex === null ||
+            content.groupIndex === undefined ||
+            !requestedTypesSet.has(content.contentType)
+        ) {
+            continue;
+        }
 
         const groupIndex = content.groupIndex;
 
-        if (!map.has(groupIndex)) {
-            map.set(groupIndex, { left: '', right: '' });
+        let entry = map.get(groupIndex);
+
+        if (!entry) {
+            const initial: Partial<Record<ContentType, string>> = {};
+            for (const type of requestedTypes) {
+                initial[type] = '';
+            }
+            map.set(groupIndex, initial);
+            entry = initial;
         }
 
-        const entry = map.get(groupIndex)!;
-
-        if (content.contentType === leftType) {
-            entry.left = getContentTextValueByType(content, leftType);
-        }
-
-        if (content.contentType === rightType) {
-            entry.right = getContentTextValueByType(content, rightType);
-        }
+        entry[content.contentType] = getContentTextValueByType(content);
     }
 
     return Array.from(map.entries())
         .sort((a, b) => a[0] - b[0])
-        .map(([groupIndex, value]) => ({
+        .map(([groupIndex, byType]) => ({
             groupIndex,
-            left: value.left,
-            right: value.right,
+            byType,
         }));
 };
 
 export const getDescriptionAuthorPairsByGroup = (contents: ProgramSectionContent[]): DescriptionAuthorPairGroup[] => {
-    return getGroupedProgramSectionTextPairs(contents, ContentType.Description, ContentType.Author).map((pair) => ({
-        groupIndex: pair.groupIndex,
-        description: pair.left,
-        author: pair.right,
-    }));
+    return getGroupedProgramSectionValuesByGroup(contents, [ContentType.Description, ContentType.Author]).map(
+        (group) => ({
+            groupIndex: group.groupIndex,
+            description: group.byType[ContentType.Description] || '',
+            author: group.byType[ContentType.Author] || '',
+        }),
+    );
 };


### PR DESCRIPTION
## Github Ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1427

## Description

This PR implements the ability to enable a public view for template 633433 in the Single Program module.

Additionally, a helper was introduced to encapsulate the public view logic and improve reusability. ProgramSectionForm was refactored to use this new helper, resulting in cleaner and more maintainable code.

## How it looks

<img width="1446" height="860" alt="image" src="https://github.com/user-attachments/assets/ecee7eac-0937-4061-b0c2-3b2cabc4c6c4" />

## How to recreate changes

1. Create a new program using template 633433.
2. Open the public view page of the created Single Program based on template 633433 and verify it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated description/author pairing and grouping logic into a shared utility, improving consistency when adding, updating, or deleting pairs; preserves form behavior and focus handling.
* **Tests**
  * Updated tests to validate normalized group indexing and the expected ordering and focus after adding pairs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->