### PR TITLE
Feature/issue 1368: implement translation fallback for detailed program page #1368

### DIFF
--- a/src/hooks/common/use-get-program-by-slug/useGetProgramBySlug.test.ts
+++ b/src/hooks/common/use-get-program-by-slug/useGetProgramBySlug.test.ts
@@ -20,6 +20,7 @@ const createMockProgram = (): DetailedProgram => ({
     backgroundImage: null,
     previewImage: null,
     sections: [],
+    localizations: [],
 });
 
 describe('useProgramBySlug', () => {

--- a/src/pages/public/detailed-program-page/components/detailed-program-page-content/DetailedProgramPageContent.test.tsx
+++ b/src/pages/public/detailed-program-page/components/detailed-program-page-content/DetailedProgramPageContent.test.tsx
@@ -65,6 +65,17 @@ jest.mock('@/components/public/cta', () => ({
     ),
 }));
 
+jest.mock('react-i18next', () => {
+    const actual = jest.requireActual('react-i18next');
+    return {
+        ...actual,
+        useTranslation: () => ({
+            t: (key: string) => key,
+            i18n: { language: 'en' },
+        }),
+    };
+});
+
 const { useParams } = require('react-router-dom');
 const { useProgramBySlug } = require('@/hooks/common/use-get-program-by-slug/useGetProgramBySlug');
 const mockUseProgramBySlug = useProgramBySlug as jest.MockedFunction<typeof useProgramBySlug>;
@@ -84,7 +95,38 @@ const mockProgram = {
     backgroundImage: {
         url: 'https://example.com/image.jpg',
     },
+    localizations: [],
 } as unknown as DetailedProgram;
+
+const mockProgramWithEnLocalization: DetailedProgram = {
+    ...(mockProgram as DetailedProgram),
+    localizations: [
+        {
+            language: { id: 2, code: 'en' },
+            translationStatus: 1,
+            name: 'Test Program EN',
+            description: 'Test description EN',
+            location: 'Test Location EN',
+            participantsCount: '200',
+            meetingsCount: '20',
+        },
+    ] as any,
+};
+
+const mockProgramWithPartialEnLocalization: DetailedProgram = {
+    ...(mockProgram as DetailedProgram),
+    localizations: [
+        {
+            language: { id: 2, code: 'en' },
+            translationStatus: 1,
+            name: 'Test Program EN',
+            description: null,
+            location: null,
+            participantsCount: '300',
+            meetingsCount: null,
+        },
+    ] as any,
+};
 
 describe('DetailedProgramPageContent', () => {
     beforeEach(() => {
@@ -326,6 +368,60 @@ describe('DetailedProgramPageContent', () => {
 
         await waitFor(() => {
             expect(screen.queryByTestId('background-media')).not.toBeInTheDocument();
+        });
+    });
+
+    it('falls back to UA fields when no localizations are provided for EN', async () => {
+        useParams.mockReturnValue({ slug: 'test-program' });
+        mockUseProgramBySlug.mockReturnValue({
+            program: mockProgram,
+            isLoading: false,
+            error: null,
+        });
+
+        render(<DetailedProgramPageContent />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Test Program')).toBeInTheDocument();
+            expect(screen.getByText('Test description')).toBeInTheDocument();
+            expect(screen.getByText('Test Location')).toBeInTheDocument();
+        });
+    });
+
+    it('uses EN localization when available for EN language', async () => {
+        useParams.mockReturnValue({ slug: 'test-program' });
+        mockUseProgramBySlug.mockReturnValue({
+            program: mockProgramWithEnLocalization,
+            isLoading: false,
+            error: null,
+        });
+
+        render(<DetailedProgramPageContent />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Test Program EN')).toBeInTheDocument();
+            expect(screen.getByText('Test description EN')).toBeInTheDocument();
+            expect(screen.getByText('Test Location EN')).toBeInTheDocument();
+            expect(screen.getByText('200')).toBeInTheDocument();
+            expect(screen.getByText('20')).toBeInTheDocument();
+        });
+    });
+
+    it('falls back to UA for missing fields in EN localization', async () => {
+        useParams.mockReturnValue({ slug: 'test-program' });
+        mockUseProgramBySlug.mockReturnValue({
+            program: mockProgramWithPartialEnLocalization,
+            isLoading: false,
+            error: null,
+        });
+
+        render(<DetailedProgramPageContent />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Test Program EN')).toBeInTheDocument();
+            expect(screen.getByText('Test description')).toBeInTheDocument();
+            expect(screen.getByText('Test Location')).toBeInTheDocument();
+            expect(screen.getByText('300')).toBeInTheDocument();
         });
     });
 });

--- a/src/pages/public/detailed-program-page/components/detailed-program-page-content/DetailedProgramPageContent.test.tsx
+++ b/src/pages/public/detailed-program-page/components/detailed-program-page-content/DetailedProgramPageContent.test.tsx
@@ -121,6 +121,24 @@ const mockProgramWithPartialEnLocalization = createMockProgramWithLocalization({
     meetingsCount: null,
 });
 
+const contentTestCases = [
+    {
+        name: 'renders program details successfully with default UA fields when EN localization is missing',
+        programToMock: mockProgram,
+        expectedTexts: ['Test Program', 'Test description', 'Test Location', '100', '10'],
+    },
+    {
+        name: 'uses EN localization when available for EN language',
+        programToMock: mockProgramWithEnLocalization,
+        expectedTexts: ['Test Program EN', 'Test description EN', 'Test Location EN', '200', '20'],
+    },
+    {
+        name: 'falls back to UA for missing fields in EN localization',
+        programToMock: mockProgramWithPartialEnLocalization,
+        expectedTexts: ['Test Program EN', 'Test description', 'Test Location', '300'],
+    },
+];
+
 describe('DetailedProgramPageContent', () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -166,25 +184,6 @@ describe('DetailedProgramPageContent', () => {
 
         await waitFor(() => {
             expect(screen.getByTestId('not-found-message-container')).toBeInTheDocument();
-        });
-    });
-
-    it('renders program details successfully with default UA fields when EN localization is missing', async () => {
-        useParams.mockReturnValue({ slug: 'test-program' });
-        mockUseProgramBySlug.mockReturnValue({
-            program: mockProgram,
-            isLoading: false,
-            error: null,
-        });
-
-        render(<DetailedProgramPageContent />);
-
-        await waitFor(() => {
-            expect(screen.getByText('Test Program')).toBeInTheDocument();
-            expect(screen.getByText('Test description')).toBeInTheDocument();
-            expect(screen.getByText('Test Location')).toBeInTheDocument();
-            expect(screen.getByText('100')).toBeInTheDocument();
-            expect(screen.getByText('10')).toBeInTheDocument();
         });
     });
 
@@ -364,10 +363,10 @@ describe('DetailedProgramPageContent', () => {
         });
     });
 
-    it('uses EN localization when available for EN language', async () => {
+    it.each(contentTestCases)('$name', async ({ programToMock, expectedTexts }) => {
         useParams.mockReturnValue({ slug: 'test-program' });
         mockUseProgramBySlug.mockReturnValue({
-            program: mockProgramWithEnLocalization,
+            program: programToMock as unknown as DetailedProgram,
             isLoading: false,
             error: null,
         });
@@ -375,29 +374,9 @@ describe('DetailedProgramPageContent', () => {
         render(<DetailedProgramPageContent />);
 
         await waitFor(() => {
-            expect(screen.getByText('Test Program EN')).toBeInTheDocument();
-            expect(screen.getByText('Test description EN')).toBeInTheDocument();
-            expect(screen.getByText('Test Location EN')).toBeInTheDocument();
-            expect(screen.getByText('200')).toBeInTheDocument();
-            expect(screen.getByText('20')).toBeInTheDocument();
-        });
-    });
-
-    it('falls back to UA for missing fields in EN localization', async () => {
-        useParams.mockReturnValue({ slug: 'test-program' });
-        mockUseProgramBySlug.mockReturnValue({
-            program: mockProgramWithPartialEnLocalization,
-            isLoading: false,
-            error: null,
-        });
-
-        render(<DetailedProgramPageContent />);
-
-        await waitFor(() => {
-            expect(screen.getByText('Test Program EN')).toBeInTheDocument();
-            expect(screen.getByText('Test description')).toBeInTheDocument();
-            expect(screen.getByText('Test Location')).toBeInTheDocument();
-            expect(screen.getByText('300')).toBeInTheDocument();
+            expectedTexts.forEach((text) => {
+                expect(screen.getByText(text)).toBeInTheDocument();
+            });
         });
     });
 });

--- a/src/pages/public/detailed-program-page/components/detailed-program-page-content/DetailedProgramPageContent.test.tsx
+++ b/src/pages/public/detailed-program-page/components/detailed-program-page-content/DetailedProgramPageContent.test.tsx
@@ -86,20 +86,18 @@ const mockProgram = {
     name: 'Test Program',
     description: 'Test description',
     location: 'Test Location',
-    participantsCount: 100,
-    meetingsCount: 10,
+    participantsCount: '100',
+    meetingsCount: '10',
     categories: [],
     status: 'published',
     previewImage: { url: 'https://example.com/preview.jpg' },
     sections: [],
-    backgroundImage: {
-        url: 'https://example.com/image.jpg',
-    },
+    backgroundImage: { url: 'https://example.com/image.jpg' },
     localizations: [],
 } as unknown as DetailedProgram;
 
-const mockProgramWithEnLocalization: DetailedProgram = {
-    ...(mockProgram as DetailedProgram),
+const createMockProgramWithLocalization = (overrides?: Partial<any>): DetailedProgram => ({
+    ...mockProgram,
     localizations: [
         {
             language: { id: 2, code: 'en' },
@@ -109,24 +107,19 @@ const mockProgramWithEnLocalization: DetailedProgram = {
             location: 'Test Location EN',
             participantsCount: '200',
             meetingsCount: '20',
+            ...overrides,
         },
     ] as any,
-};
+});
 
-const mockProgramWithPartialEnLocalization: DetailedProgram = {
-    ...(mockProgram as DetailedProgram),
-    localizations: [
-        {
-            language: { id: 2, code: 'en' },
-            translationStatus: 1,
-            name: 'Test Program EN',
-            description: null,
-            location: null,
-            participantsCount: '300',
-            meetingsCount: null,
-        },
-    ] as any,
-};
+const mockProgramWithEnLocalization = createMockProgramWithLocalization();
+
+const mockProgramWithPartialEnLocalization = createMockProgramWithLocalization({
+    description: null,
+    location: null,
+    participantsCount: '300',
+    meetingsCount: null,
+});
 
 describe('DetailedProgramPageContent', () => {
     beforeEach(() => {
@@ -176,7 +169,7 @@ describe('DetailedProgramPageContent', () => {
         });
     });
 
-    it('renders program details successfully', async () => {
+    it('renders program details successfully with default UA fields when EN localization is missing', async () => {
         useParams.mockReturnValue({ slug: 'test-program' });
         mockUseProgramBySlug.mockReturnValue({
             program: mockProgram,
@@ -368,23 +361,6 @@ describe('DetailedProgramPageContent', () => {
 
         await waitFor(() => {
             expect(screen.queryByTestId('background-media')).not.toBeInTheDocument();
-        });
-    });
-
-    it('falls back to UA fields when no localizations are provided for EN', async () => {
-        useParams.mockReturnValue({ slug: 'test-program' });
-        mockUseProgramBySlug.mockReturnValue({
-            program: mockProgram,
-            isLoading: false,
-            error: null,
-        });
-
-        render(<DetailedProgramPageContent />);
-
-        await waitFor(() => {
-            expect(screen.getByText('Test Program')).toBeInTheDocument();
-            expect(screen.getByText('Test description')).toBeInTheDocument();
-            expect(screen.getByText('Test Location')).toBeInTheDocument();
         });
     });
 

--- a/src/pages/public/detailed-program-page/components/detailed-program-page-content/DetailedProgramPageContent.tsx
+++ b/src/pages/public/detailed-program-page/components/detailed-program-page-content/DetailedProgramPageContent.tsx
@@ -14,9 +14,10 @@ import { CtaSection } from '@/components/public/cta';
 import { PUBLIC_ROUTES } from '@/const/public/routes';
 import outroVideo from '@/assets/videos/public/detailed-program-page/support_program_background.mp4';
 import { useTranslation } from 'react-i18next';
+import { getLocalizedProgram } from '@/utils/functions/localization/public/programs/programs-localization';
 
 export const DetailedProgramPageContent: React.FC = () => {
-    const { t } = useTranslation('detailedProgramPage');
+    const { t, i18n } = useTranslation('detailedProgramPage');
 
     const { slug } = useParams<{ slug: string }>();
 
@@ -34,7 +35,8 @@ export const DetailedProgramPageContent: React.FC = () => {
         return <NotFound />;
     }
 
-    const hasSections = program.sections && program.sections.length > 0;
+    const localizedProgram = getLocalizedProgram(program, i18n.language);
+    const hasSections = localizedProgram.sections && localizedProgram.sections.length > 0;
 
     return (
         <div className={styles['detailed-program-page-content']}>
@@ -48,22 +50,24 @@ export const DetailedProgramPageContent: React.FC = () => {
                         <div className={styles['content-container']}>
                             <div className={styles['left-section']}>
                                 <div>
-                                    <h1 className={styles['program-name']}>{program.name}</h1>
+                                    <h1 className={styles['program-name']}>{localizedProgram.name}</h1>
                                     <div className={styles['program-info']}>
-                                        {program.location && <InfoItem icon={MapPin} text={program.location} />}
-                                        {program.participantsCount && (
-                                            <InfoItem icon={UsersRound} text={program.participantsCount} />
+                                        {localizedProgram.location && (
+                                            <InfoItem icon={MapPin} text={localizedProgram.location} />
+                                        )}
+                                        {localizedProgram.participantsCount && (
+                                            <InfoItem icon={UsersRound} text={localizedProgram.participantsCount} />
                                         )}
                                     </div>
                                     <div className={styles['program-meetings']}>
-                                        {program.meetingsCount && (
-                                            <InfoItem icon={CalendarDays} text={program.meetingsCount} />
+                                        {localizedProgram.meetingsCount && (
+                                            <InfoItem icon={CalendarDays} text={localizedProgram.meetingsCount} />
                                         )}
                                     </div>
                                 </div>
                             </div>
                             <div className={styles['right-section']}>
-                                <p className={styles['description']}>{program.description}</p>
+                                <p className={styles['description']}>{localizedProgram.description}</p>
                             </div>
                         </div>
                     </div>
@@ -71,7 +75,7 @@ export const DetailedProgramPageContent: React.FC = () => {
             </div>
             {hasSections && (
                 <div className={styles['sections-list']}>
-                    {program.sections.map((section, index) => (
+                    {localizedProgram.sections.map((section, index) => (
                         <DetailedProgramSection key={section.id ?? `${section.template}-${index}`} section={section} />
                     ))}
                 </div>

--- a/src/services/api/public/programs/programs-api.test.ts
+++ b/src/services/api/public/programs/programs-api.test.ts
@@ -78,6 +78,7 @@ describe('programs-api', () => {
                 location: '',
                 participantsCount: '0',
                 meetingsCount: '0',
+                localizations: [],
             };
 
             (axiosInstance.get as jest.Mock).mockResolvedValue({ data: mockProgram });
@@ -100,6 +101,7 @@ describe('programs-api', () => {
                 participantsCount: '0',
                 meetingsCount: '0',
                 sections: [],
+                localizations: [],
             };
 
             (axiosInstance.get as jest.Mock).mockResolvedValue({ data: mockProgram });

--- a/src/types/public/programs-page.ts
+++ b/src/types/public/programs-page.ts
@@ -1,5 +1,6 @@
 import { Image } from '../common/image';
 import { HippotherapyProgramSectionDto } from '../common/program-sections';
+import { HippotherapyProgramLocalization } from '@/types/admin/programs';
 
 export interface ProgramCategoryDto {
     id: number;
@@ -31,4 +32,5 @@ export interface DetailedProgram {
     meetingsCount: string;
     sections: HippotherapyProgramSectionDto[];
     slug: string;
+    localizations: HippotherapyProgramLocalization[];
 }

--- a/src/utils/functions/localization/public/programs/programs-localization.test.ts
+++ b/src/utils/functions/localization/public/programs/programs-localization.test.ts
@@ -1,0 +1,95 @@
+import { getLocalizedProgram } from './programs-localization';
+import { DetailedProgram } from '@/types/public/programs-page';
+import { HippotherapyProgramLocalization } from '@/types/admin/programs';
+import { TranslationStatus } from '@/types/common/language';
+
+const createMockProgram = (overrides?: Partial<DetailedProgram>): DetailedProgram => ({
+    id: 1,
+    name: 'Програма 1',
+    description: 'Програма Програма 123 321',
+    location: 'Десь',
+    participantsCount: '1',
+    meetingsCount: '50',
+    slug: 'programa-1',
+    previewImage: null,
+    backgroundImage: null,
+    sections: [{ id: 1, template: 'TextOnly', contents: [], order: 0 } as any],
+    localizations: [],
+    ...overrides,
+});
+
+const createMockLocalization = (
+    code: string,
+    overrides?: Partial<HippotherapyProgramLocalization>,
+): HippotherapyProgramLocalization =>
+    ({
+        entityId: 1,
+        translationStatus: TranslationStatus.Relevant,
+        language: { id: 2, code },
+        name: 'Program 1',
+        description: 'Program Program 123 321',
+        location: 'Somewhere',
+        participantsCount: '1',
+        meetingsCount: '50',
+        sections: [],
+        ...overrides,
+    }) as HippotherapyProgramLocalization;
+
+describe('getLocalizedProgram', () => {
+    it('should return original program fields when localization is missing', () => {
+        const program = createMockProgram();
+
+        const result = getLocalizedProgram(program, 'en');
+
+        expect(result.name).toBe(program.name);
+        expect(result.description).toBe(program.description);
+        expect(result.location).toBe(program.location);
+        expect(result.participantsCount).toBe(program.participantsCount);
+        expect(result.meetingsCount).toBe(program.meetingsCount);
+        expect(result.sections).toEqual(program.sections);
+    });
+
+    it('should return fully localized fields when translation exists', () => {
+        const localization = createMockLocalization('en');
+        const program = createMockProgram({ localizations: [localization] });
+
+        const result = getLocalizedProgram(program, 'en');
+
+        expect(result.name).toBe(localization.name);
+        expect(result.description).toBe(localization.description);
+        expect(result.location).toBe(localization.location);
+        expect(result.participantsCount).toBe(localization.participantsCount);
+        expect(result.meetingsCount).toBe(localization.meetingsCount);
+        expect(result.sections).toEqual(program.sections);
+    });
+
+    it('should fallback to original fields for missing or nullish localized fields', () => {
+        const partialLocalization = createMockLocalization('en', {
+            description: null as unknown as string,
+            location: undefined,
+            participantsCount: null as unknown as string,
+            meetingsCount: undefined,
+        });
+
+        const program = createMockProgram({ localizations: [partialLocalization] });
+
+        const result = getLocalizedProgram(program, 'en');
+
+        expect(result.name).toBe(partialLocalization.name);
+        expect(result.description).toBe(program.description);
+        expect(result.location).toBe(program.location);
+        expect(result.participantsCount).toBe(program.participantsCount);
+        expect(result.meetingsCount).toBe(program.meetingsCount);
+        expect(result.sections).toEqual(program.sections);
+    });
+
+    it('should ignore localizations with non-matching language codes', () => {
+        const localization = createMockLocalization('fr', { name: 'Programme 1 FR' });
+        const program = createMockProgram({ localizations: [localization] });
+
+        const result = getLocalizedProgram(program, 'en');
+
+        expect(result.name).toBe(program.name);
+        expect(result.description).toBe(program.description);
+    });
+});

--- a/src/utils/functions/localization/public/programs/programs-localization.ts
+++ b/src/utils/functions/localization/public/programs/programs-localization.ts
@@ -1,0 +1,37 @@
+import { DetailedProgram } from '@/types/public/programs-page';
+import { returnDisplayedLocalization } from '@/utils/functions/localization/localization';
+import { HippotherapyProgramSectionDto } from '@/types/common/program-sections';
+
+export const getLocalizedProgram = (
+    program: DetailedProgram,
+    langCode: string,
+): {
+    name: string;
+    description: string;
+    location: string;
+    participantsCount: string;
+    meetingsCount: string;
+    sections: HippotherapyProgramSectionDto[];
+} => {
+    const localization = returnDisplayedLocalization(program, langCode);
+
+    if (!localization) {
+        return {
+            name: program.name,
+            description: program.description,
+            location: program.location,
+            participantsCount: program.participantsCount,
+            meetingsCount: program.meetingsCount,
+            sections: program.sections,
+        };
+    }
+
+    return {
+        name: localization.name,
+        description: localization.description ?? program.description,
+        location: localization.location ?? program.location,
+        participantsCount: localization.participantsCount ?? program.participantsCount,
+        meetingsCount: localization.meetingsCount ?? program.meetingsCount,
+        sections: program.sections,
+    };
+};


### PR DESCRIPTION
## Github ticker

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1368

## Description

Implemented a robust fallback mechanism for the Detailed Program Page on the public visitor interface. 

Currently, if an English-speaking visitor accesses a program that hasn't been translated yet (or is partially translated), the page might display empty fields or break. This PR ensures that the UI gracefully falls back to the default language (Ukrainian) for any missing content.

**Note on E2E Testing:** Since the admin translation publishing feature is still in progress in [#1366](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1366), end-to-end testing with real backend data is blocked. Full E2E acceptance can only be verified after both #1366 and [#1362](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1362) are merged. However, the UI language switcher is functional. I have manually verified the UI behavior in the browser by mocking the `useProgramBySlug` response and switching languages. I've also extensively covered the fallback logic with isolated unit tests (58 tests passed) to guarantee it works seamlessly once the integration is complete.

## How it looks

Fallback for empty fields on EN translation

https://github.com/user-attachments/assets/4fe88ece-3b5b-4fa3-a5f4-ff431ff6461e



## Summary of change

| File | Change |
|---|---|
| `programs-localization.ts` | Added `getLocalizedProgram` utility mapping function with fallback logic. |
| `DetailedProgramPageContent.tsx` | Replaced direct access to the `program` object with the processed `localizedProgram` data. |
| `programs-localization.test.ts` | Added pure unit tests covering 100% of branches for the mapping logic (missing, partial, and full translations). |
| `DetailedProgramPageContent.test.tsx` | Updated component tests to simulate i18n language changes and verify default content rendering. |

## How to recreate changes

Follow these steps to test locally:
1. Locally mock the `useProgramBySlug` response in the hook to include a fake EN localization (either empty or partially filled).
2. Navigate to any detailed program page on the public site (e.g., `/programs/koni-likuyut`).
3. Use the UI language switcher in the header to change the language to English.
4. Observe that the page successfully renders the default Ukrainian content for the missing translation fields, while displaying English for the mocked ones.
5. Check test coverage - all tests should pass successfully.

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures to include additional mock data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->