### PR TITLE
Feature/issue-1410: Edit mode for "Доходи та витрати" tab

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -103,10 +103,13 @@ export const PDF_FILES_SECTION_TEXT = {
     },
 };
 
+export const FUNDS_EXPENDITURES_VALIDATION = {
+    disclaimer: { min: 2, max: 1000 },
+};
+
 export const FUNDS_EXPENDITURES_TEXT = {
     DISCLAIMER_LABEL: 'Дісклеймер/ENG',
     EXCHANGE_RATE_LABEL: 'Курс USD/UAH',
-    DISCLAIMER_MAX_LENGTH: 300,
     EXCHANGE_RATE_MAX_LENGTH: 10,
     MAX_CATEGORIES_PER_TYPE: 4,
     BUTTON: {

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -106,6 +106,16 @@ export const PDF_FILES_SECTION_TEXT = {
 export const FUNDS_EXPENDITURES_TEXT = {
     DISCLAIMER_LABEL: 'Дісклеймер/ENG',
     EXCHANGE_RATE_LABEL: 'Курс USD/UAH',
+    DISCLAIMER_MAX_LENGTH: 300,
+    EXCHANGE_RATE_MAX_LENGTH: 10,
+    MAX_CATEGORIES_PER_TYPE: 4,
+    BUTTON: {
+        EDIT: 'Редагувати Доходи та витрати',
+        CANCEL: 'Відмінити',
+        PUBLISH: 'Опублікувати',
+        ADD_INCOME: 'Надходження',
+        ADD_EXPENSE: 'Витрати',
+    },
     FILTER: {
         TYPE_PLACEHOLDER: 'Тип',
         CATEGORY_PLACEHOLDER: 'Категорія',

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.module.scss
@@ -1,4 +1,5 @@
 @use '@/assets/sass/variables/colors' as c;
+@use '@/assets/sass/variables/fonts' as fonts;
 @use '@/assets/sass/mixins/typography.mixins' as type;
 
 .section {
@@ -63,14 +64,14 @@
     padding: 16px 24px;
     gap: 8px;
     white-space: nowrap;
-    font-family: 'Mulish', sans-serif;
+    font-family: fonts.$mulish-regular-font;
     font-style: normal;
     font-weight: 400;
     font-size: 24px;
     line-height: 24px;
     letter-spacing: -0.02em;
     color: c.$white;
-    background-color: #0F2957;
+    background-color: c.$blue-500;
     border-radius: 0;
 }
 
@@ -95,7 +96,7 @@
 .footer-button {
     display: flex;
     align-items: center;
-    font-family: Mulish, sans-serif;
+    font-family: fonts.$mulish-regular-font;
     gap: 20px;
     width: 311px;
     height: 60px;

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.module.scss
@@ -1,5 +1,4 @@
 @use '@/assets/sass/variables/colors' as c;
-@use '@/assets/sass/variables/fonts' as fonts;
 @use '@/assets/sass/mixins/typography.mixins' as type;
 
 .section {
@@ -64,7 +63,7 @@
     padding: 16px 24px;
     gap: 8px;
     white-space: nowrap;
-    font-family: fonts.$mulish-regular-font;
+    @include type.subtitle-1-medium;
     font-style: normal;
     font-weight: 400;
     font-size: 24px;
@@ -96,7 +95,7 @@
 .footer-button {
     display: flex;
     align-items: center;
-    font-family: fonts.$mulish-regular-font;
+    @include type.subtitle-1-medium;
     gap: 20px;
     width: 311px;
     height: 60px;

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.module.scss
@@ -44,3 +44,61 @@
     gap: 83px;
     flex-wrap: wrap;
 }
+
+.disclaimer-textarea-group {
+    width: 100%;
+}
+
+.section-header {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.edit-btn {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    width: 419px;
+    height: 60px;
+    padding: 16px 24px;
+    gap: 8px;
+    white-space: nowrap;
+    font-family: 'Mulish', sans-serif;
+    font-style: normal;
+    font-weight: 400;
+    font-size: 24px;
+    line-height: 24px;
+    letter-spacing: -0.02em;
+    color: c.$white;
+    background-color: #0F2957;
+    border-radius: 0;
+}
+
+.edit-icon {
+    width: 24px;
+    height: 24px;
+    flex-shrink: 0;
+
+    path {
+        fill: c.$white;
+    }
+}
+
+.section-footer {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    gap: 20px;
+    padding: 20px 0;
+}
+
+.footer-button {
+    display: flex;
+    align-items: center;
+    font-family: Mulish, sans-serif;
+    gap: 20px;
+    width: 311px;
+    height: 60px;
+    font-size: 24px;
+    padding: 8px 14px;
+}

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
@@ -94,7 +94,6 @@ jest.mock('./components/funds-expenditures-toolbar/FundsExpendituresToolbar', ()
         onCategoryChange,
     }: {
         categories: { id: number; name: string }[];
-        selectedType: unknown;
         selectedCategoryId: number | null | undefined;
         exchangeRate: string | null;
         isEditing: boolean;

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
@@ -203,20 +203,20 @@ describe('FundsExpenditureSection', () => {
         expect(screen.getByTestId('selected-category-id')).toHaveTextContent('none');
     });
 
-    it('should pass only income categories to toolbar when income type is selected', () => {
+    it('should pass all categories to toolbar when income type is selected', () => {
         render(<FundsExpenditureSection isEditing={false} />);
 
         fireEvent.click(screen.getByTestId('filter-income'));
 
-        expect(screen.getByTestId('funds-toolbar')).toHaveAttribute('data-category-count', '3');
+        expect(screen.getByTestId('funds-toolbar')).toHaveAttribute('data-category-count', '7');
     });
 
-    it('should pass only expense categories to toolbar when expense type is selected', () => {
+    it('should pass all categories to toolbar when expense type is selected', () => {
         render(<FundsExpenditureSection isEditing={false} />);
 
         fireEvent.click(screen.getByTestId('filter-expense'));
 
-        expect(screen.getByTestId('funds-toolbar')).toHaveAttribute('data-category-count', '4');
+        expect(screen.getByTestId('funds-toolbar')).toHaveAttribute('data-category-count', '7');
     });
 
     it('should pass all categories to toolbar when no type is selected', () => {

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
@@ -1,7 +1,8 @@
 ﻿import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { FundsExpenditureSection } from './FundsExpendituresSection';
-import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import {
     MOCK_FUNDS_EXPENDITURES_CATEGORIES,
     MOCK_FUNDS_EXPENDITURES_RECORDS,
@@ -40,15 +41,20 @@ jest.mock(
             label,
             value,
             onChange,
+            onBlur,
+            error,
         }: {
             id: string;
             label: string;
             value: string;
             onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+            onBlur?: (e: React.FocusEvent<HTMLTextAreaElement>) => void;
+            error?: string;
         }) => (
             <div data-testid={`textarea-group-${id}`}>
                 <label>{label}</label>
-                <textarea data-testid={`textarea-${id}`} value={value} onChange={onChange} />
+                <textarea data-testid={`textarea-${id}`} value={value} onChange={onChange} onBlur={onBlur} />
+                {error && <span data-testid={`error-${id}`}>{error}</span>}
             </div>
         ),
     }),
@@ -329,6 +335,111 @@ describe('FundsExpenditureSection', () => {
             fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
             fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.CANCEL));
             expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT)).toBeInTheDocument();
+        });
+    });
+
+    describe('disclaimer validation', () => {
+        beforeEach(() => {
+            jest.clearAllMocks();
+            setupMockDataFetch();
+        });
+
+        const enterEditMode = () => fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
+        const getTextarea = () => screen.getByTestId('textarea-funds-disclaimer');
+        const getPublishButton = () => screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.PUBLISH);
+
+        it('should show required error when blurring an empty disclaimer', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            fireEvent.change(getTextarea(), { target: { value: '' } });
+            fireEvent.blur(getTextarea());
+            expect(screen.getByTestId('error-funds-disclaimer')).toHaveTextContent(
+                COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED,
+            );
+        });
+
+        it('should show min-length error when blurring with 1 character', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            fireEvent.change(getTextarea(), { target: { value: 'a' } });
+            fireEvent.blur(getTextarea());
+            expect(screen.getByTestId('error-funds-disclaimer')).toHaveTextContent(
+                COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.disclaimer.min),
+            );
+        });
+
+        it('should clear error when disclaimer is corrected and blurred', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            fireEvent.change(getTextarea(), { target: { value: '' } });
+            fireEvent.blur(getTextarea());
+            expect(screen.getByTestId('error-funds-disclaimer')).toBeInTheDocument();
+
+            fireEvent.change(getTextarea(), { target: { value: 'valid disclaimer text' } });
+            fireEvent.blur(getTextarea());
+            expect(screen.queryByTestId('error-funds-disclaimer')).not.toBeInTheDocument();
+        });
+
+        it('should normalize consecutive spaces to a single space when typing', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            fireEvent.change(getTextarea(), { target: { value: 'one  two   three' } });
+            expect(getTextarea()).toHaveValue('one two three');
+        });
+
+        it('should trim and normalize spaces on blur', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            fireEvent.change(getTextarea(), { target: { value: '  leading and trailing  ' } });
+            fireEvent.blur(getTextarea());
+            expect(getTextarea()).toHaveValue('leading and trailing');
+        });
+
+        it('should disable publish button when disclaimer is empty', () => {
+            setupMockDataFetch({ id: 1, disclaimerTitle: null, exchangeRate: '42' });
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            expect(getPublishButton()).toBeDisabled();
+        });
+
+        it('should disable publish button when disclaimer has only 1 character', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            fireEvent.change(getTextarea(), { target: { value: 'a' } });
+            expect(getPublishButton()).toBeDisabled();
+        });
+
+        it('should enable publish button when disclaimer has at least 2 characters', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            fireEvent.change(getTextarea(), { target: { value: 'ok' } });
+            expect(getPublishButton()).not.toBeDisabled();
+        });
+
+        it('should enable publish button when disclaimer already has a valid value from settings', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            expect(getPublishButton()).not.toBeDisabled();
+        });
+
+        it('should disable publish button after a blur validation error', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            fireEvent.change(getTextarea(), { target: { value: 'a' } });
+            fireEvent.blur(getTextarea());
+            expect(getPublishButton()).toBeDisabled();
+        });
+
+        it('should reset disclaimer error when cancel is clicked', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            fireEvent.change(getTextarea(), { target: { value: '' } });
+            fireEvent.blur(getTextarea());
+            expect(screen.getByTestId('error-funds-disclaimer')).toBeInTheDocument();
+
+            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.CANCEL));
+            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
+            expect(screen.queryByTestId('error-funds-disclaimer')).not.toBeInTheDocument();
         });
     });
 });

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+﻿import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { FundsExpenditureSection } from './FundsExpendituresSection';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
@@ -19,12 +19,40 @@ jest.mock('./FundsExpendituresSection.module.scss', () => ({
     'disclaimer-label': 'disclaimer-label',
     'disclaimer-text-area': 'disclaimer-text-area',
     'disclaimer-text': 'disclaimer-text',
+    'disclaimer-textarea-group': 'disclaimer-textarea-group',
     'summary-cards': 'summary-cards',
+    'section-header': 'section-header',
+    'edit-btn': 'edit-btn',
+    'edit-icon': 'edit-icon',
+    'section-footer': 'section-footer',
+    'footer-button': 'footer-button',
 }));
 
 jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
     useAdminClient: () => ({}),
 }));
+
+jest.mock(
+    '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup',
+    () => ({
+        TextAreaWithCharacterLimitGroup: ({
+            id,
+            label,
+            value,
+            onChange,
+        }: {
+            id: string;
+            label: string;
+            value: string;
+            onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+        }) => (
+            <div data-testid={`textarea-group-${id}`}>
+                <label>{label}</label>
+                <textarea data-testid={`textarea-${id}`} value={value} onChange={onChange} />
+            </div>
+        ),
+    }),
+);
 
 const mockUseDataFetch = jest.fn();
 jest.mock('@/hooks/common/use-data-fetch/useDataFetch', () => ({
@@ -59,6 +87,9 @@ jest.mock('./components/funds-expenditures-toolbar/FundsExpendituresToolbar', ()
         categories,
         selectedCategoryId,
         exchangeRate,
+        isEditing,
+        isAddIncomeDisabled,
+        isAddExpenseDisabled,
         onTypeChange,
         onCategoryChange,
     }: {
@@ -66,10 +97,19 @@ jest.mock('./components/funds-expenditures-toolbar/FundsExpendituresToolbar', ()
         selectedType: unknown;
         selectedCategoryId: number | null | undefined;
         exchangeRate: string | null;
+        isEditing: boolean;
+        isAddIncomeDisabled: boolean;
+        isAddExpenseDisabled: boolean;
         onTypeChange: (v: unknown) => void;
         onCategoryChange: (v: unknown) => void;
     }) => (
-        <div data-testid="funds-toolbar" data-category-count={categories.length}>
+        <div
+            data-testid="funds-toolbar"
+            data-category-count={categories.length}
+            data-editing={String(isEditing)}
+            data-add-income-disabled={String(isAddIncomeDisabled)}
+            data-add-expense-disabled={String(isAddExpenseDisabled)}
+        >
             <span data-testid="exchange-rate">{exchangeRate}</span>
             <span data-testid="selected-category-id">{selectedCategoryId ?? 'none'}</span>
             <button onClick={() => onTypeChange(undefined)} data-testid="filter-all">
@@ -89,8 +129,8 @@ jest.mock('./components/funds-expenditures-toolbar/FundsExpendituresToolbar', ()
 }));
 
 jest.mock('./components/funds-expenditures-table/FundsExpendituresTable', () => ({
-    FundsExpendituresTable: ({ records }: { records: unknown[] }) => (
-        <div data-testid="funds-table" data-record-count={records.length} />
+    FundsExpendituresTable: ({ records, isEditing }: { records: unknown[]; isEditing?: boolean }) => (
+        <div data-testid="funds-table" data-record-count={records.length} data-editing={String(isEditing ?? false)} />
     ),
 }));
 
@@ -116,66 +156,66 @@ describe('FundsExpenditureSection', () => {
     });
 
     it('should render the disclaimer text', () => {
-        render(<FundsExpenditureSection isEditing={false} />);
+        render(<FundsExpenditureSection />);
         expect(screen.getByText(MOCK_FUNDS_EXPENDITURES_SETTINGS.disclaimerTitle!)).toBeInTheDocument();
     });
 
     it('should render the disclaimer label', () => {
-        render(<FundsExpenditureSection isEditing={false} />);
+        render(<FundsExpenditureSection />);
         expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.DISCLAIMER_LABEL)).toBeInTheDocument();
     });
 
     it('should render four summary cards', () => {
-        render(<FundsExpenditureSection isEditing={false} />);
+        render(<FundsExpenditureSection />);
         const cards = screen.getAllByTestId('summary-card');
         expect(cards).toHaveLength(4);
     });
 
-    it('should render the "Зібрано коштів" summary card', () => {
-        render(<FundsExpenditureSection isEditing={false} />);
+    it('should render the "Ð—Ñ–Ð±Ñ€Ð°Ð½Ð¾ ÐºÐ¾ÑˆÑ‚Ñ–Ð²" summary card', () => {
+        render(<FundsExpenditureSection />);
         expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.SUMMARY_CARDS.COLLECTED)).toBeInTheDocument();
     });
 
-    it('should render the "Витрачено коштів" summary card', () => {
-        render(<FundsExpenditureSection isEditing={false} />);
+    it('should render the "Ð’Ð¸Ñ‚Ñ€Ð°Ñ‡ÐµÐ½Ð¾ ÐºÐ¾ÑˆÑ‚Ñ–Ð²" summary card', () => {
+        render(<FundsExpenditureSection />);
         expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.SUMMARY_CARDS.SPENT)).toBeInTheDocument();
     });
 
-    it('should render "Категорії надходжень" summary card', () => {
-        render(<FundsExpenditureSection isEditing={false} />);
+    it('should render "ÐšÐ°Ñ‚ÐµÐ³Ð¾Ñ€Ñ–Ñ— Ð½Ð°Ð´Ñ…Ð¾Ð´Ð¶ÐµÐ½ÑŒ" summary card', () => {
+        render(<FundsExpenditureSection />);
         expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.SUMMARY_CARDS.INCOME_CATEGORIES)).toBeInTheDocument();
     });
 
-    it('should render "Категорії витрат" summary card', () => {
-        render(<FundsExpenditureSection isEditing={false} />);
+    it('should render "ÐšÐ°Ñ‚ÐµÐ³Ð¾Ñ€Ñ–Ñ— Ð²Ð¸Ñ‚Ñ€Ð°Ñ‚" summary card', () => {
+        render(<FundsExpenditureSection />);
         expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.SUMMARY_CARDS.EXPENSE_CATEGORIES)).toBeInTheDocument();
     });
 
     it('should render the toolbar with exchange rate', () => {
-        render(<FundsExpenditureSection isEditing={false} />);
+        render(<FundsExpenditureSection />);
         expect(screen.getByTestId('funds-toolbar')).toBeInTheDocument();
         expect(screen.getByTestId('exchange-rate')).toHaveTextContent(MOCK_FUNDS_EXPENDITURES_SETTINGS.exchangeRate!);
     });
 
     it('should render the table', () => {
-        render(<FundsExpenditureSection isEditing={false} />);
+        render(<FundsExpenditureSection />);
         expect(screen.getByTestId('funds-table')).toBeInTheDocument();
     });
 
     it('should pass all enriched records to the table initially', () => {
-        render(<FundsExpenditureSection isEditing={false} />);
+        render(<FundsExpenditureSection />);
         const table = screen.getByTestId('funds-table');
         expect(table).toHaveAttribute('data-record-count', String(MOCK_FUNDS_EXPENDITURES_RECORDS.length));
     });
 
     it('should not render disclaimer if settings have no disclaimerTitle', () => {
         setupMockDataFetch({ id: 1, disclaimerTitle: null, exchangeRate: '42.18' });
-        render(<FundsExpenditureSection isEditing={false} />);
+        render(<FundsExpenditureSection />);
         expect(screen.queryByText(FUNDS_EXPENDITURES_TEXT.DISCLAIMER_LABEL)).not.toBeInTheDocument();
     });
 
     it('should filter records by type when type filter is applied', () => {
-        render(<FundsExpenditureSection isEditing={false} />);
+        render(<FundsExpenditureSection />);
 
         fireEvent.click(screen.getByTestId('filter-income'));
 
@@ -185,7 +225,7 @@ describe('FundsExpenditureSection', () => {
     });
 
     it('should filter records by category when category filter is applied', () => {
-        render(<FundsExpenditureSection isEditing={false} />);
+        render(<FundsExpenditureSection />);
 
         fireEvent.click(screen.getByTestId('filter-cat-1'));
 
@@ -194,7 +234,7 @@ describe('FundsExpenditureSection', () => {
     });
 
     it('should reset category when type changes', () => {
-        render(<FundsExpenditureSection isEditing={false} />);
+        render(<FundsExpenditureSection />);
 
         fireEvent.click(screen.getByTestId('filter-cat-1'));
         expect(screen.getByTestId('selected-category-id')).toHaveTextContent('1');
@@ -204,7 +244,7 @@ describe('FundsExpenditureSection', () => {
     });
 
     it('should pass all categories to toolbar when income type is selected', () => {
-        render(<FundsExpenditureSection isEditing={false} />);
+        render(<FundsExpenditureSection />);
 
         fireEvent.click(screen.getByTestId('filter-income'));
 
@@ -212,7 +252,7 @@ describe('FundsExpenditureSection', () => {
     });
 
     it('should pass all categories to toolbar when expense type is selected', () => {
-        render(<FundsExpenditureSection isEditing={false} />);
+        render(<FundsExpenditureSection />);
 
         fireEvent.click(screen.getByTestId('filter-expense'));
 
@@ -220,8 +260,76 @@ describe('FundsExpenditureSection', () => {
     });
 
     it('should pass all categories to toolbar when no type is selected', () => {
-        render(<FundsExpenditureSection isEditing={false} />);
+        render(<FundsExpenditureSection />);
 
         expect(screen.getByTestId('funds-toolbar')).toHaveAttribute('data-category-count', '7');
+    });
+
+    describe('edit mode', () => {
+        beforeEach(() => {
+            jest.clearAllMocks();
+            setupMockDataFetch();
+        });
+
+        it('should start in read mode', () => {
+            render(<FundsExpenditureSection />);
+            expect(screen.getByTestId('funds-toolbar')).toHaveAttribute('data-editing', 'false');
+        });
+
+        it('should show edit button when not editing', () => {
+            render(<FundsExpenditureSection />);
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT)).toBeInTheDocument();
+        });
+
+        it('should enter edit mode when edit button is clicked', () => {
+            render(<FundsExpenditureSection />);
+            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
+            expect(screen.getByTestId('funds-toolbar')).toHaveAttribute('data-editing', 'true');
+        });
+
+        it('should propagate edit mode to table when edit button is clicked', () => {
+            render(<FundsExpenditureSection />);
+            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
+            expect(screen.getByTestId('funds-table')).toHaveAttribute('data-editing', 'true');
+        });
+
+        it('should show disclaimer textarea in edit mode', () => {
+            render(<FundsExpenditureSection />);
+            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
+            expect(screen.getByTestId('textarea-group-funds-disclaimer')).toBeInTheDocument();
+        });
+
+        it('should show disclaimer label inside textarea in edit mode', () => {
+            render(<FundsExpenditureSection />);
+            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.DISCLAIMER_LABEL)).toBeInTheDocument();
+        });
+
+        it('should initialize disclaimer textarea with settings value after entering edit mode', () => {
+            render(<FundsExpenditureSection />);
+            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
+            const textarea = screen.getByTestId('textarea-funds-disclaimer');
+            expect(textarea).toHaveValue(MOCK_FUNDS_EXPENDITURES_SETTINGS.disclaimerTitle);
+        });
+
+        it('should hide edit button while editing', () => {
+            render(<FundsExpenditureSection />);
+            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
+            expect(screen.queryByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT)).not.toBeInTheDocument();
+        });
+
+        it('should return to non-editing state when cancel is clicked', () => {
+            render(<FundsExpenditureSection />);
+            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
+            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.CANCEL));
+            expect(screen.getByTestId('funds-toolbar')).toHaveAttribute('data-editing', 'false');
+        });
+
+        it('should show edit button again after cancel', () => {
+            render(<FundsExpenditureSection />);
+            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
+            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.CANCEL));
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT)).toBeInTheDocument();
+        });
     });
 });

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -1,5 +1,7 @@
 import { useState, useMemo, useCallback, useEffect } from 'react';
-import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS } from '@/validation/admin/reports-schema/funds-expenditures-disclaimer-schema/funds-expenditures-disclaimer-schema';
 import { Button } from '@/components/admin/button/Button';
 import { ReactComponent as EditIcon } from '@/assets/icons/edit-default.svg';
 import { FundsExpendituresApi } from '@/services/api/admin/reports/funds-expenditures-api';
@@ -53,13 +55,28 @@ export const FundsExpenditureSection = () => {
 
     const [isEditing, setIsEditing] = useState(false);
     const [disclaimerValue, setDisclaimerValue] = useState('');
+    const [disclaimerError, setDisclaimerError] = useState<string | undefined>(undefined);
     const [exchangeRateValue, setExchangeRateValue] = useState('');
 
     const [selectedType, setSelectedType] = useState<TypeFilterValue>(undefined);
     const [selectedCategoryId, setSelectedCategoryId] = useState<CategoryFilterValue>(undefined);
 
     const handleEdit = useCallback(() => setIsEditing(true), []);
-    const handleCancel = useCallback(() => setIsEditing(false), []);
+    const handleCancel = useCallback(() => {
+        setIsEditing(false);
+        setDisclaimerError(undefined);
+    }, []);
+
+    const handleDisclaimerChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        const normalized = e.target.value.replaceAll(/ {2,}/g, ' ');
+        setDisclaimerValue(normalized);
+    }, []);
+
+    const handleDisclaimerBlur = useCallback(() => {
+        const trimmed = disclaimerValue.replaceAll(/\s+/g, ' ').trim();
+        setDisclaimerValue(trimmed);
+        setDisclaimerError(FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer(trimmed));
+    }, [disclaimerValue]);
 
     const handleTypeChange = useCallback((type: TypeFilterValue) => {
         setSelectedType(type);
@@ -85,10 +102,16 @@ export const FundsExpenditureSection = () => {
         fetchHandler: fetchRecords,
     });
 
+    const isPublishEnabled = useMemo(() => {
+        const normalized = disclaimerValue.replaceAll(/\s+/g, ' ').trim();
+        return normalized.length >= FUNDS_EXPENDITURES_VALIDATION.disclaimer.min && !disclaimerError;
+    }, [disclaimerValue, disclaimerError]);
+
     useEffect(() => {
         if (!isEditing) {
             setDisclaimerValue(settings?.disclaimerTitle ?? '');
             setExchangeRateValue(settings?.exchangeRate ?? '');
+            setDisclaimerError(undefined);
         }
     }, [settings, isEditing]);
 
@@ -131,9 +154,15 @@ export const FundsExpenditureSection = () => {
                         name="disclaimer"
                         label={FUNDS_EXPENDITURES_TEXT.DISCLAIMER_LABEL}
                         value={disclaimerValue}
-                        onChange={(e) => setDisclaimerValue(e.target.value)}
-                        maxLength={FUNDS_EXPENDITURES_TEXT.DISCLAIMER_MAX_LENGTH}
+                        onChange={handleDisclaimerChange}
+                        onBlur={handleDisclaimerBlur}
+                        maxLength={FUNDS_EXPENDITURES_VALIDATION.disclaimer.max}
+                        maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
+                            FUNDS_EXPENDITURES_VALIDATION.disclaimer.max,
+                        )}
+                        error={disclaimerError}
                         rows={3}
+                        isRequired
                         className={styles['disclaimer-textarea-group']}
                     />
                 </div>
@@ -193,7 +222,12 @@ export const FundsExpenditureSection = () => {
                     <Button buttonStyle="secondary" className={styles['footer-button']} onClick={handleCancel}>
                         {FUNDS_EXPENDITURES_TEXT.BUTTON.CANCEL}
                     </Button>
-                    <Button buttonStyle="primary" className={styles['footer-button']} onClick={() => {}} disabled>
+                    <Button
+                        buttonStyle="primary"
+                        className={styles['footer-button']}
+                        onClick={() => {}}
+                        disabled={!isPublishEnabled}
+                    >
                         {FUNDS_EXPENDITURES_TEXT.BUTTON.PUBLISH}
                     </Button>
                 </div>

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -1,5 +1,7 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { Button } from '@/components/admin/button/Button';
+import { ReactComponent as EditIcon } from '@/assets/icons/edit-default.svg';
 import { FundsExpendituresApi } from '@/services/api/admin/reports/funds-expenditures-api';
 import {
     FundsExpendituresSummary,
@@ -9,6 +11,7 @@ import {
 } from '@/types/admin/reports';
 import { useDataFetch } from '@/hooks/common/use-data-fetch/useDataFetch';
 import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
+import { TextAreaWithCharacterLimitGroup } from '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup';
 import { SummaryCard } from './components/summary-card/SummaryCard';
 import {
     CategoryFilterValue,
@@ -17,10 +20,6 @@ import {
 } from './components/funds-expenditures-toolbar/FundsExpendituresToolbar';
 import { EnrichedRecord, FundsExpendituresTable } from './components/funds-expenditures-table/FundsExpendituresTable';
 import styles from './FundsExpendituresSection.module.scss';
-
-interface FundsExpendituresSectionProps {
-    isEditing: boolean;
-}
 
 const computeSummary = (records: ReportFundsExpendituresRecord[]): FundsExpendituresSummary => {
     const incomeRecords = records.filter((r) => r.type === 'income');
@@ -49,11 +48,18 @@ const enrichRecords = (
     }));
 };
 
-export const FundsExpenditureSection = ({ isEditing: _isEditing }: FundsExpendituresSectionProps) => {
+export const FundsExpenditureSection = () => {
     const adminClient = useAdminClient();
+
+    const [isEditing, setIsEditing] = useState(false);
+    const [disclaimerValue, setDisclaimerValue] = useState('');
+    const [exchangeRateValue, setExchangeRateValue] = useState('');
 
     const [selectedType, setSelectedType] = useState<TypeFilterValue>(undefined);
     const [selectedCategoryId, setSelectedCategoryId] = useState<CategoryFilterValue>(undefined);
+
+    const handleEdit = useCallback(() => setIsEditing(true), []);
+    const handleCancel = useCallback(() => setIsEditing(false), []);
 
     const handleTypeChange = useCallback((type: TypeFilterValue) => {
         setSelectedType(type);
@@ -79,6 +85,13 @@ export const FundsExpenditureSection = ({ isEditing: _isEditing }: FundsExpendit
         fetchHandler: fetchRecords,
     });
 
+    useEffect(() => {
+        if (!isEditing) {
+            setDisclaimerValue(settings?.disclaimerTitle ?? '');
+            setExchangeRateValue(settings?.exchangeRate ?? '');
+        }
+    }, [settings, isEditing]);
+
     const summary = useMemo(() => computeSummary(allRecords), [allRecords]);
 
     const enrichedRecords = useMemo(() => enrichRecords(allRecords, categories), [allRecords, categories]);
@@ -96,15 +109,43 @@ export const FundsExpenditureSection = ({ isEditing: _isEditing }: FundsExpendit
         });
     }, [enrichedRecords, selectedType, selectedCategoryId]);
 
+    const isAddIncomeDisabled = summary.incomeCategories >= FUNDS_EXPENDITURES_TEXT.MAX_CATEGORIES_PER_TYPE;
+    const isAddExpenseDisabled = summary.expenseCategories >= FUNDS_EXPENDITURES_TEXT.MAX_CATEGORIES_PER_TYPE;
+
+    const currentExchangeRate = isEditing ? exchangeRateValue : (settings?.exchangeRate ?? null);
+
     return (
         <div className={styles.section}>
-            {settings?.disclaimerTitle && (
-                <div className={styles.disclaimer}>
-                    <span className={styles['disclaimer-label']}>{FUNDS_EXPENDITURES_TEXT.DISCLAIMER_LABEL}</span>
-                    <div className={styles['disclaimer-text-area']}>
-                        <p className={styles['disclaimer-text']}>{settings.disclaimerTitle}</p>
-                    </div>
+            {!isEditing && (
+                <div className={styles['section-header']}>
+                    <Button buttonStyle="primary" className={styles['edit-btn']} onClick={handleEdit}>
+                        <EditIcon className={styles['edit-icon']} />
+                        {FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT}
+                    </Button>
                 </div>
+            )}
+            {isEditing ? (
+                <div className={styles.disclaimer}>
+                    <TextAreaWithCharacterLimitGroup
+                        id="funds-disclaimer"
+                        name="disclaimer"
+                        label={FUNDS_EXPENDITURES_TEXT.DISCLAIMER_LABEL}
+                        value={disclaimerValue}
+                        onChange={(e) => setDisclaimerValue(e.target.value)}
+                        maxLength={FUNDS_EXPENDITURES_TEXT.DISCLAIMER_MAX_LENGTH}
+                        rows={3}
+                        className={styles['disclaimer-textarea-group']}
+                    />
+                </div>
+            ) : (
+                settings?.disclaimerTitle && (
+                    <div className={styles.disclaimer}>
+                        <span className={styles['disclaimer-label']}>{FUNDS_EXPENDITURES_TEXT.DISCLAIMER_LABEL}</span>
+                        <div className={styles['disclaimer-text-area']}>
+                            <p className={styles['disclaimer-text']}>{settings.disclaimerTitle}</p>
+                        </div>
+                    </div>
+                )
             )}
 
             <div className={styles['summary-cards']}>
@@ -134,12 +175,29 @@ export const FundsExpenditureSection = ({ isEditing: _isEditing }: FundsExpendit
                 categories={filteredCategories}
                 selectedType={selectedType}
                 selectedCategoryId={selectedCategoryId}
-                exchangeRate={settings?.exchangeRate ?? null}
+                exchangeRate={currentExchangeRate}
+                isEditing={isEditing}
+                isAddIncomeDisabled={isAddIncomeDisabled}
+                isAddExpenseDisabled={isAddExpenseDisabled}
                 onTypeChange={handleTypeChange}
                 onCategoryChange={setSelectedCategoryId}
+                onExchangeRateChange={setExchangeRateValue}
+                onAddIncome={() => {}}
+                onAddExpense={() => {}}
             />
 
-            <FundsExpendituresTable records={filteredRecords} />
+            <FundsExpendituresTable records={filteredRecords} isEditing={isEditing} />
+
+            {isEditing && (
+                <div className={styles['section-footer']}>
+                    <Button buttonStyle="secondary" className={styles['footer-button']} onClick={handleCancel}>
+                        {FUNDS_EXPENDITURES_TEXT.BUTTON.CANCEL}
+                    </Button>
+                    <Button buttonStyle="primary" className={styles['footer-button']} onClick={() => {}} disabled>
+                        {FUNDS_EXPENDITURES_TEXT.BUTTON.PUBLISH}
+                    </Button>
+                </div>
+            )}
         </div>
     );
 };

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -83,12 +83,10 @@ export const FundsExpenditureSection = ({ isEditing: _isEditing }: FundsExpendit
 
     const enrichedRecords = useMemo(() => enrichRecords(allRecords, categories), [allRecords, categories]);
 
-    const filteredCategories = useMemo((): ReportFundsExpendituresCategory[] => {
-        const relevantRecords =
-            selectedType === undefined ? allRecords : allRecords.filter((r) => r.type === selectedType);
-        const activeCategoryIds = new Set(relevantRecords.map((r) => r.categoryId));
-        return categories.filter((c) => activeCategoryIds.has(c.id)).sort((a, b) => a.name.localeCompare(b.name, 'uk'));
-    }, [allRecords, categories, selectedType]);
+    const filteredCategories = useMemo(
+        (): ReportFundsExpendituresCategory[] => [...categories].sort((a, b) => a.name.localeCompare(b.name, 'uk')),
+        [categories],
+    );
 
     const filteredRecords = useMemo((): EnrichedRecord[] => {
         return enrichedRecords.filter((record) => {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
@@ -15,12 +15,6 @@
     border-collapse: collapse;
 }
 
-.thead {
-    tr th {
-        border-bottom: 1px solid c.$grey-700;
-    }
-}
-
 .th {
     @include type.subtitle-1-medium;
     padding: 16px 20px;
@@ -135,7 +129,7 @@
 .checkbox-th,
 .checkbox-td {
     width: 48px;
-    padding: 13px 12px;
+    padding: 0 12px;
 }
 
 .row-checkbox {
@@ -148,7 +142,7 @@
 .actions-th,
 .actions-td {
     width: 80px;
-    padding: 13px 12px;
+    padding: 0 8px;
 }
 
 .row-actions {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
@@ -17,7 +17,7 @@
 
 .thead {
     tr th {
-        border-bottom: 1px solid #a4a49b;
+        border-bottom: 1px solid c.$grey-700;
     }
 }
 
@@ -128,7 +128,7 @@
 .empty-state-message {
     @include type.subtitle-2-medium;
     line-height: 24px;
-    color: #061125;
+    color: c.$blue-900;
     margin: 0;
 }
 

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
@@ -131,3 +131,58 @@
     color: #061125;
     margin: 0;
 }
+
+.checkbox-th,
+.checkbox-td {
+    width: 48px;
+    padding: 13px 12px;
+}
+
+.row-checkbox {
+    width: 20px;
+    height: 20px;
+    cursor: pointer;
+    accent-color: c.$blue-500;
+}
+
+.actions-th,
+.actions-td {
+    width: 80px;
+    padding: 13px 12px;
+}
+
+.row-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.icon-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border: none;
+    background: transparent;
+    border-radius: 6px;
+    cursor: pointer;
+    padding: 4px;
+    transition: background-color 0.15s ease;
+
+    &:hover {
+        background-color: c.$light-blue-50;
+    }
+
+    &:active {
+        background-color: c.$grey-300;
+    }
+}
+
+.action-icon {
+    width: 20px;
+    height: 20px;
+    color: c.$blue-500;
+    fill: c.$blue-500;
+}

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
@@ -21,6 +21,14 @@ jest.mock('./FundsExpendituresTable.module.scss', () => ({
     'empty-state': 'empty-state',
     'empty-state-image': 'empty-state-image',
     'empty-state-message': 'empty-state-message',
+    'checkbox-th': 'checkbox-th',
+    'checkbox-td': 'checkbox-td',
+    'row-checkbox': 'row-checkbox',
+    'actions-th': 'actions-th',
+    'actions-td': 'actions-td',
+    'row-actions': 'row-actions',
+    'icon-button': 'icon-button',
+    'action-icon': 'action-icon',
 }));
 
 jest.mock('@/assets/icons/chevron-up.svg', () => ({
@@ -33,6 +41,14 @@ jest.mock('@/assets/icons/chevron-down.svg', () => ({
 
 jest.mock('@/assets/icons/not-found.svg', () => ({
     ReactComponent: ({ className }: { className?: string }) => <svg data-testid="not-found" className={className} />,
+}));
+
+jest.mock('@/assets/icons/edit.svg', () => ({
+    ReactComponent: ({ className }: { className?: string }) => <svg data-testid="edit-icon" className={className} />,
+}));
+
+jest.mock('@/assets/icons/delete.svg', () => ({
+    ReactComponent: ({ className }: { className?: string }) => <svg data-testid="delete-icon" className={className} />,
 }));
 
 const MOCK_RECORDS: EnrichedRecord[] = [
@@ -187,5 +203,42 @@ describe('FundsExpendituresTable', () => {
         render(<FundsExpendituresTable records={MOCK_RECORDS} />);
         expect(screen.getByText('7 265')).toBeInTheDocument();
         expect(screen.getAllByText('4 200')).not.toHaveLength(0);
+    });
+
+    describe('isEditing mode', () => {
+        it('should not show checkboxes when isEditing is false (default)', () => {
+            render(<FundsExpendituresTable records={MOCK_RECORDS} />);
+            expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
+        });
+
+        it('should show a checkbox per row when isEditing is true', () => {
+            render(<FundsExpendituresTable records={MOCK_RECORDS} isEditing={true} />);
+            const checkboxes = screen.getAllByRole('checkbox');
+            expect(checkboxes).toHaveLength(MOCK_RECORDS.length);
+        });
+
+        it('should show edit and delete icons per row when isEditing is true', () => {
+            render(<FundsExpendituresTable records={MOCK_RECORDS} isEditing={true} />);
+            expect(screen.getAllByTestId('edit-icon')).toHaveLength(MOCK_RECORDS.length);
+            expect(screen.getAllByTestId('delete-icon')).toHaveLength(MOCK_RECORDS.length);
+        });
+
+        it('should not show edit and delete icons when isEditing is false', () => {
+            render(<FundsExpendituresTable records={MOCK_RECORDS} isEditing={false} />);
+            expect(screen.queryAllByTestId('edit-icon')).toHaveLength(0);
+            expect(screen.queryAllByTestId('delete-icon')).toHaveLength(0);
+        });
+
+        it('should use colSpan of 7 for empty state when isEditing is true', () => {
+            render(<FundsExpendituresTable records={[]} isEditing={true} />);
+            const emptyCell = screen.getByTestId('funds-table-empty-cell');
+            expect(emptyCell).toHaveAttribute('colspan', '7');
+        });
+
+        it('should use colSpan of 5 for empty state when not editing', () => {
+            render(<FundsExpendituresTable records={[]} isEditing={false} />);
+            const emptyCell = screen.getByTestId('funds-table-empty-cell');
+            expect(emptyCell).toHaveAttribute('colspan', '5');
+        });
     });
 });

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
@@ -4,6 +4,8 @@ import { FundsExpendituresTransactionType, ReportFundsExpendituresRecord } from 
 import { ReactComponent as ChevronUp } from '@/assets/icons/chevron-up.svg';
 import { ReactComponent as ChevronDown } from '@/assets/icons/chevron-down.svg';
 import { ReactComponent as NotFoundIcon } from '@/assets/icons/not-found.svg';
+import { ReactComponent as EditIcon } from '@/assets/icons/edit.svg';
+import { ReactComponent as DeleteIcon } from '@/assets/icons/delete.svg';
 import cn from 'classnames';
 import styles from './FundsExpendituresTable.module.scss';
 
@@ -21,6 +23,7 @@ interface ColumnSort {
 
 interface FundsExpendituresTableProps {
     records: EnrichedRecord[];
+    isEditing?: boolean;
 }
 
 const TYPE_LABEL_MAP: Record<FundsExpendituresTransactionType, string> = {
@@ -67,7 +70,7 @@ const SortIcon = ({ column, sort }: { column: SortableColumn; sort: ColumnSort }
     );
 };
 
-export const FundsExpendituresTable = ({ records }: FundsExpendituresTableProps) => {
+export const FundsExpendituresTable = ({ records, isEditing = false }: FundsExpendituresTableProps) => {
     const [sort, setSort] = useState<ColumnSort>({ column: null, direction: null });
 
     const handleSort = useCallback((column: SortableColumn) => {
@@ -79,12 +82,14 @@ export const FundsExpendituresTable = ({ records }: FundsExpendituresTableProps)
     }, []);
 
     const sortedRecords = sortRecords(records, sort);
+    const colSpan = isEditing ? 7 : 5;
 
     return (
-        <div className={styles['table-wrapper']}>
+        <div className={styles['table-wrapper']} data-testid="funds-table" data-record-count={records.length}>
             <table className={styles.table}>
                 <thead>
                     <tr>
+                        {isEditing && <th className={cn(styles.th, styles['checkbox-th'])} />}
                         <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.REPORTING_YEAR}</th>
                         <th className={cn(styles.th, styles.sortable)} onClick={() => handleSort('type')}>
                             <span className={styles['th-inner']}>
@@ -110,12 +115,13 @@ export const FundsExpendituresTable = ({ records }: FundsExpendituresTableProps)
                                 <SortIcon column="amountUsd" sort={sort} />
                             </span>
                         </th>
+                        {isEditing && <th className={cn(styles.th, styles['actions-th'])} />}
                     </tr>
                 </thead>
                 <tbody>
                     {sortedRecords.length === 0 ? (
                         <tr>
-                            <td colSpan={5} className={styles['empty-cell']}>
+                            <td colSpan={colSpan} className={styles['empty-cell']} data-testid="funds-table-empty-cell">
                                 <div className={styles['empty-state']}>
                                     <NotFoundIcon className={styles['empty-state-image']} />
                                     <p className={styles['empty-state-message']}>
@@ -127,6 +133,15 @@ export const FundsExpendituresTable = ({ records }: FundsExpendituresTableProps)
                     ) : (
                         sortedRecords.map((record) => (
                             <tr key={record.id} className={styles.tr}>
+                                {isEditing && (
+                                    <td className={cn(styles.td, styles['checkbox-td'])}>
+                                        <input
+                                            type="checkbox"
+                                            className={styles['row-checkbox']}
+                                            aria-label={`Select record ${record.id}`}
+                                        />
+                                    </td>
+                                )}
                                 <td className={styles.td}>{record.reportingYear}</td>
                                 <td className={styles.td}>
                                     <span
@@ -141,6 +156,26 @@ export const FundsExpendituresTable = ({ records }: FundsExpendituresTableProps)
                                 <td className={styles.td}>{record.categoryName}</td>
                                 <td className={styles.td}>{record.amountUah}</td>
                                 <td className={styles.td}>{record.amountUsd}</td>
+                                {isEditing && (
+                                    <td className={cn(styles.td, styles['actions-td'])}>
+                                        <div className={styles['row-actions']}>
+                                            <button
+                                                type="button"
+                                                className={styles['icon-button']}
+                                                aria-label={`Edit record ${record.id}`}
+                                            >
+                                                <EditIcon className={styles['action-icon']} />
+                                            </button>
+                                            <button
+                                                type="button"
+                                                className={styles['icon-button']}
+                                                aria-label={`Delete record ${record.id}`}
+                                            >
+                                                <DeleteIcon className={styles['action-icon']} />
+                                            </button>
+                                        </div>
+                                    </td>
+                                )}
                             </tr>
                         ))
                     )}

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
@@ -86,7 +86,7 @@
         width: 200px;
         font-size: 20px;
         font-weight: 600;
-        color: #061125;
+        color: c.$blue-900;
 
         &:hover {
             background-color: rgba(229, 83, 69, 0.06);
@@ -98,7 +98,7 @@
         min-width: 204px;
         border: 1px solid #c6c2de;
         border-radius: 6px;
-        box-shadow: 0 5px 8px rgba(0, 0, 0, 0.2);
+        box-shadow: 0 5px 8px rgba(c.$black, 0.2);
         padding: 6px 10px;
     }
 }
@@ -113,7 +113,7 @@
     height: auto;
 
     &:global(.select-options-selected) {
-        background: rgba(15, 41, 87, 0.17);
+        background: rgba(c.$blue-500, 0.17);
     }
 }
 
@@ -148,27 +148,27 @@
     width: 170px;
     height: 60px;
     border-radius: 12px;
-    background-color: #0f2957 !important;
+    background-color: c.$blue-500 !important;
     font-size: 16px;
     font-weight: 600;
     white-space: nowrap;
     transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
 
     &:not(:disabled):hover {
-        background-color: #ffef43 !important;
-        color: #061125 !important;
-        box-shadow: 0 4px 14px rgba(255, 239, 67, 0.5);
+        background-color: c.$yellow-500 !important;
+        color: c.$blue-900 !important;
+        box-shadow: 0 4px 14px rgba(c.$yellow-500, 0.5);
         transform: translateY(-1px);
 
         svg path {
-            fill: #061125;
+            fill: c.$blue-900;
         }
     }
 
     &:not(:disabled):active {
-        background-color: #e6d53c !important;
-        color: #061125 !important;
-        box-shadow: 0 2px 6px rgba(255, 239, 67, 0.35);
+        background-color: c.$yellow-600 !important;
+        color: c.$blue-900 !important;
+        box-shadow: 0 2px 6px rgba(c.$yellow-500, 0.35);
         transform: translateY(0);
     }
 
@@ -194,20 +194,20 @@
     transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
 
     &:not(:disabled):hover {
-        background-color: #ffef43 !important;
-        color: #061125 !important;
-        box-shadow: 0 4px 14px rgba(255, 239, 67, 0.5);
+        background-color: c.$yellow-500 !important;
+        color: c.$blue-900 !important;
+        box-shadow: 0 4px 14px rgba(c.$yellow-500, 0.5);
         transform: translateY(-1px);
 
         svg path {
-            fill: #061125;
+            fill: c.$blue-900;
         }
     }
 
     &:not(:disabled):active {
-        background-color: #e6d53c !important;
-        color: #061125 !important;
-        box-shadow: 0 2px 6px rgba(255, 239, 67, 0.35);
+        background-color: c.$yellow-600 !important;
+        color: c.$blue-900 !important;
+        box-shadow: 0 2px 6px rgba(c.$yellow-500, 0.35);
         transform: translateY(0);
     }
 

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
@@ -3,6 +3,12 @@
 
 .toolbar {
     display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.toolbar-row {
+    display: flex;
     align-items: center;
     justify-content: space-between;
     flex-wrap: wrap;
@@ -13,6 +19,13 @@
     display: flex;
     gap: 29px;
     align-items: center;
+    flex-wrap: wrap;
+}
+
+.toolbar-right {
+    display: flex;
+    align-items: center;
+    gap: 16px;
     flex-wrap: wrap;
 }
 
@@ -43,15 +56,35 @@
     text-align: center;
 }
 
+.exchange-rate-input {
+    @include type.small-text-medium;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 6px 12px;
+    background-color: c.$white;
+    border: 1px solid c.$bluish-black;
+    border-radius: 8px;
+    letter-spacing: 0.1px;
+    color: c.$blue-900;
+    width: 80px;
+    text-align: center;
+    outline: none;
+
+    &:focus {
+        border-color: c.$blue-500;
+        box-shadow: 0 0 0 2px rgba(c.$blue-500, 0.2);
+    }
+}
+
 .filter-select {
     :global(.select-head) {
         border: 1px solid #e55345;
         border-radius: 12px;
-        padding: 8px 9px;
-        height: 42px;
-        min-width: 123px;
-        width: auto;
-        font-size: 16px;
+        padding: 8px 10px;
+        height: 60px;
+        width: 200px;
+        font-size: 20px;
         font-weight: 600;
         color: #061125;
 
@@ -82,4 +115,110 @@
     &:global(.select-options-selected) {
         background: rgba(15, 41, 87, 0.17);
     }
+}
+
+.edit-button {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    border-radius: 12px;
+    white-space: nowrap;
+}
+
+.edit-icon {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+}
+
+.editing-actions {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    flex-wrap: wrap;
+}
+
+.add-income-button {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    padding: 8px;
+    width: 170px;
+    height: 60px;
+    border-radius: 12px;
+    background-color: #0f2957 !important;
+    font-size: 16px;
+    font-weight: 600;
+    white-space: nowrap;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
+
+    &:not(:disabled):hover {
+        background-color: #ffef43 !important;
+        color: #061125 !important;
+        box-shadow: 0 4px 14px rgba(255, 239, 67, 0.5);
+        transform: translateY(-1px);
+
+        svg path {
+            fill: #061125;
+        }
+    }
+
+    &:not(:disabled):active {
+        background-color: #e6d53c !important;
+        color: #061125 !important;
+        box-shadow: 0 2px 6px rgba(255, 239, 67, 0.35);
+        transform: translateY(0);
+    }
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+}
+
+.add-expense-button {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    padding: 8px;
+    width: 126px;
+    height: 60px;
+    border-radius: 12px;
+    background-color: #e55345 !important;
+    font-size: 16px;
+    font-weight: 600;
+    white-space: nowrap;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
+
+    &:not(:disabled):hover {
+        background-color: #ffef43 !important;
+        color: #061125 !important;
+        box-shadow: 0 4px 14px rgba(255, 239, 67, 0.5);
+        transform: translateY(-1px);
+
+        svg path {
+            fill: #061125;
+        }
+    }
+
+    &:not(:disabled):active {
+        background-color: #e6d53c !important;
+        color: #061125 !important;
+        box-shadow: 0 2px 6px rgba(255, 239, 67, 0.35);
+        transform: translateY(0);
+    }
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+}
+
+.plus-icon {
+    width: 24px;
+    height: 24px;
+    flex-shrink: 0;
 }

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { FundsExpendituresToolbar, TypeFilterValue, CategoryFilterValue } from './FundsExpendituresToolbar';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
@@ -6,12 +6,43 @@ import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
 
 jest.mock('./FundsExpendituresToolbar.module.scss', () => ({
     toolbar: 'toolbar',
+    'toolbar-row': 'toolbar-row',
+    'toolbar-right': 'toolbar-right',
     filters: 'filters',
     exchangeRate: 'exchangeRate',
     exchangeRateLabel: 'exchangeRateLabel',
     exchangeRateValue: 'exchangeRateValue',
+    'exchange-rate-input': 'exchange-rate-input',
     filterSelect: 'filterSelect',
     filterOption: 'filterOption',
+    'editing-actions': 'editing-actions',
+    'add-income-button': 'add-income-button',
+    'add-expense-button': 'add-expense-button',
+    'cancel-button': 'cancel-button',
+    'publish-button': 'publish-button',
+    'plus-icon': 'plus-icon',
+}));
+
+jest.mock('@/assets/icons/plus.svg', () => ({
+    ReactComponent: ({ className }: { className?: string }) => <svg data-testid="plus-icon" className={className} />,
+}));
+
+jest.mock('@/components/admin/button/Button', () => ({
+    Button: ({
+        children,
+        onClick,
+        disabled,
+        className,
+    }: {
+        children: React.ReactNode;
+        onClick?: () => void;
+        disabled?: boolean;
+        className?: string;
+    }) => (
+        <button onClick={onClick} disabled={disabled} className={className}>
+            {children}
+        </button>
+    ),
 }));
 
 jest.mock('@/components/common/select/Select', () => {
@@ -65,14 +96,23 @@ const MOCK_CATEGORIES: ReportFundsExpendituresCategory[] = [
 describe('FundsExpendituresToolbar', () => {
     const onTypeChange = jest.fn();
     const onCategoryChange = jest.fn();
+    const onAddIncome = jest.fn();
+    const onAddExpense = jest.fn();
+    const onExchangeRateChange = jest.fn();
 
     const defaultProps = {
         categories: MOCK_CATEGORIES,
         selectedType: undefined as TypeFilterValue,
         selectedCategoryId: undefined as CategoryFilterValue,
         exchangeRate: '42.18',
+        isEditing: false,
+        isAddIncomeDisabled: false,
+        isAddExpenseDisabled: false,
         onTypeChange,
         onCategoryChange,
+        onExchangeRateChange,
+        onAddIncome,
+        onAddExpense,
     };
 
     beforeEach(() => {
@@ -116,5 +156,43 @@ describe('FundsExpendituresToolbar', () => {
         const allBtn = screen.getByTestId(`select-${FUNDS_EXPENDITURES_TEXT.FILTER.TYPE_PLACEHOLDER}-all`);
         fireEvent.click(allBtn);
         expect(onTypeChange).toHaveBeenCalledWith(undefined);
+    });
+
+    describe('edit mode', () => {
+        it('should show Add Income button when editing', () => {
+            render(<FundsExpendituresToolbar {...defaultProps} isEditing={true} />);
+            const actions = screen.getByTestId('editing-actions');
+            expect(within(actions).getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.ADD_INCOME)).toBeInTheDocument();
+        });
+
+        it('should show Add Expense button when editing', () => {
+            render(<FundsExpendituresToolbar {...defaultProps} isEditing={true} />);
+            const actions = screen.getByTestId('editing-actions');
+            expect(within(actions).getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.ADD_EXPENSE)).toBeInTheDocument();
+        });
+
+        it('should show exchange rate input when editing', () => {
+            render(<FundsExpendituresToolbar {...defaultProps} isEditing={true} />);
+            expect(screen.getByTestId('exchange-rate-input')).toBeInTheDocument();
+        });
+
+        it('should disable Add Income button when isAddIncomeDisabled is true', () => {
+            render(<FundsExpendituresToolbar {...defaultProps} isEditing={true} isAddIncomeDisabled={true} />);
+            const actions = screen.getByTestId('editing-actions');
+            expect(within(actions).getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.ADD_INCOME)).toBeDisabled();
+        });
+
+        it('should disable Add Expense button when isAddExpenseDisabled is true', () => {
+            render(<FundsExpendituresToolbar {...defaultProps} isEditing={true} isAddExpenseDisabled={true} />);
+            const actions = screen.getByTestId('editing-actions');
+            expect(within(actions).getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.ADD_EXPENSE)).toBeDisabled();
+        });
+
+        it('should call onExchangeRateChange when exchange rate input changes', () => {
+            render(<FundsExpendituresToolbar {...defaultProps} isEditing={true} />);
+            const input = screen.getByTestId('exchange-rate-input');
+            fireEvent.change(input, { target: { value: '50.00' } });
+            expect(onExchangeRateChange).toHaveBeenCalledWith('50.00');
+        });
     });
 });

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.test.tsx
@@ -52,10 +52,8 @@ jest.mock('@/components/common/select/Select', () => {
         onValueChange,
         placeholder,
     }: {
-        children?: React.ReactNode;
         onValueChange: (value: unknown) => void;
         placeholder?: string;
-        value?: unknown;
     }) => {
         return (
             <div data-testid={`select-${placeholder}`}>

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.tsx
@@ -1,6 +1,8 @@
 import { Select } from '@/components/common/select/Select';
+import { Button } from '@/components/admin/button/Button';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
 import { FundsExpendituresTransactionType, ReportFundsExpendituresCategory } from '@/types/admin/reports';
+import { ReactComponent as PlusIcon } from '@/assets/icons/plus.svg';
 import styles from './FundsExpendituresToolbar.module.scss';
 
 export type TypeFilterValue = FundsExpendituresTransactionType | undefined;
@@ -11,8 +13,14 @@ interface FundsExpendituresToolbarProps {
     selectedType: TypeFilterValue;
     selectedCategoryId: CategoryFilterValue;
     exchangeRate: string | null;
+    isEditing: boolean;
+    isAddIncomeDisabled: boolean;
+    isAddExpenseDisabled: boolean;
     onTypeChange: (value: TypeFilterValue) => void;
     onCategoryChange: (value: CategoryFilterValue) => void;
+    onExchangeRateChange?: (value: string) => void;
+    onAddIncome: () => void;
+    onAddExpense: () => void;
 }
 
 export const FundsExpendituresToolbar = ({
@@ -20,44 +28,92 @@ export const FundsExpendituresToolbar = ({
     selectedType,
     selectedCategoryId,
     exchangeRate,
+    isEditing,
+    isAddIncomeDisabled,
+    isAddExpenseDisabled,
     onTypeChange,
     onCategoryChange,
+    onExchangeRateChange,
+    onAddIncome,
+    onAddExpense,
 }: FundsExpendituresToolbarProps) => {
     return (
-        <div className={styles.toolbar}>
-            <div className={styles.filters}>
-                <Select<TypeFilterValue>
-                    value={selectedType}
-                    onValueChange={onTypeChange}
-                    placeholder={FUNDS_EXPENDITURES_TEXT.FILTER.TYPE_PLACEHOLDER}
-                    className={styles['filter-select']}
-                    optionClassName={styles['filter-option']}
-                >
-                    <Select.Option value={undefined} name={FUNDS_EXPENDITURES_TEXT.FILTER.ALL_OPTION} />
-                    <Select.Option value="income" name={FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME} />
-                    <Select.Option value="expense" name={FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.EXPENSE} />
-                </Select>
+        <div className={styles.toolbar} data-testid="funds-toolbar">
+            <div className={styles['toolbar-row']}>
+                <div className={styles.filters}>
+                    <Select<TypeFilterValue>
+                        value={selectedType}
+                        onValueChange={onTypeChange}
+                        placeholder={FUNDS_EXPENDITURES_TEXT.FILTER.TYPE_PLACEHOLDER}
+                        className={styles['filter-select']}
+                        optionClassName={styles['filter-option']}
+                    >
+                        <Select.Option value={undefined} name={FUNDS_EXPENDITURES_TEXT.FILTER.ALL_OPTION} />
+                        <Select.Option value="income" name={FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME} />
+                        <Select.Option value="expense" name={FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.EXPENSE} />
+                    </Select>
 
-                <Select<CategoryFilterValue>
-                    value={selectedCategoryId}
-                    onValueChange={onCategoryChange}
-                    placeholder={FUNDS_EXPENDITURES_TEXT.FILTER.CATEGORY_PLACEHOLDER}
-                    className={styles['filter-select']}
-                    optionClassName={styles['filter-option']}
-                >
-                    <Select.Option value={undefined} name={FUNDS_EXPENDITURES_TEXT.FILTER.ALL_OPTION} />
-                    {categories.map((category) => (
-                        <Select.Option key={category.id} value={category.id} name={category.name} />
-                    ))}
-                </Select>
-            </div>
-
-            {exchangeRate && (
-                <div className={styles['exchange-rate']}>
-                    <span className={styles['exchange-rate-label']}>{FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL}</span>
-                    <span className={styles['exchange-rate-value']}>{exchangeRate}</span>
+                    <Select<CategoryFilterValue>
+                        value={selectedCategoryId}
+                        onValueChange={onCategoryChange}
+                        placeholder={FUNDS_EXPENDITURES_TEXT.FILTER.CATEGORY_PLACEHOLDER}
+                        className={styles['filter-select']}
+                        optionClassName={styles['filter-option']}
+                    >
+                        <Select.Option value={undefined} name={FUNDS_EXPENDITURES_TEXT.FILTER.ALL_OPTION} />
+                        {categories.map((category) => (
+                            <Select.Option key={category.id} value={category.id} name={category.name} />
+                        ))}
+                    </Select>
                 </div>
-            )}
+
+                <div className={styles['toolbar-right']}>
+                    {exchangeRate !== null && (
+                        <div className={styles['exchange-rate']} data-testid="exchange-rate-container">
+                            <span className={styles['exchange-rate-label']}>
+                                {FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL}
+                            </span>
+                            {isEditing ? (
+                                <input
+                                    type="text"
+                                    data-testid="exchange-rate-input"
+                                    className={styles['exchange-rate-input']}
+                                    value={exchangeRate}
+                                    maxLength={FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_MAX_LENGTH}
+                                    onChange={(e) => onExchangeRateChange?.(e.target.value)}
+                                />
+                            ) : (
+                                <span className={styles['exchange-rate-value']} data-testid="exchange-rate">
+                                    {exchangeRate}
+                                </span>
+                            )}
+                        </div>
+                    )}
+
+                    {isEditing && (
+                        <div className={styles['editing-actions']} data-testid="editing-actions">
+                            <Button
+                                buttonStyle="primary"
+                                className={styles['add-expense-button']}
+                                onClick={onAddExpense}
+                                disabled={isAddExpenseDisabled}
+                            >
+                                <PlusIcon className={styles['plus-icon']} />
+                                {FUNDS_EXPENDITURES_TEXT.BUTTON.ADD_EXPENSE}
+                            </Button>
+                            <Button
+                                buttonStyle="primary"
+                                className={styles['add-income-button']}
+                                onClick={onAddIncome}
+                                disabled={isAddIncomeDisabled}
+                            >
+                                <PlusIcon className={styles['plus-icon']} />
+                                {FUNDS_EXPENDITURES_TEXT.BUTTON.ADD_INCOME}
+                            </Button>
+                        </div>
+                    )}
+                </div>
+            </div>
         </div>
     );
 };

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
@@ -9,9 +9,7 @@ jest.mock('../pdf-files-section/PdfFilesSection', () => ({
 }));
 
 jest.mock('../funds-expenditures-section/FundsExpendituresSection', () => ({
-    FundsExpenditureSection: () => (
-        <div data-testid="funds-expenditure-section">FundsExpenditureSection</div>
-    ),
+    FundsExpenditureSection: () => <div data-testid="funds-expenditure-section">FundsExpenditureSection</div>,
 }));
 
 describe('ReportAnalytics', () => {

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
@@ -9,8 +9,8 @@ jest.mock('../pdf-files-section/PdfFilesSection', () => ({
 }));
 
 jest.mock('../funds-expenditures-section/FundsExpendituresSection', () => ({
-    FundsExpenditureSection: ({ isEditing }: { isEditing: boolean }) => (
-        <div data-testid="funds-expenditure-section">FundsExpenditureSection - Editing: {String(isEditing)}</div>
+    FundsExpenditureSection: () => (
+        <div data-testid="funds-expenditure-section">FundsExpenditureSection</div>
     ),
 }));
 

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
@@ -37,7 +37,7 @@ export const ReportAnalytics = ({ isEditing }: ReportAnalyticsProps) => {
             />
             <div className={styles['tab-content']}>
                 {activeTab.id === 'pdf-files' && <PdfFilesSection isEditing={isEditing} />}
-                {activeTab.id === 'income-expenses' && <FundsExpenditureSection isEditing={isEditing} />}
+                {activeTab.id === 'income-expenses' && <FundsExpenditureSection />}
                 {activeTab.id === 'program-expenses' && <div>Program expenses tab</div>}
             </div>
         </div>

--- a/src/pages/admin/reports/components/reports-page-toolbar/ReportsPageToolbar.module.scss
+++ b/src/pages/admin/reports/components/reports-page-toolbar/ReportsPageToolbar.module.scss
@@ -1,9 +1,10 @@
 @use '@/assets/sass/variables/colors' as c;
+@use '@/assets/sass/variables/fonts' as fonts;
 
 .button {
     display: flex;
     align-items: center;
-    font-family: Mulish, sans-serif;
+    font-family: fonts.$mulish-regular-font;
     gap: 20px;
     width: 311px;
     height: 60px;

--- a/src/pages/admin/reports/components/reports-page-toolbar/ReportsPageToolbar.module.scss
+++ b/src/pages/admin/reports/components/reports-page-toolbar/ReportsPageToolbar.module.scss
@@ -1,10 +1,13 @@
 @use '@/assets/sass/variables/colors' as c;
-@use '@/assets/sass/variables/fonts' as fonts;
+@use '@/assets/sass/mixins/typography.mixins' as type;
 
 .button {
     display: flex;
     align-items: center;
-    font-family: fonts.$mulish-regular-font;
+    @include type.subtitle-1-medium;
+    font-weight: 400;
+    line-height: 24px;
+    letter-spacing: -0.02em;
     gap: 20px;
     width: 311px;
     height: 60px;

--- a/src/pages/admin/reports/components/reports-page-toolbar/ReportsPageToolbar.test.tsx
+++ b/src/pages/admin/reports/components/reports-page-toolbar/ReportsPageToolbar.test.tsx
@@ -36,7 +36,6 @@ describe('ReportsPageToolbar', () => {
         isEditing: false,
         isPublishDisabled: false,
         onEdit: mockOnEdit,
-        onEditReportAnalytics: jest.fn(),
         onCancel: mockOnCancel,
         onPublish: mockOnPublish,
     };
@@ -182,19 +181,12 @@ describe('ReportsPageToolbar', () => {
     });
 
     describe('Report analytics tab', () => {
-        it('should render only Edit Page button when on report-analytics tab (no Cancel/Publish)', () => {
-            const mockOnEditReportAnalytics = jest.fn();
-            renderComponent({
-                selectedTab: REPORTS_TOOLBAR_TABS[1],
-                onEditReportAnalytics: mockOnEditReportAnalytics,
-            });
+        it('should not render any action buttons on the report-analytics tab', () => {
+            renderComponent({ selectedTab: REPORTS_TOOLBAR_TABS[1] });
 
-            expect(screen.getByText(REPORTS_TEXT.BUTTON.EDIT_PAGE)).toBeInTheDocument();
+            expect(screen.queryByText(REPORTS_TEXT.BUTTON.EDIT_PAGE)).not.toBeInTheDocument();
             expect(screen.queryByText(REPORTS_TEXT.BUTTON.CANCEL)).not.toBeInTheDocument();
             expect(screen.queryByText(REPORTS_TEXT.BUTTON.PUBLISH)).not.toBeInTheDocument();
-
-            fireEvent.click(screen.getByText(REPORTS_TEXT.BUTTON.EDIT_PAGE));
-            expect(mockOnEditReportAnalytics).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/src/pages/admin/reports/components/reports-page-toolbar/ReportsPageToolbar.tsx
+++ b/src/pages/admin/reports/components/reports-page-toolbar/ReportsPageToolbar.tsx
@@ -20,7 +20,6 @@ interface ReportsPageToolbarProps {
     isEditing: boolean;
     isPublishDisabled: boolean;
     onEdit: () => void;
-    onEditReportAnalytics?: () => void;
     onCancel: () => void;
     onPublish: () => void;
 }
@@ -31,12 +30,10 @@ export const ReportsPageToolbar = ({
     isEditing,
     isPublishDisabled,
     onEdit,
-    onEditReportAnalytics,
     onCancel,
     onPublish,
 }: ReportsPageToolbarProps) => {
     const isMediaSettingsTab = selectedTab.id === 'media-settings';
-    const handleEditClick = isMediaSettingsTab ? onEdit : (onEditReportAnalytics ?? (() => {}));
 
     return (
         <div className={styles.toolbar}>
@@ -47,26 +44,27 @@ export const ReportsPageToolbar = ({
                 getCategoryKey={(tab) => tab.id}
                 onCategorySelect={onTabSelect}
             />
-            {isMediaSettingsTab && isEditing ? (
-                <div className={styles.actions}>
-                    <Button buttonStyle="secondary" className={styles.button} onClick={onCancel}>
-                        {REPORTS_TEXT.BUTTON.CANCEL}
+            {isMediaSettingsTab &&
+                (isEditing ? (
+                    <div className={styles.actions}>
+                        <Button buttonStyle="secondary" className={styles.button} onClick={onCancel}>
+                            {REPORTS_TEXT.BUTTON.CANCEL}
+                        </Button>
+                        <Button
+                            buttonStyle="primary"
+                            className={styles.button}
+                            onClick={onPublish}
+                            disabled={isPublishDisabled}
+                        >
+                            {REPORTS_TEXT.BUTTON.PUBLISH}
+                        </Button>
+                    </div>
+                ) : (
+                    <Button buttonStyle="primary" className={styles.button} onClick={onEdit}>
+                        <EditIcon />
+                        {REPORTS_TEXT.BUTTON.EDIT_PAGE}
                     </Button>
-                    <Button
-                        buttonStyle="primary"
-                        className={styles.button}
-                        onClick={onPublish}
-                        disabled={isPublishDisabled}
-                    >
-                        {REPORTS_TEXT.BUTTON.PUBLISH}
-                    </Button>
-                </div>
-            ) : (
-                <Button buttonStyle="primary" className={styles.button} onClick={handleEditClick}>
-                    <EditIcon />
-                    {REPORTS_TEXT.BUTTON.EDIT_PAGE}
-                </Button>
-            )}
+                ))}
         </div>
     );
 };

--- a/src/pages/admin/reports/components/reports-panel-content/ReportsPanelContent.tsx
+++ b/src/pages/admin/reports/components/reports-panel-content/ReportsPanelContent.tsx
@@ -56,7 +56,6 @@ export const ReportsPanelContent = () => {
                     isEditing={isEditing}
                     isPublishDisabled={!isDirty}
                     onEdit={handleEdit}
-                    onEditReportAnalytics={() => {}}
                     onCancel={handleCancel}
                     onPublish={handlePublish}
                 />

--- a/src/validation/admin/reports-schema/funds-expenditures-disclaimer-schema/funds-expenditures-disclaimer-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-disclaimer-schema/funds-expenditures-disclaimer-schema.test.ts
@@ -1,0 +1,67 @@
+import { FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS } from './funds-expenditures-disclaimer-schema';
+import { FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+
+describe('funds-expenditures-disclaimer-schema', () => {
+    describe('FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS', () => {
+        describe('validateDisclaimer', () => {
+            it('should return undefined for a valid disclaimer', () => {
+                const result =
+                    FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer('Valid disclaimer text');
+                expect(result).toBeUndefined();
+            });
+
+            it('should return required error for an empty string', () => {
+                const result = FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer('');
+                expect(result).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED);
+            });
+
+            it('should return required error for a whitespace-only string', () => {
+                const result = FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer('   ');
+                expect(result).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED);
+            });
+
+            it('should return min error when disclaimer is too short (1 character)', () => {
+                const result = FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer('a');
+                expect(result).toBe(
+                    COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.disclaimer.min),
+                );
+            });
+
+            it('should return undefined for disclaimer at min length', () => {
+                const minValue = 'a'.repeat(FUNDS_EXPENDITURES_VALIDATION.disclaimer.min);
+                const result = FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer(minValue);
+                expect(result).toBeUndefined();
+            });
+
+            it('should return max error when disclaimer exceeds max length', () => {
+                const longValue = 'a'.repeat(FUNDS_EXPENDITURES_VALIDATION.disclaimer.max + 1);
+                const result = FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer(longValue);
+                expect(result).toBe(
+                    COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(FUNDS_EXPENDITURES_VALIDATION.disclaimer.max),
+                );
+            });
+
+            it('should return undefined for disclaimer at max length', () => {
+                const maxValue = 'a'.repeat(FUNDS_EXPENDITURES_VALIDATION.disclaimer.max);
+                const result = FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer(maxValue);
+                expect(result).toBeUndefined();
+            });
+
+            it('should trim leading and trailing spaces before validating', () => {
+                const result = FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer('  valid text  ');
+                expect(result).toBeUndefined();
+            });
+
+            it('should normalize consecutive spaces before checking min length', () => {
+                const result = FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer('a  b');
+                expect(result).toBeUndefined();
+            });
+
+            it('should treat string of only spaces as empty (required error)', () => {
+                const result = FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer('     ');
+                expect(result).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED);
+            });
+        });
+    });
+});

--- a/src/validation/admin/reports-schema/funds-expenditures-disclaimer-schema/funds-expenditures-disclaimer-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-disclaimer-schema/funds-expenditures-disclaimer-schema.ts
@@ -1,0 +1,28 @@
+import * as Yup from 'yup';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+
+const disclaimerSchema = Yup.object({
+    disclaimer: Yup.string()
+        .required(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED)
+        .min(
+            FUNDS_EXPENDITURES_VALIDATION.disclaimer.min,
+            COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.disclaimer.min),
+        )
+        .max(
+            FUNDS_EXPENDITURES_VALIDATION.disclaimer.max,
+            COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(FUNDS_EXPENDITURES_VALIDATION.disclaimer.max),
+        ),
+});
+
+export const FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS = {
+    validateDisclaimer: (value: string): string | undefined => {
+        const normalizedValue = value.replaceAll(/\s+/g, ' ').trim();
+        try {
+            disclaimerSchema.validateSyncAt('disclaimer', { disclaimer: normalizedValue });
+            return undefined;
+        } catch (error: any) {
+            return error.message;
+        }
+    },
+};


### PR DESCRIPTION
## Github ticker

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1410

## Description

This PR implements the edit mode functionality for the "Доходи та витрати" tab on the Звітність view page.

## How it looks


https://github.com/user-attachments/assets/7af35f9b-f779-4ab0-83d6-a7874336504d


## Summary of change

1. Clicking 'Редагувати Доходи та витрати' activates edit mode and hides the button
2. Disclaimer field becomes editable with a character counter
3. Exchange rate (USD/UAH) field becomes editable
4. Edit, Delete and Checkbox icons become active for each record in the list
5. 'Відмінити' button is active; 'Опублікувати' is disabled
6. 'Витрати' button is disabled when the list already contains 4 records across 4 funds categories, otherwise active
7. 'Надходження' button is disabled when the list already contains 4 records across 4 expenditure categories, otherwise active

## How to recreate changes

1. Open the Звітність page as Admin
2. Navigate to the "Доходи та витрати" tab
3. Click the 'Редагувати Доходи та витрати' button


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [x]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions
