### PR TITLE
Fix/issue-1897: The system does not respond to adding a file of an invalid format

### DIFF
--- a/src/components/admin/image-input/ImageInput.test.tsx
+++ b/src/components/admin/image-input/ImageInput.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { convertFileToBase64, ImageInput, getImageSrc } from './ImageInput';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { IMAGE_VALIDATION } from '@/const/admin/image';
 import { Image, ImageValues } from '@/types/common/image';
 import { IMAGE_VALIDATION_FUNCTIONS } from '@/validation/admin/image-schema/image-schema';
 import { IMAGE_DIMENSION_VALIDATION_FUNCTIONS } from '@/validation/admin/image-dimension-schema/image-dimension-schema';
@@ -249,14 +250,20 @@ describe('ImageInput', () => {
         expect(onChangeMock).not.toHaveBeenCalled();
     });
 
-    it('does not call onChange for non-image file', () => {
+    it('shows format error and does not call onChange for invalid file format', async () => {
         const file = new File(['dummy content'], 'example.txt', { type: 'text/plain' });
+        mockImageValidate.mockResolvedValueOnce(IMAGE_VALIDATION.getFormatError());
+
         render(<ImageInput value={null} onChange={onChangeMock} setError={setErrorMock} />);
 
         const fileInput = screen.getByTestId('image-input-hidden');
 
         fireEvent.change(fileInput, {
             target: { files: [file] },
+        });
+
+        await waitFor(() => {
+            expect(setErrorMock).toHaveBeenCalledWith(IMAGE_VALIDATION.getFormatError());
         });
 
         expect(onChangeMock).not.toHaveBeenCalled();

--- a/src/components/admin/image-input/ImageInput.tsx
+++ b/src/components/admin/image-input/ImageInput.tsx
@@ -83,9 +83,6 @@ export const ImageInput = ({
 
     const handleFile = useCallback(
         async (file: File) => {
-            setError(null);
-            if (!file.type.startsWith('image/')) return;
-
             const error = await IMAGE_VALIDATION_FUNCTIONS.validateImage(file, minWidth, minHeight, maxSizeMB);
             if (error) {
                 setError(error);

--- a/src/validation/admin/image-schema/image-schema.test.ts
+++ b/src/validation/admin/image-schema/image-schema.test.ts
@@ -77,6 +77,15 @@ describe('ImageValidationSchema', () => {
         await expect(validationSchema.validate(invalidTypeFile)).rejects.toThrow(IMAGE_VALIDATION.getFormatError());
     });
 
+    it('returns file type error first when format is invalid and size is too large', async () => {
+        mockImageDimensions(1920, 1080);
+        const invalidLargeTypeFile = createTestFile(IMAGE_VALIDATION.maxSizeBytes + 1024, 'text/plain');
+
+        await expect(validationSchema.validate(invalidLargeTypeFile)).rejects.toThrow(
+            IMAGE_VALIDATION.getFormatError(),
+        );
+    });
+
     it('rejects null or undefined input', async () => {
         await expect(validationSchema.validate(null)).rejects.toThrow();
         await expect(validationSchema.validate(undefined)).rejects.toThrow();

--- a/src/validation/admin/image-schema/image-schema.ts
+++ b/src/validation/admin/image-schema/image-schema.ts
@@ -4,16 +4,15 @@ import { IMAGE_VALIDATION } from '@/const/admin/image';
 export const getImageValidationSchema = (minWidth: number, minHeight: number, maxSizeMB: number) => {
     return Yup.mixed<File>()
         .test(
-            'fileSize',
-            IMAGE_VALIDATION.getSizeError(maxSizeMB),
-            (file) => !!file && file.size <= maxSizeMB * 1024 * 1024,
-        )
-        .test(
             'fileType',
             IMAGE_VALIDATION.getFormatError,
             (file) => !!file && IMAGE_VALIDATION.allowedFormats.includes(file.type),
         )
-
+        .test(
+            'fileSize',
+            IMAGE_VALIDATION.getSizeError(maxSizeMB),
+            (file) => !!file && file.size <= maxSizeMB * 1024 * 1024,
+        )
         .test(
             'fileDimensions',
             IMAGE_VALIDATION.ImageDimensionsTooSmallError,


### PR DESCRIPTION
## GitHub

* [[Single Program] [Додати програму] The system does not respond to adding a file of an invalid format](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1897)

## Description

This pull request improves image file validation in the admin interface by ensuring that invalid file formats are caught and reported before checking file size or other properties. The validation logic and related tests have been updated to reflect this change, prioritizing user feedback on file type errors.

## How it looks


https://github.com/user-attachments/assets/736343d5-8ff2-4777-8916-cb2e211c9d11



## Summary of change

* The image validation schema (`getImageValidationSchema` in `image-schema.ts`) now checks for valid file format before checking file size, ensuring users are informed of format errors first.
* Redundant file type checking was removed from the `handleFile` function in `ImageInput.tsx`, delegating all validation to the schema.
* A new test case was added to ensure that when a file is both too large and of an invalid format, the format error is returned first.
* The test for handling non-image files in `ImageInput.test.tsx` was updated to check that a format error is shown and `onChange` is not called for invalid file formats.

## How to recreate changes

- Navigate to https://localhost:3000/
- Go to the Programs admin page and click the add new program button
- Click on the field to add a photo.
- Choose a photo of the invalid formats. For example PDF, DOC, XLS.
- Verify that a red error message appears "Невірний формат фото, дозволено jpeg, jpg, png, webp"


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image upload validation error messaging: format validation errors now take precedence over file size errors, ensuring users see the most critical validation issue first when uploading invalid images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->