### PR TITLE
Fix/issue-1529: Show placeholder in translation status filter instead of default value

### DIFF
--- a/src/components/admin/localization-toolkit/LocalizationToolkit.test.tsx
+++ b/src/components/admin/localization-toolkit/LocalizationToolkit.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { LocalizationToolkit } from './LocalizationToolkit';
 import { DEFAULT_LOCALE } from '@/const/common/locales';
 import { LOCALIZATION_TEXT } from '@/const/admin/localization';
-import { TranslationStatusFilter } from '@/types/common/language';
 import { mapLabelToTranslationStatusFilter } from '@/utils/functions/mappers/admin/localization-status/localization-status-mappers';
 
 jest.mock('@/components/common/select/Select', () => ({
@@ -41,7 +40,7 @@ describe('LocalizationToolkit', () => {
         expect(screen.getByTestId('mock-language-toolkit')).toBeInTheDocument();
     });
 
-    it('automatically selects "All" status on mount', () => {
+    it('does not select translation status on mount', () => {
         render(
             <LocalizationToolkit
                 languages={mockLanguages}
@@ -50,7 +49,7 @@ describe('LocalizationToolkit', () => {
             />,
         );
 
-        expect(mockOnTranslationStatusChange).toHaveBeenCalledWith(TranslationStatusFilter.All);
+        expect(mockOnTranslationStatusChange).not.toHaveBeenCalled();
     });
 
     it('renders all translation status options', () => {

--- a/src/components/admin/localization-toolkit/LocalizationToolkit.tsx
+++ b/src/components/admin/localization-toolkit/LocalizationToolkit.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { LOCALIZATION_TEXT } from '@/const/admin/localization';
 import { Select } from '@/components/common/select/Select';
 import { LocalizationLanguage, TranslationStatusFilter } from '@/types/common/language';
@@ -17,24 +17,15 @@ export const LocalizationToolkit = ({
     onLanguageChange,
     onTranslationStatusFilterChange,
 }: LocalizationToolkitProps) => {
-    const [selectedTranslationStatus, setSelectedTranslationStatus] = useState<TranslationStatusFilter>(
-        TranslationStatusFilter.All,
-    );
+    const [selectedTranslationStatus, setSelectedTranslationStatus] = useState<TranslationStatusFilter | undefined>();
 
     const changeTranslationStatus = useCallback(
-        (translationFilter: TranslationStatusFilter) => {
+        (translationFilter: TranslationStatusFilter | undefined) => {
             setSelectedTranslationStatus(translationFilter);
             onTranslationStatusFilterChange(translationFilter);
         },
         [onTranslationStatusFilterChange],
     );
-
-    useEffect(() => {
-        if (!languages.length) {
-            return;
-        }
-        changeTranslationStatus(TranslationStatusFilter.All);
-    }, [languages, changeTranslationStatus]);
 
     return (
         <div className={styles.toolkit} data-testid="localization-toolkit">


### PR DESCRIPTION
## GitHub

* [No placeholder in the Translations drop-down filter list](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1529)

## Description

This pull request updates the `LocalizationToolkit` component and its tests to change how the translation status filter is initialized. Now, the translation status is not automatically set to "All" on mount; instead, it remains undefined until the user selects a status. The tests are updated to reflect this new behavior.

## How it looks

https://github.com/user-attachments/assets/ce6b3e08-14b6-42f6-b771-5cdb2c30012a

## Summary of change

**Localization status filter initialization changes:**

* Removed the `useEffect` in `LocalizationToolkit.tsx` that previously set the translation status filter to `TranslationStatusFilter.All` on mount. Now, `selectedTranslationStatus` is initialized as `undefined`, and the filter is not set until the user interacts with the component.
* Updated the type of `selectedTranslationStatus` and the `changeTranslationStatus` callback to allow `undefined`, reflecting the new initialization logic.
* Removed the unnecessary import of `useEffect` from React, since it is no longer used.

**Test updates:**

* Changed the test to expect that `onTranslationStatusFilterChange` is not called automatically on mount, reflecting the new behavior. [[1]](diffhunk://#diff-e186d07f4d60c5da7bd73f9db5629eaa6f9016d1c01f73617f42cc16686188fdL44-R43) [[2]](diffhunk://#diff-e186d07f4d60c5da7bd73f9db5629eaa6f9016d1c01f73617f42cc16686188fdL53-R52)
* Cleaned up imports in the test file by removing an unused import.

## How to recreate changes

- Navigate to page with translation status bar on admin panel
- The translation status bar should display placeholder

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic default selection of translation status filter on component initialization. Users must now explicitly select a status instead of it automatically defaulting to "All".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->