### PR TITLE
Feat/issue 917 - [Profile Company] Validation company details

### DIFF
--- a/src/const/admin/company-profile.ts
+++ b/src/const/admin/company-profile.ts
@@ -66,3 +66,43 @@ export const COMPANY_PROFILE_TEXT = {
         LIMIT_MESSAGE: 'Дозволено лише 4 контакти.',
     },
 } as const;
+
+export const COMPANY_PROFILE_VALIDATION = {
+    common: {
+        getRequiredError: () => "Поле обов'язкове",
+        getEmailError: () => 'Введіть e-mail',
+        getDigitsOnlyError: () => 'Мають бути цифри',
+    },
+
+    phone: {
+        max: 20,
+    },
+
+    address: {
+        max: 100,
+    },
+
+    email: {
+        max: 50,
+    },
+
+    motto: {
+        max: 200,
+        getMaxError: () => `Не більше ${COMPANY_PROFILE_VALIDATION.motto.max} символів`,
+    },
+
+    recipient: {
+        max: 100,
+    },
+
+    edrpou: {
+        length: 8,
+        getMinError: () => `Не менше ${COMPANY_PROFILE_VALIDATION.edrpou.length} цифр`,
+        getMaxError: () => `Не більше ${COMPANY_PROFILE_VALIDATION.edrpou.length} цифр`,
+    },
+
+    socialUrl: {
+        max: 500,
+        getMaxError: () => `Не більше ${COMPANY_PROFILE_VALIDATION.socialUrl.max} символів`,
+    },
+} as const;

--- a/src/const/admin/company-profile.ts
+++ b/src/const/admin/company-profile.ts
@@ -1,3 +1,5 @@
+import { COMMON_TEXT_ADMIN } from './common';
+
 export const COMPANY_PROFILE_TEXT = {
     TABS: {
         PROFILE: 'Профіль компанії',
@@ -69,7 +71,7 @@ export const COMPANY_PROFILE_TEXT = {
 
 export const COMPANY_PROFILE_VALIDATION = {
     common: {
-        getRequiredError: () => "Поле обов'язкове",
+        REQUIRED: COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED,
         getEmailError: () => 'Введіть e-mail',
         getDigitsOnlyError: () => 'Мають бути цифри',
     },
@@ -88,7 +90,7 @@ export const COMPANY_PROFILE_VALIDATION = {
 
     motto: {
         max: 200,
-        getMaxError: () => `Не більше ${COMPANY_PROFILE_VALIDATION.motto.max} символів`,
+        getMaxError: () => COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(200),
     },
 
     recipient: {
@@ -103,6 +105,6 @@ export const COMPANY_PROFILE_VALIDATION = {
 
     socialUrl: {
         max: 500,
-        getMaxError: () => `Не більше ${COMPANY_PROFILE_VALIDATION.socialUrl.max} символів`,
+        getMaxError: () => COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(500),
     },
 } as const;

--- a/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.test.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { CompanyProfileContent } from './CompanyProfileContent';
 import { CompanyProfileApi } from '@/services/api/admin/company-profile/company-profile-api';
 import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
+import { COMPANY_PROFILE_VALIDATION } from '@/const/admin/company-profile';
 
 jest.mock('@/components/admin/toast/toast-container/ToastContainer', () => ({
     ToastContainer: () => <div data-testid="toast-container" />,
@@ -14,7 +15,32 @@ jest.mock('../company-profile-logo-header/CompanyProfileLogoHeader', () => ({
 }));
 
 jest.mock('../company-profile-tab/CompanyProfileTab', () => ({
-    CompanyProfileTab: (props: any) => <div data-testid="tab-profile" data-disabled={String(props.disabled)} />,
+    CompanyProfileTab: (props: any) => {
+        const React = require('react');
+        const rhf = require('react-hook-form') as typeof import('react-hook-form');
+
+        const { useFormContext, Controller } = rhf;
+        const { control, formState } = useFormContext();
+
+        return (
+            <div data-testid="tab-profile" data-disabled={String(props.disabled)}>
+                <Controller
+                    name="phone"
+                    control={control}
+                    render={({ field }: any) => (
+                        <input
+                            data-testid="input-phone"
+                            disabled={props.disabled}
+                            value={field.value ?? ''}
+                            onChange={(e) => field.onChange(e)}
+                            onBlur={() => field.onBlur()}
+                        />
+                    )}
+                />
+                <div data-testid="debug-dirty">{String(formState.isDirty)}</div>
+            </div>
+        );
+    },
 }));
 
 jest.mock('../company-profile-requisites-tab/CompanyProfileRequisitesTab', () => ({
@@ -172,5 +198,23 @@ describe('CompanyProfileContent', () => {
         await waitFor(() => {
             expect(mockedGet).toHaveBeenCalledTimes(1);
         });
+    });
+
+    it('disables publish when form is dirty but invalid (required phone)', async () => {
+        render(<CompanyProfileContent />);
+
+        fireEvent.click(screen.getByTestId('edit-btn'));
+
+        const publishBtn = screen.getByTestId('publish-btn') as HTMLButtonElement;
+        const phoneInput = screen.getByTestId('input-phone') as HTMLInputElement;
+
+        fireEvent.change(phoneInput, { target: { value: '   ' } });
+        fireEvent.blur(phoneInput);
+
+        await waitFor(() => {
+            expect(publishBtn).toBeDisabled();
+        });
+
+        expect(COMPANY_PROFILE_VALIDATION.common.getRequiredError()).toBe("Поле обов'язкове");
     });
 });

--- a/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.test.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.test.tsx
@@ -16,10 +16,7 @@ jest.mock('../company-profile-logo-header/CompanyProfileLogoHeader', () => ({
 
 jest.mock('../company-profile-tab/CompanyProfileTab', () => ({
     CompanyProfileTab: (props: any) => {
-        const React = require('react');
-        const rhf = require('react-hook-form') as typeof import('react-hook-form');
-
-        const { useFormContext, Controller } = rhf;
+        const { useFormContext, Controller } = require('react-hook-form');
         const { control, formState } = useFormContext();
 
         return (

--- a/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.test.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.test.tsx
@@ -212,6 +212,6 @@ describe('CompanyProfileContent', () => {
             expect(publishBtn).toBeDisabled();
         });
 
-        expect(COMPANY_PROFILE_VALIDATION.common.getRequiredError()).toBe("Поле обов'язкове");
+        expect(COMPANY_PROFILE_VALIDATION.common.REQUIRED).toBe("Поле обов'язкове");
     });
 });

--- a/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.tsx
@@ -15,6 +15,8 @@ import { COMPANY_PROFILE_FORM_DEFAULTS, CompanyProfileFormValues } from '@/types
 import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
 import { CompanyProfileApi } from '@/services/api/admin/company-profile/company-profile-api';
 import { mapCompanyProfileToFormValues } from '@/utils/functions/mappers/admin/company-profile/company-profile-mappers';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { CompanyProfileValidationSchema } from '@/validation/admin/company-profile-schema/company-profile-schema';
 
 type TabType = 'profile' | 'requisites' | 'socials';
 
@@ -37,7 +39,10 @@ export const CompanyProfileContent = () => {
 
     const methods = useForm<CompanyProfileFormValues>({
         mode: 'onBlur',
+        reValidateMode: 'onChange',
         defaultValues: COMPANY_PROFILE_FORM_DEFAULTS,
+        resolver: yupResolver(CompanyProfileValidationSchema),
+        shouldFocusError: true,
     });
 
     const handlePublish = (_data: CompanyProfileFormValues) => {
@@ -106,7 +111,7 @@ export const CompanyProfileContent = () => {
                             onEdit={() => setIsEditMode(true)}
                             onCancel={handleCancelClick}
                             onPublish={methods.handleSubmit(handlePublish)}
-                            isPublishDisabled={!methods.formState.isDirty}
+                            isPublishDisabled={!methods.formState.isDirty || !methods.formState.isValid}
                         />
                     </div>
                 </div>

--- a/src/pages/admin/company-profile/components/company-profile-form-group/CompanyProfileFormGroup.module.scss
+++ b/src/pages/admin/company-profile/components/company-profile-form-group/CompanyProfileFormGroup.module.scss
@@ -6,6 +6,7 @@
     flex-direction: column;
     gap: 6px;
     width: 100%;
+    position: relative;
 }
 
 .custom-form-group-label-wrapper label {
@@ -23,6 +24,7 @@
 .custom-form-group-input-wrapper {
     position: relative;
     width: 100%;
+    padding-bottom: 20px;
 }
 
 .custom-form-group-tooltip-inside {
@@ -52,15 +54,34 @@
     min-width: 0;
 }
 
-.custom-form-group-tooltip {
-    position: static;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-}
-
 .custom-form-group :global(.tooltip-popup) {
     z-index: 9999;
     position: absolute;
     text-align: left;
+}
+
+.custom-form-group :global(.input-error) {
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    margin: 0;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    max-width: calc(100% - 72px);
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+.custom-form-group-input-wrapper :global(.char-limit-input__counter--bottom) {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    margin: 0;
+    height: 20px;
+    display: inline-flex;
+    align-items: center;
+    width: auto;
+    max-width: none;
+    white-space: nowrap;
 }

--- a/src/pages/admin/company-profile/components/company-profile-requisites-tab/CompanyProfileRequisitesTab.test.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-requisites-tab/CompanyProfileRequisitesTab.test.tsx
@@ -1,16 +1,22 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { CompanyProfileRequisitesTab } from './CompanyProfileRequisitesTab';
 import { COMPANY_PROFILE_FORM_DEFAULTS, CompanyProfileFormValues } from '@/types/admin/company-profile';
 import { COMPANY_PROFILE_TEXT } from '@/const/admin/company-profile';
 
 jest.mock('../company-profile-form-group/CompanyProfileFormGroup', () => ({
-    CustomFormGroup: ({ id, labelText, disabled }: any) => (
+    CustomFormGroup: ({ id, labelText, disabled, value, onChange }: any) => (
         <div data-testid={`group-${id}`}>
             <span data-testid={`label-${id}`}>{labelText}</span>
-            <input data-testid={`input-${id}`} id={id} disabled={disabled} />
+            <input
+                data-testid={`input-${id}`}
+                id={id}
+                disabled={disabled}
+                value={value ?? ''}
+                onChange={(e) => onChange?.(e)}
+            />
         </div>
     ),
 }));
@@ -51,5 +57,17 @@ describe('CompanyProfileRequisitesTab', () => {
         render(<Wrapper disabled={false} />);
         expect(screen.getByTestId('input-requisitesUa')).not.toBeDisabled();
         expect(screen.getByTestId('input-companyRegistrationNumber')).not.toBeDisabled();
+    });
+
+    it('sanitizes companyRegistrationNumber to digits only and max 8 chars', () => {
+        render(<Wrapper disabled={false} />);
+
+        const input = screen.getByTestId('input-companyRegistrationNumber') as HTMLInputElement;
+
+        fireEvent.change(input, { target: { value: '12a45-67' } });
+        expect(input.value).toBe('124567');
+
+        fireEvent.change(input, { target: { value: '123456789999' } });
+        expect(input.value).toBe('12345678');
     });
 });

--- a/src/pages/admin/company-profile/components/company-profile-requisites-tab/CompanyProfileRequisitesTab.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-requisites-tab/CompanyProfileRequisitesTab.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useFormContext, Controller } from 'react-hook-form';
 import { CustomFormGroup } from '../company-profile-form-group/CompanyProfileFormGroup';
 import styles from './CompanyProfileRequisitesTab.module.scss';
@@ -32,7 +33,7 @@ export const CompanyProfileRequisitesTab = ({ disabled }: CompanyProfileRequisit
                             id="requisitesUa"
                             labelText={COMPANY_PROFILE_TEXT.REQUISITES_TAB.REQUISITES_UA_LABEL}
                             tooltipText={COMPANY_PROFILE_TEXT.REQUISITES_TAB.TOOLTIP_REQUISITES_UA}
-                            isRequired={true}
+                            isRequired
                             maxLength={100}
                             disabled={disabled}
                             showCounter={showCounter}
@@ -50,7 +51,7 @@ export const CompanyProfileRequisitesTab = ({ disabled }: CompanyProfileRequisit
                             id="requisitesEn"
                             labelText={COMPANY_PROFILE_TEXT.REQUISITES_TAB.REQUISITES_EN_LABEL}
                             tooltipText={COMPANY_PROFILE_TEXT.REQUISITES_TAB.TOOLTIP_REQUISITES_EN}
-                            isRequired={true}
+                            isRequired
                             maxLength={100}
                             disabled={disabled}
                             showCounter={showCounter}
@@ -66,9 +67,14 @@ export const CompanyProfileRequisitesTab = ({ disabled }: CompanyProfileRequisit
                         <CustomFormGroup
                             {...field}
                             id="companyRegistrationNumber"
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                const raw = e.target.value ?? '';
+                                const digitsOnly = raw.replace(/\D/g, '').slice(0, 8);
+                                field.onChange(digitsOnly);
+                            }}
                             labelText={COMPANY_PROFILE_TEXT.REQUISITES_TAB.COMPANY_REGISTRATION_NUMBER_LABEL}
                             tooltipText={COMPANY_PROFILE_TEXT.REQUISITES_TAB.TOOLTIP_COMPANY_REGISTRATION_NUMBER}
-                            isRequired={true}
+                            isRequired
                             maxLength={8}
                             disabled={disabled}
                             showCounter={showCounter}
@@ -86,7 +92,7 @@ export const CompanyProfileRequisitesTab = ({ disabled }: CompanyProfileRequisit
                             id="addressUa_requisites"
                             labelText={COMPANY_PROFILE_TEXT.REQUISITES_TAB.REQUISITES_ADDRESS_UA_LABEL}
                             tooltipText={COMPANY_PROFILE_TEXT.REQUISITES_TAB.TOOLTIP_REQUISITES_ADDRESS_UA}
-                            isRequired={true}
+                            isRequired
                             maxLength={100}
                             disabled={disabled}
                             showCounter={showCounter}
@@ -104,7 +110,7 @@ export const CompanyProfileRequisitesTab = ({ disabled }: CompanyProfileRequisit
                             id="addressEn_requisites"
                             labelText={COMPANY_PROFILE_TEXT.REQUISITES_TAB.REQUISITES_ADDRESS_EN_LABEL}
                             tooltipText={COMPANY_PROFILE_TEXT.REQUISITES_TAB.TOOLTIP_REQUISITES_ADDRESS_EN}
-                            isRequired={true}
+                            isRequired
                             maxLength={100}
                             disabled={disabled}
                             showCounter={showCounter}

--- a/src/validation/admin/company-profile-schema/company-profile-schema.test.ts
+++ b/src/validation/admin/company-profile-schema/company-profile-schema.test.ts
@@ -1,0 +1,135 @@
+import { COMPANY_PROFILE_VALIDATION } from '@/const/admin/company-profile';
+import { COMPANY_PROFILE_VALIDATION_FUNCTIONS } from './company-profile-schema';
+
+describe('COMPANY_PROFILE_VALIDATION_FUNCTIONS', () => {
+    describe('validatePhone', () => {
+        it('returns undefined for valid phone', () => {
+            expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validatePhone('+380671234567')).toBeUndefined();
+        });
+
+        it('returns required error for empty phone', () => {
+            expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validatePhone('')).toBe(
+                COMPANY_PROFILE_VALIDATION.common.getRequiredError(),
+            );
+        });
+
+        it('treats spaces as empty', () => {
+            expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validatePhone('   ')).toBe(
+                COMPANY_PROFILE_VALIDATION.common.getRequiredError(),
+            );
+        });
+    });
+
+    describe('validateEmail', () => {
+        it('returns undefined for valid email', () => {
+            expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateEmail('test@example.com')).toBeUndefined();
+        });
+
+        it('returns required error for empty email', () => {
+            expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateEmail('')).toBe(
+                COMPANY_PROFILE_VALIDATION.common.getRequiredError(),
+            );
+        });
+
+        it('returns format error for invalid email', () => {
+            expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateEmail('not-email')).toBe(
+                COMPANY_PROFILE_VALIDATION.common.getEmailError(),
+            );
+        });
+    });
+
+    describe('validateCorrespondenceEmail', () => {
+        it('returns undefined for valid correspondence email', () => {
+            expect(
+                COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateCorrespondenceEmail('office@example.com'),
+            ).toBeUndefined();
+        });
+
+        it('returns required error for empty correspondence email', () => {
+            expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateCorrespondenceEmail('')).toBe(
+                COMPANY_PROFILE_VALIDATION.common.getRequiredError(),
+            );
+        });
+
+        it('returns format error for invalid correspondence email', () => {
+            expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateCorrespondenceEmail('not-email')).toBe(
+                COMPANY_PROFILE_VALIDATION.common.getEmailError(),
+            );
+        });
+    });
+
+    describe('validateCompanyRegistrationNumber (ЄДРПОУ)', () => {
+        it('returns undefined for valid 8 digits', () => {
+            expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateCompanyRegistrationNumber('12345678')).toBeUndefined();
+        });
+
+        it('returns required error for empty value', () => {
+            expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateCompanyRegistrationNumber('')).toBe(
+                COMPANY_PROFILE_VALIDATION.common.getRequiredError(),
+            );
+        });
+
+        it('treats spaces as empty', () => {
+            expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateCompanyRegistrationNumber('   ')).toBe(
+                COMPANY_PROFILE_VALIDATION.common.getRequiredError(),
+            );
+        });
+
+        it('returns digits-only error when non-digit chars are present', () => {
+            expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateCompanyRegistrationNumber('12a45678')).toBe(
+                COMPANY_PROFILE_VALIDATION.common.getDigitsOnlyError(),
+            );
+        });
+
+        it('returns min error when less than 8 digits', () => {
+            expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateCompanyRegistrationNumber('123')).toBe(
+                COMPANY_PROFILE_VALIDATION.edrpou.getMinError(),
+            );
+        });
+
+        it('returns max error when more than 8 digits', () => {
+            expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateCompanyRegistrationNumber('123456789')).toBe(
+                COMPANY_PROFILE_VALIDATION.edrpou.getMaxError(),
+            );
+        });
+    });
+
+    describe('validateMottoUa', () => {
+        it('returns undefined for empty (optional)', () => {
+            expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateMottoUa('')).toBeUndefined();
+        });
+
+        it('returns max error for mottoUa longer than 200 chars', () => {
+            const long = 'a'.repeat(COMPANY_PROFILE_VALIDATION.motto.max + 1);
+            expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateMottoUa(long)).toBe(
+                COMPANY_PROFILE_VALIDATION.motto.getMaxError(),
+            );
+        });
+    });
+
+    describe('validateMottoEng', () => {
+        it('returns undefined for empty (optional)', () => {
+            expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateMottoEng('')).toBeUndefined();
+        });
+
+        it('returns max error for mottoEng longer than 200 chars', () => {
+            const long = 'a'.repeat(COMPANY_PROFILE_VALIDATION.motto.max + 1);
+            expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateMottoEng(long)).toBe(
+                COMPANY_PROFILE_VALIDATION.motto.getMaxError(),
+            );
+        });
+    });
+
+    describe('validateSocialUrl', () => {
+        it('returns undefined for empty (optional)', () => {
+            expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateSocialUrl('')).toBeUndefined();
+        });
+
+        it('returns max error when url exceeds 500 chars', () => {
+            const long = 'a'.repeat(COMPANY_PROFILE_VALIDATION.socialUrl.max + 1);
+            expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateSocialUrl(long)).toBe(
+                COMPANY_PROFILE_VALIDATION.socialUrl.getMaxError(),
+            );
+        });
+    });
+});

--- a/src/validation/admin/company-profile-schema/company-profile-schema.test.ts
+++ b/src/validation/admin/company-profile-schema/company-profile-schema.test.ts
@@ -9,13 +9,13 @@ describe('COMPANY_PROFILE_VALIDATION_FUNCTIONS', () => {
 
         it('returns required error for empty phone', () => {
             expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validatePhone('')).toBe(
-                COMPANY_PROFILE_VALIDATION.common.getRequiredError(),
+                COMPANY_PROFILE_VALIDATION.common.REQUIRED,
             );
         });
 
         it('treats spaces as empty', () => {
             expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validatePhone('   ')).toBe(
-                COMPANY_PROFILE_VALIDATION.common.getRequiredError(),
+                COMPANY_PROFILE_VALIDATION.common.REQUIRED,
             );
         });
     });
@@ -27,7 +27,7 @@ describe('COMPANY_PROFILE_VALIDATION_FUNCTIONS', () => {
 
         it('returns required error for empty email', () => {
             expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateEmail('')).toBe(
-                COMPANY_PROFILE_VALIDATION.common.getRequiredError(),
+                COMPANY_PROFILE_VALIDATION.common.REQUIRED,
             );
         });
 
@@ -47,7 +47,7 @@ describe('COMPANY_PROFILE_VALIDATION_FUNCTIONS', () => {
 
         it('returns required error for empty correspondence email', () => {
             expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateCorrespondenceEmail('')).toBe(
-                COMPANY_PROFILE_VALIDATION.common.getRequiredError(),
+                COMPANY_PROFILE_VALIDATION.common.REQUIRED,
             );
         });
 
@@ -65,13 +65,13 @@ describe('COMPANY_PROFILE_VALIDATION_FUNCTIONS', () => {
 
         it('returns required error for empty value', () => {
             expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateCompanyRegistrationNumber('')).toBe(
-                COMPANY_PROFILE_VALIDATION.common.getRequiredError(),
+                COMPANY_PROFILE_VALIDATION.common.REQUIRED,
             );
         });
 
         it('treats spaces as empty', () => {
             expect(COMPANY_PROFILE_VALIDATION_FUNCTIONS.validateCompanyRegistrationNumber('   ')).toBe(
-                COMPANY_PROFILE_VALIDATION.common.getRequiredError(),
+                COMPANY_PROFILE_VALIDATION.common.REQUIRED,
             );
         });
 

--- a/src/validation/admin/company-profile-schema/company-profile-schema.ts
+++ b/src/validation/admin/company-profile-schema/company-profile-schema.ts
@@ -7,7 +7,7 @@ import {
 } from '@/types/admin/company-profile';
 
 const requiredTrimmed = (max?: number) => {
-    let s = Yup.string().trim().required(COMPANY_PROFILE_VALIDATION.common.getRequiredError());
+    let s = Yup.string().trim().required(COMPANY_PROFILE_VALIDATION.common.REQUIRED);
     if (typeof max === 'number') s = s.max(max);
     return s;
 };
@@ -50,7 +50,7 @@ export const CompanyProfileValidationSchema: Yup.ObjectSchema<CompanyProfileForm
 
     companyRegistrationNumber: Yup.string()
         .trim()
-        .required(COMPANY_PROFILE_VALIDATION.common.getRequiredError())
+        .required(COMPANY_PROFILE_VALIDATION.common.REQUIRED)
         .matches(/^\d*$/, COMPANY_PROFILE_VALIDATION.common.getDigitsOnlyError())
         .min(COMPANY_PROFILE_VALIDATION.edrpou.length, COMPANY_PROFILE_VALIDATION.edrpou.getMinError())
         .max(COMPANY_PROFILE_VALIDATION.edrpou.length, COMPANY_PROFILE_VALIDATION.edrpou.getMaxError()),

--- a/src/validation/admin/company-profile-schema/company-profile-schema.ts
+++ b/src/validation/admin/company-profile-schema/company-profile-schema.ts
@@ -1,0 +1,131 @@
+import * as Yup from 'yup';
+import { COMPANY_PROFILE_VALIDATION } from '@/const/admin/company-profile';
+import {
+    CompanyProfileFormValues,
+    CompanyProfileSocialContactFormValue,
+    SocialPlatform,
+} from '@/types/admin/company-profile';
+
+const requiredTrimmed = (max?: number) => {
+    let s = Yup.string().trim().required(COMPANY_PROFILE_VALIDATION.common.getRequiredError());
+    if (typeof max === 'number') s = s.max(max);
+    return s;
+};
+
+const optionalTrimmed = (max?: number) => {
+    let s = Yup.string().trim().defined();
+    if (typeof max === 'number') s = s.max(max);
+    return s;
+};
+
+const SocialContactSchema = Yup.object({
+    platform: Yup.mixed<SocialPlatform>().required(),
+    url: optionalTrimmed(COMPANY_PROFILE_VALIDATION.socialUrl.max)
+        .default('')
+        .max(COMPANY_PROFILE_VALIDATION.socialUrl.max, COMPANY_PROFILE_VALIDATION.socialUrl.getMaxError()),
+}).defined();
+
+export const CompanyProfileValidationSchema: Yup.ObjectSchema<CompanyProfileFormValues> = Yup.object({
+    phone: requiredTrimmed(COMPANY_PROFILE_VALIDATION.phone.max),
+
+    addressUa: requiredTrimmed(COMPANY_PROFILE_VALIDATION.address.max),
+    addressEng: requiredTrimmed(COMPANY_PROFILE_VALIDATION.address.max),
+
+    email: requiredTrimmed(COMPANY_PROFILE_VALIDATION.email.max).email(
+        COMPANY_PROFILE_VALIDATION.common.getEmailError(),
+    ),
+    correspondenceEmail: requiredTrimmed(COMPANY_PROFILE_VALIDATION.email.max).email(
+        COMPANY_PROFILE_VALIDATION.common.getEmailError(),
+    ),
+
+    mottoUa: optionalTrimmed(COMPANY_PROFILE_VALIDATION.motto.max)
+        .default('')
+        .max(COMPANY_PROFILE_VALIDATION.motto.max, COMPANY_PROFILE_VALIDATION.motto.getMaxError()),
+    mottoEng: optionalTrimmed(COMPANY_PROFILE_VALIDATION.motto.max)
+        .default('')
+        .max(COMPANY_PROFILE_VALIDATION.motto.max, COMPANY_PROFILE_VALIDATION.motto.getMaxError()),
+
+    requisitesUa: requiredTrimmed(COMPANY_PROFILE_VALIDATION.recipient.max),
+    requisitesEn: requiredTrimmed(COMPANY_PROFILE_VALIDATION.recipient.max),
+
+    companyRegistrationNumber: Yup.string()
+        .trim()
+        .required(COMPANY_PROFILE_VALIDATION.common.getRequiredError())
+        .matches(/^\d*$/, COMPANY_PROFILE_VALIDATION.common.getDigitsOnlyError())
+        .min(COMPANY_PROFILE_VALIDATION.edrpou.length, COMPANY_PROFILE_VALIDATION.edrpou.getMinError())
+        .max(COMPANY_PROFILE_VALIDATION.edrpou.length, COMPANY_PROFILE_VALIDATION.edrpou.getMaxError()),
+
+    addressUa_requisites: requiredTrimmed(COMPANY_PROFILE_VALIDATION.address.max),
+    addressEn_requisites: requiredTrimmed(COMPANY_PROFILE_VALIDATION.address.max),
+
+    socialContacts: Yup.array().defined().default([]).of(SocialContactSchema),
+});
+
+export const COMPANY_PROFILE_VALIDATION_FUNCTIONS = {
+    validatePhone: (value: string): string | undefined => {
+        try {
+            CompanyProfileValidationSchema.validateSyncAt('phone', { phone: value });
+            return undefined;
+        } catch (error: any) {
+            return error.message;
+        }
+    },
+
+    validateEmail: (value: string): string | undefined => {
+        try {
+            CompanyProfileValidationSchema.validateSyncAt('email', { email: value });
+            return undefined;
+        } catch (error: any) {
+            return error.message;
+        }
+    },
+
+    validateCorrespondenceEmail: (value: string): string | undefined => {
+        try {
+            CompanyProfileValidationSchema.validateSyncAt('correspondenceEmail', { correspondenceEmail: value });
+            return undefined;
+        } catch (error: any) {
+            return error.message;
+        }
+    },
+
+    validateCompanyRegistrationNumber: (value: string): string | undefined => {
+        try {
+            CompanyProfileValidationSchema.validateSyncAt('companyRegistrationNumber', {
+                companyRegistrationNumber: value,
+            });
+            return undefined;
+        } catch (error: any) {
+            return error.message;
+        }
+    },
+
+    validateMottoUa: (value: string): string | undefined => {
+        try {
+            CompanyProfileValidationSchema.validateSyncAt('mottoUa', { mottoUa: value });
+            return undefined;
+        } catch (error: any) {
+            return error.message;
+        }
+    },
+
+    validateMottoEng: (value: string): string | undefined => {
+        try {
+            CompanyProfileValidationSchema.validateSyncAt('mottoEng', { mottoEng: value });
+            return undefined;
+        } catch (error: any) {
+            return error.message;
+        }
+    },
+
+    validateSocialUrl: (value: string): string | undefined => {
+        try {
+            CompanyProfileValidationSchema.validateSyncAt('socialContacts', {
+                socialContacts: [{ platform: 'Instagram', url: value }] as CompanyProfileSocialContactFormValue[],
+            });
+            return undefined;
+        } catch (error: any) {
+            return error.message;
+        }
+    },
+};


### PR DESCRIPTION
## Github ticker

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/917

## Description

Implemented Company Profile details validation in Admin Panel for issue #917.
This PR adds real-time (on-blur) validation for Company Profile fields and prevents publishing invalid data:
- validation is triggered on blur and re-validated on change
- required fields treat whitespace-only input as empty
- email fields validate format
- motto fields validate max length (200)
- ЄДРПОУ input accepts digits only and is limited to 8 digits
- “Опублікувати” is disabled while the form is invalid

> **Note (UI/CSS):** To match the Figma mockups where the validation error message is displayed on the same row as the character counter, I applied absolute positioning for `.input-error` and the bottom counter within the Company Profile form group. This approach was chosen intentionally to avoid modifying the shared `InputWithCharacterLimit` component, since the counter is rendered inside that component while the error is rendered outside of it. Link to [mockup](https://www.figma.com/design/mZTSCb4NVC31facfhy6Gu1/Victory-Center-Admin-Panel?node-id=12861-9040&t=wljZTqiokCFH7Q7T-4)

### Scope Covered for #917

AC1: on-the-fly validation on blur / when switching focus or clicking buttons
AC2: ЄДРПОУ does not allow non-digit characters (input sanitization)
AC3: invalid fields show validation error state and messages (per mockups)
AC4: spaces-only values are treated as empty

## How it looks

https://github.com/user-attachments/assets/38e5e4c8-1799-4730-be4f-3aaf28275e76

## Summary of change

- Added validation constants/messages for Company Profile fields
- Added Yup validation schema for Company Profile form
- Connected Yup resolver to RHF form (onBlur + reValidateMode)
- Added digits-only + max-8 sanitization for ЄДРПОУ input
- Disabled Publish button when form is dirty but invalid
- Added/updated tests for validation behavior and sanitization

## How to recreate changes

1. Run app locally
2. Open Admin Panel -> Company Profile page (`/admin-panel/company-profile`)
3. Click “Редагувати сторінку”
4. Try leaving required fields empty (or spaces) -> blur -> error appears and Publish is disabled
5. Enter invalid email -> blur -> “Введіть e-mail”
6. Try typing/pasting non-digits into ЄДРПОУ -> only digits remain, max 8 chars
7. Enter valid values -> errors disappear and Publish becomes enabled (when form is dirty)


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized validation with real-time schema enforcement and user-facing error messages.
  * Phone and company registration inputs auto-sanitize to allowed characters and lengths.

* **Improvements**
  * Publish/save is disabled while the form is invalid.
  * Focus moves to the first invalid field; validation updates as fields are edited.
  * Error messages and character counters are positioned and spaced consistently.

* **Tests**
  * Added unit tests covering validators and input sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->