### PR TITLE
Feature/issue-1391: [Who we are] Disable the ability to translate

### DIFF
--- a/src/pages/admin/who-we-are/components/sections-wrapper/SectionsWrapper.scss
+++ b/src/pages/admin/who-we-are/components/sections-wrapper/SectionsWrapper.scss
@@ -5,19 +5,4 @@
     flex-direction: column;
     gap: 1.5rem;
     width: 100%;
-
-    .who-we-are-section-buttons {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        justify-content: flex-end;
-        gap: 0.625rem;
-        width: 100%;
-
-        .who-we-are-translate-btn {
-            border: none;
-            width: 1.5rem;
-            height: 1.5rem;
-        }
-    }
 }

--- a/src/pages/admin/who-we-are/components/sections-wrapper/SectionsWrapper.tsx
+++ b/src/pages/admin/who-we-are/components/sections-wrapper/SectionsWrapper.tsx
@@ -13,8 +13,6 @@ import { SectionType } from '@/types/common/about-us';
 import React from 'react';
 import { LocalizationLanguage } from '@/types/common/language';
 import './SectionsWrapper.scss';
-import { IconButton } from '@/components/admin/icon-button/IconButton';
-import { ACTION_ICONS } from '@/const/common/action-icons';
 
 export interface MainSectionProps {
     section: WhoWeAreSection | null;

--- a/src/pages/admin/who-we-are/components/sections-wrapper/SectionsWrapper.tsx
+++ b/src/pages/admin/who-we-are/components/sections-wrapper/SectionsWrapper.tsx
@@ -48,6 +48,7 @@ export const SectionsWrapper = ({
         onPublish,
         isPublishButtonActive,
         language,
+        onTranslate: () => handleOnTranslateContent(section),
     };
 
     const contentConfigs: Record<SectionType, SectionConfig> = {
@@ -83,15 +84,6 @@ export const SectionsWrapper = ({
 
     return (
         <div className="who-we-are-main-section">
-            <div className="who-we-are-section-buttons">
-                <IconButton
-                    type="button"
-                    className="who-we-are-translate-btn"
-                    aria-label="Translate"
-                    onClick={() => handleOnTranslateContent(section)}
-                    DefaultIcon={ACTION_ICONS.translate.default}
-                />
-            </div>
             <Component {...commonProps} {...additionalProps} />
         </div>
     );

--- a/src/pages/admin/who-we-are/components/sections/SectionsProps.ts
+++ b/src/pages/admin/who-we-are/components/sections/SectionsProps.ts
@@ -16,6 +16,7 @@ type OmittedProps =
     | 'content'
     | 'onChange'
     | 'onPublish'
+    | 'onTranslate'
     | 'setIsPublishButtonActive'
     | 'isPublishButtonActive'
     | 'language';

--- a/src/pages/admin/who-we-are/components/sections/cards-section/CardsSection.scss
+++ b/src/pages/admin/who-we-are/components/sections/cards-section/CardsSection.scss
@@ -19,6 +19,18 @@
         justify-content: space-between;
         gap: 1rem;
     }
+
+    &-buttons {
+        display: flex;
+        justify-content: flex-end;
+        width: 100%;
+
+        .translate-btn {
+            width: 1.5rem;
+            height: 1.5rem;
+            border: none;
+        }
+    }
 }
 
 .button-section {

--- a/src/pages/admin/who-we-are/components/sections/cards-section/CardsSection.test.tsx
+++ b/src/pages/admin/who-we-are/components/sections/cards-section/CardsSection.test.tsx
@@ -213,6 +213,14 @@ describe('CardsSection', () => {
         expect(mockOnPublish).toHaveBeenCalled();
     });
 
+    it('should disable translate button when publish button is active', () => {
+        renderComponent({ isPublishButtonActive: true });
+
+        const translateButton = screen.getByRole('button', { name: 'Translate' });
+
+        expect(translateButton).toBeDisabled();
+    });
+
     it('should not allow edits when language is not the base locale', () => {
         renderComponent({ language: { id: 2, code: 'en', name: 'English' } });
 

--- a/src/pages/admin/who-we-are/components/sections/cards-section/CardsSection.test.tsx
+++ b/src/pages/admin/who-we-are/components/sections/cards-section/CardsSection.test.tsx
@@ -203,22 +203,16 @@ describe('CardsSection', () => {
         });
     });
 
-    it('should enable the publish button and call onPublish when clicked', () => {
+    it('should enable publish button, disable translate button and call onPublish when clicked', () => {
         renderComponent({ isPublishButtonActive: true });
 
         const publishButton = screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED });
         expect(publishButton).toBeEnabled();
 
+        expect(screen.getByRole('button', { name: 'Translate' })).toBeDisabled();
+
         fireEvent.click(publishButton);
         expect(mockOnPublish).toHaveBeenCalled();
-    });
-
-    it('should disable translate button when publish button is active', () => {
-        renderComponent({ isPublishButtonActive: true });
-
-        const translateButton = screen.getByRole('button', { name: 'Translate' });
-
-        expect(translateButton).toBeDisabled();
     });
 
     it('should not allow edits when language is not the base locale', () => {

--- a/src/pages/admin/who-we-are/components/sections/cards-section/CardsSection.test.tsx
+++ b/src/pages/admin/who-we-are/components/sections/cards-section/CardsSection.test.tsx
@@ -59,6 +59,7 @@ jest.mock('@/validation/admin/who-we-are-schema/WhoWeAreSchema', () => ({
 describe('CardsSection', () => {
     let mockOnChange: jest.Mock;
     let mockOnPublish: jest.Mock;
+    let mockOnTranslate: jest.Mock;
     const descriptionLimit = 500;
     const cardImageConfigs = [
         { style: { width: '20rem' }, cropWidth: 20, cropHeight: 20, minWidth: 20, minHeight: 20, subText: '200x200' },
@@ -100,6 +101,7 @@ describe('CardsSection', () => {
             descriptionLimit,
             onChange: mockOnChange,
             onPublish: mockOnPublish,
+            onTranslate: mockOnTranslate,
             cardImageConfigs,
             titleText,
             isPublishButtonActive: false,
@@ -111,6 +113,7 @@ describe('CardsSection', () => {
     beforeEach(() => {
         mockOnChange = jest.fn();
         mockOnPublish = jest.fn();
+        mockOnTranslate = jest.fn();
         (WHO_WE_ARE_VALIDATION_FUNCTIONS.validateText as jest.Mock).mockReturnValue(null);
     });
 

--- a/src/pages/admin/who-we-are/components/sections/cards-section/CardsSection.tsx
+++ b/src/pages/admin/who-we-are/components/sections/cards-section/CardsSection.tsx
@@ -9,6 +9,8 @@ import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { getPlainTextFromHtml } from '@/utils/functions/get-plain-text-from-html/get-plain-text-from-html';
 import { LocalizationLanguage } from '@/types/common/language';
 import { DEFAULT_LOCALE } from '@/const/common/locales';
+import { IconButton } from '@/components/admin/icon-button/IconButton';
+import { ACTION_ICONS } from '@/const/common/action-icons';
 
 export interface CardsSectionProps {
     content: Content[] | undefined;
@@ -18,6 +20,7 @@ export interface CardsSectionProps {
     cardImageConfigs: CardImageConfig[];
     titleText?: string;
     onPublish: () => void;
+    onTranslate: () => void;
     isPublishButtonActive: boolean;
     language: LocalizationLanguage;
 }
@@ -28,6 +31,7 @@ export const CardsSection = ({
     rows,
     onChange,
     onPublish,
+    onTranslate,
     cardImageConfigs,
     titleText,
     isPublishButtonActive,
@@ -77,6 +81,16 @@ export const CardsSection = ({
         <>
             <div className="cards-section-wrapper">
                 {titleText && <span className="cards-section-wrapper-title">{titleText}</span>}
+                <div className="cards-section-wrapper-buttons">
+                    <IconButton
+                        type="button"
+                        className="translate-btn"
+                        aria-label="Translate"
+                        onClick={onTranslate}
+                        DefaultIcon={ACTION_ICONS.translate.default}
+                        disabled={isPublishButtonActive}
+                    />
+                </div>
                 <div className="cards-section-wrapper-cards">
                     {cardContents.map((c: Content, index: number) => (
                         <CardContent

--- a/src/pages/admin/who-we-are/components/sections/description-section/DescriptionSection.scss
+++ b/src/pages/admin/who-we-are/components/sections/description-section/DescriptionSection.scss
@@ -51,6 +51,18 @@
             line-height: 1.75rem;
             letter-spacing: -0.0225rem;
         }
+
+        &-buttons {
+            display: flex;
+            justify-content: flex-end;
+            width: 100%;
+            
+            .translate-btn {
+                width: 1.5rem;
+                height: 1.5rem;
+                border: none;
+            }
+        }
     }
 
     &-show-block {

--- a/src/pages/admin/who-we-are/components/sections/description-section/DescriptionSection.test.tsx
+++ b/src/pages/admin/who-we-are/components/sections/description-section/DescriptionSection.test.tsx
@@ -163,6 +163,14 @@ describe('DescriptionSection', () => {
         expect(mockOnPublish).toHaveBeenCalled();
     });
 
+    it('should disable translate button when publish button is active', () => {
+        renderComponent({ isPublishButtonActive: true });
+
+        const translateButton = screen.getByRole('button', { name: 'Translate' });
+
+        expect(translateButton).toBeDisabled();
+    });
+
     it('should not allow editing and should hide publish button for non-base language', () => {
         renderComponent({ language: { id: 2, code: 'en', name: 'English' } });
 

--- a/src/pages/admin/who-we-are/components/sections/description-section/DescriptionSection.test.tsx
+++ b/src/pages/admin/who-we-are/components/sections/description-section/DescriptionSection.test.tsx
@@ -153,22 +153,16 @@ describe('DescriptionSection', () => {
         });
     });
 
-    it('should call onPublish when the publish button is clicked and no error is present', () => {
+    it('should disable translate button and call onPublish when publish button is clicked with no errors', () => {
         renderComponent({ isPublishButtonActive: true });
 
         const publishButton = screen.getByRole('button', { name: 'Опублікувати' });
         expect(publishButton).toBeEnabled();
 
+        expect(screen.getByRole('button', { name: 'Translate' })).toBeDisabled();
+
         fireEvent.click(publishButton);
         expect(mockOnPublish).toHaveBeenCalled();
-    });
-
-    it('should disable translate button when publish button is active', () => {
-        renderComponent({ isPublishButtonActive: true });
-
-        const translateButton = screen.getByRole('button', { name: 'Translate' });
-
-        expect(translateButton).toBeDisabled();
     });
 
     it('should not allow editing and should hide publish button for non-base language', () => {

--- a/src/pages/admin/who-we-are/components/sections/description-section/DescriptionSection.test.tsx
+++ b/src/pages/admin/who-we-are/components/sections/description-section/DescriptionSection.test.tsx
@@ -54,6 +54,7 @@ jest.mock('@/validation/admin/who-we-are-schema/WhoWeAreSchema', () => ({
 describe('DescriptionSection', () => {
     let mockOnChange: jest.Mock;
     let mockOnPublish: jest.Mock;
+    let mockOnTranslate: jest.Mock;
     const descriptionLimit = 500;
     const initialDescription = 'This is an initial test description.';
 
@@ -72,6 +73,7 @@ describe('DescriptionSection', () => {
         descriptionLimit,
         onChange: mockOnChange,
         onPublish: mockOnPublish,
+        onTranslate: mockOnTranslate,
         isPublishButtonActive: false,
         language: { id: 1, code: 'uk', name: 'Ukrainian' },
         ...overrides,
@@ -83,6 +85,7 @@ describe('DescriptionSection', () => {
     beforeEach(() => {
         mockOnChange = jest.fn();
         mockOnPublish = jest.fn();
+        mockOnTranslate = jest.fn();
         (WHO_WE_ARE_VALIDATION_FUNCTIONS.validateText as jest.Mock).mockReturnValue(null);
     });
 

--- a/src/pages/admin/who-we-are/components/sections/description-section/DescriptionSection.tsx
+++ b/src/pages/admin/who-we-are/components/sections/description-section/DescriptionSection.tsx
@@ -11,12 +11,15 @@ import { getPlainTextFromHtml } from '@/utils/functions/get-plain-text-from-html
 import { LocalizationLanguage } from '@/types/common/language';
 import { returnDisplayedLocalization } from '@/utils/functions/localization/localization';
 import { DEFAULT_LOCALE } from '@/const/common/locales';
+import { IconButton } from '@/components/admin/icon-button/IconButton';
+import { ACTION_ICONS } from '@/const/common/action-icons';
 
 export interface DescriptionSectionProps {
     content: Content[] | undefined;
     descriptionLimit: number;
     onChange: (data: Content) => void;
     onPublish: () => void;
+    onTranslate: () => void;
     isPublishButtonActive: boolean;
     language: LocalizationLanguage;
 }
@@ -26,6 +29,7 @@ export const DescriptionSection = ({
     onChange,
     descriptionLimit,
     onPublish,
+    onTranslate,
     isPublishButtonActive,
     language,
 }: DescriptionSectionProps) => {
@@ -65,6 +69,16 @@ export const DescriptionSection = ({
         <div className="description-section">
             <OurMission description={displayedDescription ?? ''} className="description-section-show-block" />
             <div className="description-section-textarea">
+                <div className="description-section-textarea-buttons">
+                    <IconButton
+                        type="button"
+                        className="translate-btn"
+                        aria-label="Translate"
+                        onClick={onTranslate}
+                        DefaultIcon={ACTION_ICONS.translate.default}
+                        disabled={isPublishButtonActive}
+                    />
+                </div>
                 <RichTextInputGroup
                     key={`description-${language.code}`}
                     label={COMMON_TEXT_ADMIN.TYPE.DESCRIPTION}

--- a/src/pages/admin/who-we-are/components/sections/image-block-section/ImageBlockSection.scss
+++ b/src/pages/admin/who-we-are/components/sections/image-block-section/ImageBlockSection.scss
@@ -8,12 +8,16 @@
         color: colors.$error;
         font-size: 0.875rem;
     }
+
     .content-wrapper {
         width: 38rem;
-        display: flex;
-        flex-direction: column;
-        gap: 1.5rem;
-        justify-content: center;
+
+        &-fields { 
+            display: flex;
+            flex-direction: column;
+            gap: 1.5rem;
+            justify-content: center;
+        }
 
         &-title {
             display: flex;
@@ -46,6 +50,18 @@
                 font-weight: 400;
                 line-height: 1.5rem;
                 letter-spacing: -0.02rem;
+            }
+        }
+
+        &-buttons {
+            display: flex;
+            justify-content: flex-end;
+            width: 100%;
+            
+            .translate-btn {
+                width: 1.5rem;
+                height: 1.5rem;
+                border: none;
             }
         }
     }

--- a/src/pages/admin/who-we-are/components/sections/image-block-section/ImageBlockSection.test.tsx
+++ b/src/pages/admin/who-we-are/components/sections/image-block-section/ImageBlockSection.test.tsx
@@ -58,6 +58,7 @@ jest.mock('@/validation/admin/who-we-are-schema/WhoWeAreSchema', () => ({
 describe('ImageSection', () => {
     let mockOnChange: jest.Mock;
     let mockOnPublish: jest.Mock;
+    let mockOnTranslate: jest.Mock;
 
     const titleLimit = 50;
     const descriptionLimit = 500;
@@ -101,6 +102,7 @@ describe('ImageSection', () => {
             descriptionLimit,
             onChange: mockOnChange,
             onPublish: mockOnPublish,
+            onTranslate: mockOnTranslate,
             imageInputProps: { style: { width: '100%' }, subText: '1000x800' },
             isPublishButtonActive: false,
             language: { id: 1, code: 'uk', name: 'Ukrainian' },
@@ -112,6 +114,7 @@ describe('ImageSection', () => {
     beforeEach(() => {
         mockOnChange = jest.fn();
         mockOnPublish = jest.fn();
+        mockOnTranslate = jest.fn();
         validateTextMock().mockReset();
         validateTextMock().mockReturnValue(undefined);
     });

--- a/src/pages/admin/who-we-are/components/sections/image-block-section/ImageBlockSection.test.tsx
+++ b/src/pages/admin/who-we-are/components/sections/image-block-section/ImageBlockSection.test.tsx
@@ -195,21 +195,15 @@ describe('ImageSection', () => {
         );
     });
 
-    it('should enable the publish button and call onPublish when clicked', () => {
+    it('should enable publish button, disable translate button and call onPublish when clicked', () => {
         renderComponent({ isPublishButtonActive: true });
 
         expect(getPublishButton()).toBeEnabled();
 
+        expect(screen.getByRole('button', { name: 'Translate' })).toBeDisabled();
+
         fireEvent.click(getPublishButton());
         expect(mockOnPublish).toHaveBeenCalled();
-    });
-
-    it('should disable translate button when publish button is active', () => {
-        renderComponent({ isPublishButtonActive: true });
-
-        const translateButton = screen.getByRole('button', { name: 'Translate' });
-
-        expect(translateButton).toBeDisabled();
     });
 
     it('should display an error from ImageInput', async () => {

--- a/src/pages/admin/who-we-are/components/sections/image-block-section/ImageBlockSection.test.tsx
+++ b/src/pages/admin/who-we-are/components/sections/image-block-section/ImageBlockSection.test.tsx
@@ -204,6 +204,14 @@ describe('ImageSection', () => {
         expect(mockOnPublish).toHaveBeenCalled();
     });
 
+    it('should disable translate button when publish button is active', () => {
+        renderComponent({ isPublishButtonActive: true });
+
+        const translateButton = screen.getByRole('button', { name: 'Translate' });
+
+        expect(translateButton).toBeDisabled();
+    });
+
     it('should display an error from ImageInput', async () => {
         renderComponent({ isPublishButtonActive: true });
 

--- a/src/pages/admin/who-we-are/components/sections/image-block-section/ImageBlockSection.tsx
+++ b/src/pages/admin/who-we-are/components/sections/image-block-section/ImageBlockSection.tsx
@@ -13,6 +13,8 @@ import { getPlainTextFromHtml } from '@/utils/functions/get-plain-text-from-html
 import { LocalizationLanguage } from '@/types/common/language';
 import { DEFAULT_LOCALE } from '@/const/common/locales';
 import { returnDisplayedLocalization } from '@/utils/functions/localization/localization';
+import { IconButton } from '@/components/admin/icon-button/IconButton';
+import { ACTION_ICONS } from '@/const/common/action-icons';
 
 export interface ImageSectionProps {
     content: Content[] | undefined;
@@ -21,6 +23,7 @@ export interface ImageSectionProps {
     rows?: number;
     onChange: (data: Content) => void;
     onPublish: () => void;
+    onTranslate: () => void;
     imageInputProps: Omit<ImageInputProps, 'className' | 'value' | 'onChange' | 'setError'>;
     isPublishButtonActive: boolean;
     language: LocalizationLanguage;
@@ -32,6 +35,7 @@ export const ImageSection = ({
     descriptionLimit,
     onChange,
     onPublish,
+    onTranslate,
     imageInputProps,
     isPublishButtonActive,
     language,
@@ -131,52 +135,64 @@ export const ImageSection = ({
             </div>
 
             <div className="content-wrapper">
-                {titleContent && (
-                    <div className="content-wrapper-title">
-                        <RichTextInputGroup
-                            key={`title-${language.code}`}
-                            label={COMMON_TEXT_ADMIN.TYPE.TITLE}
-                            value={displayedTitle ?? ''}
-                            onChange={handleTitleChange}
-                            name={COMMON_TEXT_ADMIN.TYPE.TITLE}
-                            id={titleContent.id.toString()}
-                            maxLength={titleLimit}
-                            onBlur={handleTitleBlur}
-                            error={isBaseLanguage ? (titleError ?? undefined) : undefined}
-                            disabled={!isBaseLanguage}
-                            hideToolbar={!isBaseLanguage}
-                        />
-                    </div>
-                )}
+                <div className="content-wrapper-buttons">
+                    <IconButton
+                        type="button"
+                        className="translate-btn"
+                        aria-label="Translate"
+                        onClick={onTranslate}
+                        DefaultIcon={ACTION_ICONS.translate.default}
+                        disabled={isPublishButtonActive}
+                    />
+                </div>
+                <div className="content-wrapper-fields">
+                    {titleContent && (
+                        <div className="content-wrapper-title">
+                            <RichTextInputGroup
+                                key={`title-${language.code}`}
+                                label={COMMON_TEXT_ADMIN.TYPE.TITLE}
+                                value={displayedTitle ?? ''}
+                                onChange={handleTitleChange}
+                                name={COMMON_TEXT_ADMIN.TYPE.TITLE}
+                                id={titleContent.id.toString()}
+                                maxLength={titleLimit}
+                                onBlur={handleTitleBlur}
+                                error={isBaseLanguage ? (titleError ?? undefined) : undefined}
+                                disabled={!isBaseLanguage}
+                                hideToolbar={!isBaseLanguage}
+                            />
+                        </div>
+                    )}
 
-                {descriptionContent && (
-                    <div className="content-wrapper-description">
-                        <RichTextInputGroup
-                            key={`description-${language.code}`}
-                            label={COMMON_TEXT_ADMIN.TYPE.DESCRIPTION}
-                            onChange={handleDescriptionChange}
-                            value={displayedDescription ?? ''}
-                            maxLength={descriptionLimit}
-                            name={COMMON_TEXT_ADMIN.TYPE.DESCRIPTION}
-                            id={descriptionContent.id.toString()}
-                            onBlur={handleDescriptionBlur}
-                            error={isBaseLanguage ? (descriptionError ?? undefined) : undefined}
-                            disabled={!isBaseLanguage}
-                            hideToolbar={!isBaseLanguage}
-                        />
-                    </div>
-                )}
-                {isBaseLanguage && (
-                    <Button
-                        className="button"
-                        buttonStyle="primary"
-                        onClick={onPublish}
-                        type="submit"
-                        disabled={!!imageError || !!descriptionError || !!titleError || !isPublishButtonActive}
-                    >
-                        {COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED}
-                    </Button>
-                )}
+                    {descriptionContent && (
+                        <div className="content-wrapper-description">
+                            <RichTextInputGroup
+                                key={`description-${language.code}`}
+                                label={COMMON_TEXT_ADMIN.TYPE.DESCRIPTION}
+                                onChange={handleDescriptionChange}
+                                value={displayedDescription ?? ''}
+                                maxLength={descriptionLimit}
+                                name={COMMON_TEXT_ADMIN.TYPE.DESCRIPTION}
+                                id={descriptionContent.id.toString()}
+                                onBlur={handleDescriptionBlur}
+                                error={isBaseLanguage ? (descriptionError ?? undefined) : undefined}
+                                disabled={!isBaseLanguage}
+                                hideToolbar={!isBaseLanguage}
+                            />
+                        </div>
+                    )}
+                    {isBaseLanguage && (
+                        <Button
+                            className="button"
+                            buttonStyle="primary"
+                            onClick={onPublish}
+                            type="submit"
+                            disabled={!!imageError || !!descriptionError || !!titleError || !isPublishButtonActive}
+                        >
+                            {COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED}
+                        </Button>
+                    )}
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
## GitHub

* [[Who we are] Disable the ability to translate](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1391)

## Description

This pull request provides functionality to disable the "Translate" button when section contains unpublished changes. The translate button was moved from the wrapper component into each individual section component (CardsSection, DescriptionSection, and ImageSection), since each section has a different button position according to the mockup.

## How it looks

https://github.com/user-attachments/assets/3a7d7b54-9a56-4686-af55-1d6d7b153c16


## Summary of change

- Disabled Translate button when it section contains unpublished changes
- Implemented IconButton component usage instead of native button for translate Button for Who We Are admin page
- Reorganized translate button placement in the Who We Are admin page

## How to recreate changes

- Navigate to https://localhost:3000/
- Navigate to Who We Are admin page
- Write some text in an input field
- Verify that the Translate button is disabled
- Publish the changes and verify that the Translate button becomes active again

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-section "Translate" action buttons in Cards, Description and Image sections, tied to section-level translate callbacks.

* **Refactor**
  * Moved translate controls from the wrapper into individual section components for clearer structure and behavior.

* **Style**
  * Adjusted button layout and sizing so translate controls align consistently with section actions.

* **Tests**
  * Added tests verifying the "Translate" button is disabled when publish is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->