### PR TITLE
Fix/issue-1929:  Disable “Add block” for SingleTitleDescriptionAuthorPairs until fields are valid

### DIFF
--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.test.tsx
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.test.tsx
@@ -23,6 +23,14 @@ jest.mock('@/utils/functions/program-section-template-validation/programSectionT
     normalizeGroupedContentsGroupIndexes: jest.fn(),
 }));
 
+jest.mock('@/validation/admin/program-schema/program-schema', () => ({
+    PROGRAM_SECTION_VALIDATION_FUNCTIONS: {
+        validateContentText: jest.fn(),
+        validateFaqQuestion: jest.fn(),
+        validateFaqAnswer: jest.fn(),
+    },
+}));
+
 const renderProgramSectionMock = renderProgramSection as unknown as jest.Mock;
 
 const getTemplateValidationMocks = () => {
@@ -37,6 +45,18 @@ const getTemplateValidationMocks = () => {
         getProgramSectionTemplateMaxGroupCount: mod.getProgramSectionTemplateMaxGroupCount,
         normalizeGroupedContentsGroupIndexes: mod.normalizeGroupedContentsGroupIndexes,
     };
+};
+
+const getProgramValidationMocks = () => {
+    const mod = jest.requireMock('@/validation/admin/program-schema/program-schema') as {
+        PROGRAM_SECTION_VALIDATION_FUNCTIONS: {
+            validateContentText: jest.Mock;
+            validateFaqQuestion: jest.Mock;
+            validateFaqAnswer: jest.Mock;
+        };
+    };
+
+    return mod.PROGRAM_SECTION_VALIDATION_FUNCTIONS;
 };
 
 const makeImage = (id: string, url?: string): any => (url ? { id, url, mimeType: 'image/png' } : { id });
@@ -150,11 +170,18 @@ describe('ProgramSectionForm', () => {
 
         const { getProgramSectionTemplateMaxGroupCount, normalizeGroupedContentsGroupIndexes } =
             getTemplateValidationMocks();
+        const { validateContentText, validateFaqQuestion, validateFaqAnswer } = getProgramValidationMocks();
 
         getProgramSectionTemplateMaxGroupCount.mockReset();
         normalizeGroupedContentsGroupIndexes.mockReset();
+        validateContentText.mockReset();
+        validateFaqQuestion.mockReset();
+        validateFaqAnswer.mockReset();
 
         getProgramSectionTemplateMaxGroupCount.mockReturnValue(10);
+        validateContentText.mockReturnValue(undefined);
+        validateFaqQuestion.mockReturnValue(undefined);
+        validateFaqAnswer.mockReturnValue(undefined);
 
         normalizeGroupedContentsGroupIndexes.mockImplementation((contents: any[], types: ContentType[]) => {
             const allowed = new Set<number>(types as any);
@@ -440,6 +467,117 @@ describe('ProgramSectionForm', () => {
             expect(payload.handlers.onDeletePair).toEqual(expect.any(Function));
             expect(payload.handlers.onCardDescriptionChange).toEqual(expect.any(Function));
             expect(payload.handlers.onCardAuthorChange).toEqual(expect.any(Function));
+        });
+
+        it('passes canAddPair=true when title and pair fields are valid', () => {
+            const section = makePairsSection([
+                makeTitleContent('T', 0),
+                makePairDescription(1, 0, 'D0'),
+                makePairAuthor(2, 0, 'A0'),
+            ]);
+
+            renderForm({ section, isNewSection: true });
+
+            const payload = renderProgramSectionMock.mock.calls[0][0];
+
+            expect(payload.handlers.canAddPair).toBe(true);
+            expect(getProgramValidationMocks().validateContentText).toHaveBeenNthCalledWith(
+                1,
+                'T',
+                ContentType.Title,
+                true,
+                ProgramSectionTemplate.SingleTitleDescriptionAuthorPairs,
+            );
+            expect(getProgramValidationMocks().validateContentText).toHaveBeenNthCalledWith(
+                2,
+                'D0',
+                ContentType.Description,
+                true,
+                ProgramSectionTemplate.SingleTitleDescriptionAuthorPairs,
+            );
+            expect(getProgramValidationMocks().validateContentText).toHaveBeenNthCalledWith(
+                3,
+                'A0',
+                ContentType.Author,
+                true,
+                ProgramSectionTemplate.SingleTitleDescriptionAuthorPairs,
+            );
+        });
+
+        it('passes canAddPair=false when title is invalid', () => {
+            const section = makePairsSection([
+                makeTitleContent('T', 0),
+                makePairDescription(1, 0, 'D0'),
+                makePairAuthor(2, 0, 'A0'),
+            ]);
+
+            getProgramValidationMocks().validateContentText.mockImplementation((value: string, type: ContentType) =>
+                type === ContentType.Title && value === 'T' ? 'TITLE_ERROR' : undefined,
+            );
+
+            renderForm({ section, isNewSection: true });
+
+            const payload = renderProgramSectionMock.mock.calls[0][0];
+
+            expect(payload.handlers.canAddPair).toBe(false);
+            expect(getProgramValidationMocks().validateContentText).toHaveBeenCalledTimes(1);
+        });
+
+        it('passes canAddPair=false when pair description is invalid', () => {
+            const section = makePairsSection([
+                makeTitleContent('T', 0),
+                makePairDescription(1, 0, 'BAD_DESC'),
+                makePairAuthor(2, 0, 'A0'),
+            ]);
+
+            getProgramValidationMocks().validateContentText.mockImplementation((value: string, type: ContentType) =>
+                type === ContentType.Description && value === 'BAD_DESC' ? 'DESCRIPTION_ERROR' : undefined,
+            );
+
+            renderForm({ section, isNewSection: true });
+
+            const payload = renderProgramSectionMock.mock.calls[0][0];
+
+            expect(payload.handlers.canAddPair).toBe(false);
+            expect(getProgramValidationMocks().validateContentText).toHaveBeenCalledTimes(2);
+        });
+
+        it('passes canAddPair=false when pair author is invalid', () => {
+            const section = makePairsSection([
+                makeTitleContent('T', 0),
+                makePairDescription(1, 0, 'D0'),
+                makePairAuthor(2, 0, 'BAD_AUTHOR'),
+            ]);
+
+            getProgramValidationMocks().validateContentText.mockImplementation((value: string, type: ContentType) =>
+                type === ContentType.Author && value === 'BAD_AUTHOR' ? 'AUTHOR_ERROR' : undefined,
+            );
+
+            renderForm({ section, isNewSection: true });
+
+            const payload = renderProgramSectionMock.mock.calls[0][0];
+
+            expect(payload.handlers.canAddPair).toBe(false);
+            expect(getProgramValidationMocks().validateContentText).toHaveBeenCalledTimes(3);
+        });
+
+        it('skips text validation for canAddPair when max pairs count is reached', () => {
+            const section = makePairsSection([
+                makeTitleContent('T', 0),
+                makePairDescription(1, 0, 'D0'),
+                makePairAuthor(2, 0, 'A0'),
+                makePairDescription(3, 1, 'D1'),
+                makePairAuthor(4, 1, 'A1'),
+            ]);
+
+            getTemplateValidationMocks().getProgramSectionTemplateMaxGroupCount.mockReturnValue(2);
+
+            renderForm({ section, isNewSection: true });
+
+            const payload = renderProgramSectionMock.mock.calls[0][0];
+
+            expect(payload.handlers.canAddPair).toBe(false);
+            expect(getProgramValidationMocks().validateContentText).not.toHaveBeenCalled();
         });
 
         it('updates pair description when onCardDescriptionChange is invoked', () => {

--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
@@ -315,7 +315,19 @@ export const ProgramSectionForm = ({
     const pairsMaxCount = isDescriptionAuthorPairsTemplate
         ? getProgramSectionTemplateMaxGroupCount(section.template)
         : 0;
-    const canAddPair = isDescriptionAuthorPairsTemplate ? orderedPairs.length < pairsMaxCount : true;
+
+    const validateDescriptionAuthorPairContent = (value: string, type: ContentType) =>
+        PROGRAM_SECTION_VALIDATION_FUNCTIONS.validateContentText(value, type, true, section.template);
+
+    const canAddPair =
+        !isDescriptionAuthorPairsTemplate ||
+        (orderedPairs.length < pairsMaxCount &&
+            !validateDescriptionAuthorPairContent((titleContent as any)?.title || '', ContentType.Title) &&
+            orderedPairs.every(
+                (pair) =>
+                    !validateDescriptionAuthorPairContent(pair.description, ContentType.Description) &&
+                    !validateDescriptionAuthorPairContent(pair.author, ContentType.Author),
+            ));
 
     const handleAddPair = useCallback(() => {
         const prev = localSectionRef.current;


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1929

## Description

Disable the “Add block” button in the SingleTitleDescriptionAuthorPairs program section until Title, Description, and Author fields are valid (and the max pairs limit isn’t reached).

## How it looks

<img width="1474" height="833" alt="image" src="https://github.com/user-attachments/assets/a8402695-68f5-4b92-b402-cbcb93128558" />
<img width="1458" height="927" alt="image" src="https://github.com/user-attachments/assets/6cfeadbd-435c-4a74-9894-052c037ea344" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for description-author pairs to ensure title content and existing pair descriptions are valid before allowing new pairs to be added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->