### PR TITLE
Fix/issue 1846: [Single Program] Paste is blocked instead of truncating text when input exceeds max length in "Заголовок" and "Опис" fields (T-1, T-2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ yarn-error.log*
 .vs/
 *.css
 *.map
+/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,3 @@ yarn-error.log*
 .vs/
 *.css
 *.map
-/package-lock.json

--- a/src/hooks/admin/use-input-with-character-limit/useInputWithCharacterLimit.test.ts
+++ b/src/hooks/admin/use-input-with-character-limit/useInputWithCharacterLimit.test.ts
@@ -387,4 +387,58 @@ describe('useInputWithCharacterLimit', () => {
             expect(mockOnChange).toHaveBeenCalled();
         });
     });
+
+    describe('handleChange truncation', () => {
+        it('should truncate "Заголовок" to 60 characters', () => {
+            const { result } = renderHook(() =>
+                useInputWithCharacterLimit({
+                    ...defaultProps,
+                    maxLength: 60,
+                    name: 'title',
+                }),
+            );
+
+            const longText = 'a'.repeat(61);
+            const mockEvent = {
+                target: { value: longText, name: 'title', id: 'title-input' },
+            } as React.ChangeEvent<HTMLInputElement>;
+
+            act(() => {
+                result.current.handleChange(mockEvent);
+            });
+
+            expect(mockOnChange).toHaveBeenCalledWith({
+                target: {
+                    ...mockEvent.target,
+                    value: 'a'.repeat(60),
+                },
+            });
+        });
+
+        it('should truncate "Опис" to 600 characters', () => {
+            const { result } = renderHook(() =>
+                useInputWithCharacterLimit({
+                    ...defaultProps,
+                    maxLength: 600,
+                    name: 'description',
+                }),
+            );
+
+            const longText = 'b'.repeat(601);
+            const mockEvent = {
+                target: { value: longText, name: 'description', id: 'description-input' },
+            } as React.ChangeEvent<HTMLTextAreaElement>;
+
+            act(() => {
+                result.current.handleChange(mockEvent);
+            });
+
+            expect(mockOnChange).toHaveBeenCalledWith({
+                target: {
+                    ...mockEvent.target,
+                    value: 'b'.repeat(600),
+                },
+            });
+        });
+    });
 });

--- a/src/hooks/admin/use-input-with-character-limit/useInputWithCharacterLimit.ts
+++ b/src/hooks/admin/use-input-with-character-limit/useInputWithCharacterLimit.ts
@@ -35,14 +35,36 @@ export const useInputWithCharacterLimit = <T extends HTMLInputElement | HTMLText
         let newValue = e.target.value;
         const normalized = getNormalizedInputText(newValue ?? '');
 
-        if (normalized.length > maxLength || newValue.length > maxLength) {
+        const isTruncatableField = name === 'title' || name === 'description';
+
+        if (normalized.length > maxLength) {
+            if (isTruncatableField) {
+                const truncatedValue = newValue.slice(0, maxLength);
+
+                onChange({
+                    ...e,
+                    target: {
+                        ...e.target,
+                        value: truncatedValue,
+                    },
+                });
+            } else {
+                if (maxLimitWarning) {
+                    showTemporaryWarning(maxLimitWarning);
+                }
+                return;
+            }
+            return;
+        }
+
+        if (newValue.length > maxLength && normalized.length <= maxLength) {
             if (maxLimitWarning) {
                 showTemporaryWarning(maxLimitWarning);
             }
-            newValue = newValue.slice(0, maxLength);
-        } else {
-            clearWarning();
+            return;
         }
+
+        clearWarning();
 
         onChange({
             ...e,

--- a/src/hooks/admin/use-input-with-character-limit/useInputWithCharacterLimit.ts
+++ b/src/hooks/admin/use-input-with-character-limit/useInputWithCharacterLimit.ts
@@ -32,14 +32,14 @@ export const useInputWithCharacterLimit = <T extends HTMLInputElement | HTMLText
     const currentLength = getNormalizedInputText(value ?? '').length;
 
     const handleChange = (e: React.ChangeEvent<T>) => {
-        const newValue = e.target.value;
+        let newValue = e.target.value;
         const normalized = getNormalizedInputText(newValue ?? '');
 
         if (normalized.length > maxLength || newValue.length > maxLength) {
             if (maxLimitWarning) {
                 showTemporaryWarning(maxLimitWarning);
             }
-            return;
+            newValue = newValue.slice(0, maxLength);
         } else {
             clearWarning();
         }


### PR DESCRIPTION
## JIRA or Github ticker

https://github.com/ita-social-projects/VictoryCenter-Back/issues/1846

## Description

Text now correctly limits to 60 characters in 'Заголовок' and 600 in 'Опис' fields when pasted.

## How it looks



https://github.com/user-attachments/assets/a68580f7-d1a9-456c-957a-aae3325da8e5



## Summary of change
- Fixed insertion of text exceeding limits for "Title" and "Description" fields in templates T-1 and T-2.  
- Now text is properly truncated to the allowed length (60 characters for "Title", 600 characters for "Description") instead of being blocked entirely.  
- Added unit tests to verify truncation behavior.

## How to recreate changes
1. Open the form for template T-1 or T-2.  
2. Enter text longer than the allowed limit in the "Title" or "Description" fields.  
3. Verify that the text is truncated to the maximum allowed length and that the onChange handler is called correctly.  
4. Check that warnings are shown only when configured and applicable.

## Check list
- [x] Code works locally  
- [x] Added/updated unit tests  
- [x] PR linked to the corresponding issue  
- [x] Labels and assignees set




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed input handling for character limits: certain fields now truncate excess characters and ensure callbacks are invoked so form data is processed correctly when users exceed limits.

* **Tests**
  * Added tests verifying character-limit truncation behavior for relevant field types and ensuring callbacks receive truncated values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->