### PR TITLE
Fix/issue 1874: [Who we are] Publish button incorrectly enabled after applying markup to a whitespace character

### DIFF
--- a/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.tsx
+++ b/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.tsx
@@ -103,8 +103,10 @@ export const WhoWeAreContent = () => {
 
     const isPublishButtonActive = useMemo(() => {
         if (!selectedSection || !updatedSection) return false;
-        return JSON.stringify(selectedSection) !== JSON.stringify(updatedSection);
-    }, [selectedSection, updatedSection]);
+        const normalizedSelectedSectionString = JSON.stringify(normalizeSection(selectedSection));
+        const normalizedUpdatedSectionString = JSON.stringify(normalizeSection(updatedSection));
+        return normalizedSelectedSectionString !== normalizedUpdatedSectionString;
+    }, [selectedSection, updatedSection, normalizeSection]);
 
     const setErrorState = useCallback((message: string, type: 'categories' | 'entity' | 'languages') => {
         if (type === 'languages') {

--- a/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.tsx
+++ b/src/pages/admin/who-we-are/components/who-we-are-content/WhoWeAreContent.tsx
@@ -173,7 +173,9 @@ export const WhoWeAreContent = () => {
     const handlePublishChange = useCallback(async () => {
         if (!selectedSection || !updatedSection) return;
 
-        const changedContents = updatedSection.contents.filter((updatedItem) => {
+        const normalizedUpdatedSection = normalizeSection(updatedSection);
+
+        const changedContents = normalizedUpdatedSection.contents.filter((updatedItem) => {
             const originalItem = selectedSection.contents.find((sel) => sel.id === updatedItem.id);
 
             if (!originalItem) return true;

--- a/src/utils/functions/normalize-html/normalize-html.test.ts
+++ b/src/utils/functions/normalize-html/normalize-html.test.ts
@@ -49,4 +49,16 @@ describe('normalizeHtml', () => {
         const output = '<p>Text <strong>Bold</strong></p>';
         expect(normalizeHtml(input)).toBe(output);
     });
+
+    it('trims nbsp symbols after text', () => {
+        const input = '<p>Text &nbsp;</p>';
+        const output = '<p>Text</p>';
+        expect(normalizeHtml(input)).toBe(output);
+    });
+
+    it('trims whitespace characters wrapped in text formatting elements', () => {
+        const input = '<p>Text <strong>   </strong></p>';
+        const output = '<p>Text</p>';
+        expect(normalizeHtml(input)).toBe(output);
+    });
 });

--- a/src/utils/functions/normalize-html/normalize-html.ts
+++ b/src/utils/functions/normalize-html/normalize-html.ts
@@ -1,6 +1,41 @@
-export const normalizeHtml = (html: string): string =>
-    html
-        .split('</p>')
-        .map((part) => part.trimEnd())
-        .join('</p>')
-        .trim();
+const trimTrailingWhitespace = (container: Node): void => {
+    let child = container.lastChild;
+
+    while (child) {
+        const prev = child.previousSibling;
+
+        if (child.nodeType === Node.TEXT_NODE) {
+            child.textContent = child.textContent?.trimEnd() ?? '';
+            if (child.textContent.length > 0) return;
+            container.removeChild(child);
+        } else if (child.nodeType === Node.ELEMENT_NODE) {
+            const el = child as HTMLElement;
+            trimTrailingWhitespace(el);
+
+            if (el.childNodes.length === 0 && el.tagName !== 'BR') {
+                container.removeChild(el);
+            } else {
+                return;
+            }
+        }
+
+        child = prev;
+    }
+};
+
+export const normalizeHtml = (html: string): string => {
+    if (!html) return '';
+
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = html;
+
+    const paragraphs = tempDiv.querySelectorAll('p');
+
+    if (paragraphs.length > 0) {
+        paragraphs.forEach(trimTrailingWhitespace);
+    } else {
+        trimTrailingWhitespace(tempDiv);
+    }
+
+    return tempDiv.innerHTML;
+};

--- a/src/utils/functions/normalize-html/normalize-html.ts
+++ b/src/utils/functions/normalize-html/normalize-html.ts
@@ -33,9 +33,9 @@ export const normalizeHtml = (html: string): string => {
 
     if (paragraphs.length > 0) {
         paragraphs.forEach(trimTrailingWhitespace);
-    } else {
-        trimTrailingWhitespace(tempDiv);
     }
+
+    trimTrailingWhitespace(tempDiv);
 
     return tempDiv.innerHTML;
 };

--- a/src/utils/functions/normalize-html/normalize-html.ts
+++ b/src/utils/functions/normalize-html/normalize-html.ts
@@ -7,13 +7,13 @@ const trimTrailingWhitespace = (container: Node): void => {
         if (child.nodeType === Node.TEXT_NODE) {
             child.textContent = child.textContent?.trimEnd() ?? '';
             if (child.textContent.length > 0) return;
-            container.removeChild(child);
+            child.remove();
         } else if (child.nodeType === Node.ELEMENT_NODE) {
             const el = child as HTMLElement;
             trimTrailingWhitespace(el);
 
             if (el.childNodes.length === 0 && el.tagName !== 'BR') {
-                container.removeChild(el);
+                el.remove();
             } else {
                 return;
             }


### PR DESCRIPTION
## Github ticker

* [Issue 1874](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1874)

## Description

This PR fixes the issue on the Admin panel -> Who We Are page where the "Опублікувати" (Publish) button would incorrectly become active when a user added trailing spaces and applied formatting (e.g., bold, italic) to them. The button now correctly ignores styled trailing whitespace and remains disabled until meaningful, non-whitespace content is added.

## How it looks

The "Опублікувати" button stays disabled when there are trailng formatted whitespace characters
<img width="662" height="358" alt="image" src="https://github.com/user-attachments/assets/aef7246e-1db4-48e9-ace7-ee8a5d8556b7" />

## Summary of change

- Added new test cases for the normalizeHtml utility to cover the updated requirements for handling whitespace and formatted spaces.

- Updated the normalizeHtml function logic to successfully pass the new test cases.

- Modified the isPublishButtonActive check in WhoWeAreContent.tsx to normalize the section objects before stringifying and comparing them, ensuring that trailing whitespace characters are no longer flagged as new changes.


## How to recreate changes

1. Navigate to the Admin panel -> Who We Are page.

2. Select a category/section to edit.

3. Place the cursor at the end of an existing text block.

4. Type several spaces.

5. Highlight those spaces and apply a style (e.g., Bold or Italic).

6. Verify: The "Опублікувати" button remains disabled.

7. Type a visible text character (e.g., 'a').

8. Verify: The "Опублікувати" button becomes active immediately


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate publish-button change detection for "Who We Are" content so edits are recognized correctly.
  * Improved HTML normalization to trim trailing non-breaking spaces and remove whitespace-only inline formatting, preventing stray/empty markup in content.

* **Tests**
  * Added tests verifying trimming of trailing spaces and removal of whitespace-only inline elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->