### PR TITLE
Fix/issue-1893: [Single program] 'Publish' and 'Save as draft' buttons enabled incorrectly and wrong label on Edit page

### DIFF
--- a/src/hooks/admin/use-generic-modal/useGenericModal.ts
+++ b/src/hooks/admin/use-generic-modal/useGenericModal.ts
@@ -84,15 +84,18 @@ export const useGenericModal = <
 
     const isEditMode = mode === ModalMode.Edit;
 
-    const updateButtonStates = useCallback((currentIsValid: boolean) => {
-        const api = formRef.current;
-        const isDirtyForSubmit = mode === ModalMode.Edit ? (api?.isDirty?.() ?? false) : true;
+    const updateButtonStates = useCallback(
+        (currentIsValid: boolean) => {
+            const api = formRef.current;
+            const isDirtyForSubmit = mode === ModalMode.Edit ? (api?.isDirty?.() ?? false) : true;
 
-        setButtonStates({
-            isDraftValid: isDirtyForSubmit && (api?.isValid?.(false) ?? currentIsValid),
-            isPublishValid: isDirtyForSubmit && (api?.isValid?.(true) ?? currentIsValid),
-        });
-    }, []);
+            setButtonStates({
+                isDraftValid: isDirtyForSubmit && (api?.isValid?.(false) ?? currentIsValid),
+                isPublishValid: isDirtyForSubmit && (api?.isValid?.(true) ?? currentIsValid),
+            });
+        },
+        [mode],
+    );
 
     const handleFormValidationChange = useCallback(
         (isValid: boolean) => {

--- a/src/hooks/admin/use-generic-modal/useGenericModal.ts
+++ b/src/hooks/admin/use-generic-modal/useGenericModal.ts
@@ -86,10 +86,11 @@ export const useGenericModal = <
 
     const updateButtonStates = useCallback((currentIsValid: boolean) => {
         const api = formRef.current;
+        const isDirtyForSubmit = mode === ModalMode.Edit ? (api?.isDirty?.() ?? false) : true;
 
         setButtonStates({
-            isDraftValid: api?.isValid?.(false) ?? currentIsValid,
-            isPublishValid: api?.isValid?.(true) ?? currentIsValid,
+            isDraftValid: isDirtyForSubmit && (api?.isValid?.(false) ?? currentIsValid),
+            isPublishValid: isDirtyForSubmit && (api?.isValid?.(true) ?? currentIsValid),
         });
     }, []);
 

--- a/src/pages/admin/programs/components/program-form/ProgramForm.tsx
+++ b/src/pages/admin/programs/components/program-form/ProgramForm.tsx
@@ -554,7 +554,7 @@ export const ProgramForm = forwardRef<ProgramFormRef, ProgramFormProps>(
                             disabled={isSubmitting || isFormDisabled}
                             data-testid="add-program-button"
                         >
-                            {PROGRAMS_TEXT.BUTTON.ADD_NEW_SECTION} <PlusIcon />
+                            {PROGRAMS_TEXT.BUTTON.ADD_SECTION} <PlusIcon />
                         </Button>
                     </div>
                 </div>

--- a/src/pages/admin/team/components/team-member-modal/TeamMemberModal.test.tsx
+++ b/src/pages/admin/team/components/team-member-modal/TeamMemberModal.test.tsx
@@ -241,6 +241,7 @@ describe('TeamMemberModal', () => {
             />,
         );
 
+        await userEvent.click(screen.getByTestId('toggle-dirty'));
         await userEvent.click(screen.getByTestId('toggle-valid'));
         await userEvent.click(screen.getByText('Save Published'));
         expect(screen.getByTestId('modal-title')).toHaveTextContent('Publish?');
@@ -280,6 +281,7 @@ describe('TeamMemberModal', () => {
             />,
         );
         const editModal = screen.getByTestId('modal');
+        await userEvent.click(within(editModal).getByTestId('toggle-dirty'));
         await userEvent.click(within(editModal).getByTestId('toggle-valid'));
         await userEvent.click(within(editModal).getByText('Save Draft'));
         const confirmModal4 = await screen.findByTestId('question-modal');


### PR DESCRIPTION
## GitHub

* [[Single program] 'Опублікувати' and 'Зберегти як чернетку' buttons are incorrectly enabled and incorrect button label on the 'Редагування' page](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1893)

## Description

This PR renames the "Додати нову секцію" button to "Додати секцію" and disables the "Опублікувати" and "Зберегти як чернетку" buttons when no changes are made to the content.

## How it looks


https://github.com/user-attachments/assets/a5be8f79-0068-4be6-96a1-17206378a9aa


## Summary of change

- Renamed add section button from 'Додати нову секцію' to 'Додати секцію'
- Disabled 'Опублікувати' and 'Зберегти як чернетку' buttons if content wasn't edited

## How to recreate changes

- Navigate to https://localhost:3000
- Go to the Programs admin page and click the edit program icon
- Verify that the "Add section" button in the top right corner is named 'Додати секцію'
- Verify that the "Опублікувати" and "Зберегти як чернетку" buttons are disabled
- Enter some text into an input field
- Verify that the "Опублікувати" and "Зберегти як чернетку" buttons become enabled


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Form validation now properly considers whether forms have been modified before enabling save operations.

* **Style**
  * Simplified button label for section addition in program forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->