### PR TITLE
Feat/issue-1421: Add disclaimer text editing with validation for "Доходи та витрати" tab

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -103,10 +103,13 @@ export const PDF_FILES_SECTION_TEXT = {
     },
 };
 
+export const FUNDS_EXPENDITURES_VALIDATION = {
+    disclaimer: { min: 2, max: 1000 },
+};
+
 export const FUNDS_EXPENDITURES_TEXT = {
     DISCLAIMER_LABEL: 'Дісклеймер/ENG',
     EXCHANGE_RATE_LABEL: 'Курс USD/UAH',
-    DISCLAIMER_MAX_LENGTH: 300,
     EXCHANGE_RATE_MAX_LENGTH: 10,
     MAX_CATEGORIES_PER_TYPE: 4,
     BUTTON: {

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
@@ -1,7 +1,8 @@
 ﻿import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { FundsExpenditureSection } from './FundsExpendituresSection';
-import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import {
     MOCK_FUNDS_EXPENDITURES_CATEGORIES,
     MOCK_FUNDS_EXPENDITURES_RECORDS,
@@ -40,15 +41,20 @@ jest.mock(
             label,
             value,
             onChange,
+            onBlur,
+            error,
         }: {
             id: string;
             label: string;
             value: string;
             onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+            onBlur?: (e: React.FocusEvent<HTMLTextAreaElement>) => void;
+            error?: string;
         }) => (
             <div data-testid={`textarea-group-${id}`}>
                 <label>{label}</label>
-                <textarea data-testid={`textarea-${id}`} value={value} onChange={onChange} />
+                <textarea data-testid={`textarea-${id}`} value={value} onChange={onChange} onBlur={onBlur} />
+                {error && <span data-testid={`error-${id}`}>{error}</span>}
             </div>
         ),
     }),
@@ -329,6 +335,111 @@ describe('FundsExpenditureSection', () => {
             fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
             fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.CANCEL));
             expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT)).toBeInTheDocument();
+        });
+    });
+
+    describe('disclaimer validation', () => {
+        beforeEach(() => {
+            jest.clearAllMocks();
+            setupMockDataFetch();
+        });
+
+        const enterEditMode = () => fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
+        const getTextarea = () => screen.getByTestId('textarea-funds-disclaimer');
+        const getPublishButton = () => screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.PUBLISH);
+
+        it('should show required error when blurring an empty disclaimer', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            fireEvent.change(getTextarea(), { target: { value: '' } });
+            fireEvent.blur(getTextarea());
+            expect(screen.getByTestId('error-funds-disclaimer')).toHaveTextContent(
+                COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED,
+            );
+        });
+
+        it('should show min-length error when blurring with 1 character', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            fireEvent.change(getTextarea(), { target: { value: 'a' } });
+            fireEvent.blur(getTextarea());
+            expect(screen.getByTestId('error-funds-disclaimer')).toHaveTextContent(
+                COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.disclaimer.min),
+            );
+        });
+
+        it('should clear error when disclaimer is corrected and blurred', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            fireEvent.change(getTextarea(), { target: { value: '' } });
+            fireEvent.blur(getTextarea());
+            expect(screen.getByTestId('error-funds-disclaimer')).toBeInTheDocument();
+
+            fireEvent.change(getTextarea(), { target: { value: 'valid disclaimer text' } });
+            fireEvent.blur(getTextarea());
+            expect(screen.queryByTestId('error-funds-disclaimer')).not.toBeInTheDocument();
+        });
+
+        it('should normalize consecutive spaces to a single space when typing', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            fireEvent.change(getTextarea(), { target: { value: 'one  two   three' } });
+            expect(getTextarea()).toHaveValue('one two three');
+        });
+
+        it('should trim and normalize spaces on blur', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            fireEvent.change(getTextarea(), { target: { value: '  leading and trailing  ' } });
+            fireEvent.blur(getTextarea());
+            expect(getTextarea()).toHaveValue('leading and trailing');
+        });
+
+        it('should disable publish button when disclaimer is empty', () => {
+            setupMockDataFetch({ id: 1, disclaimerTitle: null, exchangeRate: '42' });
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            expect(getPublishButton()).toBeDisabled();
+        });
+
+        it('should disable publish button when disclaimer has only 1 character', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            fireEvent.change(getTextarea(), { target: { value: 'a' } });
+            expect(getPublishButton()).toBeDisabled();
+        });
+
+        it('should enable publish button when disclaimer has at least 2 characters', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            fireEvent.change(getTextarea(), { target: { value: 'ok' } });
+            expect(getPublishButton()).not.toBeDisabled();
+        });
+
+        it('should enable publish button when disclaimer already has a valid value from settings', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            expect(getPublishButton()).not.toBeDisabled();
+        });
+
+        it('should disable publish button after a blur validation error', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            fireEvent.change(getTextarea(), { target: { value: 'a' } });
+            fireEvent.blur(getTextarea());
+            expect(getPublishButton()).toBeDisabled();
+        });
+
+        it('should reset disclaimer error when cancel is clicked', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+            fireEvent.change(getTextarea(), { target: { value: '' } });
+            fireEvent.blur(getTextarea());
+            expect(screen.getByTestId('error-funds-disclaimer')).toBeInTheDocument();
+
+            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.CANCEL));
+            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
+            expect(screen.queryByTestId('error-funds-disclaimer')).not.toBeInTheDocument();
         });
     });
 });

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -1,5 +1,7 @@
 import { useState, useMemo, useCallback, useEffect } from 'react';
-import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS } from '@/validation/admin/reports-schema/funds-expenditures-disclaimer-schema/funds-expenditures-disclaimer-schema';
 import { Button } from '@/components/admin/button/Button';
 import { ReactComponent as EditIcon } from '@/assets/icons/edit-default.svg';
 import { FundsExpendituresApi } from '@/services/api/admin/reports/funds-expenditures-api';
@@ -53,13 +55,28 @@ export const FundsExpenditureSection = () => {
 
     const [isEditing, setIsEditing] = useState(false);
     const [disclaimerValue, setDisclaimerValue] = useState('');
+    const [disclaimerError, setDisclaimerError] = useState<string | undefined>(undefined);
     const [exchangeRateValue, setExchangeRateValue] = useState('');
 
     const [selectedType, setSelectedType] = useState<TypeFilterValue>(undefined);
     const [selectedCategoryId, setSelectedCategoryId] = useState<CategoryFilterValue>(undefined);
 
     const handleEdit = useCallback(() => setIsEditing(true), []);
-    const handleCancel = useCallback(() => setIsEditing(false), []);
+    const handleCancel = useCallback(() => {
+        setIsEditing(false);
+        setDisclaimerError(undefined);
+    }, []);
+
+    const handleDisclaimerChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        const normalized = e.target.value.replaceAll(/ {2,}/g, ' ');
+        setDisclaimerValue(normalized);
+    }, []);
+
+    const handleDisclaimerBlur = useCallback(() => {
+        const trimmed = disclaimerValue.replaceAll(/\s+/g, ' ').trim();
+        setDisclaimerValue(trimmed);
+        setDisclaimerError(FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer(trimmed));
+    }, [disclaimerValue]);
 
     const handleTypeChange = useCallback((type: TypeFilterValue) => {
         setSelectedType(type);
@@ -85,10 +102,16 @@ export const FundsExpenditureSection = () => {
         fetchHandler: fetchRecords,
     });
 
+    const isPublishEnabled = useMemo(() => {
+        const normalized = disclaimerValue.replaceAll(/\s+/g, ' ').trim();
+        return normalized.length >= FUNDS_EXPENDITURES_VALIDATION.disclaimer.min && !disclaimerError;
+    }, [disclaimerValue, disclaimerError]);
+
     useEffect(() => {
         if (!isEditing) {
             setDisclaimerValue(settings?.disclaimerTitle ?? '');
             setExchangeRateValue(settings?.exchangeRate ?? '');
+            setDisclaimerError(undefined);
         }
     }, [settings, isEditing]);
 
@@ -131,9 +154,15 @@ export const FundsExpenditureSection = () => {
                         name="disclaimer"
                         label={FUNDS_EXPENDITURES_TEXT.DISCLAIMER_LABEL}
                         value={disclaimerValue}
-                        onChange={(e) => setDisclaimerValue(e.target.value)}
-                        maxLength={FUNDS_EXPENDITURES_TEXT.DISCLAIMER_MAX_LENGTH}
+                        onChange={handleDisclaimerChange}
+                        onBlur={handleDisclaimerBlur}
+                        maxLength={FUNDS_EXPENDITURES_VALIDATION.disclaimer.max}
+                        maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
+                            FUNDS_EXPENDITURES_VALIDATION.disclaimer.max,
+                        )}
+                        error={disclaimerError}
                         rows={3}
+                        isRequired
                         className={styles['disclaimer-textarea-group']}
                     />
                 </div>
@@ -193,7 +222,12 @@ export const FundsExpenditureSection = () => {
                     <Button buttonStyle="secondary" className={styles['footer-button']} onClick={handleCancel}>
                         {FUNDS_EXPENDITURES_TEXT.BUTTON.CANCEL}
                     </Button>
-                    <Button buttonStyle="primary" className={styles['footer-button']} onClick={() => {}} disabled>
+                    <Button
+                        buttonStyle="primary"
+                        className={styles['footer-button']}
+                        onClick={() => {}}
+                        disabled={!isPublishEnabled}
+                    >
                         {FUNDS_EXPENDITURES_TEXT.BUTTON.PUBLISH}
                     </Button>
                 </div>

--- a/src/validation/admin/reports-schema/funds-expenditures-disclaimer-schema/funds-expenditures-disclaimer-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-disclaimer-schema/funds-expenditures-disclaimer-schema.test.ts
@@ -1,0 +1,67 @@
+import { FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS } from './funds-expenditures-disclaimer-schema';
+import { FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+
+describe('funds-expenditures-disclaimer-schema', () => {
+    describe('FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS', () => {
+        describe('validateDisclaimer', () => {
+            it('should return undefined for a valid disclaimer', () => {
+                const result =
+                    FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer('Valid disclaimer text');
+                expect(result).toBeUndefined();
+            });
+
+            it('should return required error for an empty string', () => {
+                const result = FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer('');
+                expect(result).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED);
+            });
+
+            it('should return required error for a whitespace-only string', () => {
+                const result = FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer('   ');
+                expect(result).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED);
+            });
+
+            it('should return min error when disclaimer is too short (1 character)', () => {
+                const result = FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer('a');
+                expect(result).toBe(
+                    COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.disclaimer.min),
+                );
+            });
+
+            it('should return undefined for disclaimer at min length', () => {
+                const minValue = 'a'.repeat(FUNDS_EXPENDITURES_VALIDATION.disclaimer.min);
+                const result = FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer(minValue);
+                expect(result).toBeUndefined();
+            });
+
+            it('should return max error when disclaimer exceeds max length', () => {
+                const longValue = 'a'.repeat(FUNDS_EXPENDITURES_VALIDATION.disclaimer.max + 1);
+                const result = FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer(longValue);
+                expect(result).toBe(
+                    COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(FUNDS_EXPENDITURES_VALIDATION.disclaimer.max),
+                );
+            });
+
+            it('should return undefined for disclaimer at max length', () => {
+                const maxValue = 'a'.repeat(FUNDS_EXPENDITURES_VALIDATION.disclaimer.max);
+                const result = FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer(maxValue);
+                expect(result).toBeUndefined();
+            });
+
+            it('should trim leading and trailing spaces before validating', () => {
+                const result = FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer('  valid text  ');
+                expect(result).toBeUndefined();
+            });
+
+            it('should normalize consecutive spaces before checking min length', () => {
+                const result = FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer('a  b');
+                expect(result).toBeUndefined();
+            });
+
+            it('should treat string of only spaces as empty (required error)', () => {
+                const result = FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer('     ');
+                expect(result).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED);
+            });
+        });
+    });
+});

--- a/src/validation/admin/reports-schema/funds-expenditures-disclaimer-schema/funds-expenditures-disclaimer-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-disclaimer-schema/funds-expenditures-disclaimer-schema.ts
@@ -1,0 +1,28 @@
+import * as Yup from 'yup';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+
+const disclaimerSchema = Yup.object({
+    disclaimer: Yup.string()
+        .required(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED)
+        .min(
+            FUNDS_EXPENDITURES_VALIDATION.disclaimer.min,
+            COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.disclaimer.min),
+        )
+        .max(
+            FUNDS_EXPENDITURES_VALIDATION.disclaimer.max,
+            COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(FUNDS_EXPENDITURES_VALIDATION.disclaimer.max),
+        ),
+});
+
+export const FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS = {
+    validateDisclaimer: (value: string): string | undefined => {
+        const normalizedValue = value.replaceAll(/\s+/g, ' ').trim();
+        try {
+            disclaimerSchema.validateSyncAt('disclaimer', { disclaimer: normalizedValue });
+            return undefined;
+        } catch (error: any) {
+            return error.message;
+        }
+    },
+};


### PR DESCRIPTION
## Github ticker

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1421

## Description

This PR implements the ability for Admin to edit the disclaimer text in the "Доходи та витрати" tab while in edit mode. 

## How it looks


https://github.com/user-attachments/assets/a9f5b6c7-a101-44b0-95a4-72f8f60f02e0


## Summary of change

'Дісклеймер/ENG' text input field (max 1000 chars) is editable only in edit mode
Validation on focus loss: field is mandatory, minimum 2 characters
'Опублікувати' button becomes enabled once all validation rules pass


## How to recreate changes

1. Open the Звітність page as Admin
2. Navigate to the "Доходи та витрати" tab and click 'Редагувати Доходи та витрати'
3. Locate the 'Дісклеймер/ENG' field


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [x]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions