### PR TITLE
Fix/issue 1526 - Incorrect state of Опублікувати button through tabs

### DIFF
--- a/src/components/admin/rich-text-input/plugins/InitialValuePlugin.test.tsx
+++ b/src/components/admin/rich-text-input/plugins/InitialValuePlugin.test.tsx
@@ -37,23 +37,17 @@ describe('InitialValuePlugin', () => {
     beforeEach(() => {
         jest.clearAllMocks();
 
-        const mockRoot = {
-            clear: jest.fn(),
-        };
+        const mockRoot = { clear: jest.fn() };
         mockGetRoot.mockReturnValue(mockRoot);
         mockGenerateNodesFromDOM.mockReturnValue([{ type: 'paragraph' }]);
         mockGenerateHtmlFromNodes.mockReturnValue('<p></p>');
-
         mockSanitizeHtml.mockImplementation((html: string) => html);
-
         mockGetEditorState.mockReturnValue({
             read: (callback: () => any) => callback(),
         });
 
         global.DOMParser = jest.fn().mockImplementation(() => ({
-            parseFromString: jest.fn(() => ({
-                body: { innerHTML: '' },
-            })),
+            parseFromString: jest.fn(() => ({ body: { innerHTML: '' } })),
         })) as any;
     });
 
@@ -62,111 +56,44 @@ describe('InitialValuePlugin', () => {
         expect(container).toBeEmptyDOMElement();
     });
 
-    it('updates editor on initial render with value', () => {
+    it('does not call editor.update on initial render', () => {
         render(<InitialValuePlugin value="<p>Initial content</p>" />);
-
-        expect(mockUpdate).toHaveBeenCalled();
-
-        const updateCallback = mockUpdate.mock.calls[0][0];
-        updateCallback();
-
-        expect(mockGetRoot).toHaveBeenCalled();
-        expect(mockGenerateNodesFromDOM).toHaveBeenCalled();
-        expect(mockInsertNodes).toHaveBeenCalledWith([{ type: 'paragraph' }]);
+        expect(mockUpdate).not.toHaveBeenCalled();
     });
 
     it('updates editor when value prop changes to different content', () => {
         const { rerender } = render(<InitialValuePlugin value="<p>First</p>" />);
 
-        expect(mockUpdate).toHaveBeenCalledTimes(1);
+        expect(mockUpdate).not.toHaveBeenCalled();
 
         mockGenerateHtmlFromNodes.mockReturnValue('<p>First</p>');
 
         rerender(<InitialValuePlugin value="<p>Second</p>" />);
 
-        expect(mockUpdate).toHaveBeenCalledTimes(2);
+        expect(mockUpdate).toHaveBeenCalledTimes(1);
     });
 
     it('does not update when value remains the same', () => {
         const { rerender } = render(<InitialValuePlugin value="<p>Same content</p>" />);
 
-        expect(mockUpdate).toHaveBeenCalledTimes(1);
-
         rerender(<InitialValuePlugin value="<p>Same content</p>" />);
 
-        expect(mockUpdate).toHaveBeenCalledTimes(1);
+        expect(mockUpdate).not.toHaveBeenCalled();
     });
 
-    it('handles empty value by using default paragraph', () => {
+    it('does not call editor.update on empty initial value', () => {
         render(<InitialValuePlugin value="" />);
-
-        expect(mockUpdate).toHaveBeenCalled();
-
-        const updateCallback = mockUpdate.mock.calls[0][0];
-        updateCallback();
-
-        expect(global.DOMParser).toHaveBeenCalled();
-        expect(mockGenerateNodesFromDOM).toHaveBeenCalled();
-    });
-
-    it('clears root before inserting new nodes', () => {
-        const mockClear = jest.fn();
-        const mockRoot = {
-            clear: mockClear,
-        };
-        mockGetRoot.mockReturnValue(mockRoot);
-
-        render(<InitialValuePlugin value="<p>Content</p>" />);
-
-        const updateCallback = mockUpdate.mock.calls[0][0];
-        updateCallback();
-
-        expect(mockClear).toHaveBeenCalled();
-        expect(mockInsertNodes).toHaveBeenCalled();
-        const clearCallOrder = mockClear.mock.invocationCallOrder[0];
-        const insertCallOrder = mockInsertNodes.mock.invocationCallOrder[0];
-        expect(clearCallOrder).toBeLessThan(insertCallOrder);
-    });
-
-    it('uses DOMParser to parse HTML value', () => {
-        const mockParseFromString = jest.fn(() => ({
-            body: { innerHTML: '' },
-        }));
-
-        global.DOMParser = jest.fn().mockImplementation(() => ({
-            parseFromString: mockParseFromString,
-        })) as any;
-
-        render(<InitialValuePlugin value="<p>Test <strong>HTML</strong></p>" />);
-
-        const updateCallback = mockUpdate.mock.calls[0][0];
-        updateCallback();
-
-        expect(global.DOMParser).toHaveBeenCalled();
-        expect(mockParseFromString).toHaveBeenCalledWith('<p>Test <strong>HTML</strong></p>', 'text/html');
-    });
-
-    it('handles complex HTML with multiple elements', () => {
-        const complexHtml = '<p>First</p><p><strong>Bold</strong> and <em>italic</em></p>';
-
-        render(<InitialValuePlugin value={complexHtml} />);
-
-        const updateCallback = mockUpdate.mock.calls[0][0];
-        updateCallback();
-
-        expect(mockGenerateNodesFromDOM).toHaveBeenCalledWith(mockEditor, expect.any(Object));
+        expect(mockUpdate).not.toHaveBeenCalled();
     });
 
     it('resets to new value after external change', () => {
         const { rerender } = render(<InitialValuePlugin value="<p>Original</p>" />);
 
-        mockUpdate.mockClear();
-
         mockGenerateHtmlFromNodes.mockReturnValue('<p>Original</p>');
 
         rerender(<InitialValuePlugin value="<p>Updated externally</p>" />);
 
-        expect(mockUpdate).toHaveBeenCalled();
+        expect(mockUpdate).toHaveBeenCalledTimes(1);
 
         const updateCallback = mockUpdate.mock.calls[0][0];
         updateCallback();
@@ -178,9 +105,6 @@ describe('InitialValuePlugin', () => {
     it('does not update editor when value changes but HTML content is the same', () => {
         const { rerender } = render(<InitialValuePlugin value="<p>Content</p>" />);
 
-        expect(mockUpdate).toHaveBeenCalledTimes(1);
-        mockUpdate.mockClear();
-
         mockGenerateHtmlFromNodes.mockReturnValue('<p>Content</p>');
 
         rerender(<InitialValuePlugin value="<p>Content</p>" />);
@@ -190,9 +114,6 @@ describe('InitialValuePlugin', () => {
 
     it('handles whitespace differences in HTML comparison', () => {
         const { rerender } = render(<InitialValuePlugin value="<p>First</p><p>Second</p>" />);
-
-        expect(mockUpdate).toHaveBeenCalledTimes(1);
-        mockUpdate.mockClear();
 
         mockGenerateHtmlFromNodes.mockReturnValue('<p>First</p> <p>Second</p>');
 

--- a/src/components/admin/rich-text-input/plugins/InitialValuePlugin.tsx
+++ b/src/components/admin/rich-text-input/plugins/InitialValuePlugin.tsx
@@ -18,17 +18,6 @@ export const InitialValuePlugin = ({ value }: InitialValuePluginProps) => {
         if (isFirstRender.current) {
             isFirstRender.current = false;
             lastValue.current = value;
-
-            editor.update(() => {
-                const root = $getRoot();
-
-                const parser = new DOMParser();
-                const dom = parser.parseFromString(value || '<p></p>', 'text/html');
-                const nodes = $generateNodesFromDOM(editor, dom);
-
-                root.clear();
-                $insertNodes(nodes);
-            });
             return;
         }
 

--- a/src/components/admin/rich-text-input/plugins/OnChangePlugin.test.tsx
+++ b/src/components/admin/rich-text-input/plugins/OnChangePlugin.test.tsx
@@ -17,17 +17,30 @@ jest.mock('@lexical/html', () => ({
     $generateHtmlFromNodes: (...args: any[]) => mockGenerateHtmlFromNodes(...args),
 }));
 
-const testOnChangeCallback = (onChange: jest.Mock, mockHtml: string, expectedOutput: string) => {
-    mockGenerateHtmlFromNodes.mockReturnValue(mockHtml);
-    render(<OnChangePlugin onChange={onChange} />);
-
+const triggerUserChange = (mockHtml: string) => {
     const listenerCallback = mockRegisterUpdateListener.mock.calls[0][0];
     const mockEditorState = {
         read: jest.fn((callback) => callback()),
     };
 
-    listenerCallback({ editorState: mockEditorState });
+    listenerCallback({
+        editorState: mockEditorState,
+        dirtyElements: new Map(),
+        dirtyLeaves: new Set(),
+    });
 
+    mockGenerateHtmlFromNodes.mockReturnValue(mockHtml);
+
+    listenerCallback({
+        editorState: mockEditorState,
+        dirtyElements: new Map([['key', true]]),
+        dirtyLeaves: new Set(),
+    });
+};
+
+const testOnChangeCallback = (onChange: jest.Mock, mockHtml: string, expectedOutput: string) => {
+    render(<OnChangePlugin onChange={onChange} />);
+    triggerUserChange(mockHtml);
     expect(onChange).toHaveBeenCalledWith(expectedOutput);
 };
 
@@ -47,8 +60,37 @@ describe('OnChangePlugin', () => {
     it('registers update listener on mount', () => {
         const onChange = jest.fn();
         render(<OnChangePlugin onChange={onChange} />);
-
         expect(mockRegisterUpdateListener).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('does not call onChange on initial render', () => {
+        const onChange = jest.fn();
+        render(<OnChangePlugin onChange={onChange} />);
+
+        const listenerCallback = mockRegisterUpdateListener.mock.calls[0][0];
+        const mockEditorState = { read: jest.fn((cb) => cb()) };
+
+        listenerCallback({
+            editorState: mockEditorState,
+            dirtyElements: new Map(),
+            dirtyLeaves: new Set(),
+        });
+
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('does not call onChange when there are no dirty elements or leaves', () => {
+        const onChange = jest.fn();
+        render(<OnChangePlugin onChange={onChange} />);
+
+        const listenerCallback = mockRegisterUpdateListener.mock.calls[0][0];
+        const mockEditorState = { read: jest.fn((cb) => cb()) };
+
+        listenerCallback({ editorState: mockEditorState, dirtyElements: new Map(), dirtyLeaves: new Set() });
+
+        listenerCallback({ editorState: mockEditorState, dirtyElements: new Map(), dirtyLeaves: new Set() });
+
+        expect(onChange).not.toHaveBeenCalled();
     });
 
     it('calls onChange callback when editor updates', () => {
@@ -69,9 +111,7 @@ describe('OnChangePlugin', () => {
         const { unmount } = render(<OnChangePlugin onChange={onChange} />);
 
         expect(unregister).not.toHaveBeenCalled();
-
         unmount();
-
         expect(unregister).toHaveBeenCalled();
     });
 

--- a/src/components/admin/rich-text-input/plugins/OnChangePlugin.tsx
+++ b/src/components/admin/rich-text-input/plugins/OnChangePlugin.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { $generateHtmlFromNodes } from '@lexical/html';
 import { sanitizeHtml } from './htmlSanitizer';
@@ -9,9 +9,16 @@ export interface OnChangePluginProps {
 
 export const OnChangePlugin = ({ onChange }: OnChangePluginProps) => {
     const [editor] = useLexicalComposerContext();
+    const isFirstRender = useRef(true);
 
     useEffect(() => {
-        return editor.registerUpdateListener(({ editorState }) => {
+        return editor.registerUpdateListener(({ editorState, dirtyElements, dirtyLeaves }) => {
+            if (isFirstRender.current) {
+                isFirstRender.current = false;
+                return;
+            }
+            if (dirtyElements.size === 0 && dirtyLeaves.size === 0) return;
+
             editorState.read(() => {
                 const rawHtml = $generateHtmlFromNodes(editor);
                 const cleanHtml = sanitizeHtml(rawHtml);

--- a/src/pages/admin/who-we-are/components/card-content/CardContent.test.tsx
+++ b/src/pages/admin/who-we-are/components/card-content/CardContent.test.tsx
@@ -53,7 +53,6 @@ describe('CardContent', () => {
     let mockOnChange: jest.Mock;
     let mockOnDescriptionValidate: jest.Mock;
     let mockSetImageError: jest.Mock;
-    let mockSetIsPublishButtonActive: jest.Mock;
     const descriptionLimit = 250;
 
     const baseContent = {
@@ -83,7 +82,6 @@ describe('CardContent', () => {
             descriptionError: null,
             imageError: null,
             setImageError: mockSetImageError,
-            setIsPublishButtonActive: mockSetIsPublishButtonActive,
             language: { id: 1, code: 'uk', name: 'Ukrainian' },
         };
         return render(<CardContent {...baseProps} {...props} />);
@@ -92,7 +90,6 @@ describe('CardContent', () => {
     beforeEach(() => {
         mockOnChange = jest.fn();
         mockSetImageError = jest.fn();
-        mockSetIsPublishButtonActive = jest.fn();
         mockOnDescriptionValidate = jest.fn();
     });
 
@@ -110,7 +107,7 @@ describe('CardContent', () => {
         expect(screen.queryByText('This is an image error message.')).not.toBeInTheDocument();
     });
 
-    it('should call onChange, onDescriptionValidate on change, and onDescriptionValidate on blur', () => {
+    it('should call onChange and onDescriptionValidate on change, and onDescriptionValidate on blur', () => {
         renderComponent();
         const descriptionInput = screen.getByTestId('mock-rich-input-1');
         const newDescription = 'New description text';
@@ -126,7 +123,7 @@ describe('CardContent', () => {
         expect(mockOnDescriptionValidate).toHaveBeenCalled();
     });
 
-    it('should call onChange, setIsPublishButtonActive on image change, and call setImageError', () => {
+    it('should call onChange on image change and setImageError on error', () => {
         renderComponent();
         const imageInputButton = screen.getByText('Set Error');
 
@@ -142,7 +139,6 @@ describe('CardContent', () => {
             ...baseContent,
             image: file,
         });
-        expect(mockSetIsPublishButtonActive).toHaveBeenCalledWith(true);
     });
 
     it('should display description error message when prop is provided', () => {

--- a/src/pages/admin/who-we-are/components/card-content/CardContent.tsx
+++ b/src/pages/admin/who-we-are/components/card-content/CardContent.tsx
@@ -20,7 +20,6 @@ export interface CardContentProps {
     descriptionError: string | null;
     imageError: string | null;
     setImageError: (value: string | null) => void;
-    setIsPublishButtonActive: (value: boolean) => void;
     language: LocalizationLanguage;
 }
 
@@ -33,7 +32,6 @@ export const CardContent = ({
     descriptionError,
     imageError,
     setImageError,
-    setIsPublishButtonActive,
     language,
 }: CardContentProps) => {
     const isBaseLanguage = language.code === DEFAULT_LOCALE;
@@ -48,7 +46,6 @@ export const CardContent = ({
             ...content,
             image: value,
         });
-        setIsPublishButtonActive(true);
     };
 
     const handleDescriptionChange = (value: string) => {

--- a/src/pages/admin/who-we-are/components/sections-wrapper/SectionsWrapper.test.tsx
+++ b/src/pages/admin/who-we-are/components/sections-wrapper/SectionsWrapper.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { SectionsWrapper } from './SectionsWrapper';
@@ -11,19 +10,16 @@ import { ImageSectionProps } from '@/pages/admin/who-we-are/components/sections/
 
 jest.mock('../sections/cards-section/CardsSection', () => ({
     CardsSection: (props: CardsSectionProps) => {
-        props.setIsPublishButtonActive(true);
         return <div data-testid="cards-section" data-props={JSON.stringify(props)} />;
     },
 }));
 jest.mock('../sections/description-section/DescriptionSection', () => ({
     DescriptionSection: (props: DescriptionSectionProps) => {
-        props.setIsPublishButtonActive(true);
         return <div data-testid="description-section" data-props={JSON.stringify(props)} />;
     },
 }));
 jest.mock('../sections/image-block-section/ImageBlockSection', () => ({
     ImageSection: (props: ImageSectionProps) => {
-        props.setIsPublishButtonActive(true);
         return <div data-testid="image-section" data-props={JSON.stringify(props)} />;
     },
 }));
@@ -32,7 +28,6 @@ const mockProps = {
     onChange: jest.fn(),
     onPublish: jest.fn(),
     isPublishButtonActive: false,
-    setIsPublishButtonActive: jest.fn(),
     language: { id: 1, code: 'uk', name: 'Ukrainian' },
 };
 
@@ -41,7 +36,7 @@ describe('SectionsWrapper', () => {
         jest.clearAllMocks();
     });
 
-    it('should render DescriptionSection and call setIsPublishButtonActive', () => {
+    it('should render DescriptionSection for WhatWeDo', () => {
         const section = {
             id: 1,
             sectionType: SectionType.WhatWeDo,
@@ -49,12 +44,10 @@ describe('SectionsWrapper', () => {
             contents: [{ id: 10, title: 'What We Do Title' }] as Content[],
         };
         render(<SectionsWrapper {...mockProps} section={section} />);
-
         expect(screen.getByTestId('description-section')).toBeInTheDocument();
-        expect(mockProps.setIsPublishButtonActive).toHaveBeenCalledWith(true);
     });
 
-    it('should render CardsSection and call setIsPublishButtonActive for WhoWeSupport', () => {
+    it('should render CardsSection for WhoWeSupport', () => {
         const section = {
             id: 2,
             sectionType: SectionType.WhoWeSupport,
@@ -62,12 +55,10 @@ describe('SectionsWrapper', () => {
             contents: [{ id: 20, description: 'Who We Support Desc' }] as Content[],
         };
         render(<SectionsWrapper {...mockProps} section={section} />);
-
         expect(screen.getByTestId('cards-section')).toBeInTheDocument();
-        expect(mockProps.setIsPublishButtonActive).toHaveBeenCalledWith(true);
     });
 
-    it('should render CardsSection and call setIsPublishButtonActive for People', () => {
+    it('should render CardsSection for People', () => {
         const section = {
             id: 3,
             sectionType: SectionType.People,
@@ -75,12 +66,10 @@ describe('SectionsWrapper', () => {
             contents: [{ id: 30, contentType: ContentType.Description, description: 'People Desc' }] as Content[],
         };
         render(<SectionsWrapper {...mockProps} section={section} />);
-
         expect(screen.getByTestId('cards-section')).toBeInTheDocument();
-        expect(mockProps.setIsPublishButtonActive).toHaveBeenCalledWith(true);
     });
 
-    it('should render ImageSection and call setIsPublishButtonActive for Main', () => {
+    it('should render ImageSection for Main', () => {
         const section = {
             id: 4,
             sectionType: SectionType.Main,
@@ -88,12 +77,10 @@ describe('SectionsWrapper', () => {
             contents: [{ id: 40, image: { id: 1, url: 'main.jpg', mimeType: 'image/png' } as Image }] as Content[],
         };
         render(<SectionsWrapper {...mockProps} section={section} />);
-
         expect(screen.getByTestId('image-section')).toBeInTheDocument();
-        expect(mockProps.setIsPublishButtonActive).toHaveBeenCalledWith(true);
     });
 
-    it('should render ImageSection and call setIsPublishButtonActive for Team', () => {
+    it('should render ImageSection for Team', () => {
         const section = {
             id: 5,
             sectionType: SectionType.Team,
@@ -101,9 +88,7 @@ describe('SectionsWrapper', () => {
             contents: [{ id: 50, image: { id: 1, url: 'team.jpg', mimeType: 'image/png' } as Image }] as Content[],
         };
         render(<SectionsWrapper {...mockProps} section={section} />);
-
         expect(screen.getByTestId('image-section')).toBeInTheDocument();
-        expect(mockProps.setIsPublishButtonActive).toHaveBeenCalledWith(true);
     });
 
     it('should not render anything if the section prop is null', () => {
@@ -120,6 +105,5 @@ describe('SectionsWrapper', () => {
         };
         const { container } = render(<SectionsWrapper {...mockProps} section={section} />);
         expect(container).toBeEmptyDOMElement();
-        expect(mockProps.setIsPublishButtonActive).not.toHaveBeenCalled();
     });
 });

--- a/src/pages/admin/who-we-are/components/sections-wrapper/SectionsWrapper.tsx
+++ b/src/pages/admin/who-we-are/components/sections-wrapper/SectionsWrapper.tsx
@@ -18,7 +18,6 @@ export interface MainSectionProps {
     onChange: (data: Content) => void;
     onPublish: () => void;
     isPublishButtonActive: boolean;
-    setIsPublishButtonActive: (value: boolean) => void;
     language: LocalizationLanguage;
 }
 
@@ -31,7 +30,6 @@ export const SectionsWrapper = ({
     section,
     onChange,
     onPublish,
-    setIsPublishButtonActive,
     isPublishButtonActive,
     language,
 }: MainSectionProps) => {
@@ -43,7 +41,7 @@ export const SectionsWrapper = ({
         content: section.contents,
         onChange,
         onPublish,
-        setIsPublishButtonActive,
+        //setIsPublishButtonActive,
         isPublishButtonActive,
         language,
     };

--- a/src/pages/admin/who-we-are/components/sections-wrapper/SectionsWrapper.tsx
+++ b/src/pages/admin/who-we-are/components/sections-wrapper/SectionsWrapper.tsx
@@ -41,7 +41,6 @@ export const SectionsWrapper = ({
         content: section.contents,
         onChange,
         onPublish,
-        //setIsPublishButtonActive,
         isPublishButtonActive,
         language,
     };

--- a/src/pages/admin/who-we-are/components/sections/cards-section/CardsSection.test.tsx
+++ b/src/pages/admin/who-we-are/components/sections/cards-section/CardsSection.test.tsx
@@ -15,7 +15,6 @@ jest.mock('../../card-content/CardContent', () => ({
         descriptionError,
         imageError,
         setImageError,
-        setIsPublishButtonActive,
         language,
     }: CardContentProps & { language?: any }) => {
         const disabled = language && language.code !== 'uk';
@@ -27,7 +26,6 @@ jest.mock('../../card-content/CardContent', () => ({
                         if (!disabled) {
                             onChange({ ...content, description: e.target.value });
                             onDescriptionValidate(e.target.value);
-                            setIsPublishButtonActive(true);
                         }
                     }}
                     onBlur={(e) => !disabled && onDescriptionValidate(e.currentTarget.value)}
@@ -41,7 +39,6 @@ jest.mock('../../card-content/CardContent', () => ({
                         if (!disabled) {
                             const newImage = JSON.parse(e.target.value);
                             onChange({ ...content, image: newImage });
-                            setIsPublishButtonActive(true);
                         }
                     }}
                     onBlur={() => !disabled && setImageError('test image error')}
@@ -62,7 +59,6 @@ jest.mock('@/validation/admin/who-we-are-schema/WhoWeAreSchema', () => ({
 describe('CardsSection', () => {
     let mockOnChange: jest.Mock;
     let mockOnPublish: jest.Mock;
-    let mockSetIsPublishButtonActive: jest.Mock;
     const descriptionLimit = 500;
     const cardImageConfigs = [
         { style: { width: '20rem' }, cropWidth: 20, cropHeight: 20, minWidth: 20, minHeight: 20, subText: '200x200' },
@@ -107,7 +103,6 @@ describe('CardsSection', () => {
             cardImageConfigs,
             titleText,
             isPublishButtonActive: false,
-            setIsPublishButtonActive: mockSetIsPublishButtonActive,
             language: { id: 1, code: 'uk', name: 'Ukrainian' },
         };
         return render(<CardsSection {...defaultProps} {...props} />);
@@ -116,7 +111,6 @@ describe('CardsSection', () => {
     beforeEach(() => {
         mockOnChange = jest.fn();
         mockOnPublish = jest.fn();
-        mockSetIsPublishButtonActive = jest.fn();
         (WHO_WE_ARE_VALIDATION_FUNCTIONS.validateText as jest.Mock).mockReturnValue(null);
     });
 
@@ -147,7 +141,7 @@ describe('CardsSection', () => {
         expect(noCardsContainer).toBeEmptyDOMElement();
     });
 
-    it('should call onChange and setIsPublishButtonActive on description change', () => {
+    it('should call onChange on description change', () => {
         renderComponent();
         const textarea = screen.getByTestId('mock-textarea-1');
         const newDescription = 'Updated description for card 1.';
@@ -160,10 +154,9 @@ describe('CardsSection', () => {
                 description: newDescription,
             }),
         );
-        expect(mockSetIsPublishButtonActive).toHaveBeenCalledWith(true);
     });
 
-    it('should call onChange and setIsPublishButtonActive on image change', () => {
+    it('should call onChange on image change', () => {
         renderComponent();
         const imageInput = screen.getByTestId('mock-image-input-1');
         const newImage = { id: 20, base64: 'new-image.png', mimeType: 'image/png' } as ImageValues;
@@ -176,7 +169,6 @@ describe('CardsSection', () => {
                 image: newImage,
             }),
         );
-        expect(mockSetIsPublishButtonActive).toHaveBeenCalledWith(true);
     });
 
     it('should display a description validation error and disable the publish button', async () => {

--- a/src/pages/admin/who-we-are/components/sections/cards-section/CardsSection.tsx
+++ b/src/pages/admin/who-we-are/components/sections/cards-section/CardsSection.tsx
@@ -19,7 +19,6 @@ export interface CardsSectionProps {
     titleText?: string;
     onPublish: () => void;
     isPublishButtonActive: boolean;
-    setIsPublishButtonActive: (value: boolean) => void;
     language: LocalizationLanguage;
 }
 
@@ -32,7 +31,6 @@ export const CardsSection = ({
     cardImageConfigs,
     titleText,
     isPublishButtonActive,
-    setIsPublishButtonActive,
     language,
 }: CardsSectionProps) => {
     const [errors, setErrors] = useState<Record<number, { image: string | null; description: string | null }>>({});
@@ -56,8 +54,6 @@ export const CardsSection = ({
                 },
             };
         });
-
-        setIsPublishButtonActive(true);
     };
 
     const handleSetImageError = (id: number, value: string | null) => {
@@ -94,7 +90,6 @@ export const CardsSection = ({
                             descriptionLimit={descriptionLimit}
                             imageInputProps={{ ...(cardImageConfigs[index] || {}) }}
                             rows={rows}
-                            setIsPublishButtonActive={setIsPublishButtonActive}
                             language={language}
                         />
                     ))}

--- a/src/pages/admin/who-we-are/components/sections/description-section/DescriptionSection.test.tsx
+++ b/src/pages/admin/who-we-are/components/sections/description-section/DescriptionSection.test.tsx
@@ -54,7 +54,6 @@ jest.mock('@/validation/admin/who-we-are-schema/WhoWeAreSchema', () => ({
 describe('DescriptionSection', () => {
     let mockOnChange: jest.Mock;
     let mockOnPublish: jest.Mock;
-    let mockSetIsPublishButtonActive: jest.Mock;
     const descriptionLimit = 500;
     const initialDescription = 'This is an initial test description.';
 
@@ -74,7 +73,6 @@ describe('DescriptionSection', () => {
         onChange: mockOnChange,
         onPublish: mockOnPublish,
         isPublishButtonActive: false,
-        setIsPublishButtonActive: mockSetIsPublishButtonActive,
         language: { id: 1, code: 'uk', name: 'Ukrainian' },
         ...overrides,
     });
@@ -85,7 +83,6 @@ describe('DescriptionSection', () => {
     beforeEach(() => {
         mockOnChange = jest.fn();
         mockOnPublish = jest.fn();
-        mockSetIsPublishButtonActive = jest.fn();
         (WHO_WE_ARE_VALIDATION_FUNCTIONS.validateText as jest.Mock).mockReturnValue(null);
     });
 
@@ -123,7 +120,7 @@ describe('DescriptionSection', () => {
         expect(container).toBeEmptyDOMElement();
     });
 
-    it('should call onChange and setIsPublishButtonActive on text area change', () => {
+    it('should call onChange on text area change', () => {
         renderComponent();
         const descriptionInput = screen.getByTestId('mock-rich-input-1');
         const newText = 'This is a new test description.';
@@ -135,7 +132,6 @@ describe('DescriptionSection', () => {
                 contentType: ContentType.Description,
             }),
         );
-        expect(mockSetIsPublishButtonActive).toHaveBeenCalledWith(true);
     });
 
     it('should show an error message and disable the publish button when validation fails', async () => {

--- a/src/pages/admin/who-we-are/components/sections/description-section/DescriptionSection.tsx
+++ b/src/pages/admin/who-we-are/components/sections/description-section/DescriptionSection.tsx
@@ -18,7 +18,6 @@ export interface DescriptionSectionProps {
     onChange: (data: Content) => void;
     onPublish: () => void;
     isPublishButtonActive: boolean;
-    setIsPublishButtonActive: (value: boolean) => void;
     language: LocalizationLanguage;
 }
 
@@ -27,7 +26,6 @@ export const DescriptionSection = ({
     onChange,
     descriptionLimit,
     onPublish,
-    setIsPublishButtonActive,
     isPublishButtonActive,
     language,
 }: DescriptionSectionProps) => {
@@ -54,8 +52,6 @@ export const DescriptionSection = ({
         const plainText = getPlainTextFromHtml(value);
         const error = WHO_WE_ARE_VALIDATION_FUNCTIONS.validateText(plainText);
         setDescriptionError(error || null);
-
-        setIsPublishButtonActive(true);
     };
 
     const handleBlur = () => {

--- a/src/pages/admin/who-we-are/components/sections/image-block-section/ImageBlockSection.test.tsx
+++ b/src/pages/admin/who-we-are/components/sections/image-block-section/ImageBlockSection.test.tsx
@@ -58,7 +58,6 @@ jest.mock('@/validation/admin/who-we-are-schema/WhoWeAreSchema', () => ({
 describe('ImageSection', () => {
     let mockOnChange: jest.Mock;
     let mockOnPublish: jest.Mock;
-    let mockSetIsPublishButtonActive: jest.Mock;
 
     const titleLimit = 50;
     const descriptionLimit = 500;
@@ -104,7 +103,6 @@ describe('ImageSection', () => {
             onPublish: mockOnPublish,
             imageInputProps: { style: { width: '100%' }, subText: '1000x800' },
             isPublishButtonActive: false,
-            setIsPublishButtonActive: mockSetIsPublishButtonActive,
             language: { id: 1, code: 'uk', name: 'Ukrainian' },
         };
 
@@ -114,7 +112,6 @@ describe('ImageSection', () => {
     beforeEach(() => {
         mockOnChange = jest.fn();
         mockOnPublish = jest.fn();
-        mockSetIsPublishButtonActive = jest.fn();
         validateTextMock().mockReset();
         validateTextMock().mockReturnValue(undefined);
     });
@@ -164,7 +161,7 @@ describe('ImageSection', () => {
         expect(noDescriptionContainer).toBeEmptyDOMElement();
     });
 
-    it('should call onChange and setIsPublishButtonActive on image change', () => {
+    it('should call onChange on image change', () => {
         renderComponent();
 
         const file = new File(['dummy content'], 'test.png', { type: 'image/png' });
@@ -173,10 +170,9 @@ describe('ImageSection', () => {
         expect(mockOnChange).toHaveBeenCalledWith(
             expect.objectContaining({ contentType: ContentType.Image, image: file }),
         );
-        expect(mockSetIsPublishButtonActive).toHaveBeenCalledWith(true);
     });
 
-    it('should call onChange and setIsPublishButtonActive on title change', () => {
+    it('should call onChange on title change', () => {
         renderComponent();
 
         fireEvent.change(screen.getByTestId('mock-rich-input-2'), { target: { value: 'New Title' } });
@@ -184,10 +180,9 @@ describe('ImageSection', () => {
         expect(mockOnChange).toHaveBeenCalledWith(
             expect.objectContaining({ contentType: ContentType.Title, title: 'New Title' }),
         );
-        expect(mockSetIsPublishButtonActive).toHaveBeenCalledWith(true);
     });
 
-    it('should call onChange and setIsPublishButtonActive on description change', () => {
+    it('should call onChange on description change', () => {
         renderComponent();
 
         fireEvent.change(screen.getByTestId('mock-rich-input-3'), { target: { value: 'New Description' } });
@@ -195,7 +190,6 @@ describe('ImageSection', () => {
         expect(mockOnChange).toHaveBeenCalledWith(
             expect.objectContaining({ contentType: ContentType.Description, description: 'New Description' }),
         );
-        expect(mockSetIsPublishButtonActive).toHaveBeenCalledWith(true);
     });
 
     it('should enable the publish button and call onPublish when clicked', () => {
@@ -279,7 +273,6 @@ describe('ImageSection', () => {
             imageId: null,
             localizations: [],
         });
-        expect(mockSetIsPublishButtonActive).toHaveBeenCalledWith(true);
     });
 
     it('should disable publish button when image has error', () => {

--- a/src/pages/admin/who-we-are/components/sections/image-block-section/ImageBlockSection.tsx
+++ b/src/pages/admin/who-we-are/components/sections/image-block-section/ImageBlockSection.tsx
@@ -23,7 +23,6 @@ export interface ImageSectionProps {
     onPublish: () => void;
     imageInputProps: Omit<ImageInputProps, 'className' | 'value' | 'onChange' | 'setError'>;
     isPublishButtonActive: boolean;
-    setIsPublishButtonActive: (value: boolean) => void;
     language: LocalizationLanguage;
 }
 
@@ -35,7 +34,6 @@ export const ImageSection = ({
     onPublish,
     imageInputProps,
     isPublishButtonActive,
-    setIsPublishButtonActive,
     language,
 }: ImageSectionProps) => {
     const [imageError, setImageError] = useState<string | null>(null);
@@ -73,7 +71,6 @@ export const ImageSection = ({
             imageId: null,
             localizations: imageContent?.localizations || [],
         });
-        setIsPublishButtonActive(true);
     };
 
     const handleTitleChange = (value: string) => {
@@ -82,7 +79,6 @@ export const ImageSection = ({
             ...titleContent,
             title: value,
         });
-        setIsPublishButtonActive(true);
 
         const plainText = getPlainTextFromHtml(value);
         const error = WHO_WE_ARE_VALIDATION_FUNCTIONS.validateText(plainText);
@@ -95,7 +91,6 @@ export const ImageSection = ({
             ...descriptionContent,
             description: value,
         });
-        setIsPublishButtonActive(true);
 
         const plainText = getPlainTextFromHtml(value);
         const error = WHO_WE_ARE_VALIDATION_FUNCTIONS.validateText(plainText);

--- a/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.test.tsx
+++ b/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.test.tsx
@@ -70,7 +70,7 @@ jest.mock('../sections-wrapper/SectionsWrapper', () => ({
         section,
         onChange,
         onPublish,
-        setIsPublishButtonActive,
+        //setIsPublishButtonActive,
         isPublishButtonActive,
     }: MainSectionProps) => (
         <div>
@@ -83,7 +83,6 @@ jest.mock('../sections-wrapper/SectionsWrapper', () => ({
                         data-testid={`input-${content.id}`}
                         onChange={(e) => {
                             onChange({ ...content, description: e.target.value });
-                            setIsPublishButtonActive(true);
                         }}
                     />
                 </div>

--- a/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.test.tsx
+++ b/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.test.tsx
@@ -66,13 +66,7 @@ jest.mock('@/components/admin/category-bar/CategoryBar', () => ({
 }));
 
 jest.mock('../sections-wrapper/SectionsWrapper', () => ({
-    SectionsWrapper: ({
-        section,
-        onChange,
-        onPublish,
-        //setIsPublishButtonActive,
-        isPublishButtonActive,
-    }: MainSectionProps) => (
+    SectionsWrapper: ({ section, onChange, onPublish, isPublishButtonActive }: MainSectionProps) => (
         <div>
             <h2>{section?.title}</h2>
             {section?.contents.map((content: Content) => (

--- a/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.tsx
+++ b/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.tsx
@@ -18,6 +18,7 @@ import classNames from 'classnames';
 import { WhoWeArePageToolbar } from '../who-we-are-page-toolbar/WhoWeArePageToolbar';
 import { useLocalizationToolkit } from '@/hooks/admin/use-localization-toolkit/useLocalizationToolkit';
 import { LocalizationStatuses } from '@/components/admin/localization-statuses/LocalizationStatuses';
+import { normalizeHtml } from '@/utils/functions/normalize-html/normalize-html';
 
 interface ErrorState {
     message: string | null;
@@ -34,7 +35,6 @@ export const WhoWeAreContent = () => {
     const [selectedSection, setSelectedSection] = useState<WhoWeAreSection | null>(null);
     const [updatedSection, setUpdatedSection] = useState<WhoWeAreSection | null>(null);
     const [isConfirmationModalOpen, setConfirmationModalOpen] = useState<boolean>(false);
-    const [isPublishButtonActive, setIsPublishButtonActive] = useState<boolean>(false);
     const [languagesError, setLanguagesError] = useState<string | null>(null);
 
     const { addToast } = useToast();
@@ -80,14 +80,26 @@ export const WhoWeAreContent = () => {
 
     useEffect(() => {
         if (fetchedSection) {
-            setSelectedSection(fetchedSection);
-            setUpdatedSection(fetchedSection);
+            const normalizedSection = {
+                ...fetchedSection,
+                contents: fetchedSection.contents.map((item) => ({
+                    ...item,
+                    description: item.description ? normalizeHtml(item.description) : item.description,
+                    title: item.title ? normalizeHtml(item.title) : item.title,
+                })),
+            };
+            setSelectedSection(normalizedSection);
+            setUpdatedSection(normalizedSection);
         }
     }, [fetchedSection]);
 
+    const isPublishButtonActive = useMemo(() => {
+        if (!selectedSection || !updatedSection) return false;
+        return JSON.stringify(selectedSection) !== JSON.stringify(updatedSection);
+    }, [selectedSection, updatedSection]);
+
     const handleCategorySelect = useCallback((category: WhoWeAreCategory) => {
         setSelectedCategory(category);
-        setIsPublishButtonActive(false);
     }, []);
 
     const handleContentChange = useCallback((updatedContent: Content) => {
@@ -126,7 +138,6 @@ export const WhoWeAreContent = () => {
 
                 setSelectedSection(result);
                 setUpdatedSection(result);
-                setIsPublishButtonActive(false);
                 addToast(COMMON_TEXT_ADMIN.MESSAGE.SUCCESSFULLY_PUBLISHED, ToastType.Info);
 
                 refetchCategories();
@@ -204,7 +215,6 @@ export const WhoWeAreContent = () => {
                     section={updatedSection}
                     onChange={handleContentChange}
                     onPublish={() => setConfirmationModalOpen(true)}
-                    setIsPublishButtonActive={(value) => setIsPublishButtonActive(value)}
                     isPublishButtonActive={isPublishButtonActive}
                     language={selectedLanguage}
                 />

--- a/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.tsx
+++ b/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.tsx
@@ -72,6 +72,17 @@ export const WhoWeAreContent = () => {
         autoFetchDependencies: [getSection],
     });
 
+    const normalizeSection = useCallback((section: WhoWeAreSection): WhoWeAreSection => {
+        return {
+            ...section,
+            contents: section.contents.map((item) => ({
+                ...item,
+                description: item.description ? normalizeHtml(item.description) : item.description,
+                title: item.title ? normalizeHtml(item.title) : item.title,
+            })),
+        };
+    }, []);
+
     useEffect(() => {
         if (categories && categories.length > 0 && !selectedCategory) {
             setSelectedCategory(categories[0]);
@@ -80,18 +91,11 @@ export const WhoWeAreContent = () => {
 
     useEffect(() => {
         if (fetchedSection) {
-            const normalizedSection = {
-                ...fetchedSection,
-                contents: fetchedSection.contents.map((item) => ({
-                    ...item,
-                    description: item.description ? normalizeHtml(item.description) : item.description,
-                    title: item.title ? normalizeHtml(item.title) : item.title,
-                })),
-            };
+            const normalizedSection = normalizeSection(fetchedSection);
             setSelectedSection(normalizedSection);
             setUpdatedSection(normalizedSection);
         }
-    }, [fetchedSection]);
+    }, [fetchedSection, normalizeSection]);
 
     const isPublishButtonActive = useMemo(() => {
         if (!selectedSection || !updatedSection) return false;
@@ -136,8 +140,9 @@ export const WhoWeAreContent = () => {
             try {
                 const result = await WhoWeAreApi.updateContent(client, changedContents, selectedCategory.sectionType);
 
-                setSelectedSection(result);
-                setUpdatedSection(result);
+                const normalizedResult = normalizeSection(result);
+                setSelectedSection(normalizedResult);
+                setUpdatedSection(normalizedResult);
                 addToast(COMMON_TEXT_ADMIN.MESSAGE.SUCCESSFULLY_PUBLISHED, ToastType.Info);
 
                 refetchCategories();
@@ -145,7 +150,7 @@ export const WhoWeAreContent = () => {
                 addToast(COMMON_TEXT_ADMIN.MESSAGE.FAIL_TO_PUBLISH_CHANGES, ToastType.Error);
             }
         }
-    }, [selectedSection, updatedSection, client, selectedCategory, addToast, refetchCategories]);
+    }, [selectedSection, updatedSection, client, selectedCategory, addToast, refetchCategories, normalizeSection]);
 
     const handleConfirmPublish = useCallback(() => {
         setConfirmationModalOpen(false);

--- a/src/utils/functions/normalize-html/normalize-html.test.ts
+++ b/src/utils/functions/normalize-html/normalize-html.test.ts
@@ -1,0 +1,52 @@
+import { normalizeHtml } from './normalize-html';
+
+describe('normalizeHtml', () => {
+    it('returns the same string for plain text', () => {
+        expect(normalizeHtml('Hello World')).toBe('Hello World');
+    });
+
+    it('returns the same string for clean single paragraph', () => {
+        expect(normalizeHtml('<p>Text</p>')).toBe('<p>Text</p>');
+    });
+
+    it('trims trailing spaces before closing p tag', () => {
+        expect(normalizeHtml('<p>Text  </p>')).toBe('<p>Text</p>');
+    });
+
+    it('trims trailing spaces for multiple paragraphs', () => {
+        const input = '<p>First   </p><p>Second   </p>';
+        const output = '<p>First</p><p>Second</p>';
+        expect(normalizeHtml(input)).toBe(output);
+    });
+
+    it('returns empty string for empty input', () => {
+        expect(normalizeHtml('')).toBe('');
+    });
+
+    it('returns empty string for whitespace-only input', () => {
+        expect(normalizeHtml('   ')).toBe('');
+    });
+
+    it('keeps content between paragraphs intact', () => {
+        const input = '<p>First   </p>\n  <p>Second   </p>';
+        const output = '<p>First</p>\n  <p>Second</p>';
+        expect(normalizeHtml(input)).toBe(output);
+    });
+
+    it('trims spaces after inline tags before closing p', () => {
+        const input = '<p><strong>Bold</strong>   </p>';
+        const output = '<p><strong>Bold</strong></p>';
+        expect(normalizeHtml(input)).toBe(output);
+    });
+
+    it('preserves spaces between text and inline tags', () => {
+        const input = '<p>Text <em>Italic</em> more</p>';
+        expect(normalizeHtml(input)).toBe(input);
+    });
+
+    it('trims spaces after text with inline tags', () => {
+        const input = '<p>Text <strong>Bold</strong>   </p>';
+        const output = '<p>Text <strong>Bold</strong></p>';
+        expect(normalizeHtml(input)).toBe(output);
+    });
+});

--- a/src/utils/functions/normalize-html/normalize-html.ts
+++ b/src/utils/functions/normalize-html/normalize-html.ts
@@ -1,1 +1,5 @@
-export const normalizeHtml = (html: string): string => html.replace(/\s+</g, '<').replace(/>\s+/g, '>').trim();
+export const normalizeHtml = (html: string): string =>
+    html
+        .replace(/[ \t\r\n]+</g, '<')
+        .replace(/>[ \t\r\n]+/g, '>')
+        .trim();

--- a/src/utils/functions/normalize-html/normalize-html.ts
+++ b/src/utils/functions/normalize-html/normalize-html.ts
@@ -1,5 +1,6 @@
 export const normalizeHtml = (html: string): string =>
     html
-        .replace(/[ \t\r\n]+</g, '<')
-        .replace(/>[ \t\r\n]+/g, '>')
+        .split('</p>')
+        .map((part) => part.trimEnd())
+        .join('</p>')
         .trim();

--- a/src/utils/functions/normalize-html/normalize-html.ts
+++ b/src/utils/functions/normalize-html/normalize-html.ts
@@ -1,0 +1,1 @@
+export const normalizeHtml = (html: string): string => html.replace(/\s+</g, '<').replace(/>\s+/g, '>').trim();


### PR DESCRIPTION
## JIRA or Github ticker

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1526

## Description
Fixed the "Опублікувати" button being active on initial load on the Who We Are page. The root cause had three layers:

- **Architectural** - `isPublishButtonActive` was a `useState` managed by child components via prop, which violated single source of truth. Any child could activate the button during its own mount.
- **Lexical-specific** - `OnChangePlugin` fires `registerUpdateListener` on every editor initialization (before any user action), which triggered `onChange` -> `setIsPublishButtonActive(true)`.
- **Data-level** - DB stores HTML with trailing whitespace before `</p>`, while Lexical trims it on parse. This caused `JSON.stringify` comparison to always return `true` even after the first two issues were resolved.

## How it looks

**How it was:**
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/3eb7a737-e661-4f5f-9be4-6ae28168ff49" />

**How it now:**

https://github.com/user-attachments/assets/57f4b56c-4893-4bb6-a63f-7dde9b7963fc



## Summary of change

| File | Change |
|---|---|
| `WhoWeAreContent.tsx` | `useState` -> `useMemo`, normalize HTML on fetch |
| `normalize-html.ts` | New utility for trimming trailing whitespace |
| `OnChangePlugin.tsx` | `isFirstRender` ref + `dirtyElements/dirtyLeaves` guard |
| `InitialValuePlugin.tsx` | Removed redundant `editor.update()` on mount |
| `SectionsWrapper.tsx` | Removed `setIsPublishButtonActive` prop |
| `ImageSection.tsx` | Removed `setIsPublishButtonActive` prop |
| `DescriptionSection.tsx` | Removed `setIsPublishButtonActive` prop |
| `CardsSection.tsx` | Removed `setIsPublishButtonActive` prop |
| `CardContent.tsx` | Removed `setIsPublishButtonActive` prop |
| 8 test files | Updated under new logic |

## How to recreate changes

1. Navigate to Admin Panel -> Who We Are (`/admin-panel/who-we-are`)
2. Open any tab - verify "Опублікувати" is **disabled** on initial load
3. Make a change in any field - verify button becomes **active**
4. Reload the page - verify button is **disabled** again
5. Make a change and publish - verify button becomes **disabled** after success


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rich-text change detection now skips the initial render and ignores empty/no-op updates to prevent spurious onChange/editor updates; initial content no longer force-populates the editor.

* **New Features**
  * Added HTML normalization utility to standardize whitespace for more consistent content comparison.

* **Refactor**
  * Publish-button state is now computed and no longer toggled via setter props passed through components.

* **Tests**
  * Test suites simplified and updated to reflect the new change-detection and publish-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->