### PR TITLE
Feature/issue-1429: Edit amounts UAH and USD for record

### DIFF
--- a/src/assets/sass/variables/colors.scss
+++ b/src/assets/sass/variables/colors.scss
@@ -52,7 +52,7 @@ $footer-yellow: #dfe772;
 $footer-cyan: #88dbb5;
 
 $bluish-black: #0a0d12;
-$graphite_black: #1c1c1c;
+$graphite-black: #1c1c1c;
 $black: #000000;
 $donate-tooltip-color: #333333;
 

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -152,5 +152,8 @@ export const FUNDS_EXPENDITURES_TEXT = {
     },
     VALIDATION: {
         CATEGORY_UNIQUE: 'Категорія має бути унікальна',
+        AMOUNT_ONLY_NUMBER_GT_ZERO: 'Лише число > 0',
+        AMOUNT_MAX_DIGITS: "Не більше 11 цифр, 2 після ','",
+        AMOUNT_NOT_NEGATIVE: "Сума не може бути від'ємною",
     },
 };

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -142,9 +142,23 @@ export const FundsExpenditureSection = () => {
 
     const currentExchangeRate = isEditing ? exchangeRateValue : (settings?.exchangeRate ?? null);
 
-    const handleRecordCategorySave = useCallback((recordId: number, categoryId: number) => {
-        setRecordsState((prev) => prev.map((record) => (record.id === recordId ? { ...record, categoryId } : record)));
-    }, []);
+    const handleRecordSave = useCallback(
+        (recordId: number, data: { categoryId: number; amountUah: string; amountUsd: string }) => {
+            setRecordsState((prev) =>
+                prev.map((record) =>
+                    record.id === recordId
+                        ? {
+                              ...record,
+                              categoryId: data.categoryId,
+                              amountUah: data.amountUah,
+                              amountUsd: data.amountUsd,
+                          }
+                        : record,
+                ),
+            );
+        },
+        [],
+    );
 
     return (
         <div className={styles.section}>
@@ -231,7 +245,7 @@ export const FundsExpenditureSection = () => {
                 allRecordsForTypeInference={recordsState}
                 isEditing={isEditing}
                 onRowEditModeChange={setIsRowEditMode}
-                onRecordCategorySave={handleRecordCategorySave}
+                onRecordSave={handleRecordSave}
             />
 
             {isEditing && (

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
@@ -71,7 +71,7 @@
     padding: 13px 20px;
     font-weight: 400;
     line-height: 24px;
-    color: c.$graphite_black;
+    color: c.$graphite-black;
     vertical-align: middle;
     height: 65px;
     box-sizing: border-box;
@@ -279,7 +279,7 @@
     padding: 10px 17px;
     border: 1px solid c.$grey-700;
     border-radius: 8px;
-    color: c.$graphite_black;
+    color: c.$graphite-black;
     background-color: c.$white;
     box-shadow: 0 1px 2px rgba(c.$bluish-black, 0.05);
     outline: none;

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
@@ -185,6 +185,16 @@
             stroke: c.$green;
         }
     }
+
+    &:disabled {
+        .action-icon {
+            color: c.$grey-700;
+
+            path {
+                stroke: c.$grey-700;
+            }
+        }
+    }
 }
 
 .close-icon-button {
@@ -200,6 +210,8 @@
 .category-edit-td {
     position: relative;
     overflow: visible;
+    height: auto;
+    padding: 13px 20px;
 }
 
 .category-edit-wrapper {
@@ -207,21 +219,22 @@
     flex-direction: column;
     align-items: flex-start;
     gap: 6px;
+    min-height: 80px;
 }
 
 .category-edit-select {
-    min-width: 220px;
+    width: 240px;
 
     :global(.select-head) {
-        min-height: 36px;
-        padding: 8px 10px;
+        min-height: 55px;
+        padding: 10px 17px;
         border: 1px solid c.$grey-700;
         border-radius: 8px;
         background-color: c.$white;
     }
 
     :global(.select-options) {
-        min-width: 220px;
+        min-width: 240px;
         border: 1px solid c.$grey-500;
         border-radius: 8px;
         background-color: c.$white;
@@ -237,6 +250,49 @@
 
 .category-edit-error {
     @include type.small-text-regular;
+    margin: 0;
+    color: c.$error;
+}
+
+.amount-edit-td {
+    position: relative;
+    overflow: visible;
+    height: auto;
+    padding: 13px 20px;
+}
+
+.amount-edit-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+    min-height: 80px;
+}
+
+.amount-edit-input {
+    @include type.subtitle-2-medium;
+    width: 128px;
+    min-height: 55px;
+    padding: 10px 17px;
+    border: 1px solid c.$grey-700;
+    border-radius: 8px;
+    color: c.$graphite_black;
+    background-color: c.$white;
+    box-shadow: 0 1px 2px rgba(c.$bluish-black, 0.05);
+    outline: none;
+
+    &:focus {
+        border-color: c.$blue-500;
+        box-shadow: 0 0 0 2px rgba(c.$blue-500, 0.12);
+    }
+}
+
+.amount-edit-input-error {
+    border-color: c.$error;
+}
+
+.amount-edit-error {
+    @include type.subtitle-2-medium;
     margin: 0;
     color: c.$error;
 }

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
@@ -207,14 +207,15 @@
     }
 }
 
-.category-edit-td {
+.category-edit-td,
+.amount-edit-td {
     position: relative;
     overflow: visible;
     height: auto;
-    padding: 13px 20px;
 }
 
-.category-edit-wrapper {
+.category-edit-wrapper,
+.amount-edit-wrapper {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
@@ -248,25 +249,18 @@
     border-radius: 6px;
 }
 
-.category-edit-error {
-    @include type.small-text-regular;
+.category-edit-error,
+.amount-edit-error {
     margin: 0;
     color: c.$error;
 }
 
-.amount-edit-td {
-    position: relative;
-    overflow: visible;
-    height: auto;
-    padding: 13px 20px;
+.category-edit-error {
+    @include type.small-text-regular;
 }
 
-.amount-edit-wrapper {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 6px;
-    min-height: 80px;
+.amount-edit-error {
+    @include type.subtitle-2-medium;
 }
 
 .amount-edit-input {
@@ -289,11 +283,5 @@
 
 .amount-edit-input-error {
     border-color: c.$error;
-}
-
-.amount-edit-error {
-    @include type.subtitle-2-medium;
-    margin: 0;
-    color: c.$error;
 }
 

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
@@ -239,9 +239,9 @@ describe('FundsExpendituresTable', () => {
         });
 
         it('should save category changes when valid and notify parent', () => {
-            const onRecordCategorySave = jest.fn();
+            const onRecordSave = jest.fn();
 
-            renderTable({ isEditing: true, onRecordCategorySave });
+            renderTable({ isEditing: true, onRecordSave });
 
             fireEvent.click(screen.getByLabelText('Edit record 1'));
             fireEvent.click(screen.getByTestId('select-option-Власні надходження-3'));
@@ -251,7 +251,11 @@ describe('FundsExpendituresTable', () => {
 
             fireEvent.click(acceptButton);
 
-            expect(onRecordCategorySave).toHaveBeenCalledWith(1, 3);
+            expect(onRecordSave).toHaveBeenCalledWith(1, {
+                categoryId: 3,
+                amountUah: '7 265',
+                amountUsd: '4 200',
+            });
         });
 
         it('should show unique validation message when duplicate category is selected for the same type', () => {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom';
 import type React from 'react';
 import { FundsExpendituresTable, EnrichedRecord } from './FundsExpendituresTable';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
 
 jest.mock('./FundsExpendituresTable.module.scss', () => ({
@@ -36,6 +37,11 @@ jest.mock('./FundsExpendituresTable.module.scss', () => ({
     'category-edit-select': 'category-edit-select',
     'category-edit-option': 'category-edit-option',
     'category-edit-error': 'category-edit-error',
+    'amount-edit-td': 'amount-edit-td',
+    'amount-edit-wrapper': 'amount-edit-wrapper',
+    'amount-edit-input': 'amount-edit-input',
+    'amount-edit-input-error': 'amount-edit-input-error',
+    'amount-edit-error': 'amount-edit-error',
 }));
 
 jest.mock('@/assets/icons/chevron-up.svg', () => ({
@@ -299,6 +305,69 @@ describe('FundsExpendituresTable', () => {
 
             expect(onRowEditModeChange).toHaveBeenNthCalledWith(1, true);
             expect(onRowEditModeChange).toHaveBeenNthCalledWith(2, false);
+        });
+
+        it('should save category and amounts through unified save callback', () => {
+            const onRecordSave = jest.fn();
+
+            renderTable({ isEditing: true, onRecordSave });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            fireEvent.click(screen.getByTestId('select-option-Власні надходження-3'));
+            fireEvent.change(screen.getByLabelText('Amount UAH record 1'), { target: { value: '7 300' } });
+            fireEvent.change(screen.getByLabelText('Amount USD record 1'), { target: { value: '4 250' } });
+
+            const acceptButton = screen.getByLabelText('Accept record 1');
+            expect(acceptButton).not.toBeDisabled();
+
+            fireEvent.click(acceptButton);
+
+            expect(onRecordSave).toHaveBeenCalledWith(1, {
+                categoryId: 3,
+                amountUah: '7 300',
+                amountUsd: '4 250',
+            });
+        });
+
+        it('should show required validation for empty amount on blur', () => {
+            renderTable({ isEditing: true });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            fireEvent.change(screen.getByLabelText('Amount UAH record 1'), { target: { value: '   ' } });
+            fireEvent.blur(screen.getByLabelText('Amount UAH record 1'));
+
+            expect(screen.getByText(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED)).toBeInTheDocument();
+            expect(screen.getByLabelText('Accept record 1')).toBeDisabled();
+        });
+
+        it('should show numeric validation for non-number amount', () => {
+            renderTable({ isEditing: true });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            fireEvent.change(screen.getByLabelText('Amount USD record 1'), { target: { value: 'abc' } });
+
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER_GT_ZERO)).toBeInTheDocument();
+            expect(screen.getByLabelText('Accept record 1')).toBeDisabled();
+        });
+
+        it('should show max-digits validation for too long amount', () => {
+            renderTable({ isEditing: true });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            fireEvent.change(screen.getByLabelText('Amount UAH record 1'), { target: { value: '123456789012' } });
+
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DIGITS)).toBeInTheDocument();
+            expect(screen.getByLabelText('Accept record 1')).toBeDisabled();
+        });
+
+        it('should show negative validation for negative amount', () => {
+            renderTable({ isEditing: true });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            fireEvent.change(screen.getByLabelText('Amount USD record 1'), { target: { value: '-500' } });
+
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_NEGATIVE)).toBeInTheDocument();
+            expect(screen.getByLabelText('Accept record 1')).toBeDisabled();
         });
     });
 });

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback } from 'react';
-import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
 import {
     FundsExpendituresTransactionType,
@@ -13,6 +12,11 @@ import { ReactComponent as CheckmarkIcon } from '@/assets/icons/checkmark.svg';
 import { ReactComponent as CrossIcon } from '@/assets/icons/cross.svg';
 import { Select } from '@/components/common/select/Select';
 import { SortIcon } from '@/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/components/sort-icon';
+import {
+    normalizeFundsExpendituresAmountInput,
+    validateFundsExpendituresAmount,
+    validateFundsExpendituresCategory,
+} from '@/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema';
 import { parseAmount } from '@/utils/functions/parse-amount/parse-amount';
 import cn from 'classnames';
 import styles from './FundsExpendituresTable.module.scss';
@@ -35,14 +39,22 @@ interface FundsExpendituresTableProps {
     allRecordsForTypeInference?: ReportFundsExpendituresRecord[];
     isEditing?: boolean;
     onRowEditModeChange?: (isEditMode: boolean) => void;
-    onRecordCategorySave?: (recordId: number, categoryId: number) => void;
+    onRecordSave?: (recordId: number, data: { categoryId: number; amountUah: string; amountUsd: string }) => void;
 }
 
 interface RowEditState {
     recordId: number;
     originalCategoryId: number;
+    originalAmountUah: string;
+    originalAmountUsd: string;
     categoryId: number | undefined;
-    error: string | undefined;
+    amountUah: string;
+    amountUsd: string;
+    errors: {
+        category?: string;
+        amountUah?: string;
+        amountUsd?: string;
+    };
 }
 
 const TYPE_LABEL_MAP: Record<FundsExpendituresTransactionType, string> = {
@@ -89,13 +101,39 @@ const getCategoriesForType = (
         .sort((a, b) => a.name.localeCompare(b.name, 'uk'));
 };
 
+const isAcceptButtonDisabled = (rowEditState: RowEditState | null): boolean => {
+    if (!rowEditState) {
+        return true;
+    }
+
+    const normalizedAmountUah = normalizeFundsExpendituresAmountInput(rowEditState.amountUah, true);
+    const normalizedAmountUsd = normalizeFundsExpendituresAmountInput(rowEditState.amountUsd, true);
+    const normalizedOriginalUah = normalizeFundsExpendituresAmountInput(rowEditState.originalAmountUah, true);
+    const normalizedOriginalUsd = normalizeFundsExpendituresAmountInput(rowEditState.originalAmountUsd, true);
+
+    const hasErrors =
+        rowEditState.categoryId === undefined ||
+        Boolean(rowEditState.errors.category) ||
+        Boolean(rowEditState.errors.amountUah) ||
+        Boolean(rowEditState.errors.amountUsd);
+
+    const amountsEmpty = normalizedAmountUah === '' || normalizedAmountUsd === '';
+
+    const noChanges =
+        rowEditState.categoryId === rowEditState.originalCategoryId &&
+        normalizedAmountUah === normalizedOriginalUah &&
+        normalizedAmountUsd === normalizedOriginalUsd;
+
+    return hasErrors || amountsEmpty || noChanges;
+};
+
 export const FundsExpendituresTable = ({
     records,
     categories,
     allRecordsForTypeInference,
     isEditing = false,
     onRowEditModeChange,
-    onRecordCategorySave,
+    onRecordSave,
 }: FundsExpendituresTableProps) => {
     const [sort, setSort] = useState<ColumnSort>({ column: null, direction: null });
     const [rowEditState, setRowEditState] = useState<RowEditState | null>(null);
@@ -121,15 +159,13 @@ export const FundsExpendituresTable = ({
             nextCategoryId: number | undefined,
             trigger: 'change' | 'blur' = 'change',
         ): string | undefined => {
-            if (nextCategoryId === undefined) {
-                return trigger === 'blur' ? COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED : undefined;
-            }
-
-            const hasDuplicate = typeInferenceSource.some(
-                (item) => item.id !== record.id && item.type === record.type && item.categoryId === nextCategoryId,
-            );
-
-            return hasDuplicate ? FUNDS_EXPENDITURES_TEXT.VALIDATION.CATEGORY_UNIQUE : undefined;
+            return validateFundsExpendituresCategory({
+                recordId: record.id,
+                recordType: record.type,
+                categoryId: nextCategoryId,
+                records: typeInferenceSource,
+                trigger,
+            });
         },
         [typeInferenceSource],
     );
@@ -143,8 +179,12 @@ export const FundsExpendituresTable = ({
             setRowEditMode({
                 recordId: record.id,
                 originalCategoryId: record.categoryId,
+                originalAmountUah: record.amountUah,
+                originalAmountUsd: record.amountUsd,
                 categoryId: record.categoryId,
-                error: undefined,
+                amountUah: record.amountUah,
+                amountUsd: record.amountUsd,
+                errors: {},
             });
         },
         [rowEditState, setRowEditMode],
@@ -166,7 +206,10 @@ export const FundsExpendituresTable = ({
                 return {
                     ...prev,
                     categoryId,
-                    error: nextError,
+                    errors: {
+                        ...prev.errors,
+                        category: nextError,
+                    },
                 };
             });
         },
@@ -182,12 +225,53 @@ export const FundsExpendituresTable = ({
 
                 return {
                     ...prev,
-                    error: getRowEditValidationError(record, prev.categoryId, 'blur'),
+                    errors: {
+                        ...prev.errors,
+                        category: getRowEditValidationError(record, prev.categoryId, 'blur'),
+                    },
                 };
             });
         },
         [getRowEditValidationError],
     );
+
+    const handleAmountChange = useCallback((recordId: number, field: 'amountUah' | 'amountUsd', nextValue: string) => {
+        const normalized = normalizeFundsExpendituresAmountInput(nextValue);
+
+        setRowEditState((prev) => {
+            if (prev?.recordId !== recordId) {
+                return prev;
+            }
+
+            return {
+                ...prev,
+                [field]: normalized,
+                errors: {
+                    ...prev.errors,
+                    [field]: validateFundsExpendituresAmount(normalized, 'change'),
+                },
+            };
+        });
+    }, []);
+
+    const handleAmountBlur = useCallback((recordId: number, field: 'amountUah' | 'amountUsd') => {
+        setRowEditState((prev) => {
+            if (prev?.recordId !== recordId) {
+                return prev;
+            }
+
+            const normalized = normalizeFundsExpendituresAmountInput(prev[field], true);
+
+            return {
+                ...prev,
+                [field]: normalized,
+                errors: {
+                    ...prev.errors,
+                    [field]: validateFundsExpendituresAmount(normalized, 'blur'),
+                },
+            };
+        });
+    }, []);
 
     const handleAcceptRowEdit = useCallback(
         (record: EnrichedRecord) => {
@@ -198,8 +282,21 @@ export const FundsExpendituresTable = ({
             const finalError = getRowEditValidationError(record, rowEditState.categoryId, 'blur');
             const isCategoryUnchanged = rowEditState.categoryId === rowEditState.originalCategoryId;
             const isCategoryMissing = rowEditState.categoryId === undefined;
+            const normalizedAmountUah = normalizeFundsExpendituresAmountInput(rowEditState.amountUah, true);
+            const normalizedAmountUsd = normalizeFundsExpendituresAmountInput(rowEditState.amountUsd, true);
+            const amountUahError = validateFundsExpendituresAmount(normalizedAmountUah, 'save');
+            const amountUsdError = validateFundsExpendituresAmount(normalizedAmountUsd, 'save');
+            const isAmountsUnchanged =
+                normalizeFundsExpendituresAmountInput(rowEditState.originalAmountUah, true) === normalizedAmountUah &&
+                normalizeFundsExpendituresAmountInput(rowEditState.originalAmountUsd, true) === normalizedAmountUsd;
 
-            if (finalError || isCategoryMissing || isCategoryUnchanged) {
+            if (
+                finalError ||
+                isCategoryMissing ||
+                amountUahError ||
+                amountUsdError ||
+                (isCategoryUnchanged && isAmountsUnchanged)
+            ) {
                 setRowEditState((prev) => {
                     if (prev?.recordId !== record.id) {
                         return prev;
@@ -207,7 +304,14 @@ export const FundsExpendituresTable = ({
 
                     return {
                         ...prev,
-                        error: finalError,
+                        amountUah: normalizedAmountUah,
+                        amountUsd: normalizedAmountUsd,
+                        errors: {
+                            ...prev.errors,
+                            category: finalError,
+                            amountUah: amountUahError,
+                            amountUsd: amountUsdError,
+                        },
                     };
                 });
 
@@ -219,10 +323,14 @@ export const FundsExpendituresTable = ({
                 return;
             }
 
-            onRecordCategorySave?.(record.id, nextCategoryId);
+            onRecordSave?.(record.id, {
+                categoryId: nextCategoryId,
+                amountUah: normalizedAmountUah,
+                amountUsd: normalizedAmountUsd,
+            });
             setRowEditMode(null);
         },
-        [getRowEditValidationError, onRecordCategorySave, rowEditState, setRowEditMode],
+        [getRowEditValidationError, onRecordSave, rowEditState, setRowEditMode],
     );
 
     const handleSort = useCallback(
@@ -321,11 +429,7 @@ export const FundsExpendituresTable = ({
                             const isEditedRow = rowEditState?.recordId === record.id;
                             const isAnotherRowEditing = isAnyRowEditing && !isEditedRow;
                             const editableCategories = categoriesByType[record.type];
-                            const isAcceptDisabled =
-                                !isEditedRow ||
-                                rowEditState.categoryId === undefined ||
-                                Boolean(rowEditState.error) ||
-                                rowEditState.categoryId === rowEditState.originalCategoryId;
+                            const isAcceptDisabled = !isEditedRow || isAcceptButtonDisabled(rowEditState);
 
                             return (
                                 <tr key={record.id} className={styles.tr}>
@@ -383,9 +487,9 @@ export const FundsExpendituresTable = ({
                                                         />
                                                     ))}
                                                 </Select>
-                                                {rowEditState.error && (
+                                                {rowEditState.errors.category && (
                                                     <p className={styles['category-edit-error']}>
-                                                        {rowEditState.error}
+                                                        {rowEditState.errors.category}
                                                     </p>
                                                 )}
                                             </div>
@@ -393,8 +497,58 @@ export const FundsExpendituresTable = ({
                                             record.categoryName
                                         )}
                                     </td>
-                                    <td className={styles.td}>{record.amountUah}</td>
-                                    <td className={styles.td}>{record.amountUsd}</td>
+                                    <td className={cn(styles.td, { [styles['amount-edit-td']]: isEditedRow })}>
+                                        {isEditedRow ? (
+                                            <div className={styles['amount-edit-wrapper']}>
+                                                <input
+                                                    type="text"
+                                                    className={cn(styles['amount-edit-input'], {
+                                                        [styles['amount-edit-input-error']]:
+                                                            rowEditState.errors.amountUah,
+                                                    })}
+                                                    value={rowEditState.amountUah}
+                                                    aria-label={`Amount UAH record ${record.id}`}
+                                                    onChange={(event) =>
+                                                        handleAmountChange(record.id, 'amountUah', event.target.value)
+                                                    }
+                                                    onBlur={() => handleAmountBlur(record.id, 'amountUah')}
+                                                />
+                                                {rowEditState.errors.amountUah && (
+                                                    <p className={styles['amount-edit-error']}>
+                                                        {rowEditState.errors.amountUah}
+                                                    </p>
+                                                )}
+                                            </div>
+                                        ) : (
+                                            record.amountUah
+                                        )}
+                                    </td>
+                                    <td className={cn(styles.td, { [styles['amount-edit-td']]: isEditedRow })}>
+                                        {isEditedRow ? (
+                                            <div className={styles['amount-edit-wrapper']}>
+                                                <input
+                                                    type="text"
+                                                    className={cn(styles['amount-edit-input'], {
+                                                        [styles['amount-edit-input-error']]:
+                                                            rowEditState.errors.amountUsd,
+                                                    })}
+                                                    value={rowEditState.amountUsd}
+                                                    aria-label={`Amount USD record ${record.id}`}
+                                                    onChange={(event) =>
+                                                        handleAmountChange(record.id, 'amountUsd', event.target.value)
+                                                    }
+                                                    onBlur={() => handleAmountBlur(record.id, 'amountUsd')}
+                                                />
+                                                {rowEditState.errors.amountUsd && (
+                                                    <p className={styles['amount-edit-error']}>
+                                                        {rowEditState.errors.amountUsd}
+                                                    </p>
+                                                )}
+                                            </div>
+                                        ) : (
+                                            record.amountUsd
+                                        )}
+                                    </td>
                                     {isEditing && (
                                         <td className={cn(styles.td, styles['actions-td'])}>
                                             <div className={styles['row-actions']}>

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
 import {
     FundsExpendituresTransactionType,
@@ -682,4 +681,3 @@ export const FundsExpendituresTable = ({
         </div>
     );
 };
-                                                      

--- a/src/utils/functions/parse-amount/parse-amount.test.ts
+++ b/src/utils/functions/parse-amount/parse-amount.test.ts
@@ -9,6 +9,10 @@ describe('parseAmount', () => {
         expect(parseAmount('4 200.50')).toBe(4200.5);
     });
 
+    it('parses decimal values with comma separator', () => {
+        expect(parseAmount('4 200,50')).toBe(4200.5);
+    });
+
     it('returns 0 for invalid numeric input', () => {
         expect(parseAmount('invalid')).toBe(0);
     });

--- a/src/utils/functions/parse-amount/parse-amount.ts
+++ b/src/utils/functions/parse-amount/parse-amount.ts
@@ -1,1 +1,2 @@
-export const parseAmount = (value: string): number => Number.parseFloat(value.replaceAll(' ', '')) || 0;
+export const parseAmount = (value: string): number =>
+    Number.parseFloat(value.replaceAll(' ', '').replace(',', '.')) || 0;

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
@@ -1,0 +1,90 @@
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import {
+    normalizeFundsExpendituresAmountInput,
+    validateFundsExpendituresAmount,
+    validateFundsExpendituresCategory,
+} from './funds-expenditures-record-schema';
+
+describe('FUNDS_EXPENDITURES_RECORD_VALIDATION_FUNCTIONS', () => {
+    describe('normalizeFundsExpendituresAmountInput', () => {
+        it('should trim leading spaces and normalize internal spaces', () => {
+            expect(normalizeFundsExpendituresAmountInput('   1   200   ,5')).toBe('1 200 ,5');
+        });
+
+        it('should trim trailing spaces when trimEnd is true', () => {
+            expect(normalizeFundsExpendituresAmountInput('   1 200   ', true)).toBe('1 200');
+        });
+    });
+
+    describe('validateFundsExpendituresAmount', () => {
+        it('should return required error for empty value on blur', () => {
+            expect(validateFundsExpendituresAmount('   ', 'blur')).toBe(
+                COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED,
+            );
+        });
+
+        it('should return numeric error for non-digit input', () => {
+            expect(validateFundsExpendituresAmount('abc', 'change')).toBe(
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER_GT_ZERO,
+            );
+        });
+
+        it('should return max digits error when integer part is too long', () => {
+            expect(validateFundsExpendituresAmount('123456789012', 'change')).toBe(
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DIGITS,
+            );
+        });
+
+        it('should return negative error for negative values', () => {
+            expect(validateFundsExpendituresAmount('-1', 'change')).toBe(
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_NEGATIVE,
+            );
+        });
+
+        it('should pass valid value with comma decimals', () => {
+            expect(validateFundsExpendituresAmount('1 200,50', 'save')).toBeUndefined();
+        });
+    });
+
+    describe('validateFundsExpendituresCategory', () => {
+        const records = [
+            { id: 1, categoryId: 1, type: 'income' as const, reportingYear: '2025', amountUah: '1', amountUsd: '1' },
+            { id: 2, categoryId: 2, type: 'income' as const, reportingYear: '2024', amountUah: '1', amountUsd: '1' },
+        ];
+
+        it('should return required error for undefined category on blur', () => {
+            expect(
+                validateFundsExpendituresCategory({
+                    recordId: 1,
+                    recordType: 'income',
+                    categoryId: undefined,
+                    records,
+                    trigger: 'blur',
+                }),
+            ).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED);
+        });
+
+        it('should return unique error for duplicate category in same type', () => {
+            expect(
+                validateFundsExpendituresCategory({
+                    recordId: 1,
+                    recordType: 'income',
+                    categoryId: 2,
+                    records,
+                }),
+            ).toBe(FUNDS_EXPENDITURES_TEXT.VALIDATION.CATEGORY_UNIQUE);
+        });
+
+        it('should pass for unique category', () => {
+            expect(
+                validateFundsExpendituresCategory({
+                    recordId: 1,
+                    recordType: 'income',
+                    categoryId: 3,
+                    records,
+                }),
+            ).toBeUndefined();
+        });
+    });
+});

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
@@ -1,0 +1,70 @@
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { FundsExpendituresTransactionType, ReportFundsExpendituresRecord } from '@/types/admin/reports';
+
+export type FundsExpendituresAmountValidationTrigger = 'change' | 'blur' | 'save';
+export type FundsExpendituresCategoryValidationTrigger = 'change' | 'blur';
+
+interface ValidateFundsExpendituresCategoryParams {
+    recordId: number;
+    recordType: FundsExpendituresTransactionType;
+    categoryId: number | undefined;
+    records: ReportFundsExpendituresRecord[];
+    trigger?: FundsExpendituresCategoryValidationTrigger;
+}
+
+export const normalizeFundsExpendituresAmountInput = (value: string, trimEnd = false): string => {
+    const withNormalizedSpaces = value.replaceAll(/\s+/g, ' ').trimStart();
+    return trimEnd ? withNormalizedSpaces.trim() : withNormalizedSpaces;
+};
+
+export const validateFundsExpendituresAmount = (
+    value: string,
+    trigger: FundsExpendituresAmountValidationTrigger = 'change',
+): string | undefined => {
+    const normalized = normalizeFundsExpendituresAmountInput(value, true);
+
+    if (!normalized) {
+        return trigger === 'change' ? undefined : COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
+    }
+
+    const compact = normalized.replaceAll(' ', '');
+
+    if (compact.startsWith('-')) {
+        return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_NEGATIVE;
+    }
+
+    if (!/^\d+(?:[.,]\d+)?$/.test(compact)) {
+        return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER_GT_ZERO;
+    }
+
+    const [integerPart, decimalPart = ''] = compact.split(/[.,]/);
+    if (integerPart.length > 11 || decimalPart.length > 2) {
+        return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DIGITS;
+    }
+
+    const parsed = Number.parseFloat(compact.replace(',', '.'));
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER_GT_ZERO;
+    }
+
+    return undefined;
+};
+
+export const validateFundsExpendituresCategory = ({
+    recordId,
+    recordType,
+    categoryId,
+    records,
+    trigger = 'change',
+}: ValidateFundsExpendituresCategoryParams): string | undefined => {
+    if (categoryId === undefined) {
+        return trigger === 'blur' ? COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED : undefined;
+    }
+
+    const hasDuplicate = records.some(
+        (item) => item.id !== recordId && item.type === recordType && item.categoryId === categoryId,
+    );
+
+    return hasDuplicate ? FUNDS_EXPENDITURES_TEXT.VALIDATION.CATEGORY_UNIQUE : undefined;
+};


### PR DESCRIPTION
## Github ticker

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1429

## Description

This PR adds functionality that allows editing amounts in UAH and USD for records in the funds and expenditures list.

## How it looks


https://github.com/user-attachments/assets/0a99d589-fa78-4c9d-939a-4e676b46543f


## Summary of change

1. Added ability to edit UAH and USD amounts for records in the funds and expenditures list
2. Implemented validation for both fields (required, positive number, max length)


## How to recreate changes

1. Open the funds and expenditures list
2. Click Edit on any record
3. Update UAH or USD amount
4. Check validation (invalid input disables accept)

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [x]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Users can now edit and save expenditure amounts (UAH and USD) along with category in a single action
  - Added support for comma as decimal separator in amount inputs (e.g., "4 200,50")

* **Improvements**
  - Enhanced validation for amount entries with dedicated error messages
  - Prevented duplicate category assignments within the same expenditure type
  - Improved visual feedback for editing states and validation errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->