### PR TITLE
Fix/issue-1841: Fix program preview image dimensions and cropper recalculation

### DIFF
--- a/src/components/admin/cropper-modal/CropperModal.test.tsx
+++ b/src/components/admin/cropper-modal/CropperModal.test.tsx
@@ -18,6 +18,7 @@ const mockCanvas = {
 };
 
 const originalCreateElement = document.createElement;
+let resizeObserverCallback: ResizeObserverCallback | null = null;
 
 beforeAll(() => {
     document.createElement = (tagName: keyof HTMLElementTagNameMap | string) => {
@@ -30,6 +31,18 @@ beforeAll(() => {
 
 afterAll(() => {
     document.createElement = originalCreateElement;
+});
+
+beforeEach(() => {
+    resizeObserverCallback = null;
+    global.ResizeObserver = jest.fn().mockImplementation((callback: ResizeObserverCallback) => {
+        resizeObserverCallback = callback;
+        return {
+            observe: jest.fn(),
+            disconnect: jest.fn(),
+            unobserve: jest.fn(),
+        };
+    }) as typeof ResizeObserver;
 });
 
 jest.mock('react-image-crop', () => {
@@ -128,6 +141,20 @@ const mockImageLoad = (element: HTMLImageElement | null) => {
         naturalHeight: { value: 400, writable: true },
         width: { value: 450, writable: true },
         height: { value: 300, writable: true },
+    });
+    fireEvent.load(element);
+};
+
+const mockImageLoadWithDimensions = (
+    element: HTMLImageElement | null,
+    dimensions: { naturalWidth: number; naturalHeight: number; width: number; height: number },
+) => {
+    if (!element) return;
+    Object.defineProperties(element, {
+        naturalWidth: { value: dimensions.naturalWidth, writable: true },
+        naturalHeight: { value: dimensions.naturalHeight, writable: true },
+        width: { value: dimensions.width, writable: true },
+        height: { value: dimensions.height, writable: true },
     });
     fireEvent.load(element);
 };
@@ -293,6 +320,30 @@ describe('CropModal', () => {
         expect(defaultProps.onCancel).not.toHaveBeenCalled();
     });
 
+    it('Does not initialize crop when image dimensions are missing', async () => {
+        render(<CropModal {...defaultProps} />);
+        const imgElement = screen.getByAltText('Crop target') as HTMLImageElement;
+
+        mockImageLoadWithDimensions(imgElement, {
+            naturalWidth: 0,
+            naturalHeight: 0,
+            width: 0,
+            height: 0,
+        });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('react-crop-mock').dataset.crop).toBeUndefined();
+        });
+    });
+
+    it('Ignores crop changes before crop is initialized', () => {
+        render(<CropModal {...defaultProps} />);
+
+        fireEvent.click(screen.getByTestId('mock-crop-change'));
+
+        expect(screen.getByTestId('react-crop-mock').dataset.crop).toBeUndefined();
+    });
+
     it('Restricts crop movement within image bounds', async () => {
         render(<CropModal {...defaultProps} />);
         const imgElement = screen.getByAltText('Crop target');
@@ -322,6 +373,33 @@ describe('CropModal', () => {
         });
     });
 
+    it('Restricts crop movement to zero when dragged beyond top or left bounds', async () => {
+        render(<CropModal {...defaultProps} />);
+        const imgElement = screen.getByAltText('Crop target');
+        mockImageLoad(imgElement as HTMLImageElement);
+
+        await waitFor(() => {
+            expect(JSON.parse(screen.getByTestId('react-crop-mock').dataset.crop!).x).toBeCloseTo(112.5);
+        });
+
+        const reactCropElement = screen.getByTestId('react-crop-mock');
+        act(() => {
+            (reactCropElement as any).mockOnChange({
+                unit: 'px',
+                x: -50,
+                y: -40,
+                width: 225,
+                height: 150,
+            });
+        });
+
+        await waitFor(() => {
+            const cropData = JSON.parse(screen.getByTestId('react-crop-mock').dataset.crop!);
+            expect(cropData.x).toBe(0);
+            expect(cropData.y).toBe(0);
+        });
+    });
+
     it('Recalculates crop when image dimensions change on window resize', async () => {
         render(<CropModal {...defaultProps} />);
         const imgElement = screen.getByAltText('Crop target');
@@ -345,5 +423,89 @@ describe('CropModal', () => {
             expect(cropData.width).toBeCloseTo(150);
             expect(cropData.x).toBeCloseTo(75);
         });
+    });
+
+    it('Recalculates crop when image dimensions change after load without window resize', async () => {
+        render(<CropModal {...defaultProps} />);
+        const imgElement = screen.getByAltText('Crop target') as HTMLImageElement;
+
+        mockImageLoad(imgElement);
+
+        await waitFor(() => {
+            const cropData = JSON.parse(screen.getByTestId('react-crop-mock').dataset.crop!);
+            expect(cropData.width).toBeCloseTo(225);
+            expect(cropData.height).toBeCloseTo(150);
+        });
+
+        Object.defineProperties(imgElement, {
+            width: { value: 300, writable: true },
+            height: { value: 200, writable: true },
+        });
+
+        resizeObserverCallback?.([] as ResizeObserverEntry[], {} as ResizeObserver);
+
+        await waitFor(() => {
+            const cropData = JSON.parse(screen.getByTestId('react-crop-mock').dataset.crop!);
+            expect(cropData.width).toBeCloseTo(150);
+            expect(cropData.height).toBeCloseTo(100);
+            expect(cropData.x).toBeCloseTo(75);
+            expect(cropData.y).toBeCloseTo(50);
+        });
+    });
+
+    it('Recalculates crop on window resize when ResizeObserver is unavailable', async () => {
+        global.ResizeObserver = undefined as unknown as typeof ResizeObserver;
+
+        render(<CropModal {...defaultProps} />);
+        const imgElement = screen.getByAltText('Crop target') as HTMLImageElement;
+
+        mockImageLoad(imgElement);
+
+        await waitFor(() => {
+            const cropData = JSON.parse(screen.getByTestId('react-crop-mock').dataset.crop!);
+            expect(cropData.width).toBeCloseTo(225);
+        });
+
+        Object.defineProperties(imgElement, {
+            width: { value: 300, writable: true },
+            height: { value: 200, writable: true },
+        });
+
+        fireEvent.resize(window);
+
+        await waitFor(() => {
+            const cropData = JSON.parse(screen.getByTestId('react-crop-mock').dataset.crop!);
+            expect(cropData.width).toBeCloseTo(150);
+            expect(cropData.height).toBeCloseTo(100);
+        });
+    });
+
+    it('Ignores crop changes when image ref is cleared', async () => {
+        const { rerender } = render(<CropModal {...defaultProps} />);
+        const imgElement = screen.getByAltText('Crop target') as HTMLImageElement;
+
+        mockImageLoad(imgElement);
+
+        await waitFor(() => {
+            expect(JSON.parse(screen.getByTestId('react-crop-mock').dataset.crop!).width).toBeCloseTo(225);
+        });
+
+        const reactCropElement = screen.getByTestId('react-crop-mock');
+        const oldOnChange = (reactCropElement as any).mockOnChange;
+
+        rerender(<CropModal {...defaultProps} src={null} />);
+
+        act(() => {
+            oldOnChange({
+                unit: 'px',
+                x: 10,
+                y: 10,
+                width: 225,
+                height: 150,
+            });
+        });
+
+        expect(defaultProps.onChange).not.toHaveBeenCalled();
+        expect(screen.queryByTestId('react-crop-mock')).not.toBeInTheDocument();
     });
 });

--- a/src/components/admin/cropper-modal/CropperModal.tsx
+++ b/src/components/admin/cropper-modal/CropperModal.tsx
@@ -26,7 +26,6 @@ export const CropModal = ({ src, onChange, width, height, onCancel, isOpen }: Cr
     const imgRef = useRef<HTMLImageElement>(null);
     const [rawImage, setRawImage] = useState<ImageValues | Image | null>(null);
     const [naturalWidth, setNaturalWidth] = useState<number | null>(null);
-    const [renderedWidth, setRenderedWidth] = useState(0);
     const aspectRatio = width / height;
 
     useEffect(() => {
@@ -44,13 +43,11 @@ export const CropModal = ({ src, onChange, width, height, onCancel, isOpen }: Cr
 
     const recalculateCrop = useCallback(
         (img: HTMLImageElement) => {
-            if (!img) return;
+            const { naturalWidth: naturalImageWidth, width: currentRenderedWidth, height: currentRenderedHeight } = img;
 
-            const { naturalWidth, width: currentRenderedWidth, height: currentRenderedHeight } = img;
+            if (!currentRenderedWidth || !currentRenderedHeight || !naturalImageWidth) return;
 
-            setRenderedWidth(currentRenderedWidth);
-
-            const scaleX = currentRenderedWidth / naturalWidth;
+            const scaleX = currentRenderedWidth / naturalImageWidth;
 
             const displayCropWidth = width * scaleX;
             const displayCropHeight = height * scaleX;
@@ -83,17 +80,27 @@ export const CropModal = ({ src, onChange, width, height, onCancel, isOpen }: Cr
         if (!img) return;
 
         const handleResize = () => {
-            if (img.width !== renderedWidth) {
-                recalculateCrop(img);
-            }
+            recalculateCrop(img);
         };
 
         window.addEventListener('resize', handleResize);
 
+        let resizeObserver: ResizeObserver | null = null;
+
+        if (typeof ResizeObserver !== 'undefined') {
+            resizeObserver = new ResizeObserver(() => {
+                recalculateCrop(img);
+            });
+
+            resizeObserver.observe(img);
+            recalculateCrop(img);
+        }
+
         return () => {
+            resizeObserver?.disconnect();
             window.removeEventListener('resize', handleResize);
         };
-    }, [renderedWidth, aspectRatio, recalculateCrop]);
+    }, [naturalWidth, recalculateCrop]);
 
     const handleSubmit = () => {
         const cropToUse = completedCrop || crop;

--- a/src/components/public/program-card/ProgramCardProgramsPage.module.scss
+++ b/src/components/public/program-card/ProgramCardProgramsPage.module.scss
@@ -18,6 +18,7 @@
 
         .content {
             max-height: 100%;
+            transform: translateY(-16px);
             height: auto;
             transition: all 0.5s ease;
         }
@@ -35,23 +36,18 @@
 
 .image {
     width: 100%;
-    aspect-ratio: 440 / 480;
+    aspect-ratio: 480 / 440;
     object-fit: cover;
     object-position: top;
     display: block;
 }
 
 .content {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
     display: flex;
     flex-direction: column;
     gap: 16px;
     padding: 16px;
     background-color: c.$grey-50;
-    max-height: 22%;
     overflow: hidden;
     transition: all 0.5s ease;
 }
@@ -112,7 +108,6 @@
     -webkit-line-clamp: 3;
     overflow: hidden;
     opacity: 0;
-    max-height: 0;
     transition:
         max-height 0.5s ease,
         opacity 0.4s ease 0.1s;

--- a/src/const/admin/programs.ts
+++ b/src/const/admin/programs.ts
@@ -262,12 +262,12 @@ export const PROGRAM_VALIDATION = {
         getAtLeastOneRequiredError: () => 'Потрібно обрати хоча б одну категорію',
     },
     previewImage: {
-        width: 440,
-        height: 480,
-        cropWidth: 440,
-        cropHeight: 480,
-        minWidth: 440,
-        minHeight: 480,
+        width: 480,
+        height: 440,
+        cropWidth: 480,
+        cropHeight: 440,
+        minWidth: 480,
+        minHeight: 440,
         getRequiredWhenPublishingError: () => 'Фото обов’язкове при публікації',
     },
     backgroundImage: {


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1829
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1841

## Description
Fixed program preview image dimensions in admin and public Programs page.
Updated preview image config in admin from 440x480 to 480x440.
Fixed CropModal crop recalculation when the rendered image size changes after image load.
Updated the public Programs card to use the 480x440 image ratio and render the short description in the bottom content block.
Added tests for crop recalculation, resize handling, and crop boundary cases.

In this PR, two bug fixes have been made, because fix #1829 is necessary to ensure that fix #1841 works properly.

## How it looks

<img width="1564" height="937" alt="image" src="https://github.com/user-attachments/assets/8cd44470-f956-4659-a888-fe8f44c5fccd" />
<img width="1383" height="983" alt="image" src="https://github.com/user-attachments/assets/bb3d42cf-3eac-4a9d-a6e1-221b1a7f0343" />


## How to recreate changes

1. Log in as Admin.
2. Open the Programs admin page.
3. Create a new program or edit an existing one.
4. Upload a preview image, for example a square image such as 1000x1000.
5. Verify that the crop modal opens with the correct crop frame behavior.
6. Resize the viewport or trigger a modal/image resize scenario and verify that the crop frame recalculates correctly.
7. Save the cropped preview image.
8. Publish the program or open it on the public Programs page.
9. Verify that the preview image is displayed in the new 480x440 ratio.
10. Verify that the short description is shown below the image in the card layout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test coverage for the image cropper modal with edge case scenarios.

* **Bug Fixes**
  * Improved image cropper handling for dimension changes and window resizing.
  * Fixed crop position constraints to prevent dragging beyond boundaries.
  * Enhanced cropper state management when image sources are cleared.

* **Chores**
  * Updated preview image dimension requirements to 480×440.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->