### PR TITLE
Feature/issue-1415: Implement scroll to top of the list of funds and expenditures 

### DIFF
--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
@@ -2,6 +2,11 @@
 @use '@/assets/sass/mixins/typography.mixins' as type;
 @use '@/assets/sass/variables/z-index';
 
+.table-container {
+    display: flex;
+    flex-direction: column;
+}
+
 .table-wrapper {
     width: 100%;
     overflow-x: auto;
@@ -169,9 +174,9 @@
 
 .to-top-button {
     display: inline-flex;
-    margin-top: 16px;
+    margin-top: 20px;
     margin-left: auto;
-    margin-right: 16px;
+    margin-right: 28px;
     align-items: center;
     justify-content: center;
     width: 48px;

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
@@ -1,9 +1,13 @@
 @use '@/assets/sass/variables/colors' as c;
 @use '@/assets/sass/mixins/typography.mixins' as type;
+@use '@/assets/sass/variables/z-index';
 
 .table-wrapper {
     width: 100%;
     overflow-x: auto;
+    overflow-y: auto;
+    max-height: 60vh;
+    scroll-behavior: smooth;
     background: #f8fafc;
     border: 1px solid #e2e2e2;
     border-radius: 16px;
@@ -161,4 +165,35 @@
     height: 20px;
     color: c.$blue-500;
     fill: c.$blue-500;
+}
+
+.to-top-button {
+    display: inline-flex;
+    margin-top: 16px;
+    margin-left: auto;
+    margin-right: 16px;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    border: none;
+    border-radius: 50%;
+    background-color: c.$blue-500;
+    box-shadow: 0 2px 8px rgba(c.$blue-50, 0.15);
+    cursor: pointer;
+    z-index: z-index.admin(infinite-scroll-list-arrow-up);
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+}
+
+.to-top-button-visible {
+    visibility: visible;
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.to-top-icon path {
+    stroke: c.$white;
 }

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
@@ -179,8 +179,8 @@
     margin-right: 28px;
     align-items: center;
     justify-content: center;
-    width: 48px;
-    height: 48px;
+    width: 60px;
+    height: 60px;
     border: none;
     border-radius: 50%;
     background-color: c.$blue-500;

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
@@ -29,6 +29,9 @@ jest.mock('./FundsExpendituresTable.module.scss', () => ({
     'row-actions': 'row-actions',
     'icon-button': 'icon-button',
     'action-icon': 'action-icon',
+    'to-top-button': 'to-top-button',
+    'to-top-icon': 'to-top-icon',
+    'to-top-button-visible': 'to-top-button-visible',
 }));
 
 jest.mock('@/assets/icons/chevron-up.svg', () => ({
@@ -41,6 +44,10 @@ jest.mock('@/assets/icons/chevron-down.svg', () => ({
 
 jest.mock('@/assets/icons/not-found.svg', () => ({
     ReactComponent: ({ className }: { className?: string }) => <svg data-testid="not-found" className={className} />,
+}));
+
+jest.mock('@/assets/icons/arrow-up.svg', () => ({
+    ReactComponent: ({ className }: { className?: string }) => <svg data-testid="arrow-up" className={className} />,
 }));
 
 jest.mock('@/assets/icons/edit.svg', () => ({
@@ -203,6 +210,65 @@ describe('FundsExpendituresTable', () => {
         render(<FundsExpendituresTable records={MOCK_RECORDS} />);
         expect(screen.getByText('7 265')).toBeInTheDocument();
         expect(screen.getAllByText('4 200')).not.toHaveLength(0);
+    });
+
+    describe('scroll to top button', () => {
+        it('should show to-top button when content overflows and table is scrolled', () => {
+            render(<FundsExpendituresTable records={MOCK_RECORDS} />);
+
+            const table = screen.getByTestId('funds-table');
+            Object.defineProperty(table, 'scrollHeight', { configurable: true, value: 900 });
+            Object.defineProperty(table, 'clientHeight', { configurable: true, value: 300 });
+            Object.defineProperty(table, 'scrollTop', { configurable: true, writable: true, value: 120 });
+
+            fireEvent.scroll(table);
+
+            expect(screen.getByTestId('funds-table-to-top')).toHaveClass('to-top-button-visible');
+            expect(screen.getByTestId('arrow-up')).toBeInTheDocument();
+        });
+
+        it('should hide to-top button when list is at top', () => {
+            render(<FundsExpendituresTable records={MOCK_RECORDS} />);
+
+            const table = screen.getByTestId('funds-table');
+            Object.defineProperty(table, 'scrollHeight', { configurable: true, value: 900 });
+            Object.defineProperty(table, 'clientHeight', { configurable: true, value: 300 });
+            Object.defineProperty(table, 'scrollTop', { configurable: true, writable: true, value: 0 });
+
+            fireEvent.scroll(table);
+
+            expect(screen.getByTestId('funds-table-to-top')).not.toHaveClass('to-top-button-visible');
+        });
+
+        it('should scroll to top after clicking to-top button', () => {
+            render(<FundsExpendituresTable records={MOCK_RECORDS} />);
+
+            const table = screen.getByTestId('funds-table');
+            Object.defineProperty(table, 'scrollHeight', { configurable: true, value: 900 });
+            Object.defineProperty(table, 'clientHeight', { configurable: true, value: 300 });
+            Object.defineProperty(table, 'scrollTop', { configurable: true, writable: true, value: 220 });
+
+            fireEvent.scroll(table);
+            fireEvent.click(screen.getByTestId('funds-table-to-top'));
+
+            expect((table as HTMLDivElement).scrollTop).toBe(0);
+            expect(screen.getByTestId('funds-table-to-top')).not.toHaveClass('to-top-button-visible');
+        });
+
+        it('should reset scroll position to top when sorting is changed', () => {
+            render(<FundsExpendituresTable records={MOCK_RECORDS} />);
+
+            const table = screen.getByTestId('funds-table');
+            Object.defineProperty(table, 'scrollHeight', { configurable: true, value: 900 });
+            Object.defineProperty(table, 'clientHeight', { configurable: true, value: 300 });
+            Object.defineProperty(table, 'scrollTop', { configurable: true, writable: true, value: 180 });
+
+            fireEvent.scroll(table);
+            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.TYPE));
+
+            expect((table as HTMLDivElement).scrollTop).toBe(0);
+            expect(screen.getByTestId('funds-table-to-top')).not.toHaveClass('to-top-button-visible');
+        });
     });
 
     describe('isEditing mode', () => {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
@@ -100,7 +100,7 @@ export const FundsExpendituresTable = ({ records, isEditing = false }: FundsExpe
     const colSpan = isEditing ? 7 : 5;
 
     return (
-        <>
+        <div className={styles['table-container']}>
             <div
                 ref={tableWrapperRef}
                 className={styles['table-wrapper']}
@@ -221,6 +221,6 @@ export const FundsExpendituresTable = ({ records, isEditing = false }: FundsExpe
             >
                 <ArrowUpIcon className={styles['to-top-icon']} />
             </button>
-        </>
+        </div>
     );
 };

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
@@ -1,7 +1,8 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
 import { FundsExpendituresTransactionType, ReportFundsExpendituresRecord } from '@/types/admin/reports';
 import { ReactComponent as NotFoundIcon } from '@/assets/icons/not-found.svg';
+import { ReactComponent as ArrowUpIcon } from '@/assets/icons/arrow-up.svg';
 import { ReactComponent as EditIcon } from '@/assets/icons/edit.svg';
 import { ReactComponent as DeleteIcon } from '@/assets/icons/delete.svg';
 import { SortIcon } from '@/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/components/sort-icon';
@@ -54,6 +55,28 @@ const sortRecords = (records: EnrichedRecord[], sort: ColumnSort): EnrichedRecor
 
 export const FundsExpendituresTable = ({ records, isEditing = false }: FundsExpendituresTableProps) => {
     const [sort, setSort] = useState<ColumnSort>({ column: null, direction: null });
+    const [isMoveToTopVisible, setIsMoveToTopVisible] = useState(false);
+    const tableWrapperRef = useRef<HTMLDivElement>(null);
+
+    const updateMoveToTopVisibility = useCallback(() => {
+        const tableWrapper = tableWrapperRef.current;
+        if (!tableWrapper) return;
+
+        const isScrollable = tableWrapper.scrollHeight > tableWrapper.clientHeight;
+        setIsMoveToTopVisible(isScrollable && tableWrapper.scrollTop > 0);
+    }, []);
+
+    const moveToTop = useCallback(() => {
+        const tableWrapper = tableWrapperRef.current;
+        if (!tableWrapper) return;
+
+        tableWrapper.scrollTop = 0;
+        setIsMoveToTopVisible(false);
+    }, []);
+
+    const handleTableScroll = useCallback(() => {
+        updateMoveToTopVisibility();
+    }, [updateMoveToTopVisibility]);
 
     const handleSort = useCallback((column: SortableColumn) => {
         setSort((prev) => {
@@ -61,108 +84,143 @@ export const FundsExpendituresTable = ({ records, isEditing = false }: FundsExpe
             if (prev.direction === 'asc') return { column, direction: 'desc' };
             return { column: null, direction: null };
         });
+
+        const tableWrapper = tableWrapperRef.current;
+        if (tableWrapper) {
+            tableWrapper.scrollTop = 0;
+            setIsMoveToTopVisible(false);
+        }
     }, []);
+
+    useEffect(() => {
+        updateMoveToTopVisibility();
+    }, [records.length, updateMoveToTopVisibility]);
 
     const sortedRecords = sortRecords(records, sort);
     const colSpan = isEditing ? 7 : 5;
 
     return (
-        <div className={styles['table-wrapper']} data-testid="funds-table" data-record-count={records.length}>
-            <table className={styles.table}>
-                <thead>
-                    <tr>
-                        {isEditing && <th className={cn(styles.th, styles['checkbox-th'])} />}
-                        <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.REPORTING_YEAR}</th>
-                        <th className={cn(styles.th, styles.sortable)} onClick={() => handleSort('type')}>
-                            <span className={styles['th-inner']}>
-                                <span>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.TYPE}</span>
-                                <SortIcon isActive={sort.column === 'type'} direction={sort.direction} />
-                            </span>
-                        </th>
-                        <th className={cn(styles.th, styles.sortable)} onClick={() => handleSort('categoryName')}>
-                            <span className={styles['th-inner']}>
-                                <span>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.CATEGORY}</span>
-                                <SortIcon isActive={sort.column === 'categoryName'} direction={sort.direction} />
-                            </span>
-                        </th>
-                        <th className={cn(styles.th, styles.sortable)} onClick={() => handleSort('amountUah')}>
-                            <span className={styles['th-inner']}>
-                                <span>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_UAH}</span>
-                                <SortIcon isActive={sort.column === 'amountUah'} direction={sort.direction} />
-                            </span>
-                        </th>
-                        <th className={cn(styles.th, styles.sortable)} onClick={() => handleSort('amountUsd')}>
-                            <span className={styles['th-inner']}>
-                                <span>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_USD}</span>
-                                <SortIcon isActive={sort.column === 'amountUsd'} direction={sort.direction} />
-                            </span>
-                        </th>
-                        {isEditing && <th className={cn(styles.th, styles['actions-th'])} />}
-                    </tr>
-                </thead>
-                <tbody>
-                    {sortedRecords.length === 0 ? (
+        <>
+            <div
+                ref={tableWrapperRef}
+                className={styles['table-wrapper']}
+                data-testid="funds-table"
+                data-record-count={records.length}
+                onScroll={handleTableScroll}
+            >
+                <table className={styles.table}>
+                    <thead>
                         <tr>
-                            <td colSpan={colSpan} className={styles['empty-cell']} data-testid="funds-table-empty-cell">
-                                <div className={styles['empty-state']}>
-                                    <NotFoundIcon className={styles['empty-state-image']} />
-                                    <p className={styles['empty-state-message']}>
-                                        {FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.MESSAGE}
-                                    </p>
-                                </div>
-                            </td>
+                            {isEditing && <th className={cn(styles.th, styles['checkbox-th'])} />}
+                            <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.REPORTING_YEAR}</th>
+                            <th className={cn(styles.th, styles.sortable)} onClick={() => handleSort('type')}>
+                                <span className={styles['th-inner']}>
+                                    <span>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.TYPE}</span>
+                                    <SortIcon isActive={sort.column === 'type'} direction={sort.direction} />
+                                </span>
+                            </th>
+                            <th className={cn(styles.th, styles.sortable)} onClick={() => handleSort('categoryName')}>
+                                <span className={styles['th-inner']}>
+                                    <span>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.CATEGORY}</span>
+                                    <SortIcon isActive={sort.column === 'categoryName'} direction={sort.direction} />
+                                </span>
+                            </th>
+                            <th className={cn(styles.th, styles.sortable)} onClick={() => handleSort('amountUah')}>
+                                <span className={styles['th-inner']}>
+                                    <span>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_UAH}</span>
+                                    <SortIcon isActive={sort.column === 'amountUah'} direction={sort.direction} />
+                                </span>
+                            </th>
+                            <th className={cn(styles.th, styles.sortable)} onClick={() => handleSort('amountUsd')}>
+                                <span className={styles['th-inner']}>
+                                    <span>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_USD}</span>
+                                    <SortIcon isActive={sort.column === 'amountUsd'} direction={sort.direction} />
+                                </span>
+                            </th>
+                            {isEditing && <th className={cn(styles.th, styles['actions-th'])} />}
                         </tr>
-                    ) : (
-                        sortedRecords.map((record) => (
-                            <tr key={record.id} className={styles.tr}>
-                                {isEditing && (
-                                    <td className={cn(styles.td, styles['checkbox-td'])}>
-                                        <input
-                                            type="checkbox"
-                                            className={styles['row-checkbox']}
-                                            aria-label={`Select record ${record.id}`}
-                                        />
-                                    </td>
-                                )}
-                                <td className={styles.td}>{record.reportingYear}</td>
-                                <td className={styles.td}>
-                                    <span
-                                        className={cn(styles['type-chip'], {
-                                            [styles['type-chip-income']]: record.type === 'income',
-                                            [styles['type-chip-expense']]: record.type === 'expense',
-                                        })}
-                                    >
-                                        {TYPE_LABEL_MAP[record.type]}
-                                    </span>
+                    </thead>
+                    <tbody>
+                        {sortedRecords.length === 0 ? (
+                            <tr>
+                                <td
+                                    colSpan={colSpan}
+                                    className={styles['empty-cell']}
+                                    data-testid="funds-table-empty-cell"
+                                >
+                                    <div className={styles['empty-state']}>
+                                        <NotFoundIcon className={styles['empty-state-image']} />
+                                        <p className={styles['empty-state-message']}>
+                                            {FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.MESSAGE}
+                                        </p>
+                                    </div>
                                 </td>
-                                <td className={styles.td}>{record.categoryName}</td>
-                                <td className={styles.td}>{record.amountUah}</td>
-                                <td className={styles.td}>{record.amountUsd}</td>
-                                {isEditing && (
-                                    <td className={cn(styles.td, styles['actions-td'])}>
-                                        <div className={styles['row-actions']}>
-                                            <button
-                                                type="button"
-                                                className={styles['icon-button']}
-                                                aria-label={`Edit record ${record.id}`}
-                                            >
-                                                <EditIcon className={styles['action-icon']} />
-                                            </button>
-                                            <button
-                                                type="button"
-                                                className={styles['icon-button']}
-                                                aria-label={`Delete record ${record.id}`}
-                                            >
-                                                <DeleteIcon className={styles['action-icon']} />
-                                            </button>
-                                        </div>
-                                    </td>
-                                )}
                             </tr>
-                        ))
-                    )}
-                </tbody>
-            </table>
-        </div>
+                        ) : (
+                            sortedRecords.map((record) => (
+                                <tr key={record.id} className={styles.tr}>
+                                    {isEditing && (
+                                        <td className={cn(styles.td, styles['checkbox-td'])}>
+                                            <input
+                                                type="checkbox"
+                                                className={styles['row-checkbox']}
+                                                aria-label={`Select record ${record.id}`}
+                                            />
+                                        </td>
+                                    )}
+                                    <td className={styles.td}>{record.reportingYear}</td>
+                                    <td className={styles.td}>
+                                        <span
+                                            className={cn(styles['type-chip'], {
+                                                [styles['type-chip-income']]: record.type === 'income',
+                                                [styles['type-chip-expense']]: record.type === 'expense',
+                                            })}
+                                        >
+                                            {TYPE_LABEL_MAP[record.type]}
+                                        </span>
+                                    </td>
+                                    <td className={styles.td}>{record.categoryName}</td>
+                                    <td className={styles.td}>{record.amountUah}</td>
+                                    <td className={styles.td}>{record.amountUsd}</td>
+                                    {isEditing && (
+                                        <td className={cn(styles.td, styles['actions-td'])}>
+                                            <div className={styles['row-actions']}>
+                                                <button
+                                                    type="button"
+                                                    className={styles['icon-button']}
+                                                    aria-label={`Edit record ${record.id}`}
+                                                >
+                                                    <EditIcon className={styles['action-icon']} />
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    className={styles['icon-button']}
+                                                    aria-label={`Delete record ${record.id}`}
+                                                >
+                                                    <DeleteIcon className={styles['action-icon']} />
+                                                </button>
+                                            </div>
+                                        </td>
+                                    )}
+                                </tr>
+                            ))
+                        )}
+                    </tbody>
+                </table>
+            </div>
+            <button
+                type="button"
+                className={cn(styles['to-top-button'], {
+                    [styles['to-top-button-visible']]: isMoveToTopVisible,
+                })}
+                data-testid="funds-table-to-top"
+                onClick={moveToTop}
+                aria-label="Scroll table to top"
+                aria-hidden={!isMoveToTopVisible}
+                tabIndex={isMoveToTopVisible ? 0 : -1}
+            >
+                <ArrowUpIcon className={styles['to-top-icon']} />
+            </button>
+        </>
     );
 };


### PR DESCRIPTION
## Github ticker

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1415

## Description

This PR adds a scroll-to-top button for the Funds and Expenditures table in the Admin Reports page.

## How it looks



https://github.com/user-attachments/assets/644cbcad-9924-416b-a8f3-43dc684d98b8



## Summary of change

1. Added a scroll-to-top button for the Funds and Expenditures table.
2. Made the table vertically scrollable when its content exceeds the visible area.
3. Added button visibility behavior based on scroll position.
5. Added and updated tests.

## How to recreate changes

1. Open the Admin panel.
2. Open the "Звітність" page.
3. Open the "Доходи та витрати" tab.
4. Make sure the table contains enough records to overflow the visible area.
5. Scroll down inside the table.
6. Verify that the scroll-to-top button appears below the table.
7. Click the button and verify that the table scrolls back to the top.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions
