### PR TITLE
Feature/issue-1424: Edit record category in funds and expenditures list

### DIFF
--- a/src/assets/sass/variables/colors.scss
+++ b/src/assets/sass/variables/colors.scss
@@ -52,7 +52,7 @@ $footer-yellow: #dfe772;
 $footer-cyan: #88dbb5;
 
 $bluish-black: #0a0d12;
-$graphite_black: #1c1c1c;
+$graphite-black: #1c1c1c;
 $black: #000000;
 $donate-tooltip-color: #333333;
 

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -152,5 +152,8 @@ export const FUNDS_EXPENDITURES_TEXT = {
     },
     VALIDATION: {
         CATEGORY_UNIQUE: 'Категорія має бути унікальна',
+        AMOUNT_ONLY_NUMBER_GT_ZERO: 'Лише число > 0',
+        AMOUNT_MAX_DIGITS: "Не більше 11 цифр, 2 після ','",
+        AMOUNT_NOT_NEGATIVE: "Сума не може бути від'ємною",
     },
 };

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -150,4 +150,7 @@ export const FUNDS_EXPENDITURES_TEXT = {
             ALT_TEXT: 'Записів не знайдено',
         },
     },
+    VALIDATION: {
+        CATEGORY_UNIQUE: 'Категорія має бути унікальна',
+    },
 };

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
@@ -226,7 +226,7 @@ describe('FundsExpenditureSection', () => {
 
         const table = screen.getByTestId('funds-table');
 
-        expect(table).toHaveAttribute('data-record-count', '5');
+        expect(table).toHaveAttribute('data-record-count', '3');
     });
 
     it('should filter records by category when category filter is applied', () => {
@@ -235,7 +235,7 @@ describe('FundsExpenditureSection', () => {
         fireEvent.click(screen.getByTestId('filter-cat-1'));
 
         const table = screen.getByTestId('funds-table');
-        expect(table).toHaveAttribute('data-record-count', '2');
+        expect(table).toHaveAttribute('data-record-count', '1');
     });
 
     it('should reset category when type changes', () => {
@@ -253,7 +253,7 @@ describe('FundsExpenditureSection', () => {
 
         fireEvent.click(screen.getByTestId('filter-income'));
 
-        expect(screen.getByTestId('funds-toolbar')).toHaveAttribute('data-category-count', '7');
+        expect(screen.getByTestId('funds-toolbar')).toHaveAttribute('data-category-count', '8');
     });
 
     it('should pass all categories to toolbar when expense type is selected', () => {
@@ -261,13 +261,13 @@ describe('FundsExpenditureSection', () => {
 
         fireEvent.click(screen.getByTestId('filter-expense'));
 
-        expect(screen.getByTestId('funds-toolbar')).toHaveAttribute('data-category-count', '7');
+        expect(screen.getByTestId('funds-toolbar')).toHaveAttribute('data-category-count', '8');
     });
 
     it('should pass all categories to toolbar when no type is selected', () => {
         render(<FundsExpenditureSection />);
 
-        expect(screen.getByTestId('funds-toolbar')).toHaveAttribute('data-category-count', '7');
+        expect(screen.getByTestId('funds-toolbar')).toHaveAttribute('data-category-count', '8');
     });
 
     describe('edit mode', () => {

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -142,9 +142,23 @@ export const FundsExpenditureSection = () => {
 
     const currentExchangeRate = isEditing ? exchangeRateValue : (settings?.exchangeRate ?? null);
 
-    const handleRecordCategorySave = useCallback((recordId: number, categoryId: number) => {
-        setRecordsState((prev) => prev.map((record) => (record.id === recordId ? { ...record, categoryId } : record)));
-    }, []);
+    const handleRecordSave = useCallback(
+        (recordId: number, data: { categoryId: number; amountUah: string; amountUsd: string }) => {
+            setRecordsState((prev) =>
+                prev.map((record) =>
+                    record.id === recordId
+                        ? {
+                              ...record,
+                              categoryId: data.categoryId,
+                              amountUah: data.amountUah,
+                              amountUsd: data.amountUsd,
+                          }
+                        : record,
+                ),
+            );
+        },
+        [],
+    );
 
     return (
         <div className={styles.section}>
@@ -231,7 +245,7 @@ export const FundsExpenditureSection = () => {
                 allRecordsForTypeInference={recordsState}
                 isEditing={isEditing}
                 onRowEditModeChange={setIsRowEditMode}
-                onRecordCategorySave={handleRecordCategorySave}
+                onRecordSave={handleRecordSave}
             />
 
             {isEditing && (

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -59,6 +59,8 @@ export const FundsExpenditureSection = () => {
 
     const [selectedType, setSelectedType] = useState<TypeFilterValue>(undefined);
     const [selectedCategoryId, setSelectedCategoryId] = useState<CategoryFilterValue>(undefined);
+    const [recordsState, setRecordsState] = useState<ReportFundsExpendituresRecord[]>([]);
+    const [isRowEditMode, setIsRowEditMode] = useState(false);
 
     const handleEdit = useCallback(() => setIsEditing(true), []);
     const handleCancel = useCallback(() => {
@@ -101,6 +103,10 @@ export const FundsExpenditureSection = () => {
         fetchHandler: fetchRecords,
     });
 
+    useEffect(() => {
+        setRecordsState(allRecords);
+    }, [allRecords]);
+
     const isPublishEnabled = useMemo(() => {
         const normalized = disclaimerValue.replaceAll(/\s+/g, ' ').trim();
         return normalized.length >= FUNDS_EXPENDITURES_VALIDATION.disclaimer.min && !disclaimerError;
@@ -114,9 +120,9 @@ export const FundsExpenditureSection = () => {
         }
     }, [settings, isEditing]);
 
-    const summary = useMemo(() => computeSummary(allRecords), [allRecords]);
+    const summary = useMemo(() => computeSummary(recordsState), [recordsState]);
 
-    const enrichedRecords = useMemo(() => enrichRecords(allRecords, categories), [allRecords, categories]);
+    const enrichedRecords = useMemo(() => enrichRecords(recordsState, categories), [recordsState, categories]);
 
     const filteredCategories = useMemo(
         (): ReportFundsExpendituresCategory[] => [...categories].sort((a, b) => a.name.localeCompare(b.name, 'uk')),
@@ -135,6 +141,10 @@ export const FundsExpenditureSection = () => {
     const isAddExpenseDisabled = summary.expenseCategories >= FUNDS_EXPENDITURES_TEXT.MAX_CATEGORIES_PER_TYPE;
 
     const currentExchangeRate = isEditing ? exchangeRateValue : (settings?.exchangeRate ?? null);
+
+    const handleRecordCategorySave = useCallback((recordId: number, categoryId: number) => {
+        setRecordsState((prev) => prev.map((record) => (record.id === recordId ? { ...record, categoryId } : record)));
+    }, []);
 
     return (
         <div className={styles.section}>
@@ -205,6 +215,7 @@ export const FundsExpenditureSection = () => {
                 selectedCategoryId={selectedCategoryId}
                 exchangeRate={currentExchangeRate}
                 isEditing={isEditing}
+                controlsDisabled={isRowEditMode}
                 isAddIncomeDisabled={isAddIncomeDisabled}
                 isAddExpenseDisabled={isAddExpenseDisabled}
                 onTypeChange={handleTypeChange}
@@ -214,7 +225,14 @@ export const FundsExpenditureSection = () => {
                 onAddExpense={() => {}}
             />
 
-            <FundsExpendituresTable records={filteredRecords} isEditing={isEditing} />
+            <FundsExpendituresTable
+                records={filteredRecords}
+                categories={filteredCategories}
+                allRecordsForTypeInference={recordsState}
+                isEditing={isEditing}
+                onRowEditModeChange={setIsRowEditMode}
+                onRecordCategorySave={handleRecordCategorySave}
+            />
 
             {isEditing && (
                 <div className={styles['section-footer']}>
@@ -225,7 +243,7 @@ export const FundsExpenditureSection = () => {
                         buttonStyle="primary"
                         className={styles['footer-button']}
                         onClick={() => {}}
-                        disabled={!isPublishEnabled}
+                        disabled={!isPublishEnabled || isRowEditMode}
                     >
                         {FUNDS_EXPENDITURES_TEXT.BUTTON.PUBLISH}
                     </Button>

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
@@ -71,7 +71,7 @@
     padding: 13px 20px;
     font-weight: 400;
     line-height: 24px;
-    color: c.$graphite_black;
+    color: c.$graphite-black;
     vertical-align: middle;
     height: 65px;
     box-sizing: border-box;
@@ -194,6 +194,16 @@
             stroke: c.$green;
         }
     }
+
+    &:disabled {
+        .action-icon {
+            color: c.$grey-700;
+
+            path {
+                stroke: c.$grey-700;
+            }
+        }
+    }
 }
 
 .close-icon-button {
@@ -206,31 +216,35 @@
     }
 }
 
-.category-edit-td {
+.category-edit-td,
+.amount-edit-td {
     position: relative;
     overflow: visible;
+    height: auto;
 }
 
-.category-edit-wrapper {
+.category-edit-wrapper,
+.amount-edit-wrapper {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
     gap: 6px;
+    min-height: 80px;
 }
 
 .category-edit-select {
-    min-width: 220px;
+    width: 240px;
 
     :global(.select-head) {
-        min-height: 36px;
-        padding: 8px 10px;
+        min-height: 55px;
+        padding: 10px 17px;
         border: 1px solid c.$grey-700;
         border-radius: 8px;
         background-color: c.$white;
     }
 
     :global(.select-options) {
-        min-width: 220px;
+        min-width: 240px;
         border: 1px solid c.$grey-500;
         border-radius: 8px;
         background-color: c.$white;
@@ -244,10 +258,40 @@
     border-radius: 6px;
 }
 
-.category-edit-error {
-    @include type.small-text-regular;
+.category-edit-error,
+.amount-edit-error {
     margin: 0;
     color: c.$error;
+}
+
+.category-edit-error {
+    @include type.small-text-regular;
+}
+
+.amount-edit-error {
+    @include type.subtitle-2-medium;
+}
+
+.amount-edit-input {
+    @include type.subtitle-2-medium;
+    width: 128px;
+    min-height: 55px;
+    padding: 10px 17px;
+    border: 1px solid c.$grey-700;
+    border-radius: 8px;
+    color: c.$graphite-black;
+    background-color: c.$white;
+    box-shadow: 0 1px 2px rgba(c.$bluish-black, 0.05);
+    outline: none;
+
+    &:focus {
+        border-color: c.$blue-500;
+        box-shadow: 0 0 0 2px rgba(c.$blue-500, 0.12);
+    }
+}
+
+.amount-edit-input-error {
+    border-color: c.$error;
 }
 
 .to-top-button {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
@@ -179,20 +179,20 @@
 
 .accept-icon-button {
     .action-icon {
-        color: #059669;
+        color: c.$green;
 
         path {
-            stroke: #059669;
+            stroke: c.$green;
         }
     }
 }
 
 .close-icon-button {
     .action-icon {
-        color: #f04438;
+        color: c.$error;
 
         path {
-            stroke: #f04438;
+            stroke: c.$error;
         }
     }
 }
@@ -238,6 +238,6 @@
 .category-edit-error {
     @include type.small-text-regular;
     margin: 0;
-    color: #f04438;
+    color: c.$error;
 }
 

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
@@ -31,6 +31,15 @@
             background-color: c.$grey-300;
         }
     }
+
+    &.sortable-disabled {
+        cursor: not-allowed;
+        opacity: 0.6;
+
+        &:hover {
+            background-color: transparent;
+        }
+    }
 }
 
 .th-inner {
@@ -154,11 +163,81 @@
     &:active {
         background-color: c.$grey-300;
     }
+
+    &:disabled {
+        cursor: not-allowed;
+        opacity: 0.45;
+        background-color: transparent;
+    }
 }
 
 .action-icon {
     width: 20px;
     height: 20px;
     color: c.$blue-500;
-    fill: c.$blue-500;
 }
+
+.accept-icon-button {
+    .action-icon {
+        color: #059669;
+
+        path {
+            stroke: #059669;
+        }
+    }
+}
+
+.close-icon-button {
+    .action-icon {
+        color: #f04438;
+
+        path {
+            stroke: #f04438;
+        }
+    }
+}
+
+.category-edit-td {
+    position: relative;
+    overflow: visible;
+}
+
+.category-edit-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+}
+
+.category-edit-select {
+    min-width: 220px;
+
+    :global(.select-head) {
+        min-height: 36px;
+        padding: 8px 10px;
+        border: 1px solid c.$grey-700;
+        border-radius: 8px;
+        background-color: c.$white;
+    }
+
+    :global(.select-options) {
+        min-width: 220px;
+        border: 1px solid c.$grey-500;
+        border-radius: 8px;
+        background-color: c.$white;
+        box-shadow: 0 6px 18px rgba(c.$black, 0.14);
+    }
+}
+
+.category-edit-option {
+    @include type.small-text-regular;
+    padding: 8px 10px;
+    border-radius: 6px;
+}
+
+.category-edit-error {
+    @include type.small-text-regular;
+    margin: 0;
+    color: #f04438;
+}
+

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom';
 import type React from 'react';
 import { FundsExpendituresTable, EnrichedRecord } from './FundsExpendituresTable';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
 
 jest.mock('./FundsExpendituresTable.module.scss', () => ({
@@ -36,6 +37,11 @@ jest.mock('./FundsExpendituresTable.module.scss', () => ({
     'category-edit-select': 'category-edit-select',
     'category-edit-option': 'category-edit-option',
     'category-edit-error': 'category-edit-error',
+    'amount-edit-td': 'amount-edit-td',
+    'amount-edit-wrapper': 'amount-edit-wrapper',
+    'amount-edit-input': 'amount-edit-input',
+    'amount-edit-input-error': 'amount-edit-input-error',
+    'amount-edit-error': 'amount-edit-error',
     'to-top-button': 'to-top-button',
     'to-top-icon': 'to-top-icon',
     'to-top-button-visible': 'to-top-button-visible',
@@ -306,9 +312,9 @@ describe('FundsExpendituresTable', () => {
         });
 
         it('should save category changes when valid and notify parent', () => {
-            const onRecordCategorySave = jest.fn();
+            const onRecordSave = jest.fn();
 
-            renderTable({ isEditing: true, onRecordCategorySave });
+            renderTable({ isEditing: true, onRecordSave });
 
             fireEvent.click(screen.getByLabelText('Edit record 1'));
             fireEvent.click(screen.getByTestId('select-option-Власні надходження-3'));
@@ -318,7 +324,11 @@ describe('FundsExpendituresTable', () => {
 
             fireEvent.click(acceptButton);
 
-            expect(onRecordCategorySave).toHaveBeenCalledWith(1, 3);
+            expect(onRecordSave).toHaveBeenCalledWith(1, {
+                categoryId: 3,
+                amountUah: '7 265',
+                amountUsd: '4 200',
+            });
         });
 
         it('should show unique validation message when duplicate category is selected for the same type', () => {
@@ -372,6 +382,69 @@ describe('FundsExpendituresTable', () => {
 
             expect(onRowEditModeChange).toHaveBeenNthCalledWith(1, true);
             expect(onRowEditModeChange).toHaveBeenNthCalledWith(2, false);
+        });
+
+        it('should save category and amounts through unified save callback', () => {
+            const onRecordSave = jest.fn();
+
+            renderTable({ isEditing: true, onRecordSave });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            fireEvent.click(screen.getByTestId('select-option-Власні надходження-3'));
+            fireEvent.change(screen.getByLabelText('Amount UAH record 1'), { target: { value: '7 300' } });
+            fireEvent.change(screen.getByLabelText('Amount USD record 1'), { target: { value: '4 250' } });
+
+            const acceptButton = screen.getByLabelText('Accept record 1');
+            expect(acceptButton).not.toBeDisabled();
+
+            fireEvent.click(acceptButton);
+
+            expect(onRecordSave).toHaveBeenCalledWith(1, {
+                categoryId: 3,
+                amountUah: '7 300',
+                amountUsd: '4 250',
+            });
+        });
+
+        it('should show required validation for empty amount on blur', () => {
+            renderTable({ isEditing: true });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            fireEvent.change(screen.getByLabelText('Amount UAH record 1'), { target: { value: '   ' } });
+            fireEvent.blur(screen.getByLabelText('Amount UAH record 1'));
+
+            expect(screen.getByText(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED)).toBeInTheDocument();
+            expect(screen.getByLabelText('Accept record 1')).toBeDisabled();
+        });
+
+        it('should show numeric validation for non-number amount', () => {
+            renderTable({ isEditing: true });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            fireEvent.change(screen.getByLabelText('Amount USD record 1'), { target: { value: 'abc' } });
+
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER_GT_ZERO)).toBeInTheDocument();
+            expect(screen.getByLabelText('Accept record 1')).toBeDisabled();
+        });
+
+        it('should show max-digits validation for too long amount', () => {
+            renderTable({ isEditing: true });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            fireEvent.change(screen.getByLabelText('Amount UAH record 1'), { target: { value: '123456789012' } });
+
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DIGITS)).toBeInTheDocument();
+            expect(screen.getByLabelText('Accept record 1')).toBeDisabled();
+        });
+
+        it('should show negative validation for negative amount', () => {
+            renderTable({ isEditing: true });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            fireEvent.change(screen.getByLabelText('Amount USD record 1'), { target: { value: '-500' } });
+
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_NEGATIVE)).toBeInTheDocument();
+            expect(screen.getByLabelText('Accept record 1')).toBeDisabled();
         });
     });
 });

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
@@ -204,6 +204,18 @@ describe('FundsExpendituresTable', () => {
         expect(screen.getByTestId('not-found')).toBeInTheDocument();
     });
 
+    it('should use correct empty-state colSpan in view and edit modes', () => {
+        const { rerender } = render(
+            <FundsExpendituresTable records={[]} categories={MOCK_CATEGORIES} isEditing={false} />,
+        );
+
+        expect(screen.getByTestId('funds-table-empty-cell')).toHaveAttribute('colspan', '5');
+
+        rerender(<FundsExpendituresTable records={[]} categories={MOCK_CATEGORIES} isEditing />);
+
+        expect(screen.getByTestId('funds-table-empty-cell')).toHaveAttribute('colspan', '7');
+    });
+
     it('should sort records by amountUsd ascending', () => {
         renderTable();
 
@@ -213,6 +225,45 @@ describe('FundsExpendituresTable', () => {
         const firstRowCells = within(rows[0]).getAllByRole('cell');
 
         expect(firstRowCells[4]).toHaveTextContent('1 000');
+    });
+
+    it('should render localized type labels for income and expense chips', () => {
+        renderTable();
+
+        expect(screen.getAllByText(FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME)).toHaveLength(2);
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.EXPENSE)).toBeInTheDocument();
+    });
+
+    it('should sort records by category name ascending', () => {
+        renderTable();
+
+        fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.CATEGORY));
+
+        const rows = screen.getAllByRole('row').slice(1);
+        const firstRowCells = within(rows[0]).getAllByRole('cell');
+
+        expect(firstRowCells[2]).toHaveTextContent('Адміністративні витрати');
+    });
+
+    it('should toggle sort direction and reset to default order on third click', () => {
+        renderTable();
+
+        const amountUahHeader = screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_UAH);
+
+        fireEvent.click(amountUahHeader);
+        let rows = screen.getAllByRole('row').slice(1);
+        let firstRowCells = within(rows[0]).getAllByRole('cell');
+        expect(firstRowCells[3]).toHaveTextContent('1 000');
+
+        fireEvent.click(amountUahHeader);
+        rows = screen.getAllByRole('row').slice(1);
+        firstRowCells = within(rows[0]).getAllByRole('cell');
+        expect(firstRowCells[3]).toHaveTextContent('7 265');
+
+        fireEvent.click(amountUahHeader);
+        rows = screen.getAllByRole('row').slice(1);
+        firstRowCells = within(rows[0]).getAllByRole('cell');
+        expect(firstRowCells[3]).toHaveTextContent('7 265');
     });
 
     describe('scroll to top button', () => {
@@ -271,6 +322,19 @@ describe('FundsExpendituresTable', () => {
 
             expect((table as HTMLDivElement).scrollTop).toBe(0);
             expect(screen.getByTestId('funds-table-to-top')).not.toHaveClass('to-top-button-visible');
+        });
+
+        it('should not sort or reset scroll when a row is being edited', () => {
+            renderTable({ isEditing: true });
+
+            const table = screen.getByTestId('funds-table');
+            Object.defineProperty(table, 'scrollTop', { configurable: true, writable: true, value: 180 });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_UAH));
+
+            expect((table as HTMLDivElement).scrollTop).toBe(180);
+            expect(screen.getByLabelText('Accept record 1')).toBeInTheDocument();
         });
     });
 
@@ -372,6 +436,66 @@ describe('FundsExpendituresTable', () => {
             expect(screen.getByLabelText('Accept record 1')).toBeDisabled();
         });
 
+        it('should show required category validation on blur when category is cleared', () => {
+            renderTable({ isEditing: true });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            fireEvent.click(
+                screen.getByTestId(`select-option-${FUNDS_EXPENDITURES_TEXT.FILTER.CATEGORY_PLACEHOLDER}-undefined`),
+            );
+
+            const categoryEditWrapper = document.querySelector('.category-edit-wrapper');
+            expect(categoryEditWrapper).not.toBeNull();
+
+            if (categoryEditWrapper) {
+                fireEvent.blur(categoryEditWrapper, { relatedTarget: null });
+            }
+
+            expect(screen.getByText(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED)).toBeInTheDocument();
+            expect(screen.getByLabelText('Accept record 1')).toBeDisabled();
+        });
+
+        it('should infer editable categories from allRecordsForTypeInference', () => {
+            const categoryWithoutType = {
+                id: 99,
+                name: 'Категорія без типу',
+            } as unknown as ReportFundsExpendituresCategory;
+
+            const records: EnrichedRecord[] = [
+                {
+                    id: 1,
+                    categoryId: 1,
+                    categoryName: 'Грантові кошти',
+                    type: 'income',
+                    reportingYear: '2025',
+                    amountUah: '7 265',
+                    amountUsd: '4 200',
+                },
+            ];
+
+            const allRecordsForTypeInference = [
+                {
+                    id: 100,
+                    categoryId: 99,
+                    type: 'income' as const,
+                    reportingYear: '2024',
+                    amountUah: '10',
+                    amountUsd: '10',
+                },
+            ];
+
+            renderTable({
+                isEditing: true,
+                records,
+                categories: [...MOCK_CATEGORIES, categoryWithoutType],
+                allRecordsForTypeInference,
+            });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+
+            expect(screen.getByTestId('select-option-Категорія без типу-99')).toBeInTheDocument();
+        });
+
         it('should notify parent when entering and leaving row edit mode', () => {
             const onRowEditModeChange = jest.fn();
 
@@ -382,6 +506,25 @@ describe('FundsExpendituresTable', () => {
 
             expect(onRowEditModeChange).toHaveBeenNthCalledWith(1, true);
             expect(onRowEditModeChange).toHaveBeenNthCalledWith(2, false);
+        });
+
+        it('should restore row view mode values after closing edit', () => {
+            renderTable({ isEditing: true });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            fireEvent.change(screen.getByLabelText('Amount UAH record 1'), { target: { value: '8 888' } });
+            fireEvent.change(screen.getByLabelText('Amount USD record 1'), { target: { value: '9 999' } });
+            fireEvent.click(screen.getByLabelText('Close edit for record 1'));
+
+            expect(screen.queryByLabelText('Amount UAH record 1')).not.toBeInTheDocument();
+            expect(screen.queryByLabelText('Amount USD record 1')).not.toBeInTheDocument();
+
+            const rowOne = screen.getByLabelText('Edit record 1').closest('tr');
+            expect(rowOne).not.toBeNull();
+            const rowOneScope = within(rowOne as HTMLElement);
+
+            expect(rowOneScope.getByText('7 265')).toBeInTheDocument();
+            expect(rowOneScope.getByText('4 200')).toBeInTheDocument();
         });
 
         it('should save category and amounts through unified save callback', () => {
@@ -444,6 +587,17 @@ describe('FundsExpendituresTable', () => {
             fireEvent.change(screen.getByLabelText('Amount USD record 1'), { target: { value: '-500' } });
 
             expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_NEGATIVE)).toBeInTheDocument();
+            expect(screen.getByLabelText('Accept record 1')).toBeDisabled();
+        });
+
+        it('should show required validation for empty USD amount on blur', () => {
+            renderTable({ isEditing: true });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            fireEvent.change(screen.getByLabelText('Amount USD record 1'), { target: { value: '   ' } });
+            fireEvent.blur(screen.getByLabelText('Amount USD record 1'));
+
+            expect(screen.getByText(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED)).toBeInTheDocument();
             expect(screen.getByLabelText('Accept record 1')).toBeDisabled();
         });
     });

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
@@ -1,19 +1,19 @@
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import type React from 'react';
 import { FundsExpendituresTable, EnrichedRecord } from './FundsExpendituresTable';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
 
 jest.mock('./FundsExpendituresTable.module.scss', () => ({
     'table-wrapper': 'table-wrapper',
     table: 'table',
     th: 'th',
     sortable: 'sortable',
+    'sortable-disabled': 'sortable-disabled',
     'th-inner': 'th-inner',
     tr: 'tr',
     td: 'td',
-    'sort-icons': 'sort-icons',
-    'sort-icon': 'sort-icon',
-    'sort-icon-active': 'sort-icon-active',
     'type-chip': 'type-chip',
     'type-chip-income': 'type-chip-income',
     'type-chip-expense': 'type-chip-expense',
@@ -28,7 +28,14 @@ jest.mock('./FundsExpendituresTable.module.scss', () => ({
     'actions-td': 'actions-td',
     'row-actions': 'row-actions',
     'icon-button': 'icon-button',
+    'accept-icon-button': 'accept-icon-button',
+    'close-icon-button': 'close-icon-button',
     'action-icon': 'action-icon',
+    'category-edit-td': 'category-edit-td',
+    'category-edit-wrapper': 'category-edit-wrapper',
+    'category-edit-select': 'category-edit-select',
+    'category-edit-option': 'category-edit-option',
+    'category-edit-error': 'category-edit-error',
 }));
 
 jest.mock('@/assets/icons/chevron-up.svg', () => ({
@@ -51,6 +58,73 @@ jest.mock('@/assets/icons/delete.svg', () => ({
     ReactComponent: ({ className }: { className?: string }) => <svg data-testid="delete-icon" className={className} />,
 }));
 
+jest.mock('@/assets/icons/checkmark.svg', () => ({
+    ReactComponent: ({ className }: { className?: string }) => (
+        <svg data-testid="checkmark-icon" className={className} />
+    ),
+}));
+
+jest.mock('@/assets/icons/cross.svg', () => ({
+    ReactComponent: ({ className }: { className?: string }) => <svg data-testid="cross-icon" className={className} />,
+}));
+
+jest.mock('@/components/common/select/Select', () => {
+    const React = require('react');
+
+    const stringifyValueForTestId = (value: unknown): string => {
+        if (value === undefined) return 'undefined';
+        if (value === null) return 'null';
+
+        if (typeof value === 'string') return value;
+        if (typeof value === 'number' || typeof value === 'boolean') return value.toString();
+
+        return 'non-primitive';
+    };
+
+    const SelectOption = (_props: { value: unknown; name: string }) => null;
+
+    const MockSelect = ({
+        children,
+        onValueChange,
+        placeholder,
+    }: {
+        children: React.ReactNode;
+        onValueChange: (value: unknown) => void;
+        placeholder?: string;
+    }) => {
+        const options = React.Children.toArray(children).filter(Boolean) as Array<{
+            props: { value: unknown; name: string };
+        }>;
+
+        return (
+            <div data-testid={`select-${placeholder}`}>
+                {options.map((option, index) => (
+                    <button
+                        key={`${option.props.name}-${index}`}
+                        type="button"
+                        data-testid={`select-option-${option.props.name}-${stringifyValueForTestId(option.props.value)}`}
+                        onClick={() => onValueChange(option.props.value)}
+                    >
+                        {option.props.name}
+                    </button>
+                ))}
+            </div>
+        );
+    };
+
+    MockSelect.Option = SelectOption;
+
+    return { Select: MockSelect };
+});
+
+const MOCK_CATEGORIES: ReportFundsExpendituresCategory[] = [
+    { id: 1, name: 'Грантові кошти', type: 'income' },
+    { id: 2, name: 'Благодійні внески', type: 'income' },
+    { id: 3, name: 'Власні надходження', type: 'income' },
+    { id: 4, name: 'Адміністративні витрати', type: 'expense' },
+    { id: 5, name: 'Програмні витрати', type: 'expense' },
+];
+
 const MOCK_RECORDS: EnrichedRecord[] = [
     {
         id: 1,
@@ -65,25 +139,30 @@ const MOCK_RECORDS: EnrichedRecord[] = [
         id: 2,
         categoryId: 2,
         categoryName: 'Благодійні внески',
-        type: 'expense',
-        reportingYear: '2024',
+        type: 'income',
+        reportingYear: '2025',
         amountUah: '4 200',
         amountUsd: '4 200',
     },
     {
         id: 3,
-        categoryId: 1,
-        categoryName: 'Грантові кошти',
-        type: 'income',
-        reportingYear: '2023',
+        categoryId: 4,
+        categoryName: 'Адміністративні витрати',
+        type: 'expense',
+        reportingYear: '2024',
         amountUah: '1 000',
         amountUsd: '1 000',
     },
 ];
 
+const renderTable = (props?: Partial<React.ComponentProps<typeof FundsExpendituresTable>>) => {
+    return render(<FundsExpendituresTable records={MOCK_RECORDS} categories={MOCK_CATEGORIES} {...props} />);
+};
+
 describe('FundsExpendituresTable', () => {
     it('should render all column headers', () => {
-        render(<FundsExpendituresTable records={[]} />);
+        renderTable({ records: [] });
+
         expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.REPORTING_YEAR)).toBeInTheDocument();
         expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.TYPE)).toBeInTheDocument();
         expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.CATEGORY)).toBeInTheDocument();
@@ -92,153 +171,134 @@ describe('FundsExpendituresTable', () => {
     });
 
     it('should render all records', () => {
-        render(<FundsExpendituresTable records={MOCK_RECORDS} />);
-        expect(screen.getByText('2025')).toBeInTheDocument();
+        renderTable();
+
+        expect(screen.getAllByText('2025')).toHaveLength(2);
         expect(screen.getByText('2024')).toBeInTheDocument();
-        expect(screen.getByText('2023')).toBeInTheDocument();
     });
 
-    it('should display category names', () => {
-        render(<FundsExpendituresTable records={MOCK_RECORDS} />);
-        expect(screen.getAllByText('Грантові кошти')).toHaveLength(2);
-        expect(screen.getByText('Благодійні внески')).toBeInTheDocument();
-    });
+    it('should show edit and delete icons per row in edit mode', () => {
+        renderTable({ isEditing: true });
 
-    it('should display income type chip with correct label', () => {
-        render(<FundsExpendituresTable records={MOCK_RECORDS} />);
-        const incomeChips = screen.getAllByText(FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME);
-        expect(incomeChips.length).toBeGreaterThan(0);
-        incomeChips.forEach((chip) => {
-            expect(chip).toHaveClass('type-chip-income');
-        });
-    });
-
-    it('should display expense type chip with correct label', () => {
-        render(<FundsExpendituresTable records={MOCK_RECORDS} />);
-        const expenseChips = screen.getAllByText(FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.EXPENSE);
-        expect(expenseChips.length).toBeGreaterThan(0);
-        expenseChips.forEach((chip) => {
-            expect(chip).toHaveClass('type-chip-expense');
-        });
+        expect(screen.getAllByTestId('edit-icon')).toHaveLength(MOCK_RECORDS.length);
+        expect(screen.getAllByTestId('delete-icon')).toHaveLength(MOCK_RECORDS.length);
     });
 
     it('should render empty state row when records is empty', () => {
-        render(<FundsExpendituresTable records={[]} />);
-        const rows = screen.queryAllByRole('row');
-        expect(rows).toHaveLength(2);
-    });
+        renderTable({ records: [] });
 
-    it('should show empty state message and image when records is empty', () => {
-        render(<FundsExpendituresTable records={[]} />);
         expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.MESSAGE)).toBeInTheDocument();
         expect(screen.getByTestId('not-found')).toBeInTheDocument();
     });
 
-    describe('sorting', () => {
-        it('should sort by type ascending on first click', () => {
-            render(<FundsExpendituresTable records={MOCK_RECORDS} />);
-            const typeHeader = screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.TYPE);
-            fireEvent.click(typeHeader);
+    it('should sort records by amountUsd ascending', () => {
+        renderTable();
 
-            const rows = screen.getAllByRole('row').slice(1);
-            const firstRowCells = within(rows[0]).getAllByRole('cell');
-            expect(firstRowCells[1]).toHaveTextContent(FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.EXPENSE);
-        });
+        fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_USD));
 
-        it('should sort by type descending on second click', () => {
-            render(<FundsExpendituresTable records={MOCK_RECORDS} />);
-            const typeHeader = screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.TYPE);
-            fireEvent.click(typeHeader);
-            fireEvent.click(typeHeader);
+        const rows = screen.getAllByRole('row').slice(1);
+        const firstRowCells = within(rows[0]).getAllByRole('cell');
 
-            const rows = screen.getAllByRole('row').slice(1);
-            const firstRowCells = within(rows[0]).getAllByRole('cell');
-            expect(firstRowCells[1]).toHaveTextContent(FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME);
-        });
-
-        it('should reset sort on third click', () => {
-            render(<FundsExpendituresTable records={MOCK_RECORDS} />);
-            const typeHeader = screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.TYPE);
-            fireEvent.click(typeHeader);
-            fireEvent.click(typeHeader);
-            fireEvent.click(typeHeader);
-
-            const rows = screen.getAllByRole('row').slice(1);
-            const firstRowCells = within(rows[0]).getAllByRole('cell');
-            expect(firstRowCells[0]).toHaveTextContent('2025');
-        });
-
-        it('should sort by categoryName ascending on first click', () => {
-            render(<FundsExpendituresTable records={MOCK_RECORDS} />);
-            const categoryHeader = screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.CATEGORY);
-            fireEvent.click(categoryHeader);
-
-            const rows = screen.getAllByRole('row').slice(1);
-            const firstRowCells = within(rows[0]).getAllByRole('cell');
-            expect(firstRowCells[2]).toHaveTextContent('Благодійні внески');
-        });
-
-        it('should sort by amountUah ascending on first click', () => {
-            render(<FundsExpendituresTable records={MOCK_RECORDS} />);
-            const amountUahHeader = screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_UAH);
-            fireEvent.click(amountUahHeader);
-
-            const rows = screen.getAllByRole('row').slice(1);
-            const firstRowCells = within(rows[0]).getAllByRole('cell');
-            expect(firstRowCells[3]).toHaveTextContent('1 000');
-        });
-
-        it('should sort by amountUsd ascending on first click', () => {
-            render(<FundsExpendituresTable records={MOCK_RECORDS} />);
-            const amountUsdHeader = screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_USD);
-            fireEvent.click(amountUsdHeader);
-
-            const rows = screen.getAllByRole('row').slice(1);
-            const firstRowCells = within(rows[0]).getAllByRole('cell');
-            expect(firstRowCells[4]).toHaveTextContent('1 000');
-        });
+        expect(firstRowCells[4]).toHaveTextContent('1 000');
     });
 
-    it('should display amount values', () => {
-        render(<FundsExpendituresTable records={MOCK_RECORDS} />);
-        expect(screen.getByText('7 265')).toBeInTheDocument();
-        expect(screen.getAllByText('4 200')).not.toHaveLength(0);
-    });
+    describe('row category editing', () => {
+        it('should switch row actions to accept and close icons when row enters edit mode', () => {
+            renderTable({ isEditing: true });
 
-    describe('isEditing mode', () => {
-        it('should not show checkboxes when isEditing is false (default)', () => {
-            render(<FundsExpendituresTable records={MOCK_RECORDS} />);
-            expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+
+            expect(screen.getByLabelText('Accept record 1')).toBeInTheDocument();
+            expect(screen.getByLabelText('Close edit for record 1')).toBeInTheDocument();
+            expect(screen.getByTestId('checkmark-icon')).toBeInTheDocument();
+            expect(screen.getByTestId('cross-icon')).toBeInTheDocument();
         });
 
-        it('should show a checkbox per row when isEditing is true', () => {
-            render(<FundsExpendituresTable records={MOCK_RECORDS} isEditing={true} />);
-            const checkboxes = screen.getAllByRole('checkbox');
-            expect(checkboxes).toHaveLength(MOCK_RECORDS.length);
+        it('should disable other edit/delete actions and checkboxes while one row is in edit mode', () => {
+            renderTable({ isEditing: true });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+
+            expect(screen.getByLabelText('Edit record 2')).toBeDisabled();
+            expect(screen.getByLabelText('Delete record 2')).toBeDisabled();
+            expect(screen.getByLabelText('Select record 2')).toBeDisabled();
         });
 
-        it('should show edit and delete icons per row when isEditing is true', () => {
-            render(<FundsExpendituresTable records={MOCK_RECORDS} isEditing={true} />);
-            expect(screen.getAllByTestId('edit-icon')).toHaveLength(MOCK_RECORDS.length);
-            expect(screen.getAllByTestId('delete-icon')).toHaveLength(MOCK_RECORDS.length);
+        it('should disable accept when no category changes were made', () => {
+            renderTable({ isEditing: true });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+
+            expect(screen.getByLabelText('Accept record 1')).toBeDisabled();
         });
 
-        it('should not show edit and delete icons when isEditing is false', () => {
-            render(<FundsExpendituresTable records={MOCK_RECORDS} isEditing={false} />);
-            expect(screen.queryAllByTestId('edit-icon')).toHaveLength(0);
-            expect(screen.queryAllByTestId('delete-icon')).toHaveLength(0);
+        it('should save category changes when valid and notify parent', () => {
+            const onRecordCategorySave = jest.fn();
+
+            renderTable({ isEditing: true, onRecordCategorySave });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            fireEvent.click(screen.getByTestId('select-option-Власні надходження-3'));
+
+            const acceptButton = screen.getByLabelText('Accept record 1');
+            expect(acceptButton).not.toBeDisabled();
+
+            fireEvent.click(acceptButton);
+
+            expect(onRecordCategorySave).toHaveBeenCalledWith(1, 3);
         });
 
-        it('should use colSpan of 7 for empty state when isEditing is true', () => {
-            render(<FundsExpendituresTable records={[]} isEditing={true} />);
-            const emptyCell = screen.getByTestId('funds-table-empty-cell');
-            expect(emptyCell).toHaveAttribute('colspan', '7');
+        it('should show unique validation message when duplicate category is selected for the same type', () => {
+            renderTable({ isEditing: true });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            fireEvent.click(screen.getByTestId('select-option-Благодійні внески-2'));
+
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.CATEGORY_UNIQUE)).toBeInTheDocument();
+            expect(screen.getByLabelText('Accept record 1')).toBeDisabled();
         });
 
-        it('should use colSpan of 5 for empty state when not editing', () => {
-            render(<FundsExpendituresTable records={[]} isEditing={false} />);
-            const emptyCell = screen.getByTestId('funds-table-empty-cell');
-            expect(emptyCell).toHaveAttribute('colspan', '5');
+        it('should show unique validation message when duplicate category exists in another year', () => {
+            const recordsWithDuplicateAcrossYears: EnrichedRecord[] = [
+                {
+                    id: 1,
+                    categoryId: 1,
+                    categoryName: 'Грантові кошти',
+                    type: 'income',
+                    reportingYear: '2025',
+                    amountUah: '7 265',
+                    amountUsd: '4 200',
+                },
+                {
+                    id: 2,
+                    categoryId: 3,
+                    categoryName: 'Власні надходження',
+                    type: 'income',
+                    reportingYear: '2024',
+                    amountUah: '3 000',
+                    amountUsd: '1 700',
+                },
+            ];
+
+            renderTable({ isEditing: true, records: recordsWithDuplicateAcrossYears });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            fireEvent.click(screen.getByTestId('select-option-Власні надходження-3'));
+
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.CATEGORY_UNIQUE)).toBeInTheDocument();
+            expect(screen.getByLabelText('Accept record 1')).toBeDisabled();
+        });
+
+        it('should notify parent when entering and leaving row edit mode', () => {
+            const onRowEditModeChange = jest.fn();
+
+            renderTable({ isEditing: true, onRowEditModeChange });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            fireEvent.click(screen.getByLabelText('Close edit for record 1'));
+
+            expect(onRowEditModeChange).toHaveBeenNthCalledWith(1, true);
+            expect(onRowEditModeChange).toHaveBeenNthCalledWith(2, false);
         });
     });
 });

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
@@ -211,7 +211,7 @@ describe('FundsExpendituresTable', () => {
 
     describe('scroll to top button', () => {
         it('should show to-top button when content overflows and table is scrolled', () => {
-            render(<FundsExpendituresTable records={MOCK_RECORDS} />);
+            render(<FundsExpendituresTable records={MOCK_RECORDS} categories={MOCK_CATEGORIES} />);
 
             const table = screen.getByTestId('funds-table');
             Object.defineProperty(table, 'scrollHeight', { configurable: true, value: 900 });
@@ -225,7 +225,7 @@ describe('FundsExpendituresTable', () => {
         });
 
         it('should hide to-top button when list is at top', () => {
-            render(<FundsExpendituresTable records={MOCK_RECORDS} />);
+            render(<FundsExpendituresTable records={MOCK_RECORDS} categories={MOCK_CATEGORIES} />);
 
             const table = screen.getByTestId('funds-table');
             Object.defineProperty(table, 'scrollHeight', { configurable: true, value: 900 });
@@ -238,7 +238,7 @@ describe('FundsExpendituresTable', () => {
         });
 
         it('should scroll to top after clicking to-top button', () => {
-            render(<FundsExpendituresTable records={MOCK_RECORDS} />);
+            render(<FundsExpendituresTable records={MOCK_RECORDS} categories={MOCK_CATEGORIES} />);
 
             const table = screen.getByTestId('funds-table');
             Object.defineProperty(table, 'scrollHeight', { configurable: true, value: 900 });
@@ -253,7 +253,7 @@ describe('FundsExpendituresTable', () => {
         });
 
         it('should reset scroll position to top when sorting is changed', () => {
-            render(<FundsExpendituresTable records={MOCK_RECORDS} />);
+            render(<FundsExpendituresTable records={MOCK_RECORDS} categories={MOCK_CATEGORIES} />);
 
             const table = screen.getByTestId('funds-table');
             Object.defineProperty(table, 'scrollHeight', { configurable: true, value: 900 });
@@ -270,7 +270,7 @@ describe('FundsExpendituresTable', () => {
 
     describe('isEditing mode', () => {
         it('should not show checkboxes when isEditing is false (default)', () => {
-            render(<FundsExpendituresTable records={MOCK_RECORDS} />);
+            render(<FundsExpendituresTable records={MOCK_RECORDS} categories={MOCK_CATEGORIES} />);
             expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
         });
     });

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
@@ -1,9 +1,17 @@
 import { useState, useCallback } from 'react';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
-import { FundsExpendituresTransactionType, ReportFundsExpendituresRecord } from '@/types/admin/reports';
+import {
+    FundsExpendituresTransactionType,
+    ReportFundsExpendituresCategory,
+    ReportFundsExpendituresRecord,
+} from '@/types/admin/reports';
 import { ReactComponent as NotFoundIcon } from '@/assets/icons/not-found.svg';
 import { ReactComponent as EditIcon } from '@/assets/icons/edit.svg';
 import { ReactComponent as DeleteIcon } from '@/assets/icons/delete.svg';
+import { ReactComponent as CheckmarkIcon } from '@/assets/icons/checkmark.svg';
+import { ReactComponent as CrossIcon } from '@/assets/icons/cross.svg';
+import { Select } from '@/components/common/select/Select';
 import { SortIcon } from '@/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/components/sort-icon';
 import { parseAmount } from '@/utils/functions/parse-amount/parse-amount';
 import cn from 'classnames';
@@ -23,7 +31,18 @@ interface ColumnSort {
 
 interface FundsExpendituresTableProps {
     records: EnrichedRecord[];
+    categories: ReportFundsExpendituresCategory[];
+    allRecordsForTypeInference?: ReportFundsExpendituresRecord[];
     isEditing?: boolean;
+    onRowEditModeChange?: (isEditMode: boolean) => void;
+    onRecordCategorySave?: (recordId: number, categoryId: number) => void;
+}
+
+interface RowEditState {
+    recordId: number;
+    originalCategoryId: number;
+    categoryId: number | undefined;
+    error: string | undefined;
 }
 
 const TYPE_LABEL_MAP: Record<FundsExpendituresTransactionType, string> = {
@@ -32,7 +51,9 @@ const TYPE_LABEL_MAP: Record<FundsExpendituresTransactionType, string> = {
 };
 
 const sortRecords = (records: EnrichedRecord[], sort: ColumnSort): EnrichedRecord[] => {
-    if (!sort.column || !sort.direction) return records;
+    if (!sort.column || !sort.direction) {
+        return records;
+    }
 
     return [...records].sort((a, b) => {
         const { column, direction } = sort;
@@ -52,17 +73,180 @@ const sortRecords = (records: EnrichedRecord[], sort: ColumnSort): EnrichedRecor
     });
 };
 
-export const FundsExpendituresTable = ({ records, isEditing = false }: FundsExpendituresTableProps) => {
+const getCategoriesForType = (
+    categories: ReportFundsExpendituresCategory[],
+    records: ReportFundsExpendituresRecord[],
+    type: FundsExpendituresTransactionType,
+): ReportFundsExpendituresCategory[] => {
+    return categories
+        .filter((category) => {
+            if (category.type) {
+                return category.type === type;
+            }
+
+            return records.some((record) => record.type === type && record.categoryId === category.id);
+        })
+        .sort((a, b) => a.name.localeCompare(b.name, 'uk'));
+};
+
+export const FundsExpendituresTable = ({
+    records,
+    categories,
+    allRecordsForTypeInference,
+    isEditing = false,
+    onRowEditModeChange,
+    onRecordCategorySave,
+}: FundsExpendituresTableProps) => {
     const [sort, setSort] = useState<ColumnSort>({ column: null, direction: null });
+    const [rowEditState, setRowEditState] = useState<RowEditState | null>(null);
 
-    const handleSort = useCallback((column: SortableColumn) => {
-        setSort((prev) => {
-            if (prev.column !== column) return { column, direction: 'asc' };
-            if (prev.direction === 'asc') return { column, direction: 'desc' };
-            return { column: null, direction: null };
-        });
-    }, []);
+    const typeInferenceSource = allRecordsForTypeInference ?? records;
 
+    const categoriesByType = {
+        income: getCategoriesForType(categories, typeInferenceSource, 'income'),
+        expense: getCategoriesForType(categories, typeInferenceSource, 'expense'),
+    };
+
+    const setRowEditMode = useCallback(
+        (nextState: RowEditState | null) => {
+            setRowEditState(nextState);
+            onRowEditModeChange?.(nextState !== null);
+        },
+        [onRowEditModeChange],
+    );
+
+    const getRowEditValidationError = useCallback(
+        (
+            record: EnrichedRecord,
+            nextCategoryId: number | undefined,
+            trigger: 'change' | 'blur' = 'change',
+        ): string | undefined => {
+            if (nextCategoryId === undefined) {
+                return trigger === 'blur' ? COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED : undefined;
+            }
+
+            const hasDuplicate = typeInferenceSource.some(
+                (item) => item.id !== record.id && item.type === record.type && item.categoryId === nextCategoryId,
+            );
+
+            return hasDuplicate ? FUNDS_EXPENDITURES_TEXT.VALIDATION.CATEGORY_UNIQUE : undefined;
+        },
+        [typeInferenceSource],
+    );
+
+    const handleStartRowEdit = useCallback(
+        (record: EnrichedRecord) => {
+            if (rowEditState) {
+                return;
+            }
+
+            setRowEditMode({
+                recordId: record.id,
+                originalCategoryId: record.categoryId,
+                categoryId: record.categoryId,
+                error: undefined,
+            });
+        },
+        [rowEditState, setRowEditMode],
+    );
+
+    const handleCloseRowEdit = useCallback(() => {
+        setRowEditMode(null);
+    }, [setRowEditMode]);
+
+    const handleRowCategoryChange = useCallback(
+        (record: EnrichedRecord, categoryId: number | undefined) => {
+            const nextError = getRowEditValidationError(record, categoryId, 'change');
+
+            setRowEditState((prev) => {
+                if (prev?.recordId !== record.id) {
+                    return prev;
+                }
+
+                return {
+                    ...prev,
+                    categoryId,
+                    error: nextError,
+                };
+            });
+        },
+        [getRowEditValidationError],
+    );
+
+    const handleRowCategoryBlur = useCallback(
+        (record: EnrichedRecord) => {
+            setRowEditState((prev) => {
+                if (prev?.recordId !== record.id) {
+                    return prev;
+                }
+
+                return {
+                    ...prev,
+                    error: getRowEditValidationError(record, prev.categoryId, 'blur'),
+                };
+            });
+        },
+        [getRowEditValidationError],
+    );
+
+    const handleAcceptRowEdit = useCallback(
+        (record: EnrichedRecord) => {
+            if (rowEditState?.recordId !== record.id) {
+                return;
+            }
+
+            const finalError = getRowEditValidationError(record, rowEditState.categoryId, 'blur');
+            const isCategoryUnchanged = rowEditState.categoryId === rowEditState.originalCategoryId;
+            const isCategoryMissing = rowEditState.categoryId === undefined;
+
+            if (finalError || isCategoryMissing || isCategoryUnchanged) {
+                setRowEditState((prev) => {
+                    if (prev?.recordId !== record.id) {
+                        return prev;
+                    }
+
+                    return {
+                        ...prev,
+                        error: finalError,
+                    };
+                });
+
+                return;
+            }
+
+            const nextCategoryId = rowEditState.categoryId;
+            if (nextCategoryId === undefined) {
+                return;
+            }
+
+            onRecordCategorySave?.(record.id, nextCategoryId);
+            setRowEditMode(null);
+        },
+        [getRowEditValidationError, onRecordCategorySave, rowEditState, setRowEditMode],
+    );
+
+    const handleSort = useCallback(
+        (column: SortableColumn) => {
+            if (rowEditState) {
+                return;
+            }
+
+            setSort((prev) => {
+                if (prev.column !== column) {
+                    return { column, direction: 'asc' };
+                }
+
+                if (prev.direction === 'asc') {
+                    return { column, direction: 'desc' };
+                }
+
+                return { column: null, direction: null };
+            });
+        },
+        [rowEditState],
+    );
+
+    const isAnyRowEditing = rowEditState !== null;
     const sortedRecords = sortRecords(records, sort);
     const colSpan = isEditing ? 7 : 5;
 
@@ -73,25 +257,45 @@ export const FundsExpendituresTable = ({ records, isEditing = false }: FundsExpe
                     <tr>
                         {isEditing && <th className={cn(styles.th, styles['checkbox-th'])} />}
                         <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.REPORTING_YEAR}</th>
-                        <th className={cn(styles.th, styles.sortable)} onClick={() => handleSort('type')}>
+                        <th
+                            className={cn(styles.th, styles.sortable, {
+                                [styles['sortable-disabled']]: isAnyRowEditing,
+                            })}
+                            onClick={() => handleSort('type')}
+                        >
                             <span className={styles['th-inner']}>
                                 <span>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.TYPE}</span>
                                 <SortIcon isActive={sort.column === 'type'} direction={sort.direction} />
                             </span>
                         </th>
-                        <th className={cn(styles.th, styles.sortable)} onClick={() => handleSort('categoryName')}>
+                        <th
+                            className={cn(styles.th, styles.sortable, {
+                                [styles['sortable-disabled']]: isAnyRowEditing,
+                            })}
+                            onClick={() => handleSort('categoryName')}
+                        >
                             <span className={styles['th-inner']}>
                                 <span>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.CATEGORY}</span>
                                 <SortIcon isActive={sort.column === 'categoryName'} direction={sort.direction} />
                             </span>
                         </th>
-                        <th className={cn(styles.th, styles.sortable)} onClick={() => handleSort('amountUah')}>
+                        <th
+                            className={cn(styles.th, styles.sortable, {
+                                [styles['sortable-disabled']]: isAnyRowEditing,
+                            })}
+                            onClick={() => handleSort('amountUah')}
+                        >
                             <span className={styles['th-inner']}>
                                 <span>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_UAH}</span>
                                 <SortIcon isActive={sort.column === 'amountUah'} direction={sort.direction} />
                             </span>
                         </th>
-                        <th className={cn(styles.th, styles.sortable)} onClick={() => handleSort('amountUsd')}>
+                        <th
+                            className={cn(styles.th, styles.sortable, {
+                                [styles['sortable-disabled']]: isAnyRowEditing,
+                            })}
+                            onClick={() => handleSort('amountUsd')}
+                        >
                             <span className={styles['th-inner']}>
                                 <span>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_USD}</span>
                                 <SortIcon isActive={sort.column === 'amountUsd'} direction={sort.direction} />
@@ -113,53 +317,140 @@ export const FundsExpendituresTable = ({ records, isEditing = false }: FundsExpe
                             </td>
                         </tr>
                     ) : (
-                        sortedRecords.map((record) => (
-                            <tr key={record.id} className={styles.tr}>
-                                {isEditing && (
-                                    <td className={cn(styles.td, styles['checkbox-td'])}>
-                                        <input
-                                            type="checkbox"
-                                            className={styles['row-checkbox']}
-                                            aria-label={`Select record ${record.id}`}
-                                        />
+                        sortedRecords.map((record) => {
+                            const isEditedRow = rowEditState?.recordId === record.id;
+                            const isAnotherRowEditing = isAnyRowEditing && !isEditedRow;
+                            const editableCategories = categoriesByType[record.type];
+                            const isAcceptDisabled =
+                                !isEditedRow ||
+                                rowEditState.categoryId === undefined ||
+                                Boolean(rowEditState.error) ||
+                                rowEditState.categoryId === rowEditState.originalCategoryId;
+
+                            return (
+                                <tr key={record.id} className={styles.tr}>
+                                    {isEditing && (
+                                        <td className={cn(styles.td, styles['checkbox-td'])}>
+                                            <input
+                                                type="checkbox"
+                                                className={styles['row-checkbox']}
+                                                aria-label={`Select record ${record.id}`}
+                                                disabled={isAnyRowEditing}
+                                            />
+                                        </td>
+                                    )}
+                                    <td className={styles.td}>{record.reportingYear}</td>
+                                    <td className={styles.td}>
+                                        <span
+                                            className={cn(styles['type-chip'], {
+                                                [styles['type-chip-income']]: record.type === 'income',
+                                                [styles['type-chip-expense']]: record.type === 'expense',
+                                            })}
+                                        >
+                                            {TYPE_LABEL_MAP[record.type]}
+                                        </span>
                                     </td>
-                                )}
-                                <td className={styles.td}>{record.reportingYear}</td>
-                                <td className={styles.td}>
-                                    <span
-                                        className={cn(styles['type-chip'], {
-                                            [styles['type-chip-income']]: record.type === 'income',
-                                            [styles['type-chip-expense']]: record.type === 'expense',
-                                        })}
-                                    >
-                                        {TYPE_LABEL_MAP[record.type]}
-                                    </span>
-                                </td>
-                                <td className={styles.td}>{record.categoryName}</td>
-                                <td className={styles.td}>{record.amountUah}</td>
-                                <td className={styles.td}>{record.amountUsd}</td>
-                                {isEditing && (
-                                    <td className={cn(styles.td, styles['actions-td'])}>
-                                        <div className={styles['row-actions']}>
-                                            <button
-                                                type="button"
-                                                className={styles['icon-button']}
-                                                aria-label={`Edit record ${record.id}`}
+                                    <td className={cn(styles.td, { [styles['category-edit-td']]: isEditedRow })}>
+                                        {isEditedRow ? (
+                                            <div
+                                                className={styles['category-edit-wrapper']}
+                                                onBlurCapture={(event) => {
+                                                    if (
+                                                        !event.currentTarget.contains(
+                                                            event.relatedTarget as Node | null,
+                                                        )
+                                                    ) {
+                                                        handleRowCategoryBlur(record);
+                                                    }
+                                                }}
                                             >
-                                                <EditIcon className={styles['action-icon']} />
-                                            </button>
-                                            <button
-                                                type="button"
-                                                className={styles['icon-button']}
-                                                aria-label={`Delete record ${record.id}`}
-                                            >
-                                                <DeleteIcon className={styles['action-icon']} />
-                                            </button>
-                                        </div>
+                                                <Select<number | undefined>
+                                                    value={rowEditState.categoryId}
+                                                    onValueChange={(value) => handleRowCategoryChange(record, value)}
+                                                    placeholder={FUNDS_EXPENDITURES_TEXT.FILTER.CATEGORY_PLACEHOLDER}
+                                                    className={styles['category-edit-select']}
+                                                    optionClassName={styles['category-edit-option']}
+                                                >
+                                                    <Select.Option
+                                                        value={undefined}
+                                                        name={FUNDS_EXPENDITURES_TEXT.FILTER.CATEGORY_PLACEHOLDER}
+                                                    />
+                                                    {editableCategories.map((category) => (
+                                                        <Select.Option
+                                                            key={category.id}
+                                                            value={category.id}
+                                                            name={category.name}
+                                                        />
+                                                    ))}
+                                                </Select>
+                                                {rowEditState.error && (
+                                                    <p className={styles['category-edit-error']}>
+                                                        {rowEditState.error}
+                                                    </p>
+                                                )}
+                                            </div>
+                                        ) : (
+                                            record.categoryName
+                                        )}
                                     </td>
-                                )}
-                            </tr>
-                        ))
+                                    <td className={styles.td}>{record.amountUah}</td>
+                                    <td className={styles.td}>{record.amountUsd}</td>
+                                    {isEditing && (
+                                        <td className={cn(styles.td, styles['actions-td'])}>
+                                            <div className={styles['row-actions']}>
+                                                {isEditedRow ? (
+                                                    <>
+                                                        <button
+                                                            type="button"
+                                                            className={cn(
+                                                                styles['icon-button'],
+                                                                styles['accept-icon-button'],
+                                                            )}
+                                                            aria-label={`Accept record ${record.id}`}
+                                                            onClick={() => handleAcceptRowEdit(record)}
+                                                            disabled={isAcceptDisabled}
+                                                        >
+                                                            <CheckmarkIcon className={styles['action-icon']} />
+                                                        </button>
+                                                        <button
+                                                            type="button"
+                                                            className={cn(
+                                                                styles['icon-button'],
+                                                                styles['close-icon-button'],
+                                                            )}
+                                                            aria-label={`Close edit for record ${record.id}`}
+                                                            onClick={handleCloseRowEdit}
+                                                        >
+                                                            <CrossIcon className={styles['action-icon']} />
+                                                        </button>
+                                                    </>
+                                                ) : (
+                                                    <>
+                                                        <button
+                                                            type="button"
+                                                            className={styles['icon-button']}
+                                                            aria-label={`Edit record ${record.id}`}
+                                                            onClick={() => handleStartRowEdit(record)}
+                                                            disabled={isAnotherRowEditing}
+                                                        >
+                                                            <EditIcon className={styles['action-icon']} />
+                                                        </button>
+                                                        <button
+                                                            type="button"
+                                                            className={styles['icon-button']}
+                                                            aria-label={`Delete record ${record.id}`}
+                                                            disabled={isAnotherRowEditing}
+                                                        >
+                                                            <DeleteIcon className={styles['action-icon']} />
+                                                        </button>
+                                                    </>
+                                                )}
+                                            </div>
+                                        </td>
+                                    )}
+                                </tr>
+                            );
+                        })
                     )}
                 </tbody>
             </table>

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
 import {
     FundsExpendituresTransactionType,
@@ -420,9 +421,7 @@ export const FundsExpendituresTable = ({
                                                     >
                                                         <Select.Option
                                                             value={undefined}
-                                                            name={
-                                                                FUNDS_EXPENDITURES_TEXT.FILTER.CATEGORY_PLACEHOLDER
-                                                            }
+                                                            name={FUNDS_EXPENDITURES_TEXT.FILTER.CATEGORY_PLACEHOLDER}
                                                         />
                                                         {editableCategories.map((category) => (
                                                             <Select.Option

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
 import {
     FundsExpendituresTransactionType,
@@ -14,6 +13,11 @@ import { ReactComponent as CheckmarkIcon } from '@/assets/icons/checkmark.svg';
 import { ReactComponent as CrossIcon } from '@/assets/icons/cross.svg';
 import { Select } from '@/components/common/select/Select';
 import { SortIcon } from '@/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/components/sort-icon';
+import {
+    normalizeFundsExpendituresAmountInput,
+    validateFundsExpendituresAmount,
+    validateFundsExpendituresCategory,
+} from '@/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema';
 import { parseAmount } from '@/utils/functions/parse-amount/parse-amount';
 import cn from 'classnames';
 import styles from './FundsExpendituresTable.module.scss';
@@ -36,14 +40,22 @@ interface FundsExpendituresTableProps {
     allRecordsForTypeInference?: ReportFundsExpendituresRecord[];
     isEditing?: boolean;
     onRowEditModeChange?: (isEditMode: boolean) => void;
-    onRecordCategorySave?: (recordId: number, categoryId: number) => void;
+    onRecordSave?: (recordId: number, data: { categoryId: number; amountUah: string; amountUsd: string }) => void;
 }
 
 interface RowEditState {
     recordId: number;
     originalCategoryId: number;
+    originalAmountUah: string;
+    originalAmountUsd: string;
     categoryId: number | undefined;
-    error: string | undefined;
+    amountUah: string;
+    amountUsd: string;
+    errors: {
+        category?: string;
+        amountUah?: string;
+        amountUsd?: string;
+    };
 }
 
 const TYPE_LABEL_MAP: Record<FundsExpendituresTransactionType, string> = {
@@ -90,13 +102,39 @@ const getCategoriesForType = (
         .sort((a, b) => a.name.localeCompare(b.name, 'uk'));
 };
 
+const isAcceptButtonDisabled = (rowEditState: RowEditState | null): boolean => {
+    if (!rowEditState) {
+        return true;
+    }
+
+    const normalizedAmountUah = normalizeFundsExpendituresAmountInput(rowEditState.amountUah, true);
+    const normalizedAmountUsd = normalizeFundsExpendituresAmountInput(rowEditState.amountUsd, true);
+    const normalizedOriginalUah = normalizeFundsExpendituresAmountInput(rowEditState.originalAmountUah, true);
+    const normalizedOriginalUsd = normalizeFundsExpendituresAmountInput(rowEditState.originalAmountUsd, true);
+
+    const hasErrors =
+        rowEditState.categoryId === undefined ||
+        Boolean(rowEditState.errors.category) ||
+        Boolean(rowEditState.errors.amountUah) ||
+        Boolean(rowEditState.errors.amountUsd);
+
+    const amountsEmpty = normalizedAmountUah === '' || normalizedAmountUsd === '';
+
+    const noChanges =
+        rowEditState.categoryId === rowEditState.originalCategoryId &&
+        normalizedAmountUah === normalizedOriginalUah &&
+        normalizedAmountUsd === normalizedOriginalUsd;
+
+    return hasErrors || amountsEmpty || noChanges;
+};
+
 export const FundsExpendituresTable = ({
     records,
     categories,
     allRecordsForTypeInference,
     isEditing = false,
     onRowEditModeChange,
-    onRecordCategorySave,
+    onRecordSave,
 }: FundsExpendituresTableProps) => {
     const [sort, setSort] = useState<ColumnSort>({ column: null, direction: null });
     const [rowEditState, setRowEditState] = useState<RowEditState | null>(null);
@@ -148,15 +186,13 @@ export const FundsExpendituresTable = ({
             nextCategoryId: number | undefined,
             trigger: 'change' | 'blur' = 'change',
         ): string | undefined => {
-            if (nextCategoryId === undefined) {
-                return trigger === 'blur' ? COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED : undefined;
-            }
-
-            const hasDuplicate = typeInferenceSource.some(
-                (item) => item.id !== record.id && item.type === record.type && item.categoryId === nextCategoryId,
-            );
-
-            return hasDuplicate ? FUNDS_EXPENDITURES_TEXT.VALIDATION.CATEGORY_UNIQUE : undefined;
+            return validateFundsExpendituresCategory({
+                recordId: record.id,
+                recordType: record.type,
+                categoryId: nextCategoryId,
+                records: typeInferenceSource,
+                trigger,
+            });
         },
         [typeInferenceSource],
     );
@@ -170,8 +206,12 @@ export const FundsExpendituresTable = ({
             setRowEditMode({
                 recordId: record.id,
                 originalCategoryId: record.categoryId,
+                originalAmountUah: record.amountUah,
+                originalAmountUsd: record.amountUsd,
                 categoryId: record.categoryId,
-                error: undefined,
+                amountUah: record.amountUah,
+                amountUsd: record.amountUsd,
+                errors: {},
             });
         },
         [rowEditState, setRowEditMode],
@@ -193,7 +233,10 @@ export const FundsExpendituresTable = ({
                 return {
                     ...prev,
                     categoryId,
-                    error: nextError,
+                    errors: {
+                        ...prev.errors,
+                        category: nextError,
+                    },
                 };
             });
         },
@@ -209,12 +252,53 @@ export const FundsExpendituresTable = ({
 
                 return {
                     ...prev,
-                    error: getRowEditValidationError(record, prev.categoryId, 'blur'),
+                    errors: {
+                        ...prev.errors,
+                        category: getRowEditValidationError(record, prev.categoryId, 'blur'),
+                    },
                 };
             });
         },
         [getRowEditValidationError],
     );
+
+    const handleAmountChange = useCallback((recordId: number, field: 'amountUah' | 'amountUsd', nextValue: string) => {
+        const normalized = normalizeFundsExpendituresAmountInput(nextValue);
+
+        setRowEditState((prev) => {
+            if (prev?.recordId !== recordId) {
+                return prev;
+            }
+
+            return {
+                ...prev,
+                [field]: normalized,
+                errors: {
+                    ...prev.errors,
+                    [field]: validateFundsExpendituresAmount(normalized, 'change'),
+                },
+            };
+        });
+    }, []);
+
+    const handleAmountBlur = useCallback((recordId: number, field: 'amountUah' | 'amountUsd') => {
+        setRowEditState((prev) => {
+            if (prev?.recordId !== recordId) {
+                return prev;
+            }
+
+            const normalized = normalizeFundsExpendituresAmountInput(prev[field], true);
+
+            return {
+                ...prev,
+                [field]: normalized,
+                errors: {
+                    ...prev.errors,
+                    [field]: validateFundsExpendituresAmount(normalized, 'blur'),
+                },
+            };
+        });
+    }, []);
 
     const handleAcceptRowEdit = useCallback(
         (record: EnrichedRecord) => {
@@ -225,8 +309,21 @@ export const FundsExpendituresTable = ({
             const finalError = getRowEditValidationError(record, rowEditState.categoryId, 'blur');
             const isCategoryUnchanged = rowEditState.categoryId === rowEditState.originalCategoryId;
             const isCategoryMissing = rowEditState.categoryId === undefined;
+            const normalizedAmountUah = normalizeFundsExpendituresAmountInput(rowEditState.amountUah, true);
+            const normalizedAmountUsd = normalizeFundsExpendituresAmountInput(rowEditState.amountUsd, true);
+            const amountUahError = validateFundsExpendituresAmount(normalizedAmountUah, 'save');
+            const amountUsdError = validateFundsExpendituresAmount(normalizedAmountUsd, 'save');
+            const isAmountsUnchanged =
+                normalizeFundsExpendituresAmountInput(rowEditState.originalAmountUah, true) === normalizedAmountUah &&
+                normalizeFundsExpendituresAmountInput(rowEditState.originalAmountUsd, true) === normalizedAmountUsd;
 
-            if (finalError || isCategoryMissing || isCategoryUnchanged) {
+            if (
+                finalError ||
+                isCategoryMissing ||
+                amountUahError ||
+                amountUsdError ||
+                (isCategoryUnchanged && isAmountsUnchanged)
+            ) {
                 setRowEditState((prev) => {
                     if (prev?.recordId !== record.id) {
                         return prev;
@@ -234,7 +331,14 @@ export const FundsExpendituresTable = ({
 
                     return {
                         ...prev,
-                        error: finalError,
+                        amountUah: normalizedAmountUah,
+                        amountUsd: normalizedAmountUsd,
+                        errors: {
+                            ...prev.errors,
+                            category: finalError,
+                            amountUah: amountUahError,
+                            amountUsd: amountUsdError,
+                        },
                     };
                 });
 
@@ -246,10 +350,14 @@ export const FundsExpendituresTable = ({
                 return;
             }
 
-            onRecordCategorySave?.(record.id, nextCategoryId);
+            onRecordSave?.(record.id, {
+                categoryId: nextCategoryId,
+                amountUah: normalizedAmountUah,
+                amountUsd: normalizedAmountUsd,
+            });
             setRowEditMode(null);
         },
-        [getRowEditValidationError, onRecordCategorySave, rowEditState, setRowEditMode],
+        [getRowEditValidationError, onRecordSave, rowEditState, setRowEditMode],
     );
 
     const handleSort = useCallback(
@@ -365,11 +473,7 @@ export const FundsExpendituresTable = ({
                                 const isEditedRow = rowEditState?.recordId === record.id;
                                 const isAnotherRowEditing = isAnyRowEditing && !isEditedRow;
                                 const editableCategories = categoriesByType[record.type];
-                                const isAcceptDisabled =
-                                    !isEditedRow ||
-                                    rowEditState.categoryId === undefined ||
-                                    Boolean(rowEditState.error) ||
-                                    rowEditState.categoryId === rowEditState.originalCategoryId;
+                                const isAcceptDisabled = !isEditedRow || isAcceptButtonDisabled(rowEditState);
 
                                 return (
                                     <tr key={record.id} className={styles.tr}>
@@ -431,9 +535,9 @@ export const FundsExpendituresTable = ({
                                                             />
                                                         ))}
                                                     </Select>
-                                                    {rowEditState.error && (
+                                                    {rowEditState.errors.category && (
                                                         <p className={styles['category-edit-error']}>
-                                                            {rowEditState.error}
+                                                            {rowEditState.errors.category}
                                                         </p>
                                                     )}
                                                 </div>
@@ -441,8 +545,66 @@ export const FundsExpendituresTable = ({
                                                 record.categoryName
                                             )}
                                         </td>
-                                        <td className={styles.td}>{record.amountUah}</td>
-                                        <td className={styles.td}>{record.amountUsd}</td>
+                                        <td className={cn(styles.td, { [styles['amount-edit-td']]: isEditedRow })}>
+                                            {isEditedRow ? (
+                                                <div className={styles['amount-edit-wrapper']}>
+                                                    <input
+                                                        type="text"
+                                                        className={cn(styles['amount-edit-input'], {
+                                                            [styles['amount-edit-input-error']]:
+                                                                rowEditState.errors.amountUah,
+                                                        })}
+                                                        value={rowEditState.amountUah}
+                                                        aria-label={`Amount UAH record ${record.id}`}
+                                                        onChange={(event) =>
+                                                            handleAmountChange(
+                                                                record.id,
+                                                                'amountUah',
+                                                                event.target.value,
+                                                            )
+                                                        }
+                                                        onBlur={() => handleAmountBlur(record.id, 'amountUah')}
+                                                    />
+                                                    {rowEditState.errors.amountUah && (
+                                                        <p className={styles['amount-edit-error']}>
+                                                            {rowEditState.errors.amountUah}
+                                                        </p>
+                                                    )}
+                                                </div>
+                                            ) : (
+                                                record.amountUah
+                                            )}
+                                        </td>
+                                        <td className={cn(styles.td, { [styles['amount-edit-td']]: isEditedRow })}>
+                                            {isEditedRow ? (
+                                                <div className={styles['amount-edit-wrapper']}>
+                                                    <input
+                                                        type="text"
+                                                        className={cn(styles['amount-edit-input'], {
+                                                            [styles['amount-edit-input-error']]:
+                                                                rowEditState.errors.amountUsd,
+                                                        })}
+                                                        value={rowEditState.amountUsd}
+                                                        aria-label={`Amount USD record ${record.id}`}
+                                                        onChange={(event) =>
+                                                            handleAmountChange(
+                                                                record.id,
+                                                                'amountUsd',
+                                                                event.target.value,
+                                                            )
+                                                        }
+                                                        onBlur={() => handleAmountBlur(record.id, 'amountUsd')}
+                                                    />
+                                                    {rowEditState.errors.amountUsd && (
+                                                        <p className={styles['amount-edit-error']}>
+                                                            {rowEditState.errors.amountUsd}
+                                                        </p>
+                                                    )}
+                                                </div>
+                                            ) : (
+                                                record.amountUsd
+                                            )}
+                                        </td>
                                         {isEditing && (
                                             <td className={cn(styles.td, styles['actions-td'])}>
                                                 <div className={styles['row-actions']}>

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
@@ -127,7 +127,7 @@
     pointer-events: none;
 
     :global(.select-head) {
-        background: rgba(c.$black, 0.04);
+        background-color: rgba(c.$black, 0.04);
         border-color: c.$grey-700;
         color: c.$grey-700;
     }
@@ -149,7 +149,7 @@
     height: auto;
 
     &:global(.select-options-selected) {
-        background: rgba(c.$blue-500, 0.17);
+        background-color: rgba(c.$blue-500, 0.17);
     }
 }
 

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
@@ -88,17 +88,17 @@
 }
 
 .exchange-rate-input-disabled {
-    background-color: c.$grey-600 !important;
-    border: 1px solid c.$bluish-black !important;
-    color: c.$blue-900 !important;
-    box-shadow: none !important;
+    background-color: c.$grey-600;
+    border: 1px solid c.$bluish-black;
+    color: c.$blue-900;
+    box-shadow: none;
     opacity: 1;
     -webkit-text-fill-color: c.$blue-900;
 }
 
 .filter-select {
     :global(.select-head) {
-        border: 1px solid #e55345;
+        border: 1px solid c.$error;
         border-radius: 12px;
         padding: 8px 10px;
         height: 60px;
@@ -108,7 +108,7 @@
         color: c.$blue-900;
 
         &:hover {
-            background-color: rgba(229, 83, 69, 0.06);
+            background-color: rgba(c.$error, 0.06);
         }
     }
 
@@ -160,8 +160,8 @@
     flex-wrap: wrap;
 }
 
-.add-income-button,
-.add-expense-button {
+.editing-actions .add-income-button,
+.editing-actions .add-expense-button {
     display: flex;
     justify-content: center;
     align-items: center;
@@ -175,8 +175,8 @@
     transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
 
     &:not(:disabled):hover {
-        background-color: c.$yellow-500 !important;
-        color: c.$blue-900 !important;
+        background-color: c.$yellow-500;
+        color: c.$blue-900;
         box-shadow: 0 4px 14px rgba(c.$yellow-500, 0.5);
         transform: translateY(-1px);
 
@@ -186,8 +186,8 @@
     }
 
     &:not(:disabled):active {
-        background-color: c.$yellow-600 !important;
-        color: c.$blue-900 !important;
+        background-color: c.$yellow-600;
+        color: c.$blue-900;
         box-shadow: 0 2px 6px rgba(c.$yellow-500, 0.35);
         transform: translateY(0);
     }
@@ -195,8 +195,8 @@
     &:disabled {
         opacity: 1;
         cursor: not-allowed;
-        background: c.$grey-700 !important;
-        color: c.$white !important;
+        background: c.$grey-700;
+        color: c.$white;
         box-shadow: none;
 
         svg,
@@ -207,19 +207,20 @@
     }
 }
 
-.action-button-disabled-by-row-edit {
-    background: c.$grey-700 !important;
-    color: c.$white !important;
+.editing-actions .add-income-button.action-button-disabled-by-row-edit,
+.editing-actions .add-expense-button.action-button-disabled-by-row-edit {
+    background: c.$grey-700;
+    color: c.$white;
 }
 
-.add-income-button {
+.editing-actions .add-income-button {
     width: 170px;
-    background-color: c.$blue-500 !important;
+    background-color: c.$blue-500;
 }
 
-.add-expense-button {
+.editing-actions .add-expense-button {
     width: 126px;
-    background-color: #e55345 !important;
+    background-color: c.$error;
 }
 
 .plus-icon {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
@@ -75,6 +75,25 @@
         border-color: c.$blue-500;
         box-shadow: 0 0 0 2px rgba(c.$blue-500, 0.2);
     }
+
+    &:disabled {
+        background-color: c.$grey-600;
+        border: 1px solid c.$bluish-black;
+        color: c.$blue-900;
+        cursor: not-allowed;
+        box-shadow: none;
+        opacity: 1;
+        -webkit-text-fill-color: c.$blue-900;
+    }
+}
+
+.exchange-rate-input-disabled {
+    background-color: c.$grey-600 !important;
+    border: 1px solid c.$bluish-black !important;
+    color: c.$blue-900 !important;
+    box-shadow: none !important;
+    opacity: 1;
+    -webkit-text-fill-color: c.$blue-900;
 }
 
 .filter-select {
@@ -100,6 +119,23 @@
         border-radius: 6px;
         box-shadow: 0 5px 8px rgba(c.$black, 0.2);
         padding: 6px 10px;
+    }
+}
+
+.filter-select-disabled {
+    opacity: 1;
+    pointer-events: none;
+
+    :global(.select-head) {
+        background: rgba(c.$black, 0.04);
+        border-color: c.$grey-700;
+        color: c.$grey-700;
+    }
+
+    :global(.select-head svg),
+    :global(.select-head svg path) {
+        fill: c.$grey-700;
+        stroke: c.$grey-700;
     }
 }
 
@@ -157,9 +193,23 @@
     }
 
     &:disabled {
-        opacity: 0.5;
+        opacity: 1;
         cursor: not-allowed;
+        background: c.$grey-700 !important;
+        color: c.$white !important;
+        box-shadow: none;
+
+        svg,
+        svg path {
+            fill: c.$white;
+            stroke: c.$white;
+        }
     }
+}
+
+.action-button-disabled-by-row-edit {
+    background: c.$grey-700 !important;
+    color: c.$white !important;
 }
 
 .add-income-button {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.test.tsx
@@ -156,6 +156,33 @@ describe('FundsExpendituresToolbar', () => {
         expect(onTypeChange).toHaveBeenCalledWith(undefined);
     });
 
+    it('should call onCategoryChange when category filter "Всі" is selected', () => {
+        render(<FundsExpendituresToolbar {...defaultProps} />);
+
+        const allBtn = screen.getByTestId(`select-${FUNDS_EXPENDITURES_TEXT.FILTER.CATEGORY_PLACEHOLDER}-all`);
+        fireEvent.click(allBtn);
+
+        expect(onCategoryChange).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should not call onTypeChange when controls are disabled', () => {
+        render(<FundsExpendituresToolbar {...defaultProps} controlsDisabled={true} />);
+
+        const incomeBtn = screen.getByTestId(`select-${FUNDS_EXPENDITURES_TEXT.FILTER.TYPE_PLACEHOLDER}-income`);
+        fireEvent.click(incomeBtn);
+
+        expect(onTypeChange).not.toHaveBeenCalled();
+    });
+
+    it('should not call onCategoryChange when controls are disabled', () => {
+        render(<FundsExpendituresToolbar {...defaultProps} controlsDisabled={true} />);
+
+        const allBtn = screen.getByTestId(`select-${FUNDS_EXPENDITURES_TEXT.FILTER.CATEGORY_PLACEHOLDER}-all`);
+        fireEvent.click(allBtn);
+
+        expect(onCategoryChange).not.toHaveBeenCalled();
+    });
+
     describe('edit mode', () => {
         it('should show Add Income button when editing', () => {
             render(<FundsExpendituresToolbar {...defaultProps} isEditing={true} />);

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.test.tsx
@@ -87,8 +87,8 @@ jest.mock('@/components/common/select/Select', () => {
 });
 
 const MOCK_CATEGORIES: ReportFundsExpendituresCategory[] = [
-    { id: 1, name: 'Грантові кошти' },
-    { id: 2, name: 'Благодійні внески' },
+    { id: 1, name: 'Грантові кошти', type: 'income' },
+    { id: 2, name: 'Благодійні внески', type: 'income' },
 ];
 
 describe('FundsExpendituresToolbar', () => {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/admin/button/Button';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
 import { FundsExpendituresTransactionType, ReportFundsExpendituresCategory } from '@/types/admin/reports';
 import { ReactComponent as PlusIcon } from '@/assets/icons/plus.svg';
+import cn from 'classnames';
 import styles from './FundsExpendituresToolbar.module.scss';
 
 export type TypeFilterValue = FundsExpendituresTransactionType | undefined;
@@ -14,6 +15,7 @@ interface FundsExpendituresToolbarProps {
     selectedCategoryId: CategoryFilterValue;
     exchangeRate: string | null;
     isEditing: boolean;
+    controlsDisabled?: boolean;
     isAddIncomeDisabled: boolean;
     isAddExpenseDisabled: boolean;
     onTypeChange: (value: TypeFilterValue) => void;
@@ -29,6 +31,7 @@ export const FundsExpendituresToolbar = ({
     selectedCategoryId,
     exchangeRate,
     isEditing,
+    controlsDisabled = false,
     isAddIncomeDisabled,
     isAddExpenseDisabled,
     onTypeChange,
@@ -38,14 +41,20 @@ export const FundsExpendituresToolbar = ({
     onAddExpense,
 }: FundsExpendituresToolbarProps) => {
     return (
-        <div className={styles.toolbar} data-testid="funds-toolbar">
+        <div className={styles.toolbar} data-testid="funds-toolbar" data-controls-disabled={String(controlsDisabled)}>
             <div className={styles['toolbar-row']}>
                 <div className={styles.filters}>
                     <Select<TypeFilterValue>
                         value={selectedType}
-                        onValueChange={onTypeChange}
+                        onValueChange={(value) => {
+                            if (!controlsDisabled) {
+                                onTypeChange(value);
+                            }
+                        }}
                         placeholder={FUNDS_EXPENDITURES_TEXT.FILTER.TYPE_PLACEHOLDER}
-                        className={styles['filter-select']}
+                        className={cn(styles['filter-select'], {
+                            [styles['filter-select-disabled']]: controlsDisabled,
+                        })}
                         optionClassName={styles['filter-option']}
                     >
                         <Select.Option value={undefined} name={FUNDS_EXPENDITURES_TEXT.FILTER.ALL_OPTION} />
@@ -55,9 +64,15 @@ export const FundsExpendituresToolbar = ({
 
                     <Select<CategoryFilterValue>
                         value={selectedCategoryId}
-                        onValueChange={onCategoryChange}
+                        onValueChange={(value) => {
+                            if (!controlsDisabled) {
+                                onCategoryChange(value);
+                            }
+                        }}
                         placeholder={FUNDS_EXPENDITURES_TEXT.FILTER.CATEGORY_PLACEHOLDER}
-                        className={styles['filter-select']}
+                        className={cn(styles['filter-select'], {
+                            [styles['filter-select-disabled']]: controlsDisabled,
+                        })}
                         optionClassName={styles['filter-option']}
                     >
                         <Select.Option value={undefined} name={FUNDS_EXPENDITURES_TEXT.FILTER.ALL_OPTION} />
@@ -77,9 +92,12 @@ export const FundsExpendituresToolbar = ({
                                 <input
                                     type="text"
                                     data-testid="exchange-rate-input"
-                                    className={styles['exchange-rate-input']}
+                                    className={cn(styles['exchange-rate-input'], {
+                                        [styles['exchange-rate-input-disabled']]: controlsDisabled,
+                                    })}
                                     value={exchangeRate}
                                     maxLength={FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_MAX_LENGTH}
+                                    disabled={controlsDisabled}
                                     onChange={(e) => onExchangeRateChange?.(e.target.value)}
                                 />
                             ) : (
@@ -94,18 +112,22 @@ export const FundsExpendituresToolbar = ({
                         <div className={styles['editing-actions']} data-testid="editing-actions">
                             <Button
                                 buttonStyle="primary"
-                                className={styles['add-expense-button']}
+                                className={cn(styles['add-expense-button'], {
+                                    [styles['action-button-disabled-by-row-edit']]: controlsDisabled,
+                                })}
                                 onClick={onAddExpense}
-                                disabled={isAddExpenseDisabled}
+                                disabled={isAddExpenseDisabled || controlsDisabled}
                             >
                                 <PlusIcon className={styles['plus-icon']} />
                                 {FUNDS_EXPENDITURES_TEXT.BUTTON.ADD_EXPENSE}
                             </Button>
                             <Button
                                 buttonStyle="primary"
-                                className={styles['add-income-button']}
+                                className={cn(styles['add-income-button'], {
+                                    [styles['action-button-disabled-by-row-edit']]: controlsDisabled,
+                                })}
                                 onClick={onAddIncome}
-                                disabled={isAddIncomeDisabled}
+                                disabled={isAddIncomeDisabled || controlsDisabled}
                             >
                                 <PlusIcon className={styles['plus-icon']} />
                                 {FUNDS_EXPENDITURES_TEXT.BUTTON.ADD_INCOME}

--- a/src/types/admin/reports.ts
+++ b/src/types/admin/reports.ts
@@ -89,6 +89,7 @@ export interface ReportFundsExpendituresSettings {
 export interface ReportFundsExpendituresCategory {
     id: number;
     name: string;
+    type: FundsExpendituresTransactionType;
 }
 
 export interface ReportFundsExpendituresRecord {

--- a/src/utils/functions/parse-amount/parse-amount.test.ts
+++ b/src/utils/functions/parse-amount/parse-amount.test.ts
@@ -9,6 +9,10 @@ describe('parseAmount', () => {
         expect(parseAmount('4 200.50')).toBe(4200.5);
     });
 
+    it('parses decimal values with comma separator', () => {
+        expect(parseAmount('4 200,50')).toBe(4200.5);
+    });
+
     it('returns 0 for invalid numeric input', () => {
         expect(parseAmount('invalid')).toBe(0);
     });

--- a/src/utils/functions/parse-amount/parse-amount.ts
+++ b/src/utils/functions/parse-amount/parse-amount.ts
@@ -1,1 +1,2 @@
-export const parseAmount = (value: string): number => Number.parseFloat(value.replaceAll(' ', '')) || 0;
+export const parseAmount = (value: string): number =>
+    Number.parseFloat(value.replaceAll(' ', '').replace(',', '.')) || 0;

--- a/src/utils/mock-data/admin/funds-expenditures-mock.ts
+++ b/src/utils/mock-data/admin/funds-expenditures-mock.ts
@@ -11,24 +11,22 @@ export const MOCK_FUNDS_EXPENDITURES_SETTINGS: ReportFundsExpendituresSettings =
 };
 
 export const MOCK_FUNDS_EXPENDITURES_CATEGORIES: ReportFundsExpendituresCategory[] = [
-    { id: 1, name: 'Грантові кошти' },
-    { id: 2, name: 'Благодійні внески' },
-    { id: 3, name: 'Власні надходження' },
-    { id: 4, name: 'Адміністративні витрати' },
-    { id: 5, name: 'Програмні витрати' },
-    { id: 6, name: 'Обладнання' },
-    { id: 7, name: 'Заробітна плата' },
+    { id: 1, name: 'Грантові кошти', type: 'income' },
+    { id: 2, name: 'Благодійні внески', type: 'income' },
+    { id: 3, name: 'Власні надходження', type: 'income' },
+    { id: 4, name: 'Інші надходження', type: 'income' },
+    { id: 5, name: 'Адміністративні витрати', type: 'expense' },
+    { id: 6, name: 'Програмні витрати', type: 'expense' },
+    { id: 7, name: 'Обладнання', type: 'expense' },
+    { id: 8, name: 'Заробітна плата', type: 'expense' },
 ];
 
 export const MOCK_FUNDS_EXPENDITURES_RECORDS: ReportFundsExpendituresRecord[] = [
     { id: 1, categoryId: 1, type: 'income', reportingYear: '2025', amountUah: '7 265', amountUsd: '4 200' },
-    { id: 2, categoryId: 4, type: 'expense', reportingYear: '2025', amountUah: '3 100', amountUsd: '1 800' },
+    { id: 2, categoryId: 5, type: 'expense', reportingYear: '2025', amountUah: '3 100', amountUsd: '1 800' },
     { id: 3, categoryId: 2, type: 'income', reportingYear: '2025', amountUah: '5 800', amountUsd: '3 360' },
-    { id: 4, categoryId: 5, type: 'expense', reportingYear: '2025', amountUah: '4 200', amountUsd: '2 430' },
+    { id: 4, categoryId: 6, type: 'expense', reportingYear: '2025', amountUah: '4 200', amountUsd: '2 430' },
     { id: 5, categoryId: 3, type: 'income', reportingYear: '2025', amountUah: '2 400', amountUsd: '1 390' },
-    { id: 6, categoryId: 6, type: 'expense', reportingYear: '2025', amountUah: '1 950', amountUsd: '1 130' },
-    { id: 7, categoryId: 1, type: 'income', reportingYear: '2024', amountUah: '6 500', amountUsd: '3 800' },
-    { id: 8, categoryId: 7, type: 'expense', reportingYear: '2024', amountUah: '5 000', amountUsd: '2 900' },
-    { id: 9, categoryId: 2, type: 'income', reportingYear: '2024', amountUah: '3 200', amountUsd: '1 850' },
-    { id: 10, categoryId: 4, type: 'expense', reportingYear: '2024', amountUah: '2 750', amountUsd: '1 590' },
+    { id: 6, categoryId: 7, type: 'expense', reportingYear: '2024', amountUah: '1 950', amountUsd: '1 130' },
+    { id: 7, categoryId: 8, type: 'expense', reportingYear: '2024', amountUah: '5 000', amountUsd: '2 900' },
 ];

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
@@ -1,0 +1,90 @@
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import {
+    normalizeFundsExpendituresAmountInput,
+    validateFundsExpendituresAmount,
+    validateFundsExpendituresCategory,
+} from './funds-expenditures-record-schema';
+
+describe('FUNDS_EXPENDITURES_RECORD_VALIDATION_FUNCTIONS', () => {
+    describe('normalizeFundsExpendituresAmountInput', () => {
+        it('should trim leading spaces and normalize internal spaces', () => {
+            expect(normalizeFundsExpendituresAmountInput('   1   200   ,5')).toBe('1 200 ,5');
+        });
+
+        it('should trim trailing spaces when trimEnd is true', () => {
+            expect(normalizeFundsExpendituresAmountInput('   1 200   ', true)).toBe('1 200');
+        });
+    });
+
+    describe('validateFundsExpendituresAmount', () => {
+        it('should return required error for empty value on blur', () => {
+            expect(validateFundsExpendituresAmount('   ', 'blur')).toBe(
+                COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED,
+            );
+        });
+
+        it('should return numeric error for non-digit input', () => {
+            expect(validateFundsExpendituresAmount('abc', 'change')).toBe(
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER_GT_ZERO,
+            );
+        });
+
+        it('should return max digits error when integer part is too long', () => {
+            expect(validateFundsExpendituresAmount('123456789012', 'change')).toBe(
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DIGITS,
+            );
+        });
+
+        it('should return negative error for negative values', () => {
+            expect(validateFundsExpendituresAmount('-1', 'change')).toBe(
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_NEGATIVE,
+            );
+        });
+
+        it('should pass valid value with comma decimals', () => {
+            expect(validateFundsExpendituresAmount('1 200,50', 'save')).toBeUndefined();
+        });
+    });
+
+    describe('validateFundsExpendituresCategory', () => {
+        const records = [
+            { id: 1, categoryId: 1, type: 'income' as const, reportingYear: '2025', amountUah: '1', amountUsd: '1' },
+            { id: 2, categoryId: 2, type: 'income' as const, reportingYear: '2024', amountUah: '1', amountUsd: '1' },
+        ];
+
+        it('should return required error for undefined category on blur', () => {
+            expect(
+                validateFundsExpendituresCategory({
+                    recordId: 1,
+                    recordType: 'income',
+                    categoryId: undefined,
+                    records,
+                    trigger: 'blur',
+                }),
+            ).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED);
+        });
+
+        it('should return unique error for duplicate category in same type', () => {
+            expect(
+                validateFundsExpendituresCategory({
+                    recordId: 1,
+                    recordType: 'income',
+                    categoryId: 2,
+                    records,
+                }),
+            ).toBe(FUNDS_EXPENDITURES_TEXT.VALIDATION.CATEGORY_UNIQUE);
+        });
+
+        it('should pass for unique category', () => {
+            expect(
+                validateFundsExpendituresCategory({
+                    recordId: 1,
+                    recordType: 'income',
+                    categoryId: 3,
+                    records,
+                }),
+            ).toBeUndefined();
+        });
+    });
+});

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
@@ -1,0 +1,70 @@
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { FundsExpendituresTransactionType, ReportFundsExpendituresRecord } from '@/types/admin/reports';
+
+export type FundsExpendituresAmountValidationTrigger = 'change' | 'blur' | 'save';
+export type FundsExpendituresCategoryValidationTrigger = 'change' | 'blur';
+
+interface ValidateFundsExpendituresCategoryParams {
+    recordId: number;
+    recordType: FundsExpendituresTransactionType;
+    categoryId: number | undefined;
+    records: ReportFundsExpendituresRecord[];
+    trigger?: FundsExpendituresCategoryValidationTrigger;
+}
+
+export const normalizeFundsExpendituresAmountInput = (value: string, trimEnd = false): string => {
+    const withNormalizedSpaces = value.replaceAll(/\s+/g, ' ').trimStart();
+    return trimEnd ? withNormalizedSpaces.trim() : withNormalizedSpaces;
+};
+
+export const validateFundsExpendituresAmount = (
+    value: string,
+    trigger: FundsExpendituresAmountValidationTrigger = 'change',
+): string | undefined => {
+    const normalized = normalizeFundsExpendituresAmountInput(value, true);
+
+    if (!normalized) {
+        return trigger === 'change' ? undefined : COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
+    }
+
+    const compact = normalized.replaceAll(' ', '');
+
+    if (compact.startsWith('-')) {
+        return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_NEGATIVE;
+    }
+
+    if (!/^\d+(?:[.,]\d+)?$/.test(compact)) {
+        return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER_GT_ZERO;
+    }
+
+    const [integerPart, decimalPart = ''] = compact.split(/[.,]/);
+    if (integerPart.length > 11 || decimalPart.length > 2) {
+        return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DIGITS;
+    }
+
+    const parsed = Number.parseFloat(compact.replace(',', '.'));
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER_GT_ZERO;
+    }
+
+    return undefined;
+};
+
+export const validateFundsExpendituresCategory = ({
+    recordId,
+    recordType,
+    categoryId,
+    records,
+    trigger = 'change',
+}: ValidateFundsExpendituresCategoryParams): string | undefined => {
+    if (categoryId === undefined) {
+        return trigger === 'blur' ? COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED : undefined;
+    }
+
+    const hasDuplicate = records.some(
+        (item) => item.id !== recordId && item.type === recordType && item.categoryId === categoryId,
+    );
+
+    return hasDuplicate ? FUNDS_EXPENDITURES_TEXT.VALIDATION.CATEGORY_UNIQUE : undefined;
+};


### PR DESCRIPTION
## Github ticker

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1424

## Description

This PR adds the ability to change the category of a record while the ‘Доходи та Витрати’ tab is in editing mode

## How it looks


https://github.com/user-attachments/assets/379eeefa-b8a4-47f6-a9ec-24b9d6fc84b1


## Summary of change

1. Added inline editing for the Категорія field
2. Restricted editing to one row at a time
3. Disabled unrelated controls during edit mode (filters, buttons, other rows)
4. Added validation for the category field (required, unique per type)
5. Triggered recalculation of dashboard totals after successful update


## How to recreate changes

1. Open the "Доходи та Витрати" tab
2. Click Edit on any record in the list
3. Change the category


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [x]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions
