### PR TITLE
Fix/issue 1983, 1984, 1926: [Single Program] Wrong validation message text is displayed for "Опис" and "Заголовок" fields

### DIFF
--- a/src/const/admin/programs.ts
+++ b/src/const/admin/programs.ts
@@ -310,18 +310,6 @@ export const PROGRAM_CATEGORY_VALIDATION = {
     },
 };
 
-export const PROGRAM_SECTION_VALIDATION = {
-    title: {
-        getRequiredError: () => "Заголовок обов'язковий",
-    },
-    description: {
-        getRequiredError: () => "Опис обов'язковий",
-    },
-    author: {
-        getRequiredError: () => "Ім'я обов'язкове",
-    },
-} as const;
-
 const createSingleImageTemplateValidation = () =>
     ({
         counts: {

--- a/src/hooks/admin/use-program-section-validation/useProgramSectionValidation.test.ts
+++ b/src/hooks/admin/use-program-section-validation/useProgramSectionValidation.test.ts
@@ -3,7 +3,7 @@ import type React from 'react';
 
 import { useProgramSectionValidation } from './useProgramSectionValidation';
 
-import { PROGRAM_SECTION_TEMPLATE_VALIDATION, PROGRAM_SECTION_VALIDATION } from '@/const/admin/programs';
+import { PROGRAM_SECTION_TEMPLATE_VALIDATION } from '@/const/admin/programs';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { ProgramSectionTemplate } from '@/types/common/program-sections';
 import { ContentType } from '@/types/common/programs';
@@ -58,7 +58,7 @@ describe('useProgramSectionValidation', () => {
                 result.current.handleTitleBlur(createBlurEvent(value));
             });
 
-            expect(result.current.titleError).toBe(PROGRAM_SECTION_VALIDATION.title.getRequiredError());
+            expect(result.current.titleError).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED);
         });
 
         it('should not show error when title is valid (draft)', () => {
@@ -181,7 +181,7 @@ describe('useProgramSectionValidation', () => {
                 result.current.handleDescriptionBlur(createTextAreaBlurEvent(value));
             });
 
-            expect(result.current.descriptionError).toBe(PROGRAM_SECTION_VALIDATION.description.getRequiredError());
+            expect(result.current.descriptionError).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED);
         });
 
         it('should show min error for short but non-empty description in draft mode', () => {

--- a/src/validation/admin/program-schema/program-schema.test.ts
+++ b/src/validation/admin/program-schema/program-schema.test.ts
@@ -15,7 +15,7 @@ const T_IMG_REQ_UNDEF = 91007 as any;
 const T_LEN_IMAGE = 91008 as any;
 const T_IMG_SORT = 91009 as any;
 
-const loadSchema = (over?: { programValidation?: any; sectionValidation?: any; templateValidation?: any }) => {
+const loadSchema = (over?: { programValidation?: any; templateValidation?: any }) => {
     jest.resetModules();
 
     jest.doMock('@/const/admin/common', () => ({
@@ -40,14 +40,6 @@ const loadSchema = (over?: { programValidation?: any; sectionValidation?: any; t
             meetingCount: { max: 20, getRequiredWhenPublishingError: () => 'mc required' },
             images: { maxSizeMB: 1 },
             ...(over?.programValidation ?? {}),
-        };
-
-        const sv = {
-            title: { getRequiredError: () => 'title required' },
-            description: { getRequiredError: () => 'description required' },
-            author: { getRequiredError: () => 'author required' },
-            cardAuthor: { getRequiredError: () => 'card author required' },
-            ...(over?.sectionValidation ?? {}),
         };
 
         const tv: any = {
@@ -213,7 +205,6 @@ const loadSchema = (over?: { programValidation?: any; sectionValidation?: any; t
 
         return {
             PROGRAM_VALIDATION: pv,
-            PROGRAM_SECTION_VALIDATION: sv,
             PROGRAM_SECTION_TEMPLATE_VALIDATION: tv,
         };
     });
@@ -653,7 +644,7 @@ describe('program-schema.ts coverage (templates are bottom-only)', () => {
         const m = loadSchema();
         expect(
             m.PROGRAM_SECTION_VALIDATION_FUNCTIONS.validateSectionTitle('', true, ProgramSectionTemplate.TextOnly),
-        ).toBe('title required');
+        ).toBe('required');
     });
 
     it('PROGRAM_SECTION_VALIDATION_FUNCTIONS: validateSectionDescription returns max error', () => {
@@ -679,40 +670,12 @@ describe('program-schema.ts coverage (templates are bottom-only)', () => {
 });
 
 describe('program-schema.ts required-message fallbacks', () => {
-    it('author required uses cardAuthor when author is missing', () => {
-        const m = loadSchema({
-            sectionValidation: { author: undefined, cardAuthor: { getRequiredError: () => 'card author required' } },
-        });
+    it('content required uses FIELD_REQUIRED by default', () => {
+        const m = loadSchema();
         expect(
             m.PROGRAM_SECTION_VALIDATION_FUNCTIONS.validateContentText(
                 '',
                 ContentType.Author,
-                true,
-                ProgramSectionTemplate.TextOnly,
-            ),
-        ).toBe('card author required');
-    });
-
-    it('author required falls back to FIELD_REQUIRED when author and cardAuthor are missing', () => {
-        const m = loadSchema({ sectionValidation: { author: undefined, cardAuthor: undefined } });
-        expect(
-            m.PROGRAM_SECTION_VALIDATION_FUNCTIONS.validateContentText(
-                '',
-                ContentType.Author,
-                true,
-                ProgramSectionTemplate.TextOnly,
-            ),
-        ).toBe('required');
-    });
-
-    it('unknown content type required falls back to FIELD_REQUIRED', () => {
-        const m = loadSchema({
-            sectionValidation: { title: undefined, description: undefined, author: undefined, cardAuthor: undefined },
-        });
-        expect(
-            m.PROGRAM_SECTION_VALIDATION_FUNCTIONS.validateContentText(
-                '',
-                999 as any,
                 true,
                 ProgramSectionTemplate.TextOnly,
             ),

--- a/src/validation/admin/program-schema/program-schema.ts
+++ b/src/validation/admin/program-schema/program-schema.ts
@@ -1,8 +1,4 @@
-import {
-    PROGRAM_VALIDATION,
-    PROGRAM_SECTION_VALIDATION,
-    PROGRAM_SECTION_TEMPLATE_VALIDATION,
-} from '@/const/admin/programs';
+import { PROGRAM_VALIDATION, PROGRAM_SECTION_TEMPLATE_VALIDATION } from '@/const/admin/programs';
 import { FAQ_VALIDATION } from '@/const/admin/faq';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { ProgramCategory } from '@/types/admin/programs';
@@ -66,29 +62,10 @@ const getTextValue = (content: SectionContent): string | undefined => {
     }
 };
 
-const getRequiredMessage = (type: ContentType): string => {
-    const v = PROGRAM_SECTION_VALIDATION as any;
-
-    switch (type) {
-        case ContentType.Title:
-            return v?.title?.getRequiredError?.() ?? COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
-        case ContentType.Description:
-            return v?.description?.getRequiredError?.() ?? COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
-        case ContentType.Author:
-            return (
-                v?.author?.getRequiredError?.() ??
-                v?.cardAuthor?.getRequiredError?.() ??
-                COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED
-            );
-        default:
-            return COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
-    }
-};
-
 const createTemplateTextSchema = (type: ContentType) =>
     Yup.string()
         .trim()
-        .required(getRequiredMessage(type))
+        .required(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED)
         .test('template-length', function (value) {
             const ctx = (this.options.context ?? {}) as ProgramValidationContext & { template?: SectionTemplate };
             const template = ctx.template;


### PR DESCRIPTION
## GitHub

*  [[Single Program] Wrong validation message text is displayed for "Опис" field](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1983)
* [[Single Program] Wrong validation message text is displayed for "Заголовок" field](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1984)
* [[Single Program] Incorrect validation error messages for required fields (spaces-only input)](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1926)

## Description

This pull request refactors how required field validation messages are handled for program section fields. The main change is the removal of the custom `PROGRAM_SECTION_VALIDATION` object and a shift to consistently using the common admin validation message for required fields.

## How it looks

Before:
<img width="1654" height="600" alt="image" src="https://github.com/user-attachments/assets/b7f668a3-c0f5-45e9-8ac8-d65e06a658d8" />

After:
<img width="1517" height="611" alt="image" src="https://github.com/user-attachments/assets/cd824618-ae6f-4f87-b297-618826f0453a" />


Also now for author name field in 633433 template, instead of 'Ім'я обов'язкове' the message 'Поле обов'язкове' is displayed, due to user story: [#760](https://github.com/ita-social-projects/VictoryCenter-Back/issues/760):
<img width="1158" height="785" alt="image" src="https://github.com/user-attachments/assets/faa1da98-eaf5-4af0-8f44-83172db38577" />

## Summary of change

* Removed the `PROGRAM_SECTION_VALIDATION` object from `src/const/admin/programs.ts` and all its usages, consolidating required field error messages to use `COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED` throughout the codebase.
* Updated tests in `useProgramSectionValidation.test.ts` to expect the common required field message instead of the custom messages from `PROGRAM_SECTION_VALIDATION`.
* Refactored `program-schema.test.ts` to remove dependencies on the deleted validation object and to expect the common required message in all cases, including fallback scenarios.

## How to recreate changes

- Navigate to https://localhost:3000/
- Go to the Programs admin page and click the add new program button
- Select a specific template and click on "Обрати шаблон" button
- Focus on the 'Заголовок' field.
- Do not enter any value in “Заголовок” field.
- Focus on the 'Опис' field.
- Do not enter any value in “Опис” field.
- Observe the validation message text is displayed "Поле обов'язкове"


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions
