### PR TITLE
Change styles in team member component to not cut off the second line in member's name

### DIFF
--- a/src/pages/admin/team/components/member-component/MemberComponent.scss
+++ b/src/pages/admin/team/components/member-component/MemberComponent.scss
@@ -33,14 +33,9 @@
 
             p {
                 margin: 0.25rem 0 0 0;
-                display: -webkit-box;
                 font-size: 18px;
-                -webkit-line-clamp: 2;
-                -webkit-box-orient: vertical;
-                overflow: hidden;
                 overflow-wrap: break-word;
                 word-break: break-word;
-                text-overflow: ellipsis;
             }
         }
     }
@@ -52,13 +47,8 @@
         p {
             font-size: 18px;
             padding-right: 2.5rem;
-            display: -webkit-box;
-            -webkit-line-clamp: 2;
-            -webkit-box-orient: vertical;
-            overflow: hidden;
             overflow-wrap: break-word;
             word-break: break-word;
-            text-overflow: ellipsis;
         }
     }
 


### PR DESCRIPTION
## JIRA or Github ticker

https://github.com/ita-social-projects/VictoryCenter-Back/issues/1446

## Description

<!--- Please decripe the main goal of this PR and why it was created --->

## How it looks

How it was:
<img width="2879" height="1108" alt="image" src="https://github.com/user-attachments/assets/090355cc-413c-4e48-8b13-f2fd8daf1eaa" />

How it now:
<img width="2879" height="1115" alt="image" src="https://github.com/user-attachments/assets/2b962ba2-e2dc-441c-b320-a5906a89b710" />


## Summary of change

<!--- Please specify what was changed --->

## How to recreate changes

<!--- Please provide short instruction step-by-step how to see changes that was implemented by this PR --->


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Team member information now displays fully without text truncation, improving readability in the admin team section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->