### PR TITLE
fix/issue-1880: The system does not display a validation message when the input in the 'Description' field is less than 10 characters 

### DIFF
--- a/src/pages/admin/company-profile/components/company-profile-logo-header/CompanyProfileLogoHeader.module.scss
+++ b/src/pages/admin/company-profile/components/company-profile-logo-header/CompanyProfileLogoHeader.module.scss
@@ -72,11 +72,19 @@
 }
 
 @media (max-height: 950px) {
-  .company-logo-section { width: 165px; }
-  .company-logo-wrapper { height: 138px; }
+    .company-logo-section {
+        width: 165px;
+    }
+    .company-logo-wrapper {
+        height: 138px;
+    }
 }
 
 @media (max-height: 820px) {
-  .company-logo-section { width: 145px; }
-  .company-logo-wrapper { height: 120px; }
+    .company-logo-section {
+        width: 145px;
+    }
+    .company-logo-wrapper {
+        height: 120px;
+    }
 }

--- a/src/pages/admin/company-profile/components/company-profile-social-media-tab/CompanyProfileSocialMediaTab.module.scss
+++ b/src/pages/admin/company-profile/components/company-profile-social-media-tab/CompanyProfileSocialMediaTab.module.scss
@@ -66,9 +66,9 @@
 }
 
 .social-media-contact-icon-btn {
-  width: 24px;
-  height: 24px;
-  padding: 0;
-  border: none;
-  background: transparent;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: none;
+    background: transparent;
 }

--- a/src/validation/admin/program-schema/program-schema.test.ts
+++ b/src/validation/admin/program-schema/program-schema.test.ts
@@ -750,6 +750,21 @@ describe('PROGRAM_VALIDATION_FUNCTIONS', () => {
             const longDesc = 'a'.repeat(51);
             expect(m.PROGRAM_VALIDATION_FUNCTIONS.validateDescription(longDesc, false)).toBe('max 50');
         });
+
+        it('returns error when description is less than min length in draft mode', () => {
+            const m = loadSchema({ programValidation: { description: { min: 3, max: 50, getRequiredWhenPublishingError: () => 'desc required' } } });
+            expect(m.PROGRAM_VALIDATION_FUNCTIONS.validateDescription('ab', false)).toBe('min 3');
+        });
+
+        it('returns error when description is less than min length when publishing', () => {
+            const m = loadSchema({ programValidation: { description: { min: 3, max: 50, getRequiredWhenPublishingError: () => 'desc required' } } });
+            expect(m.PROGRAM_VALIDATION_FUNCTIONS.validateDescription('ab', true)).toBe('min 3');
+        });
+
+        it('returns undefined for empty description in draft mode (even with min requirement)', () => {
+            const m = loadSchema({ programValidation: { description: { min: 3, max: 50, getRequiredWhenPublishingError: () => 'desc required' } } });
+            expect(m.PROGRAM_VALIDATION_FUNCTIONS.validateDescription('', false)).toBeUndefined();
+        });
     });
 
     describe('validatePreviewImage', () => {

--- a/src/validation/admin/program-schema/program-schema.test.ts
+++ b/src/validation/admin/program-schema/program-schema.test.ts
@@ -752,17 +752,29 @@ describe('PROGRAM_VALIDATION_FUNCTIONS', () => {
         });
 
         it('returns error when description is less than min length in draft mode', () => {
-            const m = loadSchema({ programValidation: { description: { min: 3, max: 50, getRequiredWhenPublishingError: () => 'desc required' } } });
+            const m = loadSchema({
+                programValidation: {
+                    description: { min: 3, max: 50, getRequiredWhenPublishingError: () => 'desc required' },
+                },
+            });
             expect(m.PROGRAM_VALIDATION_FUNCTIONS.validateDescription('ab', false)).toBe('min 3');
         });
 
         it('returns error when description is less than min length when publishing', () => {
-            const m = loadSchema({ programValidation: { description: { min: 3, max: 50, getRequiredWhenPublishingError: () => 'desc required' } } });
+            const m = loadSchema({
+                programValidation: {
+                    description: { min: 3, max: 50, getRequiredWhenPublishingError: () => 'desc required' },
+                },
+            });
             expect(m.PROGRAM_VALIDATION_FUNCTIONS.validateDescription('ab', true)).toBe('min 3');
         });
 
         it('returns undefined for empty description in draft mode (even with min requirement)', () => {
-            const m = loadSchema({ programValidation: { description: { min: 3, max: 50, getRequiredWhenPublishingError: () => 'desc required' } } });
+            const m = loadSchema({
+                programValidation: {
+                    description: { min: 3, max: 50, getRequiredWhenPublishingError: () => 'desc required' },
+                },
+            });
             expect(m.PROGRAM_VALIDATION_FUNCTIONS.validateDescription('', false)).toBeUndefined();
         });
     });

--- a/src/validation/admin/program-schema/program-schema.ts
+++ b/src/validation/admin/program-schema/program-schema.ts
@@ -115,14 +115,16 @@ export const programValidationSchema = Yup.object({
             PROGRAM_VALIDATION.description.max,
             COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(PROGRAM_VALIDATION.description.max),
         )
+        .test(
+            'min-length-if-not-empty',
+            COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(PROGRAM_VALIDATION.description.min),
+            (value) => {
+                return !value || value.length >= PROGRAM_VALIDATION.description.min;
+            },
+        )
         .when('$isPublishing', ([isPublishing], schema) =>
             isPublishing
-                ? schema
-                      .required(PROGRAM_VALIDATION.description.getRequiredWhenPublishingError())
-                      .min(
-                          PROGRAM_VALIDATION.description.min,
-                          COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(PROGRAM_VALIDATION.description.min),
-                      )
+                ? schema.required(PROGRAM_VALIDATION.description.getRequiredWhenPublishingError())
                 : schema.notRequired(),
         ),
 


### PR DESCRIPTION
## Github ticker

* [1880](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1880)

## Description

The system does not display a validation message when the input in the 'Опис' field is less than 10 characters while editing the program brief description

## How it looks

https://github.com/user-attachments/assets/14108edc-4c64-403c-b278-3248d97e7e36

## Summary of change

Change program validation schema to fix bug

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure description minimum-length rules are enforced consistently for non-empty values while allowing empty drafts.

* **Tests**
  * Added unit tests covering description validation across draft and publish scenarios.

* **Style**
  * Consistent formatting applied to stylesheet files for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->