### PR TITLE
Feature/issue-1422: Implement validation for USD/UAH Exchange Rate

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -122,6 +122,10 @@ export const PDF_FILES_SECTION_TEXT = {
 
 export const FUNDS_EXPENDITURES_VALIDATION = {
     disclaimer: { min: 2, max: 1000 },
+    exchangeRate: {
+        maxIntegerDigits: 9,
+        maxDecimalDigits: 6,
+    },
 };
 
 export const FUNDS_EXPENDITURES_TEXT = {
@@ -172,5 +176,8 @@ export const FUNDS_EXPENDITURES_TEXT = {
         AMOUNT_ONLY_NUMBER_GT_ZERO: 'Лише число > 0',
         AMOUNT_MAX_DIGITS: "Не більше 11 цифр, 2 після ','",
         AMOUNT_NOT_NEGATIVE: "Сума не може бути від'ємною",
+        EXCHANGE_RATE_ONLY_NUMERIC: 'Дозволено тільки числові значення десяткові та цілі',
+        EXCHANGE_RATE_GT_ZERO: 'Значення має бути більше 0',
+        EXCHANGE_RATE_MAX_DIGITS: "Не більше 9 цифр, 6 після ','",
     },
 };

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -126,13 +126,12 @@ export const FUNDS_EXPENDITURES_VALIDATION = {
         maxIntegerDigits: 9,
         maxDecimalDigits: 6,
     },
+    maxCategoriesPerType: 4,
 };
 
 export const FUNDS_EXPENDITURES_TEXT = {
     DISCLAIMER_LABEL: 'Дісклеймер/ENG',
     EXCHANGE_RATE_LABEL: 'Курс USD/UAH',
-    EXCHANGE_RATE_MAX_LENGTH: 10,
-    MAX_CATEGORIES_PER_TYPE: 4,
     BUTTON: {
         EDIT: 'Редагувати Доходи та витрати',
         CANCEL: 'Відмінити',

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -187,8 +187,8 @@ export const FundsExpenditureSection = () => {
         });
     }, [enrichedRecords, selectedType, selectedCategoryId]);
 
-    const isAddIncomeDisabled = summary.incomeCategories >= FUNDS_EXPENDITURES_TEXT.MAX_CATEGORIES_PER_TYPE;
-    const isAddExpenseDisabled = summary.expenseCategories >= FUNDS_EXPENDITURES_TEXT.MAX_CATEGORIES_PER_TYPE;
+    const isAddIncomeDisabled = summary.incomeCategories >= FUNDS_EXPENDITURES_VALIDATION.maxCategoriesPerType;
+    const isAddExpenseDisabled = summary.expenseCategories >= FUNDS_EXPENDITURES_VALIDATION.maxCategoriesPerType;
 
     const currentExchangeRate = isEditing ? exchangeRateValue : (settings?.exchangeRate ?? null);
 

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -2,6 +2,10 @@ import { useState, useMemo, useCallback, useEffect } from 'react';
 import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION, REPORTS_TEXT } from '@/const/admin/reports';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS } from '@/validation/admin/reports-schema/funds-expenditures-disclaimer-schema/funds-expenditures-disclaimer-schema';
+import {
+    normalizeFundsExpendituresExchangeRateInput,
+    validateFundsExpendituresExchangeRate,
+} from '@/validation/admin/reports-schema/funds-expenditures-exchange-rate-schema/funds-expenditures-exchange-rate-schema';
 import { Button } from '@/components/admin/button/Button';
 import { ACTION_ICONS } from '@/const/common/action-icons';
 import { FundsExpendituresApi } from '@/services/api/admin/reports/funds-expenditures-api';
@@ -45,6 +49,7 @@ export const FundsExpenditureSection = () => {
     const [disclaimerValue, setDisclaimerValue] = useState('');
     const [disclaimerError, setDisclaimerError] = useState<string | undefined>(undefined);
     const [exchangeRateValue, setExchangeRateValue] = useState('');
+    const [exchangeRateError, setExchangeRateError] = useState<string | undefined>(undefined);
 
     const [selectedType, setSelectedType] = useState<TypeFilterValue>(undefined);
     const [selectedCategoryId, setSelectedCategoryId] = useState<CategoryFilterValue>(undefined);
@@ -55,6 +60,7 @@ export const FundsExpenditureSection = () => {
     const handleCancel = useCallback(() => {
         setIsEditing(false);
         setDisclaimerError(undefined);
+        setExchangeRateError(undefined);
     }, []);
 
     const handleDisclaimerChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -67,6 +73,18 @@ export const FundsExpenditureSection = () => {
         setDisclaimerValue(trimmed);
         setDisclaimerError(FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer(trimmed));
     }, [disclaimerValue]);
+
+    const handleExchangeRateChange = useCallback((value: string) => {
+        const normalized = normalizeFundsExpendituresExchangeRateInput(value);
+        setExchangeRateValue(normalized);
+        setExchangeRateError(validateFundsExpendituresExchangeRate(normalized, 'change'));
+    }, []);
+
+    const handleExchangeRateBlur = useCallback(() => {
+        const normalized = normalizeFundsExpendituresExchangeRateInput(exchangeRateValue, true);
+        setExchangeRateValue(normalized);
+        setExchangeRateError(validateFundsExpendituresExchangeRate(normalized, 'blur'));
+    }, [exchangeRateValue]);
 
     const handleTypeChange = useCallback((type: TypeFilterValue) => {
         setSelectedType(type);
@@ -136,14 +154,21 @@ export const FundsExpenditureSection = () => {
 
     const isPublishEnabled = useMemo(() => {
         const normalized = disclaimerValue.replaceAll(/\s+/g, ' ').trim();
-        return normalized.length >= FUNDS_EXPENDITURES_VALIDATION.disclaimer.min && !disclaimerError;
-    }, [disclaimerValue, disclaimerError]);
+        const exchangeRateValidationError = validateFundsExpendituresExchangeRate(exchangeRateValue, 'blur');
+
+        return (
+            normalized.length >= FUNDS_EXPENDITURES_VALIDATION.disclaimer.min &&
+            !disclaimerError &&
+            !exchangeRateValidationError
+        );
+    }, [disclaimerValue, disclaimerError, exchangeRateValue]);
 
     useEffect(() => {
         if (!isEditing) {
             setDisclaimerValue(settings?.disclaimerTitle ?? '');
             setExchangeRateValue(settings?.exchangeRate ?? '');
             setDisclaimerError(undefined);
+            setExchangeRateError(undefined);
         }
     }, [settings, isEditing]);
 
@@ -303,7 +328,9 @@ export const FundsExpenditureSection = () => {
                 isAddExpenseDisabled={isAddExpenseDisabled}
                 onTypeChange={handleTypeChange}
                 onCategoryChange={setSelectedCategoryId}
-                onExchangeRateChange={setExchangeRateValue}
+                onExchangeRateChange={handleExchangeRateChange}
+                onExchangeRateBlur={handleExchangeRateBlur}
+                exchangeRateError={exchangeRateError}
                 onAddIncome={() => {}}
                 onAddExpense={() => {}}
             />

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -90,7 +90,11 @@ export const FundsExpenditureSection = () => {
         [adminClient],
     );
 
-    const { data: settings, isLoading: isSettingsLoading } = useDataFetch<ReportFundsExpendituresSettings | null>({
+    const {
+        data: settings,
+        isLoading: isSettingsLoading,
+        refetch: refetchSettings,
+    } = useDataFetch<ReportFundsExpendituresSettings | null>({
         initialData: null,
         fetchHandler: fetchSettings,
     });
@@ -204,11 +208,14 @@ export const FundsExpenditureSection = () => {
             setDisclaimerValue(updatedSettings.disclaimerTitle ?? '');
             setExchangeRateValue(updatedSettings.exchangeRate ?? '');
             setIsEditing(false);
+
+            refetchSettings();
+
             addToast(COMMON_TEXT_ADMIN.MESSAGE.SUCCESSFULLY_PUBLISHED, ToastType.Success);
         } catch {
             addToast(REPORTS_TEXT.MESSAGE.FAIL_TO_UPDATE_REPORT, ToastType.Error);
         }
-    }, [addToast, adminClient, disclaimerValue, exchangeRateValue]);
+    }, [addToast, adminClient, disclaimerValue, exchangeRateValue, refetchSettings]);
 
     if (isInitialLoading) {
         return (

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -163,6 +163,8 @@ export const FundsExpenditureSection = () => {
         );
     }, [disclaimerValue, disclaimerError, exchangeRateValue]);
 
+    const hasExchangeRateError = Boolean(exchangeRateError);
+
     useEffect(() => {
         if (!isEditing) {
             setDisclaimerValue(settings?.disclaimerTitle ?? '');
@@ -187,8 +189,10 @@ export const FundsExpenditureSection = () => {
         });
     }, [enrichedRecords, selectedType, selectedCategoryId]);
 
-    const isAddIncomeDisabled = summary.incomeCategories >= FUNDS_EXPENDITURES_VALIDATION.maxCategoriesPerType;
-    const isAddExpenseDisabled = summary.expenseCategories >= FUNDS_EXPENDITURES_VALIDATION.maxCategoriesPerType;
+    const isAddIncomeDisabled =
+        summary.incomeCategories >= FUNDS_EXPENDITURES_VALIDATION.maxCategoriesPerType || hasExchangeRateError;
+    const isAddExpenseDisabled =
+        summary.expenseCategories >= FUNDS_EXPENDITURES_VALIDATION.maxCategoriesPerType || hasExchangeRateError;
 
     const currentExchangeRate = isEditing ? exchangeRateValue : (settings?.exchangeRate ?? null);
 
@@ -341,6 +345,7 @@ export const FundsExpenditureSection = () => {
                 exchangeRate={currentExchangeRate}
                 allRecordsForTypeInference={recordsState}
                 isEditing={isEditing}
+                isRowActionsDisabled={hasExchangeRateError}
                 onRowEditModeChange={setIsRowEditMode}
                 onRecordSave={handleRecordSave}
             />

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
@@ -350,6 +350,15 @@ describe('FundsExpendituresTable', () => {
     });
 
     describe('row category editing', () => {
+        it('should disable edit and delete actions when isRowActionsDisabled is true', () => {
+            renderTable({ isEditing: true, isRowActionsDisabled: true });
+
+            expect(screen.getByLabelText('Edit record 1')).toBeDisabled();
+            expect(screen.getByLabelText('Delete record 1')).toBeDisabled();
+            expect(screen.getByLabelText('Edit record 2')).toBeDisabled();
+            expect(screen.getByLabelText('Delete record 2')).toBeDisabled();
+        });
+
         it('should switch row actions to accept and close icons when row enters edit mode', () => {
             renderTable({ isEditing: true });
 

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
@@ -42,6 +42,7 @@ interface FundsExpendituresTableProps {
     exchangeRate?: string | null;
     allRecordsForTypeInference?: ReportFundsExpendituresRecord[];
     isEditing?: boolean;
+    isRowActionsDisabled?: boolean;
     onRowEditModeChange?: (isEditMode: boolean) => void;
     onRecordSave?: (
         recordId: number,
@@ -140,6 +141,7 @@ export const FundsExpendituresTable = ({
     exchangeRate,
     allRecordsForTypeInference,
     isEditing = false,
+    isRowActionsDisabled = false,
     onRowEditModeChange,
     onRecordSave,
 }: FundsExpendituresTableProps) => {
@@ -207,7 +209,7 @@ export const FundsExpendituresTable = ({
 
     const handleStartRowEdit = useCallback(
         (record: EnrichedRecord) => {
-            if (rowEditState) {
+            if (rowEditState || isRowActionsDisabled) {
                 return;
             }
 
@@ -222,7 +224,7 @@ export const FundsExpendituresTable = ({
                 errors: {},
             });
         },
-        [rowEditState, setRowEditMode],
+        [isRowActionsDisabled, rowEditState, setRowEditMode],
     );
 
     const handleCloseRowEdit = useCallback(() => {
@@ -544,7 +546,8 @@ export const FundsExpendituresTable = ({
                         ) : (
                             sortedRecords.map((record) => {
                                 const isEditedRow = rowEditState?.recordId === record.id;
-                                const isAnotherRowEditing = (isAnyRowEditing && !isEditedRow) || isSavingInProgress;
+                                const isAnotherRowEditing =
+                                    (isAnyRowEditing && !isEditedRow) || isSavingInProgress || isRowActionsDisabled;
                                 const isSavingCurrentRow = savingRecordId === record.id;
                                 const editableCategories = categoriesByType[record.type];
                                 const isAcceptDisabled = !isEditedRow || isAcceptButtonDisabled(rowEditState);

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
@@ -36,6 +36,16 @@
     gap: 12px;
 }
 
+.exchange-rate-field {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    inline-size: 150px;
+    overflow-wrap: break-word;
+    text-align: center;
+    gap: 4px;
+}
+
 .exchange-rate-label {
     @include type.subtitle-2-medium;
     color: c.$bluish-black;
@@ -85,6 +95,16 @@
         opacity: 1;
         -webkit-text-fill-color: c.$blue-900;
     }
+}
+
+.exchange-rate-input-error {
+    border-color: c.$error;
+}
+
+.exchange-rate-error {
+    @include type.small-text-regular;
+    color: c.$error;
+    margin: 0;
 }
 
 .exchange-rate-input-disabled {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
@@ -104,7 +104,6 @@
 .exchange-rate-error {
     @include type.small-text-regular;
     color: c.$error;
-    margin: 0;
 }
 
 .exchange-rate-input-disabled {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.test.tsx
@@ -219,5 +219,12 @@ describe('FundsExpendituresToolbar', () => {
             fireEvent.change(input, { target: { value: '50.00' } });
             expect(onExchangeRateChange).toHaveBeenCalledWith('50.00');
         });
+
+        it('should show exchange rate validation error when provided', () => {
+            const errorMessage = FUNDS_EXPENDITURES_TEXT.VALIDATION.EXCHANGE_RATE_ONLY_NUMERIC;
+            render(<FundsExpendituresToolbar {...defaultProps} isEditing={true} exchangeRateError={errorMessage} />);
+
+            expect(screen.getByTestId('exchange-rate-error')).toHaveTextContent(errorMessage);
+        });
     });
 });

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.tsx
@@ -21,6 +21,8 @@ interface FundsExpendituresToolbarProps {
     onTypeChange: (value: TypeFilterValue) => void;
     onCategoryChange: (value: CategoryFilterValue) => void;
     onExchangeRateChange?: (value: string) => void;
+    onExchangeRateBlur?: () => void;
+    exchangeRateError?: string;
     onAddIncome: () => void;
     onAddExpense: () => void;
 }
@@ -37,6 +39,8 @@ export const FundsExpendituresToolbar = ({
     onTypeChange,
     onCategoryChange,
     onExchangeRateChange,
+    onExchangeRateBlur,
+    exchangeRateError,
     onAddIncome,
     onAddExpense,
 }: FundsExpendituresToolbarProps) => {
@@ -89,17 +93,26 @@ export const FundsExpendituresToolbar = ({
                                 {FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL}
                             </span>
                             {isEditing ? (
-                                <input
-                                    type="text"
-                                    data-testid="exchange-rate-input"
-                                    className={cn(styles['exchange-rate-input'], {
-                                        [styles['exchange-rate-input-disabled']]: controlsDisabled,
-                                    })}
-                                    value={exchangeRate}
-                                    maxLength={FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_MAX_LENGTH}
-                                    disabled={controlsDisabled}
-                                    onChange={(e) => onExchangeRateChange?.(e.target.value)}
-                                />
+                                <div className={styles['exchange-rate-field']}>
+                                    <input
+                                        type="text"
+                                        data-testid="exchange-rate-input"
+                                        className={cn(styles['exchange-rate-input'], {
+                                            [styles['exchange-rate-input-disabled']]: controlsDisabled,
+                                            [styles['exchange-rate-input-error']]: Boolean(exchangeRateError),
+                                        })}
+                                        value={exchangeRate}
+                                        maxLength={FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_MAX_LENGTH}
+                                        disabled={controlsDisabled}
+                                        onChange={(e) => onExchangeRateChange?.(e.target.value)}
+                                        onBlur={onExchangeRateBlur}
+                                    />
+                                    {exchangeRateError && (
+                                        <p className={styles['exchange-rate-error']} data-testid="exchange-rate-error">
+                                            {exchangeRateError}
+                                        </p>
+                                    )}
+                                </div>
                             ) : (
                                 <span className={styles['exchange-rate-value']} data-testid="exchange-rate">
                                     {exchangeRate}

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.tsx
@@ -102,7 +102,6 @@ export const FundsExpendituresToolbar = ({
                                             [styles['exchange-rate-input-error']]: Boolean(exchangeRateError),
                                         })}
                                         value={exchangeRate}
-                                        maxLength={FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_MAX_LENGTH}
                                         disabled={controlsDisabled}
                                         onChange={(e) => onExchangeRateChange?.(e.target.value)}
                                         onBlur={onExchangeRateBlur}

--- a/src/validation/admin/reports-schema/funds-expenditures-exchange-rate-schema/funds-expenditures-exchange-rate-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-exchange-rate-schema/funds-expenditures-exchange-rate-schema.test.ts
@@ -1,0 +1,68 @@
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import {
+    normalizeFundsExpendituresExchangeRateInput,
+    validateFundsExpendituresExchangeRate,
+} from './funds-expenditures-exchange-rate-schema';
+
+describe('funds-expenditures-exchange-rate-schema', () => {
+    describe('normalizeFundsExpendituresExchangeRateInput', () => {
+        it('removes spaces from input', () => {
+            expect(normalizeFundsExpendituresExchangeRateInput(' 4 2. 1 2 ')).toBe('42.12');
+        });
+
+        it('trims value when trimEnd is true', () => {
+            expect(normalizeFundsExpendituresExchangeRateInput(' 42.12 ', true)).toBe('42.12');
+        });
+    });
+
+    describe('validateFundsExpendituresExchangeRate', () => {
+        it('returns required on blur for empty value', () => {
+            expect(validateFundsExpendituresExchangeRate('', 'blur')).toBe(
+                COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED,
+            );
+        });
+
+        it('does not return required on change for empty value', () => {
+            expect(validateFundsExpendituresExchangeRate('', 'change')).toBeUndefined();
+        });
+
+        it('returns numeric validation for non-numeric value', () => {
+            expect(validateFundsExpendituresExchangeRate('abc')).toBe(
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.EXCHANGE_RATE_ONLY_NUMERIC,
+            );
+        });
+
+        it('returns gt-zero validation for zero', () => {
+            expect(validateFundsExpendituresExchangeRate('0')).toBe(
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.EXCHANGE_RATE_GT_ZERO,
+            );
+        });
+
+        it('returns gt-zero validation for negative value', () => {
+            expect(validateFundsExpendituresExchangeRate('-1')).toBe(
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.EXCHANGE_RATE_ONLY_NUMERIC,
+            );
+        });
+
+        it('returns max-digits validation for too many integer digits', () => {
+            expect(validateFundsExpendituresExchangeRate('1234567890')).toBe(
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.EXCHANGE_RATE_MAX_DIGITS,
+            );
+        });
+
+        it('returns max-digits validation for too many decimal digits', () => {
+            expect(validateFundsExpendituresExchangeRate('1.1234567')).toBe(
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.EXCHANGE_RATE_MAX_DIGITS,
+            );
+        });
+
+        it('accepts valid decimal value', () => {
+            expect(validateFundsExpendituresExchangeRate('42.123456')).toBeUndefined();
+        });
+
+        it('accepts valid integer value', () => {
+            expect(validateFundsExpendituresExchangeRate('42')).toBeUndefined();
+        });
+    });
+});

--- a/src/validation/admin/reports-schema/funds-expenditures-exchange-rate-schema/funds-expenditures-exchange-rate-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-exchange-rate-schema/funds-expenditures-exchange-rate-schema.ts
@@ -1,0 +1,39 @@
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+
+export type ExchangeRateValidationTrigger = 'change' | 'blur';
+
+export const normalizeFundsExpendituresExchangeRateInput = (value: string, trimEnd = false): string => {
+    const withoutSpaces = value.replaceAll(/\s+/g, '').trimStart();
+    return trimEnd ? withoutSpaces.trim() : withoutSpaces;
+};
+
+export const validateFundsExpendituresExchangeRate = (
+    value: string,
+    trigger: ExchangeRateValidationTrigger = 'change',
+): string | undefined => {
+    const normalized = normalizeFundsExpendituresExchangeRateInput(value, true);
+
+    if (!normalized) {
+        return trigger === 'blur' ? COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED : undefined;
+    }
+
+    if (!/^\d+(?:[.,]\d+)?$/.test(normalized)) {
+        return FUNDS_EXPENDITURES_TEXT.VALIDATION.EXCHANGE_RATE_ONLY_NUMERIC;
+    }
+
+    const [integerPart, decimalPart = ''] = normalized.split(/[.,]/);
+    if (
+        integerPart.length > FUNDS_EXPENDITURES_VALIDATION.exchangeRate.maxIntegerDigits ||
+        decimalPart.length > FUNDS_EXPENDITURES_VALIDATION.exchangeRate.maxDecimalDigits
+    ) {
+        return FUNDS_EXPENDITURES_TEXT.VALIDATION.EXCHANGE_RATE_MAX_DIGITS;
+    }
+
+    const parsed = Number.parseFloat(normalized.replace(',', '.'));
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        return FUNDS_EXPENDITURES_TEXT.VALIDATION.EXCHANGE_RATE_GT_ZERO;
+    }
+
+    return undefined;
+};


### PR DESCRIPTION
## Github ticker

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1422

## Description

Added validation for the global USD/UAH exchange rate in Reports -> “Доходи та витрати” edit mode, with inline error messages.

## How it looks


https://github.com/user-attachments/assets/fa02530a-5632-4610-bbb7-ebb1647fd34c


## Summary of change

1. Added exchange rate validation rules: numeric only, value > 0, required on blur, max 9 integer digits and 6 decimals.
2. Added validation messages.

## How to recreate changes

1. Open Admin panel -> Reports -> “Доходи та витрати”.
3. Click Edit.
4. In “Курс USD/UAH”, enter invalid values like abc, 0, or clear the field and blur.
5. Confirm error message appears and Publish is disabled.
6. Enter a valid value like 42.123456 and confirm error disappears and Publish becomes available.

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [x]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced exchange-rate input: normalization, stricter validation (9 integer / 6 decimal digits) and inline error display.
  * Table/toolbar updated to surface exchange-rate state and disable row actions when invalid.

* **Bug Fixes**
  * Enforced category limit (max 4 per type) and prevent adding categories while exchange-rate has errors.
  * Settings now refresh after publishing funds expenditure updates.

* **Tests**
  * Added unit and UI tests covering exchange-rate validation and disabled row actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->