### PR TITLE
Feature/issue-1388 [Who we are] Translation indicators for blocks

### DIFF
--- a/src/components/admin/localization-statuses/LocalizationStatuses.test.tsx
+++ b/src/components/admin/localization-statuses/LocalizationStatuses.test.tsx
@@ -17,30 +17,49 @@ const languages: LocalizationLanguage[] = [
     { id: 3, code: 'pl', name: 'Польська' },
 ];
 
+const translationStatusesByLanguage = [
+    {
+        languageId: 1,
+        languageCode: 'en',
+        translationStatus: TranslationStatus.Relevant,
+    },
+    {
+        languageId: 2,
+        languageCode: 'es',
+        translationStatus: TranslationStatus.Outdated,
+    },
+];
+
 const localizedEntity: EntityWithLocalizations<TestLocalization> = {
-    localizations: [
-        {
-            language: { id: 1, code: 'en' },
-            translationStatus: TranslationStatus.Relevant,
-        },
-        {
-            language: { id: 2, code: 'es' },
-            translationStatus: TranslationStatus.Outdated,
-        },
-    ],
+    localizations: translationStatusesByLanguage.map(({ languageId, languageCode, translationStatus }) => ({
+        language: { id: languageId, code: languageCode },
+        translationStatus,
+    })),
 };
 
 const entityWithTranslationStatuses: EntityWithTranslationStatuses = {
-    translationStatuses: [
-        {
-            languageId: 1,
-            translationStatus: TranslationStatus.Relevant,
-        },
-        {
-            languageId: 2,
-            translationStatus: TranslationStatus.Outdated,
-        },
-    ],
+    translationStatuses: translationStatusesByLanguage.map(({ languageId, translationStatus }) => ({
+        languageId,
+        translationStatus,
+    })),
+};
+
+const assertStatusBadges = () => {
+    const enBadge = screen.getByText('EN');
+    const esBadge = screen.getByText('ES');
+    const plBadge = screen.getByText('PL');
+
+    expect(enBadge).toHaveClass(styles.badge);
+    expect(enBadge).toHaveClass(styles.relevant);
+    expect(enBadge).not.toHaveClass(styles.outdated);
+
+    expect(esBadge).toHaveClass(styles.badge);
+    expect(esBadge).toHaveClass(styles.outdated);
+    expect(esBadge).not.toHaveClass(styles.relevant);
+
+    expect(plBadge).toHaveClass(styles.badge);
+    expect(plBadge).not.toHaveClass(styles.relevant);
+    expect(plBadge).not.toHaveClass(styles.outdated);
 };
 
 describe('LocalizationStatuses component', () => {
@@ -55,21 +74,7 @@ describe('LocalizationStatuses component', () => {
     it('applies correct class based on translation status', () => {
         render(<LocalizationStatuses languages={languages} localizedEntity={localizedEntity} />);
 
-        const enBadge = screen.getByText('EN');
-        const esBadge = screen.getByText('ES');
-        const plBadge = screen.getByText('PL');
-
-        expect(enBadge).toHaveClass(styles.badge);
-        expect(enBadge).toHaveClass(styles.relevant);
-        expect(enBadge).not.toHaveClass(styles.outdated);
-
-        expect(esBadge).toHaveClass(styles.badge);
-        expect(esBadge).toHaveClass(styles.outdated);
-        expect(esBadge).not.toHaveClass(styles.relevant);
-
-        expect(plBadge).toHaveClass(styles.badge);
-        expect(plBadge).not.toHaveClass(styles.relevant);
-        expect(plBadge).not.toHaveClass(styles.outdated);
+        assertStatusBadges();
     });
 
     it('renders wrapper with correct test id', () => {
@@ -81,20 +86,6 @@ describe('LocalizationStatuses component', () => {
     it('applies statuses correctly for entities with translationStatuses', () => {
         render(<LocalizationStatuses languages={languages} localizedEntity={entityWithTranslationStatuses} />);
 
-        const enBadge = screen.getByText('EN');
-        const esBadge = screen.getByText('ES');
-        const plBadge = screen.getByText('PL');
-
-        expect(enBadge).toHaveClass(styles.badge);
-        expect(enBadge).toHaveClass(styles.relevant);
-        expect(enBadge).not.toHaveClass(styles.outdated);
-
-        expect(esBadge).toHaveClass(styles.badge);
-        expect(esBadge).toHaveClass(styles.outdated);
-        expect(esBadge).not.toHaveClass(styles.relevant);
-
-        expect(plBadge).toHaveClass(styles.badge);
-        expect(plBadge).not.toHaveClass(styles.relevant);
-        expect(plBadge).not.toHaveClass(styles.outdated);
+        assertStatusBadges();
     });
 });

--- a/src/components/admin/localization-statuses/LocalizationStatuses.test.tsx
+++ b/src/components/admin/localization-statuses/LocalizationStatuses.test.tsx
@@ -6,6 +6,7 @@ import {
     LocalizationLanguage,
     EntityWithLocalizations,
     EntityLocalization,
+    EntityWithTranslationStatuses,
 } from '@/types/common/language';
 
 type TestLocalization = EntityLocalization;
@@ -24,6 +25,19 @@ const localizedEntity: EntityWithLocalizations<TestLocalization> = {
         },
         {
             language: { id: 2, code: 'es' },
+            translationStatus: TranslationStatus.Outdated,
+        },
+    ],
+};
+
+const entityWithTranslationStatuses: EntityWithTranslationStatuses = {
+    translationStatuses: [
+        {
+            languageId: 1,
+            translationStatus: TranslationStatus.Relevant,
+        },
+        {
+            languageId: 2,
             translationStatus: TranslationStatus.Outdated,
         },
     ],
@@ -62,5 +76,25 @@ describe('LocalizationStatuses component', () => {
         render(<LocalizationStatuses languages={languages} localizedEntity={localizedEntity} />);
 
         expect(screen.getByTestId('localization-statuses')).toBeInTheDocument();
+    });
+
+    it('applies statuses correctly for entities with translationStatuses', () => {
+        render(<LocalizationStatuses languages={languages} localizedEntity={entityWithTranslationStatuses} />);
+
+        const enBadge = screen.getByText('EN');
+        const esBadge = screen.getByText('ES');
+        const plBadge = screen.getByText('PL');
+
+        expect(enBadge).toHaveClass(styles.badge);
+        expect(enBadge).toHaveClass(styles.relevant);
+        expect(enBadge).not.toHaveClass(styles.outdated);
+
+        expect(esBadge).toHaveClass(styles.badge);
+        expect(esBadge).toHaveClass(styles.outdated);
+        expect(esBadge).not.toHaveClass(styles.relevant);
+
+        expect(plBadge).toHaveClass(styles.badge);
+        expect(plBadge).not.toHaveClass(styles.relevant);
+        expect(plBadge).not.toHaveClass(styles.outdated);
     });
 });

--- a/src/components/admin/localization-statuses/LocalizationStatuses.tsx
+++ b/src/components/admin/localization-statuses/LocalizationStatuses.tsx
@@ -2,6 +2,7 @@ import cn from 'classnames';
 import {
     EntityLocalization,
     EntityWithLocalizations,
+    EntityWithTranslationStatuses,
     LocalizationLanguage,
     TranslationStatus,
 } from '@/types/common/language';
@@ -9,14 +10,18 @@ import styles from './LocalizationStatuses.module.scss';
 
 export interface LocalizationStatusProps<TLocalization extends EntityLocalization> {
     languages: LocalizationLanguage[];
-    localizedEntity: EntityWithLocalizations<TLocalization>;
+    localizedEntity: EntityWithLocalizations<TLocalization> | EntityWithTranslationStatuses;
 }
 
 const getTranslationStatus = <TLocalization extends EntityLocalization>(
-    languageCode: string,
-    localizations: TLocalization[],
+    language: LocalizationLanguage,
+    localizedEntity: EntityWithLocalizations<TLocalization> | EntityWithTranslationStatuses,
 ): TranslationStatus | undefined => {
-    return localizations.find((loc) => loc.language?.code === languageCode)?.translationStatus;
+    if ('translationStatuses' in localizedEntity) {
+        return localizedEntity.translationStatuses?.find((loc) => loc.languageId === language.id)?.translationStatus;
+    }
+
+    return localizedEntity.localizations?.find((loc) => loc.language?.code === language.code)?.translationStatus;
 };
 
 export const LocalizationStatuses = <TLocalization extends EntityLocalization>({
@@ -26,7 +31,7 @@ export const LocalizationStatuses = <TLocalization extends EntityLocalization>({
     return (
         <div className={styles.statuses} data-testid="localization-statuses">
             {languages.map((language) => {
-                const status = getTranslationStatus(language.code, localizedEntity.localizations);
+                const status = getTranslationStatus(language, localizedEntity);
 
                 const statusClass = cn(styles.badge, {
                     [styles.relevant]: status === TranslationStatus.Relevant,

--- a/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.scss
+++ b/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.scss
@@ -4,7 +4,7 @@
     &-page-container {
         display: flex;
         flex-direction: column;
-        gap: 3.375rem;
+        gap: 2rem;
         padding: 2.5rem 2.5rem 3.375rem 2.5rem;
         height: 100vh;
         width: 100%;

--- a/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.test.tsx
+++ b/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.test.tsx
@@ -112,8 +112,8 @@ jest.mock('@/components/admin/toast/toast-container/ToastContainer', () => ({
 }));
 
 const mockCategories: WhoWeAreCategory[] = [
-    { id: 1, title: 'Main', sectionType: SectionType.Main },
-    { id: 2, title: 'People', sectionType: SectionType.People },
+    { id: 1, title: 'Main', sectionType: SectionType.Main, translationStatuses: [] },
+    { id: 2, title: 'People', sectionType: SectionType.People, translationStatuses: [] },
 ];
 
 const mockSection1: WhoWeAreSection = {

--- a/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.test.tsx
+++ b/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.test.tsx
@@ -276,6 +276,10 @@ describe('WhoWeAreContent Component', () => {
         });
 
         await waitFor(() => {
+            expect(mockedWhoWeAreApi.getPreviews).toHaveBeenCalledTimes(2);
+        });
+
+        await waitFor(() => {
             expect(publishButton).toBeDisabled();
         });
     });

--- a/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.tsx
+++ b/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.tsx
@@ -17,6 +17,7 @@ import { InlineLoader } from '@/components/common/inline-loader/InlineLoader';
 import classNames from 'classnames';
 import { WhoWeArePageToolbar } from '../who-we-are-page-toolbar/WhoWeArePageToolbar';
 import { useLocalizationToolkit } from '@/hooks/admin/use-localization-toolkit/useLocalizationToolkit';
+import { LocalizationStatuses } from '@/components/admin/localization-statuses/LocalizationStatuses';
 
 interface ErrorState {
     message: string | null;
@@ -127,11 +128,13 @@ export const WhoWeAreContent = () => {
                 setUpdatedSection(result);
                 setIsPublishButtonActive(false);
                 addToast(COMMON_TEXT_ADMIN.MESSAGE.SUCCESSFULLY_PUBLISHED, ToastType.Info);
+
+                refetchCategories();
             } catch (error) {
                 addToast(COMMON_TEXT_ADMIN.MESSAGE.FAIL_TO_PUBLISH_CHANGES, ToastType.Error);
             }
         }
-    }, [selectedSection, updatedSection, client, selectedCategory, addToast]);
+    }, [selectedSection, updatedSection, client, selectedCategory, addToast, refetchCategories]);
 
     const handleConfirmPublish = useCallback(() => {
         setConfirmationModalOpen(false);
@@ -157,9 +160,10 @@ export const WhoWeAreContent = () => {
         }
     }, []);
 
-    const { allLanguages, selectedLanguage, onLanguageChange, retryFetchLanguages } = useLocalizationToolkit({
-        setErrorState,
-    });
+    const { allLanguages, translationLanguages, selectedLanguage, onLanguageChange, retryFetchLanguages } =
+        useLocalizationToolkit({
+            setErrorState,
+        });
 
     const handleRetry = useCallback(() => {
         if (error.type === 'categories') {
@@ -221,6 +225,9 @@ export const WhoWeAreContent = () => {
                         getCategoryDisplayName={(category) => category.title}
                         getCategoryKey={(category) => category.id}
                         onCategorySelect={handleCategorySelect}
+                        renderCategoryExtra={(category) => (
+                            <LocalizationStatuses languages={translationLanguages} localizedEntity={category} />
+                        )}
                     />
                     {renderContent()}
                 </div>

--- a/src/services/api/admin/who-we-are/who-we-are-api.test.ts
+++ b/src/services/api/admin/who-we-are/who-we-are-api.test.ts
@@ -24,7 +24,9 @@ describe('WhoWeAreApi', () => {
 
     describe('getPreviews', () => {
         it('should call client.get with the correct URL and return data', async () => {
-            const mockData: WhoWeAreCategory[] = [{ id: 1, title: 'Category 1', sectionType: SectionType.Main }];
+            const mockData: WhoWeAreCategory[] = [
+                { id: 1, title: 'Category 1', sectionType: SectionType.Main, translationStatuses: [] },
+            ];
             mockClient.get.mockResolvedValue({ data: mockData });
 
             const result = await WhoWeAreApi.getPreviews(mockClient);

--- a/src/types/admin/who-we-are.ts
+++ b/src/types/admin/who-we-are.ts
@@ -6,9 +6,10 @@ import {
     EntityLocalizationDto,
     EntityWithDtoLocalizations,
     EntityWithLocalizations,
+    EntityWithTranslationStatuses,
 } from '../common/language';
 
-export type WhoWeAreCategory = {
+export type WhoWeAreCategory = EntityWithTranslationStatuses & {
     id: number;
     sectionType: SectionType;
     title: string;

--- a/src/types/common/language.ts
+++ b/src/types/common/language.ts
@@ -25,6 +25,15 @@ export interface EntityWithDtoLocalizations<TLocalization extends EntityLocaliza
     localizations: TLocalization[];
 }
 
+export type EntityWithTranslationStatuses = {
+    translationStatuses: TranslationStatusInfo[];
+};
+
+export type TranslationStatusInfo = {
+    languageId: number;
+    translationStatus: TranslationStatus;
+};
+
 export enum TranslationStatus {
     Outdated,
     Relevant,


### PR DESCRIPTION
## GitHub

* [GitHub ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1388)

## Description

Added translation status indicators for each section on the Who We Are admin page

## How it looks

https://github.com/user-attachments/assets/90729828-7936-475e-aa3e-344c4476540f

## Summary of change

- Updated LocalizationStatuses to support entities with translationStatuses returned from the backend.
- Integrated localization status badges into Who We Are category list.
- Refetched category previews after publish so statuses are updated immediately.
- Updated tests for Who We Are content flow and LocalizationStatuses.
## How to recreate changes

- Navigate to the Admin -> Хто ми (Who We Are) page.
- Ensure that translation status indicators are displayed and changes after publishing content

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Translation status badges now show per language (EN, ES, PL) on category listings, indicating completion/update state.
  * Category displays now integrate translation-status data from both old and new metadata formats.

* **Style**
  * Reduced vertical spacing in the Who We Are content area.

* **Tests**
  * Added tests verifying translation-status badge rendering and data-handling across both metadata shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->