### PR TITLE
Feature/issue 1393 Edit the translation manually

### DIFF
--- a/src/hooks/admin/use-translate-who-we-are-section/useTranslateWhoWeAreSection.test.ts
+++ b/src/hooks/admin/use-translate-who-we-are-section/useTranslateWhoWeAreSection.test.ts
@@ -15,6 +15,7 @@ jest.mock('../use-admin-client/useAdminClient', () => ({
 }));
 
 const mockedCreate = WhoWeAreLocalizationsApi.create as jest.MockedFunction<typeof WhoWeAreLocalizationsApi.create>;
+const mockedUpdate = WhoWeAreLocalizationsApi.update as jest.MockedFunction<typeof WhoWeAreLocalizationsApi.update>;
 const mockedMapper = mapLocalizationDtoToModel as jest.MockedFunction<typeof mapLocalizationDtoToModel>;
 
 interface CreatePayloadOptions {
@@ -295,7 +296,10 @@ describe('useTranslateWhoWeAreSection', () => {
         expect(onSuccess).not.toHaveBeenCalled();
     });
 
-    it('does not call API in edit mode with current implementation', async () => {
+    it('calls update API in edit mode and completes successfully', async () => {
+        mockedUpdate.mockResolvedValue([] as any);
+        mockedMapper.mockImplementation((dto: any) => dto);
+
         const onSuccess = jest.fn();
 
         const { result } = renderTranslateHook({ mode: ModalMode.Edit, onSuccess });
@@ -305,8 +309,34 @@ describe('useTranslateWhoWeAreSection', () => {
         });
 
         expect(mockedCreate).not.toHaveBeenCalled();
-        expect(onSuccess).not.toHaveBeenCalled();
+        expect(mockedUpdate).toHaveBeenCalledWith(
+            expect.anything(),
+            SectionType.Main,
+            buildUniformExpectedCreatePayload({
+                description: 'Edit flow value',
+                titles: ['Original title 1', 'Original title 2', 'Original title 4'],
+            }),
+        );
+        expect(onSuccess).toHaveBeenCalledTimes(1);
         expect(result.current.error).toBe('');
+        expect(result.current.isSubmitting).toBe(false);
+    });
+
+    it('sets translation error and rethrows on edit mode API failure', async () => {
+        mockedUpdate.mockRejectedValue(new Error('update failed'));
+
+        const { result } = renderTranslateHook({ mode: ModalMode.Edit });
+
+        await act(async () => {
+            await expect(result.current.translateSection({ description: 'Will fail in edit' })).rejects.toThrow(
+                'update failed',
+            );
+        });
+
+        await waitFor(() => {
+            expect(result.current.error).toBe(WHO_WE_ARE_TEXT.FORM.MESSAGE.FAIL_TO_UPDATE_TRANSLATION);
+        });
+
         expect(result.current.isSubmitting).toBe(false);
     });
 

--- a/src/hooks/admin/use-translate-who-we-are-section/useTranslateWhoWeAreSection.ts
+++ b/src/hooks/admin/use-translate-who-we-are-section/useTranslateWhoWeAreSection.ts
@@ -84,17 +84,24 @@ export const useTranslateWhoWeAreSection = ({
             setIsSubmitting(true);
             setError('');
 
+            const localizationData = mapFormValuesToPayload(data, section, language.id);
+            let localizationDto: ContentLocalizationDto[];
+
             if (isEditMode) {
-                return;
-            } else {
-                const localizationData = mapFormValuesToPayload(data, section, language.id);
-                const localizationDto = await WhoWeAreLocalizationsApi.create(
+                localizationDto = await WhoWeAreLocalizationsApi.update(
                     client,
                     section.sectionType,
                     localizationData,
                 );
+            } else {
+                localizationDto = await WhoWeAreLocalizationsApi.create(
+                    client,
+                    section.sectionType,
+                    localizationData,
+                );
+            }
 
-                const localization = localizationDto.map((content) =>
+            const localization = localizationDto.map((content) =>
                     mapLocalizationDtoToModel<ContentLocalizationDto, ContentLocalization>(content),
                 );
 
@@ -121,7 +128,6 @@ export const useTranslateWhoWeAreSection = ({
                 };
 
                 onSuccess(updatedSection);
-            }
         } catch (err) {
             const errorMessage = isEditMode
                 ? WHO_WE_ARE_TEXT.FORM?.MESSAGE?.FAIL_TO_UPDATE_TRANSLATION

--- a/src/hooks/admin/use-translate-who-we-are-section/useTranslateWhoWeAreSection.ts
+++ b/src/hooks/admin/use-translate-who-we-are-section/useTranslateWhoWeAreSection.ts
@@ -88,46 +88,38 @@ export const useTranslateWhoWeAreSection = ({
             let localizationDto: ContentLocalizationDto[];
 
             if (isEditMode) {
-                localizationDto = await WhoWeAreLocalizationsApi.update(
-                    client,
-                    section.sectionType,
-                    localizationData,
-                );
+                localizationDto = await WhoWeAreLocalizationsApi.update(client, section.sectionType, localizationData);
             } else {
-                localizationDto = await WhoWeAreLocalizationsApi.create(
-                    client,
-                    section.sectionType,
-                    localizationData,
-                );
+                localizationDto = await WhoWeAreLocalizationsApi.create(client, section.sectionType, localizationData);
             }
 
             const localization = localizationDto.map((content) =>
-                    mapLocalizationDtoToModel<ContentLocalizationDto, ContentLocalization>(content),
-                );
+                mapLocalizationDtoToModel<ContentLocalizationDto, ContentLocalization>(content),
+            );
 
-                const updatedSection: WhoWeAreSection = {
-                    ...section,
-                    contents: section.contents.map((content) => {
-                        const translatedLocalization = localization.find((item) => item.entityId === content.id);
-                        const existingLocalizations = content.localizations ?? [];
-                        const hasTargetLanguage = existingLocalizations.some((loc) => loc.language.id === language.id);
+            const updatedSection: WhoWeAreSection = {
+                ...section,
+                contents: section.contents.map((content) => {
+                    const translatedLocalization = localization.find((item) => item.entityId === content.id);
+                    const existingLocalizations = content.localizations ?? [];
+                    const hasTargetLanguage = existingLocalizations.some((loc) => loc.language.id === language.id);
 
-                        const nextLocalizations = translatedLocalization
-                            ? hasTargetLanguage
-                                ? existingLocalizations.map((loc) =>
-                                      loc.language.id === language.id ? translatedLocalization : loc,
-                                  )
-                                : [...existingLocalizations, translatedLocalization]
-                            : existingLocalizations;
+                    const nextLocalizations = translatedLocalization
+                        ? hasTargetLanguage
+                            ? existingLocalizations.map((loc) =>
+                                  loc.language.id === language.id ? translatedLocalization : loc,
+                              )
+                            : [...existingLocalizations, translatedLocalization]
+                        : existingLocalizations;
 
-                        return {
-                            ...content,
-                            localizations: nextLocalizations,
-                        };
-                    }),
-                };
+                    return {
+                        ...content,
+                        localizations: nextLocalizations,
+                    };
+                }),
+            };
 
-                onSuccess(updatedSection);
+            onSuccess(updatedSection);
         } catch (err) {
             const errorMessage = isEditMode
                 ? WHO_WE_ARE_TEXT.FORM?.MESSAGE?.FAIL_TO_UPDATE_TRANSLATION

--- a/src/pages/admin/who-we-are/components/modals/forms/translate-description-form/TranslateWhoWeAreDescriptionForm.tsx
+++ b/src/pages/admin/who-we-are/components/modals/forms/translate-description-form/TranslateWhoWeAreDescriptionForm.tsx
@@ -62,7 +62,7 @@ export const TranslateWhoWeAreDescriptionForm = forwardRef<
             TranslateWhoWeAreDescriptionFormValues,
             TranslateWhoWeAreDescriptionFormErrorState
         >({
-            defaultFormState: DEFAULT_FORM_STATE,
+            defaultFormState: initialData ?? DEFAULT_FORM_STATE,
             initialData,
             validateForm,
             onValidationChange,

--- a/src/pages/admin/who-we-are/components/modals/forms/translate-multiple-descriptions-form/TranslateWhoWeAreMultipleDescriptionsForm.tsx
+++ b/src/pages/admin/who-we-are/components/modals/forms/translate-multiple-descriptions-form/TranslateWhoWeAreMultipleDescriptionsForm.tsx
@@ -83,7 +83,7 @@ export const TranslateWhoWeAreMultipleDescriptionsForm = forwardRef<
             TranslateWhoWeAreMultipleDescriptionsFormValues,
             TranslateWhoWeAreMultipleDescriptionsFormErrorState
         >({
-            defaultFormState: defaultFormStateRef.current,
+            defaultFormState: initialData ?? defaultFormStateRef.current,
             initialData,
             validateForm,
             onValidationChange,

--- a/src/pages/admin/who-we-are/components/modals/forms/translate-title-and-description-form/TranslateWhoWeAreTitleAndDescriptionForm.tsx
+++ b/src/pages/admin/who-we-are/components/modals/forms/translate-title-and-description-form/TranslateWhoWeAreTitleAndDescriptionForm.tsx
@@ -68,7 +68,7 @@ export const TranslateWhoWeAreTitleAndDescriptionForm = forwardRef<
             TranslateWhoWeAreTitleAndDescriptionFormValues,
             TranslateWhoWeAreTitleAndDescriptionFormErrorState
         >({
-            defaultFormState: DEFAULT_FORM_STATE,
+            defaultFormState: initialData ?? DEFAULT_FORM_STATE,
             initialData,
             validateForm,
             onValidationChange,

--- a/src/pages/admin/who-we-are/components/modals/strategies/description/translate-title-and-description-strategy.test.ts
+++ b/src/pages/admin/who-we-are/components/modals/strategies/description/translate-title-and-description-strategy.test.ts
@@ -117,9 +117,7 @@ describe('translateTitleAndDescriptionStrategy', () => {
     });
 
     it('returns empty title when title content is missing', () => {
-        const section = buildSection([
-            createContent(11, ContentType.Description, descriptionLocalizations),
-        ]);
+        const section = buildSection([createContent(11, ContentType.Description, descriptionLocalizations)]);
 
         const result = translateTitleAndDescriptionStrategy.getInitialData(section, english, true);
 
@@ -130,9 +128,7 @@ describe('translateTitleAndDescriptionStrategy', () => {
     });
 
     it('returns empty description when description content is missing', () => {
-        const section = buildSection([
-            createContent(10, ContentType.Title, titleLocalizations),
-        ]);
+        const section = buildSection([createContent(10, ContentType.Title, titleLocalizations)]);
 
         const result = translateTitleAndDescriptionStrategy.getInitialData(section, english, true);
 

--- a/src/pages/admin/who-we-are/components/modals/strategies/description/translate-title-and-description-strategy.test.ts
+++ b/src/pages/admin/who-we-are/components/modals/strategies/description/translate-title-and-description-strategy.test.ts
@@ -11,50 +11,88 @@ jest.mock('../../forms/translate-title-and-description-form/TranslateWhoWeAreTit
 const english: LocalizationLanguage = { id: 2, code: 'en', name: 'English' };
 const ukrainian: LocalizationLanguage = { id: 1, code: 'uk', name: 'Ukrainian' };
 
-const section: WhoWeAreSection = {
+type SectionLocalization = NonNullable<WhoWeAreSection['contents'][number]['localizations']>[number];
+
+const titleLocalizations: SectionLocalization[] = [
+    {
+        language: ukrainian,
+        translationStatus: TranslationStatus.Relevant,
+        title: '<p>Заголовок</p>',
+        description: null,
+    },
+    {
+        language: english,
+        translationStatus: TranslationStatus.Relevant,
+        title: '<p>Title</p>',
+        description: null,
+    },
+];
+
+const descriptionLocalizations: SectionLocalization[] = [
+    {
+        language: ukrainian,
+        translationStatus: TranslationStatus.Relevant,
+        title: null,
+        description: '<p>Опис українською</p>',
+    },
+    {
+        language: english,
+        translationStatus: TranslationStatus.Relevant,
+        title: null,
+        description: '<p>Description in English</p>',
+    },
+];
+
+const createContent = (
+    id: number,
+    contentType: ContentType,
+    localizations: SectionLocalization[] = descriptionLocalizations,
+) => ({
+    id,
+    contentType,
+    title: null,
+    description: null,
+    image: null,
+    imageId: null,
+    localizations,
+});
+
+const buildSection = (contents: WhoWeAreSection['contents']): WhoWeAreSection => ({
     id: 1,
     title: 'Main',
     sectionType: SectionType.Main,
-    contents: [
-        {
-            id: 10,
-            contentType: ContentType.Description,
-            title: null,
-            description: null,
-            image: null,
-            imageId: null,
-            localizations: [
-                {
-                    language: ukrainian,
-                    translationStatus: TranslationStatus.Relevant,
-                    title: '<p>Заголовок</p>',
-                    description: '<p>Опис українською</p>',
-                },
-                {
-                    language: english,
-                    translationStatus: TranslationStatus.Relevant,
-                    title: '<p>Title</p>',
-                    description: '<p>Description in English</p>',
-                },
-            ],
-        },
-    ],
-};
+    contents,
+});
 
 describe('translateTitleAndDescriptionStrategy', () => {
     it('returns null when mode is add', () => {
+        const section = buildSection([
+            createContent(10, ContentType.Title, titleLocalizations),
+            createContent(11, ContentType.Description, descriptionLocalizations),
+        ]);
+
         const result = translateTitleAndDescriptionStrategy.getInitialData(section, english, false);
 
         expect(result).toBeNull();
     });
 
     it('returns null when language is not provided', () => {
+        const section = buildSection([
+            createContent(10, ContentType.Title, titleLocalizations),
+            createContent(11, ContentType.Description, descriptionLocalizations),
+        ]);
+
         const result = translateTitleAndDescriptionStrategy.getInitialData(section, null, true);
 
         expect(result).toBeNull();
     });
 
     it('returns localized title and description when mode is edit', () => {
+        const section = buildSection([
+            createContent(10, ContentType.Title, titleLocalizations),
+            createContent(11, ContentType.Description, descriptionLocalizations),
+        ]);
+
         const result = translateTitleAndDescriptionStrategy.getInitialData(section, english, true);
 
         expect(result).toEqual({
@@ -65,11 +103,41 @@ describe('translateTitleAndDescriptionStrategy', () => {
 
     it('returns empty values when localization for language does not exist', () => {
         const germanLanguage: LocalizationLanguage = { id: 3, code: 'de', name: 'German' };
+        const section = buildSection([
+            createContent(10, ContentType.Title, titleLocalizations),
+            createContent(11, ContentType.Description, descriptionLocalizations),
+        ]);
 
         const result = translateTitleAndDescriptionStrategy.getInitialData(section, germanLanguage, true);
 
         expect(result).toEqual({
             title: '',
+            description: '',
+        });
+    });
+
+    it('returns empty title when title content is missing', () => {
+        const section = buildSection([
+            createContent(11, ContentType.Description, descriptionLocalizations),
+        ]);
+
+        const result = translateTitleAndDescriptionStrategy.getInitialData(section, english, true);
+
+        expect(result).toEqual({
+            title: '',
+            description: '<p>Description in English</p>',
+        });
+    });
+
+    it('returns empty description when description content is missing', () => {
+        const section = buildSection([
+            createContent(10, ContentType.Title, titleLocalizations),
+        ]);
+
+        const result = translateTitleAndDescriptionStrategy.getInitialData(section, english, true);
+
+        expect(result).toEqual({
+            title: '<p>Title</p>',
             description: '',
         });
     });

--- a/src/pages/admin/who-we-are/components/modals/strategies/description/translate-title-and-description-strategy.ts
+++ b/src/pages/admin/who-we-are/components/modals/strategies/description/translate-title-and-description-strategy.ts
@@ -1,3 +1,4 @@
+import { ContentType } from '@/types/common/about-us';
 import {
     TranslateWhoWeAreTitleAndDescriptionForm,
     TranslateWhoWeAreTitleAndDescriptionFormValues,
@@ -11,13 +12,14 @@ export const translateTitleAndDescriptionStrategy: WhoWeAreModalStrategy<Transla
         getInitialData: (section, language, isEditMode) => {
             if (!isEditMode || !language) return null;
 
-            const localized = section.contents
-                .flatMap((content) => content.localizations ?? [])
-                .find((loc) => loc.language.code === language.code);
+            const titleContent = section.contents
+                .find((content) => content.contentType === ContentType.Title);
+            const descriptionContent = section.contents
+                .find((content) => content.contentType === ContentType.Description);
 
             return {
-                title: localized?.title ?? '',
-                description: localized?.description ?? '',
+                title: titleContent?.localizations?.find((loc) => loc.language.code === language.code)?.title ?? '',
+                description: descriptionContent?.localizations?.find((loc) => loc.language.code === language.code)?.description ?? '',
             };
         },
     };

--- a/src/pages/admin/who-we-are/components/modals/strategies/description/translate-title-and-description-strategy.ts
+++ b/src/pages/admin/who-we-are/components/modals/strategies/description/translate-title-and-description-strategy.ts
@@ -12,14 +12,16 @@ export const translateTitleAndDescriptionStrategy: WhoWeAreModalStrategy<Transla
         getInitialData: (section, language, isEditMode) => {
             if (!isEditMode || !language) return null;
 
-            const titleContent = section.contents
-                .find((content) => content.contentType === ContentType.Title);
-            const descriptionContent = section.contents
-                .find((content) => content.contentType === ContentType.Description);
+            const titleContent = section.contents.find((content) => content.contentType === ContentType.Title);
+            const descriptionContent = section.contents.find(
+                (content) => content.contentType === ContentType.Description,
+            );
 
             return {
                 title: titleContent?.localizations?.find((loc) => loc.language.code === language.code)?.title ?? '',
-                description: descriptionContent?.localizations?.find((loc) => loc.language.code === language.code)?.description ?? '',
+                description:
+                    descriptionContent?.localizations?.find((loc) => loc.language.code === language.code)
+                        ?.description ?? '',
             };
         },
     };

--- a/src/services/api/admin/who-we-are/who-we-are-localizations/who-we-are-localizations-api.ts
+++ b/src/services/api/admin/who-we-are/who-we-are-localizations/who-we-are-localizations-api.ts
@@ -1,5 +1,9 @@
 import { API_ROUTES } from '@/const/common/api-routes/main-api';
-import { ContentLocalizationDto, CreateContentLocalizationDto, UpdateContentLocalizationDto } from '@/types/admin/who-we-are';
+import {
+    ContentLocalizationDto,
+    CreateContentLocalizationDto,
+    UpdateContentLocalizationDto,
+} from '@/types/admin/who-we-are';
 import { SectionType } from '@/types/common/about-us';
 import { AxiosInstance } from 'axios';
 

--- a/src/services/api/admin/who-we-are/who-we-are-localizations/who-we-are-localizations-api.ts
+++ b/src/services/api/admin/who-we-are/who-we-are-localizations/who-we-are-localizations-api.ts
@@ -1,5 +1,5 @@
 import { API_ROUTES } from '@/const/common/api-routes/main-api';
-import { ContentLocalizationDto, CreateContentLocalizationDto } from '@/types/admin/who-we-are';
+import { ContentLocalizationDto, CreateContentLocalizationDto, UpdateContentLocalizationDto } from '@/types/admin/who-we-are';
 import { SectionType } from '@/types/common/about-us';
 import { AxiosInstance } from 'axios';
 
@@ -10,6 +10,18 @@ export const WhoWeAreLocalizationsApi = {
         data: CreateContentLocalizationDto[],
     ): Promise<ContentLocalizationDto[]> => {
         const response = await client.post<ContentLocalizationDto[]>(
+            `${API_ROUTES.WHO_WE_ARE_CONTENT_LOCALIZATIONS.BASE}/${sectionType}`,
+            data,
+        );
+        return response.data;
+    },
+
+    update: async (
+        client: AxiosInstance,
+        sectionType: SectionType,
+        data: UpdateContentLocalizationDto[],
+    ): Promise<ContentLocalizationDto[]> => {
+        const response = await client.put<ContentLocalizationDto[]>(
             `${API_ROUTES.WHO_WE_ARE_CONTENT_LOCALIZATIONS.BASE}/${sectionType}`,
             data,
         );

--- a/src/types/admin/who-we-are.ts
+++ b/src/types/admin/who-we-are.ts
@@ -52,10 +52,12 @@ export type ContentLocalizationDto = EntityLocalizationDto &
 
 export type ContentLocalization = EntityLocalization & ContentLocalizableFields;
 
-export type CreateContentLocalizationDto = ContentLocalizableFields & {
+export type UpdateContentLocalizationDto = ContentLocalizableFields & {
     entityId: number;
     languageId: number;
 };
+
+export type CreateContentLocalizationDto = UpdateContentLocalizationDto;
 
 export type ContentLocalizableFields = {
     description: string | null;


### PR DESCRIPTION
## GitHub

* [Github #1392](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1392)
* [Github #1393](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1393)

## Description
This pull request introduces enhancements and fixes to the translation flow for the "Who We Are" section in the admin area. The main improvements are the addition of edit mode support for updating localizations, improved form initialization logic, and more robust handling of missing localization data. The changes also include expanded test coverage to ensure correct behavior for various scenarios.

### API and Hook Enhancements

* Added `update` method to `WhoWeAreLocalizationsApi` for updating content localizations, and integrated it into the `useTranslateWhoWeAreSection` hook to enable edit mode support for updating translations.
* Updated the DTO types: introduced `UpdateContentLocalizationDto` and clarified the relationship between create and update DTOs.

### Form Initialization Improvements

* Modified translation forms (`TranslateWhoWeAreDescriptionForm`, `TranslateWhoWeAreMultipleDescriptionsForm`, `TranslateWhoWeAreTitleAndDescriptionForm`) to initialize their state with `initialData` when available, ensuring correct pre-filling in edit mode. 

### Strategy and Data Handling

* Refactored `translateTitleAndDescriptionStrategy.getInitialData` to separately retrieve title and description localizations, returning empty values when content is missing, which improves robustness and clarity.

### Test Coverage

* Expanded tests for `useTranslateWhoWeAreSection` to verify edit mode API calls, error handling, and success callbacks. 
* Refactored and extended tests for `translateTitleAndDescriptionStrategy` to cover cases with missing title or description content and languages without localization.

### Miscellaneous

* Added missing import for `ContentType` in `translate-title-and-description-strategy.ts`.

## How it looks

https://github.com/user-attachments/assets/289655e2-33f7-4d61-8b91-0316b07750fc

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editing translations for the "Who We Are" section now properly saves updates and triggers success handling.

* **Bug Fixes**
  * Forms now initialize from provided initial data instead of resetting to defaults.
  * Improved failure handling and user-facing error messaging when translation updates fail.

* **Tests**
  * Expanded test coverage for translate workflows, including edit-mode success/failure cases and initial-data scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->