### PR TITLE
Fix/issue 1449 - Update Footer Layout and Navigation Links

### DIFF
--- a/src/components/public/footer/Footer.scss
+++ b/src/components/public/footer/Footer.scss
@@ -36,50 +36,14 @@
             }
         }
 
-        .email-field {
-            font-weight: 600;
+        .logo-container {
             width: 20rem;
-            gap: 0.3em;
             display: flex;
-            flex-direction: column;
+            align-items: flex-start;
 
-            .input-block {
-                margin-top: 1.25rem;
-                border-bottom: 1px solid colors.$grey-700;
-                display: flex;
-                align-items: center;
-
-                input {
-                    width: 18rem;
-                    border: none;
-                    outline: none;
-                    background: transparent;
-                    font-size: inherit;
-                    color: inherit;
-                    padding-bottom: 0.4375rem;
-                    margin: 0;
-                }
-
-                input::placeholder {
-                    font-size: 1rem;
-                    font-weight: 400;
-                    font-family: fonts.$mulish-regular-font;
-                }
-
-                button {
-                    border: none;
-                    outline: none;
-                    background: transparent;
-                    font-size: inherit;
-                    color: inherit;
-                    padding: 0;
-                    margin: 0;
-                }
-
-                .arrow-up-icon {
-                    width: 1.5rem;
-                    height: 1.5rem;
-                }
+            .logo {
+                max-width: 140px;
+                height: auto;
             }
         }
 
@@ -205,35 +169,11 @@
             grid-template-columns: 2fr 1fr 1fr 1fr;
             grid-template-rows: auto;
             gap: 2rem;
-            grid-template-areas: 'email menu about hippotherapy';
+            grid-template-areas: 'logo menu about hippotherapy';
 
-            .email-field {
-                grid-area: email;
+            .logo-container {
+                grid-area: logo;
                 width: 100%;
-
-                .title {
-                    font-size: 1.25rem;
-                    margin-bottom: 1rem;
-                    font-weight: 600;
-                }
-
-                .input-block {
-                    margin-top: 1rem;
-                    position: relative;
-                    max-width: 100%;
-
-                    input {
-                        width: 100%;
-                        font-size: 1rem;
-                        padding-bottom: 0.75rem;
-                        padding-right: 2rem;
-                    }
-
-                    button {
-                        position: absolute;
-                        right: 0;
-                    }
-                }
             }
 
             .menu,
@@ -304,36 +244,12 @@
             grid-template-columns: 1fr 1fr 1fr;
             grid-template-rows: auto auto;
             gap: 2rem;
-            grid-template-areas: 'email email email' 'menu about hippotherapy';
+            grid-template-areas: 'logo logo logo' 'menu about hippotherapy';
 
-            .email-field {
-                grid-area: email;
+            .logo-container {
+                grid-area: logo;
                 width: 100%;
                 margin-bottom: 0;
-
-                .title {
-                    font-size: 1.125rem;
-                    margin-bottom: 1rem;
-                    font-weight: 600;
-                }
-
-                .input-block {
-                    margin-top: 1rem;
-                    position: relative;
-                    max-width: 400px;
-
-                    input {
-                        width: 100%;
-                        font-size: 1rem;
-                        padding-bottom: 0.75rem;
-                        padding-right: 2rem;
-                    }
-
-                    button {
-                        position: absolute;
-                        right: 0;
-                    }
-                }
             }
 
             .menu {
@@ -439,37 +355,12 @@
             grid-template-columns: 1fr 1fr;
             grid-template-rows: auto auto auto;
             gap: 2rem;
-            grid-template-areas: 'email email' 'menu about' 'hippotherapy hippotherapy';
+            grid-template-areas: 'logo logo' 'menu about' 'hippotherapy hippotherapy';
 
-            .email-field {
-                grid-area: email;
+            .logo-container {
+                grid-area: logo;
                 width: 100%;
                 margin-bottom: 0;
-
-                .title {
-                    font-size: 1.125rem;
-                    margin-bottom: 1rem;
-                    font-weight: 600;
-                }
-
-                .input-block {
-                    margin-top: 1rem;
-                    position: relative;
-                    max-width: 400px;
-
-                    input {
-                        width: 100%;
-                        font-size: 1rem;
-                        padding-bottom: 0.75rem;
-                        padding-right: 2rem;
-                    }
-
-                    button {
-                        position: absolute;
-                        right: 0;
-                        bottom: 0.75rem;
-                    }
-                }
             }
 
             .menu {
@@ -591,37 +482,12 @@
             display: grid;
             grid-template-columns: 1fr;
             grid-template-rows: auto auto auto auto;
-            grid-template-areas: 'email' 'menu' 'about' 'hippotherapy';
+            grid-template-areas: 'logo' 'menu' 'about' 'hippotherapy';
 
-            .email-field {
-                grid-area: email;
+            .logo-container {
+                grid-area: logo;
                 width: 100%;
                 margin-bottom: 0;
-
-                .title {
-                    font-size: 1rem;
-                    margin-bottom: 1rem;
-                    font-weight: 600;
-                }
-
-                .input-block {
-                    margin-top: 1rem;
-                    position: relative;
-                    max-width: 300px;
-
-                    input {
-                        width: 100%;
-                        font-size: 0.875rem;
-                        padding-bottom: 0.75rem;
-                        padding-right: 2rem;
-                    }
-
-                    button {
-                        position: absolute;
-                        right: 0;
-                        bottom: 0.75rem;
-                    }
-                }
             }
 
             .menu {

--- a/src/components/public/footer/Footer.test.tsx
+++ b/src/components/public/footer/Footer.test.tsx
@@ -5,8 +5,8 @@ import { MemoryRouter } from 'react-router-dom';
 import { PUBLIC_ROUTES } from '@/const/public/routes';
 import footerUk from '@/locales/uk/footer.json';
 
-jest.mock('@/assets/icons/arrow-up-right.svg', () => ({
-    ReactComponent: (props: any) => <svg {...props} data-testid="arrow-icon" />,
+jest.mock('@/assets/icons/logo-with-text.svg', () => ({
+    ReactComponent: (props: any) => <svg {...props} data-testid="victory-logo" />,
 }));
 
 jest.mock('@/assets/icons/phone.svg', () => ({
@@ -31,15 +31,9 @@ function escapeRegExp(string: string) {
 }
 
 describe('Footer', () => {
-    it('renders email input and clears on subscribe click', () => {
+    it('renders the logo', () => {
         render(<Footer />, { wrapper: MemoryRouter });
-        const input = screen.getByPlaceholderText(footerUk['ENTER_YOUR_EMAIL']) as HTMLInputElement;
-        fireEvent.change(input, { target: { value: 'user@example.com' } });
-        expect(input.value).toBe('user@example.com');
-
-        const button = screen.getByRole('button', { name: footerUk['SIGN_UP'] });
-        fireEvent.click(button);
-        expect(input.value).toBe('');
+        expect(screen.getByTestId('victory-logo')).toBeInTheDocument();
     });
 
     it('renders the menu section with correct links', () => {
@@ -52,7 +46,7 @@ describe('Footer', () => {
         );
         expect(screen.getByRole('link', { name: footerUk['HOW_TO_SUPPORT'] })).toHaveAttribute(
             'href',
-            PUBLIC_ROUTES.MOCK.FULL,
+            PUBLIC_ROUTES.DONATE.FULL,
         );
         expect(screen.getByRole('link', { name: footerUk['STORIES_OF_VICTORIES'] })).toHaveAttribute(
             'href',
@@ -120,7 +114,7 @@ describe('Footer', () => {
 
     it('renders icons correctly', () => {
         render(<Footer />, { wrapper: MemoryRouter });
-        expect(screen.getByTestId('arrow-icon')).toBeInTheDocument();
+        expect(screen.getByTestId('victory-logo')).toBeInTheDocument();
         expect(screen.getByTestId('mail-icon')).toBeInTheDocument();
         expect(screen.getByTestId('phone-icon')).toBeInTheDocument();
     });

--- a/src/components/public/footer/Footer.tsx
+++ b/src/components/public/footer/Footer.tsx
@@ -1,6 +1,5 @@
-import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { ReactComponent as ArrowUpIcon } from '@/assets/icons/arrow-up-right.svg';
+import { ReactComponent as VictoryCenterLogo } from '@/assets/icons/logo-with-text.svg';
 import { ReactComponent as PhoneIcon } from '@/assets/icons/phone.svg';
 import { ReactComponent as MailIcon } from '@/assets/icons/mail.svg';
 import { PUBLIC_ROUTES } from '@/const/public/routes';
@@ -9,12 +8,6 @@ import './Footer.scss';
 
 export const Footer = () => {
     const { t } = useTranslation('footer');
-
-    const [email, setEmail] = useState('');
-
-    const handleClick = () => {
-        setEmail('');
-    };
 
     const copyToClipboard = (text: string) => {
         navigator.clipboard.writeText(text);
@@ -34,28 +27,16 @@ export const Footer = () => {
     return (
         <div className="footer-content">
             <div className="main-block">
-                <div className="email-field">
-                    <span className="title">{t('STAY_UP_TO_DATE_WITH_THE_NEWS')}</span>
-                    <div className="input-block">
-                        <input
-                            type="email"
-                            placeholder={t('ENTER_YOUR_EMAIL')}
-                            value={email}
-                            onChange={(e) => setEmail(e.target.value)}
-                            required
-                        />
-                        <button onClick={handleClick} className="subscribe-btn" aria-label={t('SIGN_UP')}>
-                            <ArrowUpIcon className="arrow-up-icon" />
-                        </button>
-                    </div>
+                <div className="logo-container">
+                    <Link to="/">
+                        <VictoryCenterLogo className="logo" />
+                    </Link>
                 </div>
 
                 <div className="menu">
                     <span className="title">{t('MENU')}</span>
                     <Link to={PUBLIC_ROUTES.REPORTS.FULL}>{t('REPORTING')}</Link>
-                    <Link to={PUBLIC_ROUTES.MOCK.FULL} className="disable">
-                        {t('HOW_TO_SUPPORT')}
-                    </Link>
+                    <Link to={PUBLIC_ROUTES.DONATE.FULL}>{t('HOW_TO_SUPPORT')}</Link>
                     <Link to={PUBLIC_ROUTES.MOCK.FULL} className="disable">
                         {t('STORIES_OF_VICTORIES')}
                     </Link>


### PR DESCRIPTION
## Github ticker

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1449

## Description

Removed the newsletter subscription block ("Будьте в курсі новин та можливостей / Вкажіть ваш Email") from the footer and replaced it with the VictoryCenter logo as per the design. Added navigation link to existing page Як підтримати? (`/donate`). Pages without corresponding routes are kept as disabled links (`className="disable"`).

## How it looks

**Desktop - Before**:
<img width="1760" height="908" alt="Image" src="https://github.com/user-attachments/assets/d9ae0e19-2871-49f7-b128-86b4a09df5a8" />

**Desktop - After**:
<img width="1760" height="908" alt="image" src="https://github.com/user-attachments/assets/2f7e25b4-9ae1-4b0a-88fd-3ab0d47509fe" />

**Mobile 368px - After:**
<img width="300" alt="Screen Shot 2026-03-09 at 15 55 55" src="https://github.com/user-attachments/assets/5402ef6a-0efb-467a-a002-f20af2721091" />
**Mobile 768px- After:**
<img width="500" alt="Screen Shot 2026-03-09 at 15 56 30" src="https://github.com/user-attachments/assets/3d17f28a-23cc-4fbe-864b-b8aee3dbb9be" />



## Summary of change
- Removed newsletter subscription block from footer
- Added VictoryCenter logo with link to home page in its place
- Linked existing page: Як підтримати? (`/donate`)
- Non-existent pages remain as disabled links
- Updated `Footer.scss` to maintain responsive layout
- Updated `Footer.test.tsx` to reflect component changes

## How to recreate changes

1. Open the application locally
2. Scroll to the footer on any public page
3. Verify the newsletter block is removed and logo is displayed
4. Verify navigation links redirect to correct pages
5. Verify disabled links are non-interactive


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions
