### PR TITLE
fix: correct footer how to support link on release/1.0.0 #1449

### DIFF
--- a/src/components/public/footer/Footer.test.tsx
+++ b/src/components/public/footer/Footer.test.tsx
@@ -44,10 +44,9 @@ describe('Footer', () => {
             'href',
             PUBLIC_ROUTES.REPORTS.FULL,
         );
-        expect(screen.getByRole('link', { name: footerUk['HOW_TO_SUPPORT'] })).toHaveAttribute(
-            'href',
-            PUBLIC_ROUTES.DONATE.FULL,
-        );
+        const howToSupportLink = screen.getByRole('link', { name: footerUk['HOW_TO_SUPPORT'] });
+        expect(howToSupportLink).toHaveAttribute('href', PUBLIC_ROUTES.MOCK.FULL);
+        expect(howToSupportLink).toHaveClass('disable');
         expect(screen.getByRole('link', { name: footerUk['STORIES_OF_VICTORIES'] })).toHaveAttribute(
             'href',
             PUBLIC_ROUTES.MOCK.FULL,

--- a/src/components/public/footer/Footer.tsx
+++ b/src/components/public/footer/Footer.tsx
@@ -36,7 +36,9 @@ export const Footer = () => {
                 <div className="menu">
                     <span className="title">{t('MENU')}</span>
                     <Link to={PUBLIC_ROUTES.REPORTS.FULL}>{t('REPORTING')}</Link>
-                    <Link to={PUBLIC_ROUTES.DONATE.FULL}>{t('HOW_TO_SUPPORT')}</Link>
+                    <Link to={PUBLIC_ROUTES.MOCK.FULL} className="disable">
+                        {t('HOW_TO_SUPPORT')}
+                    </Link>
                     <Link to={PUBLIC_ROUTES.MOCK.FULL} className="disable">
                         {t('STORIES_OF_VICTORIES')}
                     </Link>


### PR DESCRIPTION
## Github ticker

* Issue: https://github.com/ita-social-projects/VictoryCenter-Back/issues/1449
* Follow-up for PR: https://github.com/ita-social-projects/VictoryCenter-Client/pull/262

## Description

This PR fixes a follow-up issue from PR #262. The footer link "Як підтримати" was mistakenly connected to `/donate`, but there is no separate page for this footer item. The link has now been returned to the disabled mock route, and the footer tests were updated to verify the correct behavior.

## How it looks

**How it was:**
<img width="556" alt="image" src="https://github.com/user-attachments/assets/de426352-ad40-4684-9c78-b10a0274bc27" />


**How it now:**
"Як підтримати" links to mock route and remains visually disabled
<img width="556" alt="image" src="https://github.com/user-attachments/assets/3f5a013f-33a9-4b1b-aa86-f5f57a981af4" />

## Summary of change

- Changed footer link "Як підтримати" from `PUBLIC_ROUTES.DONATE.FULL` to `PUBLIC_ROUTES.MOCK.FULL`
- Added `disable` class back to the footer link
- Updated footer test to verify that "Як підтримати" points to `PUBLIC_ROUTES.MOCK.FULL`
- Added test assertion to verify the link has `disable` class

## How to recreate changes

1. Open the application locally
2. Scroll to the footer on any public page
3. Find the "Як підтримати" link in the Menu section
4. Verify it is visually disabled
5. Verify it no longer points to `/donate`
6. Run footer tests and verify updated expectations pass

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions
