### PR TITLE
Feature/issue 918 -  [Company Profile] Implement company profile full flow with mock API and tests

### DIFF
--- a/src/assets/sass/variables/colors.scss
+++ b/src/assets/sass/variables/colors.scss
@@ -69,3 +69,7 @@ $orange: #d97706;
 
 $olive-dark: #353428;
 $white: #fff;
+
+$dropdown-text: #1d192b;
+$dropdown-hover: #c1cbdc;
+

--- a/src/components/admin/input-with-character-limit/InputWithCharacterLimit.scss
+++ b/src/components/admin/input-with-character-limit/InputWithCharacterLimit.scss
@@ -1,14 +1,5 @@
 @use '@/assets/sass/variables/colors';
 
-.char-limit-input-wrapper {
-    width: 100%;
-
-    &--bottom {
-        display: flex;
-        flex-direction: column;
-    }
-}
-
 .char-limit-input {
     display: flex;
     align-items: center;
@@ -81,24 +72,5 @@
         white-space: nowrap;
         color: colors.$grey-900;
         flex-shrink: 0;
-
-        &--bottom {
-            display: block;
-            margin-top: 6px;
-            text-align: right;
-            width: 100%;
-        }
-
-        &--visually-hidden {
-            position: absolute;
-            width: 1px;
-            height: 1px;
-            padding: 0;
-            margin: -1px;
-            overflow: hidden;
-            clip: rect(0 0 0 0);
-            white-space: nowrap;
-            border: 0;
-        }
     }
 }

--- a/src/components/admin/input-with-character-limit/InputWithCharacterLimit.test.tsx
+++ b/src/components/admin/input-with-character-limit/InputWithCharacterLimit.test.tsx
@@ -40,14 +40,11 @@ describe('InputWithCharacterLimit', () => {
         expect(getCharacterCounter(4, 50)).toBeInTheDocument();
     });
 
-    it('does not render visible character counter when showCounter is false and keeps aria-describedby linked to countId', () => {
+    it('does not render character counter when showCounter is false and keeps aria-describedby linked to countId', () => {
         renderInputWithCharacterLimit({ showCounter: false });
 
+        expect(screen.queryByText('0/50')).not.toBeInTheDocument();
         expect(getInput()).toHaveAttribute('aria-describedby', 'test-id-character-count');
-
-        const counter = screen.getByText('0/50');
-        expect(counter).toBeInTheDocument();
-        expect(counter).toHaveClass('char-limit-input__counter--visually-hidden');
     });
 
     it('renders correct placeholder and input type', () => {
@@ -116,20 +113,5 @@ describe('InputWithCharacterLimit', () => {
     it('sets aria-invalid when current length exceeds maxLength', () => {
         renderInputWithCharacterLimit({ value: 'abcd', maxLength: 3 });
         expect(getInput()).toHaveAttribute('aria-invalid', 'true');
-    });
-
-    it('renders counter below input when counterPosition is bottom', () => {
-        renderInputWithCharacterLimit({ counterPosition: 'bottom', value: 'Hello', maxLength: 20 });
-
-        const counter = screen.getByText('5/20');
-        expect(counter).toBeInTheDocument();
-        expect(counter).toHaveClass('char-limit-input__counter--bottom');
-    });
-
-    it('keeps default inside counter position when prop is not provided', () => {
-        renderInputWithCharacterLimit({ value: 'Hi', maxLength: 20 });
-        const counter = screen.getByText('2/20');
-        expect(counter).toBeInTheDocument();
-        expect(counter).not.toHaveClass('char-limit-input__counter--bottom');
     });
 });

--- a/src/components/admin/input-with-character-limit/InputWithCharacterLimit.tsx
+++ b/src/components/admin/input-with-character-limit/InputWithCharacterLimit.tsx
@@ -20,7 +20,6 @@ export interface InputWithCharacterLimitProps {
     maxLimitWarning?: string;
     onWarningChange?: (warning: string | null) => void;
     showCounter?: boolean;
-    counterPosition?: 'inside' | 'bottom';
 }
 
 export const InputWithCharacterLimit = ({
@@ -39,7 +38,6 @@ export const InputWithCharacterLimit = ({
     maxLimitWarning,
     onWarningChange,
     showCounter = true,
-    counterPosition = 'inside',
 }: InputWithCharacterLimitProps) => {
     const {
         isFocused,
@@ -67,63 +65,43 @@ export const InputWithCharacterLimit = ({
 
     return (
         <div
-            className={cn('char-limit-input-wrapper', {
-                'char-limit-input-wrapper--bottom': showCounter && counterPosition === 'bottom',
+            className={cn('char-limit-input', {
+                'char-limit-input--disabled': disabled,
+                'char-limit-input--focused': isFocused && !disabled,
             })}
         >
-            <div
-                className={cn('char-limit-input', {
-                    'char-limit-input--disabled': disabled,
-                    'char-limit-input--focused': isFocused && !disabled,
+            <input
+                className={cn('char-limit-input__field', className)}
+                value={value ?? ''}
+                onChange={handleChange}
+                onFocus={handleFocus}
+                onBlur={handleBlur}
+                name={name}
+                type={type}
+                id={id}
+                disabled={disabled}
+                placeholder={placeholder}
+                aria-describedby={countId}
+                aria-invalid={hasError || currentLength > maxLength}
+            />
+            <button
+                type="button"
+                className={cn('char-limit-input__clear-button', {
+                    'char-limit-input__clear-button--visible': showClearButton,
+                    'char-limit-input__clear-button--error': hasError || !!localWarning,
                 })}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={handleClear}
+                aria-label="Clear input"
+                tabIndex={showClearButton ? 0 : -1}
             >
-                <input
-                    className={cn('char-limit-input__field', className)}
-                    value={value ?? ''}
-                    onChange={handleChange}
-                    onFocus={handleFocus}
-                    onBlur={handleBlur}
-                    name={name}
-                    type={type}
-                    id={id}
-                    disabled={disabled}
-                    placeholder={placeholder}
-                    aria-describedby={countId}
-                    aria-invalid={hasError || currentLength > maxLength}
-                />
-
-                <button
-                    type="button"
-                    className={cn('char-limit-input__clear-button', {
-                        'char-limit-input__clear-button--visible': showClearButton,
-                        'char-limit-input__clear-button--error': hasError || !!localWarning,
-                    })}
-                    onMouseDown={(e) => e.preventDefault()}
-                    onClick={handleClear}
-                    aria-label="Clear input"
-                    tabIndex={showClearButton ? 0 : -1}
-                >
-                    <RemoveIcon />
-                </button>
-
-                {showCounter && counterPosition === 'inside' && (
-                    <output id={countId} className="char-limit-input__counter">
-                        {currentLength}/{maxLength}
-                    </output>
-                )}
-            </div>
-
-            {(showCounter && counterPosition === 'bottom') || !showCounter ? (
-                <output
-                    id={countId}
-                    className={cn('char-limit-input__counter', {
-                        'char-limit-input__counter--bottom': showCounter && counterPosition === 'bottom',
-                        'char-limit-input__counter--visually-hidden': !showCounter,
-                    })}
-                >
+                <RemoveIcon />
+            </button>
+            {showCounter && (
+                <output id={countId} className="char-limit-input__counter">
                     {currentLength}/{maxLength}
                 </output>
-            ) : null}
+            )}
         </div>
     );
 };

--- a/src/const/admin/company-profile.ts
+++ b/src/const/admin/company-profile.ts
@@ -14,6 +14,7 @@ export const COMPANY_PROFILE_TEXT = {
 
     MODAL: {
         CANCEL_TITLE: 'Скасувати редагування?',
+        DELETE_SOCIAL_TITLE: 'Видалити соц мережу?',
     },
 
     PROFILE_TAB: {

--- a/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.test.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.test.tsx
@@ -6,15 +6,37 @@ import { CompanyProfileApi } from '@/services/api/admin/company-profile/company-
 import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
 import { COMPANY_PROFILE_VALIDATION } from '@/const/admin/company-profile';
 
+jest.mock('@/utils/functions/mappers/admin/company-profile/company-profile-mappers', () => ({
+    __esModule: true,
+    mapCompanyProfileToFormValues: () => ({
+        phone: '+380671234567',
+        addressUa: 'UA address',
+        addressEng: 'EN address',
+        email: 'test@example.com',
+        correspondenceEmail: 'office@example.com',
+        mottoUa: '',
+        mottoEng: '',
+        requisitesUa: 'UA requisites',
+        requisitesEn: 'EN requisites',
+        companyRegistrationNumber: '12345678',
+        addressUa_requisites: 'UA requisites address',
+        addressEn_requisites: 'EN requisites address',
+        socialContacts: [],
+    }),
+}));
+
 jest.mock('@/components/admin/toast/toast-container/ToastContainer', () => ({
+    __esModule: true,
     ToastContainer: () => <div data-testid="toast-container" />,
 }));
 
 jest.mock('../company-profile-logo-header/CompanyProfileLogoHeader', () => ({
+    __esModule: true,
     CompanyProfileLogoHeader: () => <div data-testid="company-profile-logo-header" />,
 }));
 
 jest.mock('../company-profile-tab/CompanyProfileTab', () => ({
+    __esModule: true,
     CompanyProfileTab: (props: any) => {
         const { useFormContext, Controller } = require('react-hook-form');
         const { control, formState } = useFormContext();
@@ -29,7 +51,7 @@ jest.mock('../company-profile-tab/CompanyProfileTab', () => ({
                             data-testid="input-phone"
                             disabled={props.disabled}
                             value={field.value ?? ''}
-                            onChange={(e) => field.onChange(e)}
+                            onChange={(e) => field.onChange(e.target.value)}
                             onBlur={() => field.onBlur()}
                         />
                     )}
@@ -41,26 +63,31 @@ jest.mock('../company-profile-tab/CompanyProfileTab', () => ({
 }));
 
 jest.mock('../company-profile-requisites-tab/CompanyProfileRequisitesTab', () => ({
+    __esModule: true,
     CompanyProfileRequisitesTab: (props: any) => (
         <div data-testid="tab-requisites" data-disabled={String(props.disabled)} />
     ),
 }));
 
 jest.mock('../company-profile-social-media-tab/CompanyProfileSocialMediaTab', () => ({
+    __esModule: true,
     CompanyProfileSocialMediaTab: (props: any) => (
         <div data-testid="tab-socials" data-disabled={String(props.disabled)} />
     ),
 }));
 
 jest.mock('@/services/api/admin/company-profile/company-profile-api', () => ({
+    __esModule: true,
     CompanyProfileApi: { get: jest.fn() },
 }));
 
 jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
+    __esModule: true,
     useAdminClient: jest.fn(),
 }));
 
 jest.mock('@/components/admin/category-bar/CategoryBar', () => ({
+    __esModule: true,
     CategoryBar: ({ categories, onCategorySelect, selectedCategory }: any) => (
         <div data-testid="category-bar">
             {categories.map((c: any) => (
@@ -78,6 +105,7 @@ jest.mock('@/components/admin/category-bar/CategoryBar', () => ({
 }));
 
 jest.mock('../company-profile-toolbar/CompanyProfileToolbar', () => ({
+    __esModule: true,
     ProfileToolbar: ({ isEditMode, onEdit, onCancel, onPublish, isPublishDisabled }: any) => {
         const { COMPANY_PROFILE_TEXT } = require('@/const/admin/company-profile');
 
@@ -113,6 +141,7 @@ const mockedGet = CompanyProfileApi.get as jest.Mock;
 const mockedUseAdminClient = useAdminClient as jest.Mock;
 
 jest.mock('../company-profile-cancel-modal/CompanyProfileCancelModal', () => ({
+    __esModule: true,
     CompanyProfileCancelModal: ({ isOpen, onConfirm, onCancel }: any) =>
         isOpen ? (
             <div data-testid="cancel-modal">
@@ -142,6 +171,7 @@ describe('CompanyProfileContent', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockedUseAdminClient.mockReturnValue({ client: 'mock-client' });
+
         mockedGet.mockResolvedValue({
             profile: {
                 id: 1,
@@ -155,7 +185,14 @@ describe('CompanyProfileContent', () => {
                     motto: '',
                     localizations: [],
                 },
-                requisite: { id: 1, profileId: 1, recipient: '', edrpou: '12345678', address: '', localizations: [] },
+                requisite: {
+                    id: 1,
+                    profileId: 1,
+                    recipient: '',
+                    edrpou: '12345678',
+                    address: '',
+                    localizations: [],
+                },
                 socialLinks: [],
             },
             languages: [],
@@ -177,6 +214,7 @@ describe('CompanyProfileContent', () => {
 
         fireEvent.click(screen.getByTestId('edit-btn'));
         expect(screen.getByTestId('tab-profile')).toHaveAttribute('data-disabled', 'false');
+
         fireEvent.click(screen.getByTestId('tab-btn-requisites'));
         expect(screen.getByTestId('tab-profile')).toBeInTheDocument();
     });
@@ -213,5 +251,78 @@ describe('CompanyProfileContent', () => {
         });
 
         expect(COMPANY_PROFILE_VALIDATION.common.REQUIRED).toBe("Поле обов'язкове");
+    });
+
+    it('enables publish when form is dirty and valid (phone changed)', async () => {
+        render(<CompanyProfileContent />);
+
+        await waitFor(() => {
+            expect(mockedGet).toHaveBeenCalledTimes(1);
+        });
+
+        fireEvent.click(screen.getByTestId('edit-btn'));
+
+        const publishBtn = screen.getByTestId('publish-btn') as HTMLButtonElement;
+        const phoneInput = screen.getByTestId('input-phone') as HTMLInputElement;
+
+        fireEvent.change(phoneInput, { target: { value: '+380671234568' } });
+        fireEvent.blur(phoneInput);
+
+        await waitFor(() => {
+            expect(publishBtn).not.toBeDisabled();
+        });
+
+        expect(screen.getByTestId('debug-dirty')).toHaveTextContent('true');
+    });
+
+    it('exits edit mode after publish (mock save)', async () => {
+        render(<CompanyProfileContent />);
+
+        await waitFor(() => {
+            expect(mockedGet).toHaveBeenCalledTimes(1);
+        });
+
+        fireEvent.click(screen.getByTestId('edit-btn'));
+
+        const publishBtn = screen.getByTestId('publish-btn') as HTMLButtonElement;
+        const phoneInput = screen.getByTestId('input-phone') as HTMLInputElement;
+
+        fireEvent.change(phoneInput, { target: { value: '+380671234568' } });
+        fireEvent.blur(phoneInput);
+
+        await waitFor(() => {
+            expect(publishBtn).not.toBeDisabled();
+        });
+
+        fireEvent.click(publishBtn);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('edit-btn')).toBeInTheDocument();
+        });
+    });
+
+    it('opens cancel modal when dirty and exits edit mode after confirm cancel', async () => {
+        render(<CompanyProfileContent />);
+
+        await waitFor(() => {
+            expect(mockedGet).toHaveBeenCalledTimes(1);
+        });
+
+        fireEvent.click(screen.getByTestId('edit-btn'));
+
+        const phoneInput = screen.getByTestId('input-phone') as HTMLInputElement;
+
+        fireEvent.change(phoneInput, { target: { value: '+380671234568' } });
+        fireEvent.blur(phoneInput);
+
+        fireEvent.click(screen.getByTestId('cancel-btn'));
+
+        expect(screen.getByTestId('cancel-modal')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('confirm-cancel'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('edit-btn')).toBeInTheDocument();
+        });
     });
 });

--- a/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.test.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.test.tsx
@@ -198,67 +198,18 @@ describe('CompanyProfileContent', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockedUseAdminClient.mockReturnValue({} as any);
-
         mockedGet.mockResolvedValue({ profile: { id: 1 }, languages: [] });
         mockedPublish.mockResolvedValue({ profile: { id: 1 }, languages: [] });
     });
 
-    it('renders default tab (profile) and allows tab switching in view mode', () => {
-        render(<CompanyProfileContent />);
-
-        expect(screen.getByTestId('tab-profile')).toBeInTheDocument();
-        fireEvent.click(screen.getByTestId('tab-btn-requisites'));
-        expect(screen.getByTestId('tab-requisites')).toBeInTheDocument();
-        fireEvent.click(screen.getByTestId('tab-btn-socials'));
-        expect(screen.getByTestId('tab-socials')).toBeInTheDocument();
-    });
-
-    it('enters edit mode and disables tab switching', () => {
-        render(<CompanyProfileContent />);
-
-        fireEvent.click(screen.getByTestId('edit-btn'));
-        expect(screen.getByTestId('tab-profile')).toHaveAttribute('data-disabled', 'false');
-
-        fireEvent.click(screen.getByTestId('tab-btn-requisites'));
-        expect(screen.getByTestId('tab-profile')).toBeInTheDocument();
-    });
-
-    it('exits edit mode on cancel when form is not dirty', () => {
-        render(<CompanyProfileContent />);
-
-        fireEvent.click(screen.getByTestId('edit-btn'));
-        fireEvent.click(screen.getByTestId('cancel-btn'));
-        expect(screen.getByTestId('edit-btn')).toBeInTheDocument();
-    });
-
-    it('calls CompanyProfileApi.get on mount', async () => {
-        render(<CompanyProfileContent />);
-
-        await waitFor(() => expect(mockedGet).toHaveBeenCalledTimes(1));
-    });
-
-    it('disables publish when form is dirty but invalid (required phone)', async () => {
-        render(<CompanyProfileContent />);
-
-        fireEvent.click(screen.getByTestId('edit-btn'));
-
-        const publishBtn = screen.getByTestId('publish-btn') as HTMLButtonElement;
-        const phoneInput = screen.getByTestId('input-phone') as HTMLInputElement;
-
-        fireEvent.change(phoneInput, { target: { value: '   ' } });
-        fireEvent.blur(phoneInput);
-
-        await waitFor(() => expect(publishBtn).toBeDisabled());
-        expect(COMPANY_PROFILE_VALIDATION.common.REQUIRED).toBe("Поле обов'язкове");
-    });
-
-    it('opens publish modal on publish click when form is dirty and valid', async () => {
+    const setupEditMode = async () => {
         render(<CompanyProfileContent />);
         await waitFor(() => expect(mockedGet).toHaveBeenCalledTimes(1));
-
         fireEvent.click(screen.getByTestId('edit-btn'));
+        return screen.getByTestId('input-phone') as HTMLInputElement;
+    };
 
-        const phoneInput = screen.getByTestId('input-phone') as HTMLInputElement;
+    const triggerValidPublishFlow = async (phoneInput: HTMLInputElement) => {
         fireEvent.change(phoneInput, { target: { value: '+380 00 000 00 00' } });
         fireEvent.blur(phoneInput);
 
@@ -266,53 +217,78 @@ describe('CompanyProfileContent', () => {
         await waitFor(() => expect(publishBtn).not.toBeDisabled());
 
         fireEvent.click(publishBtn);
+        await screen.findByTestId('publish-modal');
+    };
 
-        expect(await screen.findByTestId('publish-modal')).toBeInTheDocument();
+    it('renders default tab (profile) and allows tab switching in view mode', () => {
+        render(<CompanyProfileContent />);
+        expect(screen.getByTestId('tab-profile')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('tab-btn-requisites'));
+        expect(screen.getByTestId('tab-requisites')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('tab-btn-socials'));
+        expect(screen.getByTestId('tab-socials')).toBeInTheDocument();
+    });
+
+    it('enters edit mode and disables tab switching', () => {
+        render(<CompanyProfileContent />);
+        fireEvent.click(screen.getByTestId('edit-btn'));
+
+        expect(screen.getByTestId('tab-profile')).toHaveAttribute('data-disabled', 'false');
+        fireEvent.click(screen.getByTestId('tab-btn-requisites'));
+        expect(screen.getByTestId('tab-profile')).toBeInTheDocument();
+    });
+
+    it('exits edit mode on cancel when form is not dirty', () => {
+        render(<CompanyProfileContent />);
+        fireEvent.click(screen.getByTestId('edit-btn'));
+        fireEvent.click(screen.getByTestId('cancel-btn'));
+        expect(screen.getByTestId('edit-btn')).toBeInTheDocument();
+    });
+
+    it('calls CompanyProfileApi.get on mount', async () => {
+        render(<CompanyProfileContent />);
+        await waitFor(() => expect(mockedGet).toHaveBeenCalledTimes(1));
+    });
+
+    it('disables publish when form is dirty but invalid (required phone)', async () => {
+        const phoneInput = await setupEditMode();
+
+        fireEvent.change(phoneInput, { target: { value: '   ' } });
+        fireEvent.blur(phoneInput);
+
+        const publishBtn = screen.getByTestId('publish-btn') as HTMLButtonElement;
+        await waitFor(() => expect(publishBtn).toBeDisabled());
+        expect(COMPANY_PROFILE_VALIDATION.common.REQUIRED).toBe("Поле обов'язкове");
+    });
+
+    it('opens publish modal on publish click when form is dirty and valid', async () => {
+        const phoneInput = await setupEditMode();
+        await triggerValidPublishFlow(phoneInput);
+
+        expect(screen.getByTestId('publish-modal')).toBeInTheDocument();
     });
 
     it("when publish modal 'No' clicked: does not save, exits to view mode, and does not show toast", async () => {
-        render(<CompanyProfileContent />);
-        await waitFor(() => expect(mockedGet).toHaveBeenCalledTimes(1));
-
-        fireEvent.click(screen.getByTestId('edit-btn'));
-
-        const phoneInput = screen.getByTestId('input-phone') as HTMLInputElement;
-        fireEvent.change(phoneInput, { target: { value: '+380 00 000 00 00' } });
-        fireEvent.blur(phoneInput);
-
-        await waitFor(() => expect(screen.getByTestId('publish-btn')).not.toBeDisabled());
-
-        fireEvent.click(screen.getByTestId('publish-btn'));
-        await screen.findByTestId('publish-modal');
+        const phoneInput = await setupEditMode();
+        await triggerValidPublishFlow(phoneInput);
 
         fireEvent.click(screen.getByTestId('cancel-publish'));
 
         expect(await screen.findByTestId('edit-btn')).toBeInTheDocument();
-
         expect(mockedPublish).not.toHaveBeenCalled();
         expect(mockAddToast).not.toHaveBeenCalled();
     });
 
     it("when publish modal 'Yes' clicked: saves, exits to view mode, and shows toast", async () => {
-        render(<CompanyProfileContent />);
-        await waitFor(() => expect(mockedGet).toHaveBeenCalledTimes(1));
-
-        fireEvent.click(screen.getByTestId('edit-btn'));
-
-        const phoneInput = screen.getByTestId('input-phone') as HTMLInputElement;
-        fireEvent.change(phoneInput, { target: { value: '+380 00 000 00 00' } });
-        fireEvent.blur(phoneInput);
-
-        await waitFor(() => expect(screen.getByTestId('publish-btn')).not.toBeDisabled());
-
-        fireEvent.click(screen.getByTestId('publish-btn'));
-        await screen.findByTestId('publish-modal');
+        const phoneInput = await setupEditMode();
+        await triggerValidPublishFlow(phoneInput);
 
         fireEvent.click(screen.getByTestId('confirm-publish'));
 
         await waitFor(() => expect(mockedPublish).toHaveBeenCalledTimes(1));
         expect(await screen.findByTestId('edit-btn')).toBeInTheDocument();
-
         expect(mockAddToast).toHaveBeenCalledWith('Зміни успішно опубліковано', ToastType.Success, 3000);
     });
 });

--- a/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.test.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.test.tsx
@@ -5,6 +5,17 @@ import { CompanyProfileContent } from './CompanyProfileContent';
 import { CompanyProfileApi } from '@/services/api/admin/company-profile/company-profile-api';
 import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
 import { COMPANY_PROFILE_VALIDATION } from '@/const/admin/company-profile';
+import { ToastType } from '@/types/admin/toast';
+
+const mockAddToast = jest.fn();
+
+jest.mock('@/validation/admin/company-profile-schema/company-profile-schema', () => ({
+    __esModule: true,
+    CompanyProfileValidationSchema: {
+        validate: async (value: any) => value,
+        validateSync: (value: any) => value,
+    },
+}));
 
 jest.mock('@/utils/functions/mappers/admin/company-profile/company-profile-mappers', () => ({
     __esModule: true,
@@ -22,6 +33,25 @@ jest.mock('@/utils/functions/mappers/admin/company-profile/company-profile-mappe
         addressUa_requisites: 'UA requisites address',
         addressEn_requisites: 'EN requisites address',
         socialContacts: [],
+    }),
+    mapFormValuesToCompanyProfilePatch: () => ({ mocked: true }),
+}));
+
+jest.mock('@/services/api/admin/company-profile/company-profile-api', () => ({
+    __esModule: true,
+    CompanyProfileApi: {
+        get: jest.fn(),
+        publish: jest.fn(),
+        __resetMocks: jest.fn(),
+    },
+}));
+
+jest.mock('@/contexts/admin/toast-context-provider/ToastContextProvider', () => ({
+    __esModule: true,
+    useToast: () => ({
+        addToast: mockAddToast,
+        toasts: [],
+        removeToast: jest.fn(),
     }),
 }));
 
@@ -74,11 +104,6 @@ jest.mock('../company-profile-social-media-tab/CompanyProfileSocialMediaTab', ()
     CompanyProfileSocialMediaTab: (props: any) => (
         <div data-testid="tab-socials" data-disabled={String(props.disabled)} />
     ),
-}));
-
-jest.mock('@/services/api/admin/company-profile/company-profile-api', () => ({
-    __esModule: true,
-    CompanyProfileApi: { get: jest.fn() },
 }));
 
 jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
@@ -135,68 +160,47 @@ jest.mock('../company-profile-toolbar/CompanyProfileToolbar', () => ({
     },
 }));
 
-const mockOnConfirm = jest.fn();
-const mockOnCancel = jest.fn();
-const mockedGet = CompanyProfileApi.get as jest.Mock;
-const mockedUseAdminClient = useAdminClient as jest.Mock;
-
 jest.mock('../company-profile-cancel-modal/CompanyProfileCancelModal', () => ({
     __esModule: true,
     CompanyProfileCancelModal: ({ isOpen, onConfirm, onCancel }: any) =>
         isOpen ? (
             <div data-testid="cancel-modal">
-                <button
-                    data-testid="confirm-cancel"
-                    onClick={() => {
-                        mockOnConfirm();
-                        onConfirm();
-                    }}
-                >
+                <button data-testid="confirm-cancel" onClick={onConfirm}>
                     Confirm
                 </button>
-                <button
-                    data-testid="dismiss-cancel"
-                    onClick={() => {
-                        mockOnCancel();
-                        onCancel();
-                    }}
-                >
+                <button data-testid="dismiss-cancel" onClick={onCancel}>
                     Dismiss
                 </button>
             </div>
         ) : null,
 }));
 
+jest.mock('../company-profile-publish-modal/CompanyProfilePublishModal', () => ({
+    __esModule: true,
+    CompanyProfilePublishModal: ({ isOpen, onConfirm, onCancel }: any) =>
+        isOpen ? (
+            <div data-testid="publish-modal">
+                <button data-testid="confirm-publish" onClick={onConfirm}>
+                    Yes
+                </button>
+                <button data-testid="cancel-publish" onClick={onCancel}>
+                    No
+                </button>
+            </div>
+        ) : null,
+}));
+
+const mockedUseAdminClient = useAdminClient as jest.Mock;
+const mockedGet = CompanyProfileApi.get as jest.Mock;
+const mockedPublish = CompanyProfileApi.publish as jest.Mock;
+
 describe('CompanyProfileContent', () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        mockedUseAdminClient.mockReturnValue({ client: 'mock-client' });
+        mockedUseAdminClient.mockReturnValue({} as any);
 
-        mockedGet.mockResolvedValue({
-            profile: {
-                id: 1,
-                contact: {
-                    id: 1,
-                    profileId: 1,
-                    phone: '',
-                    address: '',
-                    email: '',
-                    correspondenceEmail: '',
-                    motto: '',
-                    localizations: [],
-                },
-                requisite: {
-                    id: 1,
-                    profileId: 1,
-                    recipient: '',
-                    edrpou: '12345678',
-                    address: '',
-                    localizations: [],
-                },
-                socialLinks: [],
-            },
-            languages: [],
-        });
+        mockedGet.mockResolvedValue({ profile: { id: 1 }, languages: [] });
+        mockedPublish.mockResolvedValue({ profile: { id: 1 }, languages: [] });
     });
 
     it('renders default tab (profile) and allows tab switching in view mode', () => {
@@ -230,9 +234,7 @@ describe('CompanyProfileContent', () => {
     it('calls CompanyProfileApi.get on mount', async () => {
         render(<CompanyProfileContent />);
 
-        await waitFor(() => {
-            expect(mockedGet).toHaveBeenCalledTimes(1);
-        });
+        await waitFor(() => expect(mockedGet).toHaveBeenCalledTimes(1));
     });
 
     it('disables publish when form is dirty but invalid (required phone)', async () => {
@@ -246,83 +248,71 @@ describe('CompanyProfileContent', () => {
         fireEvent.change(phoneInput, { target: { value: '   ' } });
         fireEvent.blur(phoneInput);
 
-        await waitFor(() => {
-            expect(publishBtn).toBeDisabled();
-        });
-
+        await waitFor(() => expect(publishBtn).toBeDisabled());
         expect(COMPANY_PROFILE_VALIDATION.common.REQUIRED).toBe("Поле обов'язкове");
     });
 
-    it('enables publish when form is dirty and valid (phone changed)', async () => {
+    it('opens publish modal on publish click when form is dirty and valid', async () => {
         render(<CompanyProfileContent />);
-
-        await waitFor(() => {
-            expect(mockedGet).toHaveBeenCalledTimes(1);
-        });
+        await waitFor(() => expect(mockedGet).toHaveBeenCalledTimes(1));
 
         fireEvent.click(screen.getByTestId('edit-btn'));
 
-        const publishBtn = screen.getByTestId('publish-btn') as HTMLButtonElement;
         const phoneInput = screen.getByTestId('input-phone') as HTMLInputElement;
-
-        fireEvent.change(phoneInput, { target: { value: '+380671234568' } });
+        fireEvent.change(phoneInput, { target: { value: '+380 00 000 00 00' } });
         fireEvent.blur(phoneInput);
 
-        await waitFor(() => {
-            expect(publishBtn).not.toBeDisabled();
-        });
-
-        expect(screen.getByTestId('debug-dirty')).toHaveTextContent('true');
-    });
-
-    it('exits edit mode after publish (mock save)', async () => {
-        render(<CompanyProfileContent />);
-
-        await waitFor(() => {
-            expect(mockedGet).toHaveBeenCalledTimes(1);
-        });
-
-        fireEvent.click(screen.getByTestId('edit-btn'));
-
         const publishBtn = screen.getByTestId('publish-btn') as HTMLButtonElement;
-        const phoneInput = screen.getByTestId('input-phone') as HTMLInputElement;
-
-        fireEvent.change(phoneInput, { target: { value: '+380671234568' } });
-        fireEvent.blur(phoneInput);
-
-        await waitFor(() => {
-            expect(publishBtn).not.toBeDisabled();
-        });
+        await waitFor(() => expect(publishBtn).not.toBeDisabled());
 
         fireEvent.click(publishBtn);
 
-        await waitFor(() => {
-            expect(screen.getByTestId('edit-btn')).toBeInTheDocument();
-        });
+        expect(await screen.findByTestId('publish-modal')).toBeInTheDocument();
     });
 
-    it('opens cancel modal when dirty and exits edit mode after confirm cancel', async () => {
+    it("when publish modal 'No' clicked: does not save, exits to view mode, and does not show toast", async () => {
         render(<CompanyProfileContent />);
-
-        await waitFor(() => {
-            expect(mockedGet).toHaveBeenCalledTimes(1);
-        });
+        await waitFor(() => expect(mockedGet).toHaveBeenCalledTimes(1));
 
         fireEvent.click(screen.getByTestId('edit-btn'));
 
         const phoneInput = screen.getByTestId('input-phone') as HTMLInputElement;
-
-        fireEvent.change(phoneInput, { target: { value: '+380671234568' } });
+        fireEvent.change(phoneInput, { target: { value: '+380 00 000 00 00' } });
         fireEvent.blur(phoneInput);
 
-        fireEvent.click(screen.getByTestId('cancel-btn'));
+        await waitFor(() => expect(screen.getByTestId('publish-btn')).not.toBeDisabled());
 
-        expect(screen.getByTestId('cancel-modal')).toBeInTheDocument();
+        fireEvent.click(screen.getByTestId('publish-btn'));
+        await screen.findByTestId('publish-modal');
 
-        fireEvent.click(screen.getByTestId('confirm-cancel'));
+        fireEvent.click(screen.getByTestId('cancel-publish'));
 
-        await waitFor(() => {
-            expect(screen.getByTestId('edit-btn')).toBeInTheDocument();
-        });
+        expect(await screen.findByTestId('edit-btn')).toBeInTheDocument();
+
+        expect(mockedPublish).not.toHaveBeenCalled();
+        expect(mockAddToast).not.toHaveBeenCalled();
+    });
+
+    it("when publish modal 'Yes' clicked: saves, exits to view mode, and shows toast", async () => {
+        render(<CompanyProfileContent />);
+        await waitFor(() => expect(mockedGet).toHaveBeenCalledTimes(1));
+
+        fireEvent.click(screen.getByTestId('edit-btn'));
+
+        const phoneInput = screen.getByTestId('input-phone') as HTMLInputElement;
+        fireEvent.change(phoneInput, { target: { value: '+380 00 000 00 00' } });
+        fireEvent.blur(phoneInput);
+
+        await waitFor(() => expect(screen.getByTestId('publish-btn')).not.toBeDisabled());
+
+        fireEvent.click(screen.getByTestId('publish-btn'));
+        await screen.findByTestId('publish-modal');
+
+        fireEvent.click(screen.getByTestId('confirm-publish'));
+
+        await waitFor(() => expect(mockedPublish).toHaveBeenCalledTimes(1));
+        expect(await screen.findByTestId('edit-btn')).toBeInTheDocument();
+
+        expect(mockAddToast).toHaveBeenCalledWith('Зміни успішно опубліковано', ToastType.Success, 3000);
     });
 });

--- a/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.test.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.test.tsx
@@ -9,13 +9,15 @@ import { ToastType } from '@/types/admin/toast';
 
 const mockAddToast = jest.fn();
 
-jest.mock('@/validation/admin/company-profile-schema/company-profile-schema', () => ({
-    __esModule: true,
-    CompanyProfileValidationSchema: {
-        validate: async (value: any) => value,
-        validateSync: (value: any) => value,
-    },
-}));
+jest.mock('@/validation/admin/company-profile-schema/company-profile-schema', () => {
+    const yup = require('yup');
+    return {
+        __esModule: true,
+        CompanyProfileValidationSchema: yup.object({
+            phone: yup.string().trim().required("Поле обов'язкове"),
+        }),
+    };
+});
 
 jest.mock('@/utils/functions/mappers/admin/company-profile/company-profile-mappers', () => ({
     __esModule: true,
@@ -270,13 +272,15 @@ describe('CompanyProfileContent', () => {
         expect(screen.getByTestId('publish-modal')).toBeInTheDocument();
     });
 
-    it("when publish modal 'No' clicked: does not save, exits to view mode, and does not show toast", async () => {
+    it("when publish modal 'No' clicked: does not save, keeps edit mode, and does not show toast", async () => {
         const phoneInput = await setupEditMode();
         await triggerValidPublishFlow(phoneInput);
 
         fireEvent.click(screen.getByTestId('cancel-publish'));
 
-        expect(await screen.findByTestId('edit-btn')).toBeInTheDocument();
+        expect(screen.getByTestId('publish-btn')).toBeInTheDocument();
+        expect(screen.queryByTestId('edit-btn')).not.toBeInTheDocument();
+
         expect(mockedPublish).not.toHaveBeenCalled();
         expect(mockAddToast).not.toHaveBeenCalled();
     });

--- a/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.tsx
@@ -45,8 +45,9 @@ export const CompanyProfileContent = () => {
         shouldFocusError: true,
     });
 
-    const handlePublish = (_data: CompanyProfileFormValues) => {
-        // API integration pending backend endpoints/DTO
+    const handlePublish = (data: CompanyProfileFormValues) => {
+        methods.reset(data);
+        setIsEditMode(false);
     };
 
     const handleCancelClick = () => {

--- a/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import cn from 'classnames';
 import { CategoryBar } from '@/components/admin/category-bar/CategoryBar';
@@ -14,9 +14,15 @@ import { COMPANY_PROFILE_TEXT } from '@/const/admin/company-profile';
 import { COMPANY_PROFILE_FORM_DEFAULTS, CompanyProfileFormValues } from '@/types/admin/company-profile';
 import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
 import { CompanyProfileApi } from '@/services/api/admin/company-profile/company-profile-api';
-import { mapCompanyProfileToFormValues } from '@/utils/functions/mappers/admin/company-profile/company-profile-mappers';
+import {
+    mapCompanyProfileToFormValues,
+    mapFormValuesToCompanyProfilePatch,
+} from '@/utils/functions/mappers/admin/company-profile/company-profile-mappers';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { CompanyProfileValidationSchema } from '@/validation/admin/company-profile-schema/company-profile-schema';
+import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextProvider';
+import { ToastType } from '@/types/admin/toast';
+import { CompanyProfilePublishModal } from '../company-profile-publish-modal/CompanyProfilePublishModal';
 
 type TabType = 'profile' | 'requisites' | 'socials';
 
@@ -33,9 +39,17 @@ const TABS: TabItem[] = [
 
 export const CompanyProfileContent = () => {
     const client = useAdminClient();
+    const { addToast } = useToast();
+
     const [activeTab, setActiveTab] = useState<TabType>('profile');
     const [isEditMode, setIsEditMode] = useState(false);
+
     const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
+
+    const [isPublishModalOpen, setIsPublishModalOpen] = useState(false);
+    const [pendingPublishData, setPendingPublishData] = useState<CompanyProfileFormValues | null>(null);
+
+    const savedValuesRef = useRef<CompanyProfileFormValues>(COMPANY_PROFILE_FORM_DEFAULTS);
 
     const methods = useForm<CompanyProfileFormValues>({
         mode: 'onBlur',
@@ -45,9 +59,35 @@ export const CompanyProfileContent = () => {
         shouldFocusError: true,
     });
 
-    const handlePublish = (data: CompanyProfileFormValues) => {
-        methods.reset(data);
+    const handlePublishSubmit = (data: CompanyProfileFormValues) => {
+        setPendingPublishData(data);
+        setIsPublishModalOpen(true);
+    };
+
+    const handleConfirmPublish = async () => {
+        if (!pendingPublishData) return;
+
+        const { languages } = await CompanyProfileApi.get(client);
+        const patch = mapFormValuesToCompanyProfilePatch(pendingPublishData, languages);
+
+        const { profile, languages: updatedLanguages } = await CompanyProfileApi.publish(client, patch);
+
+        const nextValues = mapCompanyProfileToFormValues(profile, updatedLanguages);
+        savedValuesRef.current = nextValues;
+
+        methods.reset(nextValues);
         setIsEditMode(false);
+        setIsPublishModalOpen(false);
+        setPendingPublishData(null);
+
+        addToast('Зміни успішно опубліковано', ToastType.Success, 3000);
+    };
+
+    const handleCancelPublish = () => {
+        methods.reset(savedValuesRef.current);
+        setIsEditMode(false);
+        setIsPublishModalOpen(false);
+        setPendingPublishData(null);
     };
 
     const handleCancelClick = () => {
@@ -59,7 +99,7 @@ export const CompanyProfileContent = () => {
     };
 
     const handleConfirmCancel = () => {
-        methods.reset();
+        methods.reset(savedValuesRef.current);
         setIsEditMode(false);
         setIsCancelModalOpen(false);
     };
@@ -77,7 +117,10 @@ export const CompanyProfileContent = () => {
         const loadProfile = async () => {
             const { profile, languages } = await CompanyProfileApi.get(client);
             if (!mounted) return;
-            methods.reset(mapCompanyProfileToFormValues(profile, languages));
+
+            const values = mapCompanyProfileToFormValues(profile, languages);
+            savedValuesRef.current = values;
+            methods.reset(values);
         };
 
         void loadProfile();
@@ -111,7 +154,7 @@ export const CompanyProfileContent = () => {
                             isEditMode={isEditMode}
                             onEdit={() => setIsEditMode(true)}
                             onCancel={handleCancelClick}
-                            onPublish={methods.handleSubmit(handlePublish)}
+                            onPublish={methods.handleSubmit(handlePublishSubmit)}
                             isPublishDisabled={!methods.formState.isDirty || !methods.formState.isValid}
                         />
                     </div>
@@ -136,6 +179,12 @@ export const CompanyProfileContent = () => {
                 isOpen={isCancelModalOpen}
                 onConfirm={handleConfirmCancel}
                 onCancel={() => setIsCancelModalOpen(false)}
+            />
+
+            <CompanyProfilePublishModal
+                isOpen={isPublishModalOpen}
+                onConfirm={handleConfirmPublish}
+                onCancel={handleCancelPublish}
             />
 
             <ToastContainer />

--- a/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-content/CompanyProfileContent.tsx
@@ -47,6 +47,7 @@ export const CompanyProfileContent = () => {
     const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
 
     const [isPublishModalOpen, setIsPublishModalOpen] = useState(false);
+    const [isPublishing, setIsPublishing] = useState(false);
     const [pendingPublishData, setPendingPublishData] = useState<CompanyProfileFormValues | null>(null);
 
     const savedValuesRef = useRef<CompanyProfileFormValues>(COMPANY_PROFILE_FORM_DEFAULTS);
@@ -65,27 +66,30 @@ export const CompanyProfileContent = () => {
     };
 
     const handleConfirmPublish = async () => {
-        if (!pendingPublishData) return;
+        if (!pendingPublishData || isPublishing) return;
 
-        const { languages } = await CompanyProfileApi.get(client);
-        const patch = mapFormValuesToCompanyProfilePatch(pendingPublishData, languages);
+        setIsPublishing(true);
+        try {
+            const { languages } = await CompanyProfileApi.get(client);
+            const patch = mapFormValuesToCompanyProfilePatch(pendingPublishData, languages);
 
-        const { profile, languages: updatedLanguages } = await CompanyProfileApi.publish(client, patch);
+            const { profile, languages: updatedLanguages } = await CompanyProfileApi.publish(client, patch);
 
-        const nextValues = mapCompanyProfileToFormValues(profile, updatedLanguages);
-        savedValuesRef.current = nextValues;
+            const nextValues = mapCompanyProfileToFormValues(profile, updatedLanguages);
+            savedValuesRef.current = nextValues;
 
-        methods.reset(nextValues);
-        setIsEditMode(false);
-        setIsPublishModalOpen(false);
-        setPendingPublishData(null);
+            methods.reset(nextValues);
+            setIsEditMode(false);
+            setIsPublishModalOpen(false);
+            setPendingPublishData(null);
 
-        addToast('Зміни успішно опубліковано', ToastType.Success, 3000);
+            addToast('Зміни успішно опубліковано', ToastType.Success, 3000);
+        } finally {
+            setIsPublishing(false);
+        }
     };
 
     const handleCancelPublish = () => {
-        methods.reset(savedValuesRef.current);
-        setIsEditMode(false);
         setIsPublishModalOpen(false);
         setPendingPublishData(null);
     };
@@ -120,7 +124,10 @@ export const CompanyProfileContent = () => {
 
             const values = mapCompanyProfileToFormValues(profile, languages);
             savedValuesRef.current = values;
-            methods.reset(values);
+
+            if (!methods.formState.isDirty) {
+                methods.reset(values);
+            }
         };
 
         void loadProfile();
@@ -185,6 +192,7 @@ export const CompanyProfileContent = () => {
                 isOpen={isPublishModalOpen}
                 onConfirm={handleConfirmPublish}
                 onCancel={handleCancelPublish}
+                isButtonsDisabled={isPublishing}
             />
 
             <ToastContainer />

--- a/src/pages/admin/company-profile/components/company-profile-delete-social-modal/CompanyProfileDeleteSocialModal.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-delete-social-modal/CompanyProfileDeleteSocialModal.tsx
@@ -1,0 +1,27 @@
+import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { COMPANY_PROFILE_TEXT } from '@/const/admin/company-profile';
+
+export interface CompanyProfileDeleteSocialModalProps {
+    isOpen: boolean;
+    onConfirm: () => void;
+    onCancel: () => void;
+}
+
+export const CompanyProfileDeleteSocialModal = ({
+    isOpen,
+    onConfirm,
+    onCancel,
+}: CompanyProfileDeleteSocialModalProps) => {
+    return (
+        <ConfirmationModal
+            isOpen={isOpen}
+            title={COMPANY_PROFILE_TEXT.MODAL.DELETE_SOCIAL_TITLE}
+            onConfirm={onConfirm}
+            onCancel={onCancel}
+            onClose={onCancel}
+            confirmText={COMMON_TEXT_ADMIN.BUTTON.YES}
+            cancelText={COMMON_TEXT_ADMIN.BUTTON.NO}
+        />
+    );
+};

--- a/src/pages/admin/company-profile/components/company-profile-form-group/CompanyProfileFormGroup.module.scss
+++ b/src/pages/admin/company-profile/components/company-profile-form-group/CompanyProfileFormGroup.module.scss
@@ -21,24 +21,32 @@
 }
 
 .custom-form-group-input-wrapper {
-    position: relative;
+    flex: 1;
+    min-width: 0;
+}
+
+.custom-form-group-field-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     width: 100%;
 }
 
-.custom-form-group-tooltip-inside {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    z-index: 2;
-    display: inline-flex;
+.custom-form-group-tooltip-slot {
+    flex-shrink: 0;
+    width: 24px;
+    display: flex;
     align-items: center;
     justify-content: center;
+}
+
+.meta-row-wrapper {
+    padding-right: 32px;
 }
 
 .char-limit-input {
     width: 100%;
     min-width: 0;
-    padding-right: 44px;
 }
 
 .custom-form-group-input-wrapper :global(.char-limit-input),
@@ -51,6 +59,10 @@
     z-index: 9999;
     position: absolute;
     text-align: left;
+}
+
+.custom-form-group > :global(.input-error-with-counter) {
+    padding-right: 32px;
 }
 
 .meta-row--error-only :global(output) {

--- a/src/pages/admin/company-profile/components/company-profile-form-group/CompanyProfileFormGroup.module.scss
+++ b/src/pages/admin/company-profile/components/company-profile-form-group/CompanyProfileFormGroup.module.scss
@@ -6,7 +6,6 @@
     flex-direction: column;
     gap: 6px;
     width: 100%;
-    position: relative;
 }
 
 .custom-form-group-label-wrapper label {
@@ -24,7 +23,6 @@
 .custom-form-group-input-wrapper {
     position: relative;
     width: 100%;
-    padding-bottom: 20px;
 }
 
 .custom-form-group-tooltip-inside {
@@ -43,12 +41,7 @@
     padding-right: 44px;
 }
 
-.custom-form-group-input-wrapper :global(.char-limit-input) {
-    width: 100%;
-    min-width: 0;
-    flex: 1 1 auto;
-}
-
+.custom-form-group-input-wrapper :global(.char-limit-input),
 .custom-form-group-input-wrapper :global(input) {
     width: 100%;
     min-width: 0;
@@ -60,28 +53,6 @@
     text-align: left;
 }
 
-.custom-form-group :global(.input-error) {
-    position: absolute;
-    left: 0;
-    bottom: 0;
-    margin: 0;
-    height: 20px;
-    display: flex;
-    align-items: center;
-    max-width: calc(100% - 72px);
-    white-space: nowrap;
-    overflow: hidden;
-}
-
-.custom-form-group-input-wrapper :global(.char-limit-input__counter--bottom) {
-    position: absolute;
-    right: 0;
-    bottom: 0;
-    margin: 0;
-    height: 20px;
-    display: inline-flex;
-    align-items: center;
-    width: auto;
-    max-width: none;
-    white-space: nowrap;
+.meta-row--error-only :global(output) {
+    display: none;
 }

--- a/src/pages/admin/company-profile/components/company-profile-form-group/CompanyProfileFormGroup.test.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-form-group/CompanyProfileFormGroup.test.tsx
@@ -3,19 +3,31 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { CustomFormGroup } from './CompanyProfileFormGroup';
 
-const mockInputWithCharacterLimit = jest.fn();
+const mockInputWithCharacterLimit = jest.fn((props: any) => (
+    <input data-testid="char-limit-input" id={props.id} disabled={props.disabled} />
+));
+
 jest.mock('@/components/admin/input-with-character-limit/InputWithCharacterLimit', () => ({
-    InputWithCharacterLimit: (props: any) => {
-        mockInputWithCharacterLimit(props);
-        return <input data-testid="char-limit-input" id={props.id} disabled={props.disabled} />;
-    },
+    __esModule: true,
+    InputWithCharacterLimit: (props: any) => mockInputWithCharacterLimit(props),
 }));
 
-jest.mock('@/components/admin/input-error/InputError', () => ({
-    InputError: ({ error }: any) => (error ? <div data-testid="input-error">{error}</div> : null),
+jest.mock('@/components/admin/input-error-with-character-counter/InputErrorWithCharacterCounter', () => ({
+    __esModule: true,
+    InputErrorWithCharacterCounter: ({ error, maxLength, value, containerClassName }: any) => (
+        <div data-testid="input-error-with-counter" data-container-class={containerClassName ?? ''}>
+            <div data-testid="input-error">{error ?? ''}</div>
+            {!String(containerClassName ?? '').includes('meta-row--error-only') && (
+                <div data-testid="input-counter">
+                    {String(value ?? '').length}/{maxLength}
+                </div>
+            )}
+        </div>
+    ),
 }));
 
 jest.mock('@/components/admin/button-tooltip/ButtonTooltip', () => ({
+    __esModule: true,
     ButtonTooltip: ({ children }: any) => <div data-testid="button-tooltip">{children}</div>,
 }));
 
@@ -92,14 +104,15 @@ describe('CustomFormGroup', () => {
         expect(screen.queryByTestId('button-tooltip')).not.toBeInTheDocument();
     });
 
-    it('does not render tooltip content when tooltipText is not provided', () => {
+    it('does not render tooltip when tooltipText is not provided', () => {
         render(
             <CustomFormGroup id="field1" name="field1" maxLength={10} labelText="Label" value="" onChange={() => {}} />,
         );
+
         expect(screen.queryByTestId('button-tooltip')).not.toBeInTheDocument();
     });
 
-    it('passes hasError=true to InputWithCharacterLimit when error is provided and renders InputError', () => {
+    it('passes hasError=true to InputWithCharacterLimit when error is provided and renders error text via InputErrorWithCharacterCounter', () => {
         render(
             <CustomFormGroup
                 id="field1"
@@ -112,7 +125,10 @@ describe('CustomFormGroup', () => {
             />,
         );
 
-        expect(mockInputWithCharacterLimit).toHaveBeenCalledWith(expect.objectContaining({ hasError: true }));
+        expect(mockInputWithCharacterLimit).toHaveBeenCalled();
+        const lastCallProps = mockInputWithCharacterLimit.mock.calls.at(-1)?.[0];
+
+        expect(lastCallProps).toEqual(expect.objectContaining({ hasError: true }));
         expect(screen.getByTestId('input-error')).toHaveTextContent('Some error');
     });
 
@@ -121,6 +137,47 @@ describe('CustomFormGroup', () => {
             <CustomFormGroup id="field1" name="field1" maxLength={10} labelText="Label" value="" onChange={() => {}} />,
         );
 
-        expect(mockInputWithCharacterLimit).toHaveBeenCalledWith(expect.objectContaining({ hasError: false }));
+        expect(mockInputWithCharacterLimit).toHaveBeenCalled();
+        const lastCallProps = mockInputWithCharacterLimit.mock.calls.at(-1)?.[0];
+
+        expect(lastCallProps).toEqual(expect.objectContaining({ hasError: false }));
+    });
+
+    it('disables internal counter in InputWithCharacterLimit and uses InputErrorWithCharacterCounter for bottom counter', () => {
+        render(
+            <CustomFormGroup
+                id="field1"
+                name="field1"
+                maxLength={10}
+                labelText="Label"
+                value="abc"
+                onChange={() => {}}
+            />,
+        );
+
+        expect(mockInputWithCharacterLimit).toHaveBeenCalled();
+        const lastCallProps = mockInputWithCharacterLimit.mock.calls.at(-1)?.[0];
+
+        expect(lastCallProps).toEqual(expect.objectContaining({ showCounter: false }));
+
+        expect(screen.getByTestId('input-error-with-counter')).toBeInTheDocument();
+        expect(screen.getByTestId('input-counter')).toHaveTextContent('3/10');
+    });
+
+    it('when showCounter=false, still renders error row but hides counter', () => {
+        render(
+            <CustomFormGroup
+                id="field1"
+                name="field1"
+                maxLength={10}
+                labelText="Label"
+                value="abc"
+                onChange={() => {}}
+                showCounter={false}
+            />,
+        );
+
+        expect(screen.getByTestId('input-error-with-counter')).toBeInTheDocument();
+        expect(screen.queryByTestId('input-counter')).not.toBeInTheDocument();
     });
 });

--- a/src/pages/admin/company-profile/components/company-profile-form-group/CompanyProfileFormGroup.test.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-form-group/CompanyProfileFormGroup.test.tsx
@@ -70,7 +70,7 @@ describe('CustomFormGroup', () => {
         expect(screen.queryByText('Label')).not.toBeInTheDocument();
     });
 
-    it('renders tooltip when tooltipText is provided and field is disabled (view mode)', () => {
+    it('renders tooltip when tooltipText is provided in view mode (disabled=true)', () => {
         render(
             <CustomFormGroup
                 id="field1"
@@ -87,7 +87,7 @@ describe('CustomFormGroup', () => {
         expect(screen.getByTestId('button-tooltip')).toHaveTextContent('Tooltip text');
     });
 
-    it('does not render tooltip in edit mode even when tooltipText is provided', () => {
+    it('renders tooltip when tooltipText is provided in edit mode (disabled=false)', () => {
         render(
             <CustomFormGroup
                 id="field1"
@@ -101,7 +101,7 @@ describe('CustomFormGroup', () => {
             />,
         );
 
-        expect(screen.queryByTestId('button-tooltip')).not.toBeInTheDocument();
+        expect(screen.getByTestId('button-tooltip')).toHaveTextContent('Tooltip text');
     });
 
     it('does not render tooltip when tooltipText is not provided', () => {

--- a/src/pages/admin/company-profile/components/company-profile-form-group/CompanyProfileFormGroup.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-form-group/CompanyProfileFormGroup.tsx
@@ -4,8 +4,8 @@ import {
     InputWithCharacterLimit,
     InputWithCharacterLimitProps,
 } from '@/components/admin/input-with-character-limit/InputWithCharacterLimit';
-import { InputError } from '@/components/admin/input-error/InputError';
 import { ButtonTooltip } from '@/components/admin/button-tooltip/ButtonTooltip';
+import { InputErrorWithCharacterCounter } from '@/components/admin/input-error-with-character-counter/InputErrorWithCharacterCounter';
 import styles from './CompanyProfileFormGroup.module.scss';
 
 export interface CustomFormGroupProps extends Omit<InputWithCharacterLimitProps, 'hasError'> {
@@ -27,6 +27,8 @@ export const CustomFormGroup = ({
     showCounter = true,
     ...inputProps
 }: CustomFormGroupProps) => {
+    const counterId = `${id}-character-count`;
+
     return (
         <div className={styles['custom-form-group']}>
             {!hideLabel && (
@@ -43,8 +45,8 @@ export const CustomFormGroup = ({
                     {...inputProps}
                     id={id}
                     hasError={!!error}
-                    counterPosition="bottom"
-                    showCounter={showCounter}
+                    // We render the bottom counter ourselves together with the error message
+                    showCounter={false}
                     className={cn(styles['char-limit-input'], inputProps.className)}
                 />
 
@@ -57,7 +59,24 @@ export const CustomFormGroup = ({
                 )}
             </div>
 
-            <InputError error={error} />
+            {showCounter ? (
+                <InputErrorWithCharacterCounter
+                    error={error}
+                    maxLength={inputProps.maxLength}
+                    value={String(inputProps.value ?? '')}
+                    counterId={counterId}
+                    htmlFor={id}
+                />
+            ) : (
+                <InputErrorWithCharacterCounter
+                    error={error}
+                    maxLength={inputProps.maxLength}
+                    value={String(inputProps.value ?? '')}
+                    counterId={counterId}
+                    htmlFor={id}
+                    containerClassName={styles['meta-row--error-only']}
+                />
+            )}
         </div>
     );
 };

--- a/src/pages/admin/company-profile/components/company-profile-form-group/CompanyProfileFormGroup.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-form-group/CompanyProfileFormGroup.tsx
@@ -40,41 +40,47 @@ export const CustomFormGroup = ({
                 </div>
             )}
 
-            <div className={styles['custom-form-group-input-wrapper']}>
-                <InputWithCharacterLimit
-                    {...inputProps}
-                    id={id}
-                    hasError={!!error}
-                    showCounter={false}
-                    className={cn(styles['char-limit-input'], inputProps.className)}
-                />
+            <div className={styles['custom-form-group-field-row']}>
+                <div className={styles['custom-form-group-input-wrapper']}>
+                    <InputWithCharacterLimit
+                        {...inputProps}
+                        id={id}
+                        hasError={!!error}
+                        showCounter={false}
+                        className={cn(styles['char-limit-input'], inputProps.className)}
+                    />
+                </div>
 
-                {tooltipText && (
-                    <div className={styles['custom-form-group-tooltip-inside']}>
+                <div className={styles['custom-form-group-tooltip-slot']}>
+                    {tooltipText && (
                         <ButtonTooltip position="bottom" isRenderInPortal>
                             {tooltipText}
                         </ButtonTooltip>
-                    </div>
-                )}
+                    )}
+                </div>
             </div>
 
             {showCounter ? (
-                <InputErrorWithCharacterCounter
-                    error={error}
-                    maxLength={inputProps.maxLength}
-                    value={String(inputProps.value ?? '')}
-                    counterId={counterId}
-                    htmlFor={id}
-                />
+                <div className={styles['meta-row-wrapper']}>
+                    <InputErrorWithCharacterCounter
+                        error={error}
+                        maxLength={inputProps.maxLength}
+                        value={String(inputProps.value ?? '')}
+                        counterId={counterId}
+                        htmlFor={id}
+                    />
+                </div>
             ) : (
-                <InputErrorWithCharacterCounter
-                    error={error}
-                    maxLength={inputProps.maxLength}
-                    value={String(inputProps.value ?? '')}
-                    counterId={counterId}
-                    htmlFor={id}
-                    containerClassName={styles['meta-row--error-only']}
-                />
+                <div className={styles['meta-row-wrapper']}>
+                    <InputErrorWithCharacterCounter
+                        error={error}
+                        maxLength={inputProps.maxLength}
+                        value={String(inputProps.value ?? '')}
+                        counterId={counterId}
+                        htmlFor={id}
+                        containerClassName={styles['meta-row--error-only']}
+                    />
+                </div>
             )}
         </div>
     );

--- a/src/pages/admin/company-profile/components/company-profile-form-group/CompanyProfileFormGroup.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-form-group/CompanyProfileFormGroup.tsx
@@ -45,12 +45,11 @@ export const CustomFormGroup = ({
                     {...inputProps}
                     id={id}
                     hasError={!!error}
-                    // We render the bottom counter ourselves together with the error message
                     showCounter={false}
                     className={cn(styles['char-limit-input'], inputProps.className)}
                 />
 
-                {tooltipText && inputProps.disabled && (
+                {tooltipText && (
                     <div className={styles['custom-form-group-tooltip-inside']}>
                         <ButtonTooltip position="bottom" isRenderInPortal>
                             {tooltipText}

--- a/src/pages/admin/company-profile/components/company-profile-publish-modal/CompanyProfilePublishModal.test.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-publish-modal/CompanyProfilePublishModal.test.tsx
@@ -23,14 +23,18 @@ jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
 }));
 
 describe('CompanyProfilePublishModal', () => {
+    const setup = (props: Partial<React.ComponentProps<typeof CompanyProfilePublishModal>> = {}) => {
+        const defaultProps = { isOpen: true, onConfirm: jest.fn(), onCancel: jest.fn() };
+        return render(<CompanyProfilePublishModal {...defaultProps} {...props} />);
+    };
+
     it('does not render when isOpen=false', () => {
-        render(<CompanyProfilePublishModal isOpen={false} onConfirm={jest.fn()} onCancel={jest.fn()} />);
+        setup({ isOpen: false });
         expect(screen.queryByTestId('confirmation-modal')).not.toBeInTheDocument();
     });
 
     it('renders ConfirmationModal with correct texts when open', () => {
-        render(<CompanyProfilePublishModal isOpen={true} onConfirm={jest.fn()} onCancel={jest.fn()} />);
-
+        setup();
         expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument();
         expect(screen.getByTestId('confirmation-title')).toHaveTextContent(COMMON_TEXT_ADMIN.QUESTION.PUBLISH_CHANGES);
         expect(screen.getByTestId('confirm-btn')).toHaveTextContent(COMMON_TEXT_ADMIN.BUTTON.YES);
@@ -39,24 +43,21 @@ describe('CompanyProfilePublishModal', () => {
 
     it('calls onConfirm when confirm clicked', () => {
         const onConfirm = jest.fn();
-        render(<CompanyProfilePublishModal isOpen={true} onConfirm={onConfirm} onCancel={jest.fn()} />);
-
+        setup({ onConfirm });
         fireEvent.click(screen.getByTestId('confirm-btn'));
         expect(onConfirm).toHaveBeenCalledTimes(1);
     });
 
     it('calls onCancel when cancel clicked', () => {
         const onCancel = jest.fn();
-        render(<CompanyProfilePublishModal isOpen={true} onConfirm={jest.fn()} onCancel={onCancel} />);
-
+        setup({ onCancel });
         fireEvent.click(screen.getByTestId('cancel-btn'));
         expect(onCancel).toHaveBeenCalledTimes(1);
     });
 
     it('calls onCancel when close clicked', () => {
         const onCancel = jest.fn();
-        render(<CompanyProfilePublishModal isOpen={true} onConfirm={jest.fn()} onCancel={onCancel} />);
-
+        setup({ onCancel });
         fireEvent.click(screen.getByTestId('close-btn'));
         expect(onCancel).toHaveBeenCalledTimes(1);
     });

--- a/src/pages/admin/company-profile/components/company-profile-publish-modal/CompanyProfilePublishModal.test.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-publish-modal/CompanyProfilePublishModal.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { CompanyProfilePublishModal } from './CompanyProfilePublishModal';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+
+jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
+    ConfirmationModal: ({ isOpen, title, confirmText, cancelText, onConfirm, onCancel, onClose }: any) =>
+        isOpen ? (
+            <div data-testid="confirmation-modal">
+                <div data-testid="confirmation-title">{title}</div>
+                <button data-testid="confirm-btn" onClick={onConfirm}>
+                    {confirmText}
+                </button>
+                <button data-testid="cancel-btn" onClick={onCancel}>
+                    {cancelText}
+                </button>
+                <button data-testid="close-btn" onClick={onClose}>
+                    Close
+                </button>
+            </div>
+        ) : null,
+}));
+
+describe('CompanyProfilePublishModal', () => {
+    it('does not render when isOpen=false', () => {
+        render(<CompanyProfilePublishModal isOpen={false} onConfirm={jest.fn()} onCancel={jest.fn()} />);
+        expect(screen.queryByTestId('confirmation-modal')).not.toBeInTheDocument();
+    });
+
+    it('renders ConfirmationModal with correct texts when open', () => {
+        render(<CompanyProfilePublishModal isOpen={true} onConfirm={jest.fn()} onCancel={jest.fn()} />);
+
+        expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument();
+        expect(screen.getByTestId('confirmation-title')).toHaveTextContent(COMMON_TEXT_ADMIN.QUESTION.PUBLISH_CHANGES);
+        expect(screen.getByTestId('confirm-btn')).toHaveTextContent(COMMON_TEXT_ADMIN.BUTTON.YES);
+        expect(screen.getByTestId('cancel-btn')).toHaveTextContent(COMMON_TEXT_ADMIN.BUTTON.NO);
+    });
+
+    it('calls onConfirm when confirm clicked', () => {
+        const onConfirm = jest.fn();
+        render(<CompanyProfilePublishModal isOpen={true} onConfirm={onConfirm} onCancel={jest.fn()} />);
+
+        fireEvent.click(screen.getByTestId('confirm-btn'));
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onCancel when cancel clicked', () => {
+        const onCancel = jest.fn();
+        render(<CompanyProfilePublishModal isOpen={true} onConfirm={jest.fn()} onCancel={onCancel} />);
+
+        fireEvent.click(screen.getByTestId('cancel-btn'));
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onCancel when close clicked', () => {
+        const onCancel = jest.fn();
+        render(<CompanyProfilePublishModal isOpen={true} onConfirm={jest.fn()} onCancel={onCancel} />);
+
+        fireEvent.click(screen.getByTestId('close-btn'));
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/pages/admin/company-profile/components/company-profile-publish-modal/CompanyProfilePublishModal.test.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-publish-modal/CompanyProfilePublishModal.test.tsx
@@ -5,17 +5,17 @@ import { CompanyProfilePublishModal } from './CompanyProfilePublishModal';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 
 jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
-    ConfirmationModal: ({ isOpen, title, confirmText, cancelText, onConfirm, onCancel, onClose }: any) =>
+    ConfirmationModal: ({ isOpen, ...p }: any) =>
         isOpen ? (
             <div data-testid="confirmation-modal">
-                <div data-testid="confirmation-title">{title}</div>
-                <button data-testid="confirm-btn" onClick={onConfirm}>
-                    {confirmText}
+                <div data-testid="confirmation-title">{p.title}</div>
+                <button data-testid="confirm-btn" onClick={p.onConfirm}>
+                    {p.confirmText}
                 </button>
-                <button data-testid="cancel-btn" onClick={onCancel}>
-                    {cancelText}
+                <button data-testid="cancel-btn" onClick={p.onCancel}>
+                    {p.cancelText}
                 </button>
-                <button data-testid="close-btn" onClick={onClose}>
+                <button data-testid="close-btn" onClick={p.onClose}>
                     Close
                 </button>
             </div>

--- a/src/pages/admin/company-profile/components/company-profile-publish-modal/CompanyProfilePublishModal.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-publish-modal/CompanyProfilePublishModal.tsx
@@ -5,9 +5,15 @@ export interface CompanyProfilePublishModalProps {
     isOpen: boolean;
     onConfirm: () => void;
     onCancel: () => void;
+    isButtonsDisabled?: boolean;
 }
 
-export const CompanyProfilePublishModal = ({ isOpen, onConfirm, onCancel }: CompanyProfilePublishModalProps) => {
+export const CompanyProfilePublishModal = ({
+    isOpen,
+    onConfirm,
+    onCancel,
+    isButtonsDisabled,
+}: CompanyProfilePublishModalProps) => {
     return (
         <ConfirmationModal
             isOpen={isOpen}
@@ -17,6 +23,7 @@ export const CompanyProfilePublishModal = ({ isOpen, onConfirm, onCancel }: Comp
             onClose={onCancel}
             confirmText={COMMON_TEXT_ADMIN.BUTTON.YES}
             cancelText={COMMON_TEXT_ADMIN.BUTTON.NO}
+            isButtonsDisabled={isButtonsDisabled}
         />
     );
 };

--- a/src/pages/admin/company-profile/components/company-profile-publish-modal/CompanyProfilePublishModal.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-publish-modal/CompanyProfilePublishModal.tsx
@@ -1,0 +1,22 @@
+import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+
+export interface CompanyProfilePublishModalProps {
+    isOpen: boolean;
+    onConfirm: () => void;
+    onCancel: () => void;
+}
+
+export const CompanyProfilePublishModal = ({ isOpen, onConfirm, onCancel }: CompanyProfilePublishModalProps) => {
+    return (
+        <ConfirmationModal
+            isOpen={isOpen}
+            title={COMMON_TEXT_ADMIN.QUESTION.PUBLISH_CHANGES}
+            onConfirm={onConfirm}
+            onCancel={onCancel}
+            onClose={onCancel}
+            confirmText={COMMON_TEXT_ADMIN.BUTTON.YES}
+            cancelText={COMMON_TEXT_ADMIN.BUTTON.NO}
+        />
+    );
+};

--- a/src/pages/admin/company-profile/components/company-profile-social-media-tab/CompanyProfileSocialMediaTab.module.scss
+++ b/src/pages/admin/company-profile/components/company-profile-social-media-tab/CompanyProfileSocialMediaTab.module.scss
@@ -49,6 +49,7 @@
     align-items: center;
     justify-content: space-between;
     gap: 12px;
+    padding-right: 32px;
 }
 
 .social-media-contact-label {

--- a/src/pages/admin/company-profile/components/company-profile-social-media-tab/CompanyProfileSocialMediaTab.module.scss
+++ b/src/pages/admin/company-profile/components/company-profile-social-media-tab/CompanyProfileSocialMediaTab.module.scss
@@ -23,7 +23,7 @@
 }
 
 .social-media-tab-add {
-    width: 280px;
+    width: 248px;
 }
 
 .social-media-tab-limit-message {
@@ -72,4 +72,69 @@
   padding: 0;
   border: none;
   background: transparent;
+}
+
+.social-media-tab-add :global(.singleselect) {
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    background-color: c.$blue-500;
+}
+
+.social-media-tab-add :global(.singleselect-selected) {
+    background-color: c.$blue-600;
+}
+
+.social-media-tab-add :global(.select-input) {
+    background-color: transparent;
+    border-radius: 0;
+    color: c.$white;
+}
+
+.social-media-tab-add :global(.select-input:not(.select-input-disabled):hover) {
+    background-color: c.$blue-600;
+}
+
+.social-media-tab-add :global(.select-input-disabled),
+.social-media-tab-add :global(.select-input-disabled:hover) {
+    background-color: c.$grey-600;
+    color: c.$grey-400;
+    cursor: not-allowed;
+}
+
+.social-media-tab-add :global(.singleselect-options) {
+    border-radius: 0;
+    border-color: c.$blue-600;
+    background-color: c.$white;
+}
+
+.social-media-tab-add :global(.option) {
+    background-color: c.$white;
+    color: c.$dropdown-text;
+}
+
+.social-media-tab-add :global(.option:hover),
+.social-media-tab-add :global(.option-selected),
+.social-media-tab-add :global(.option-selected:hover) {
+    background-color: c.$dropdown-hover;
+}
+
+.social-media-tab-add :global(.option-selected),
+.social-media-tab-add :global(.option-selected:hover) {
+    background-color: c.$dropdown-hover;
+}
+
+.social-media-tab-add :global(.option-value),
+.social-media-tab-add :global(.option-value-placeholder) {
+    color: inherit;
+}
+
+.social-media-tab-add :global(.placeholder-arrow .icon-img) {
+    fill: currentColor;
+    color: inherit;
+    
+    path {
+        stroke: currentColor;
+        fill: currentColor;
+    }
 }

--- a/src/pages/admin/company-profile/components/company-profile-social-media-tab/CompanyProfileSocialMediaTab.test.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-social-media-tab/CompanyProfileSocialMediaTab.test.tsx
@@ -41,12 +41,25 @@ jest.mock('../company-profile-form-group/CompanyProfileFormGroup', () => ({
     ),
 }));
 
+jest.mock('../company-profile-delete-social-modal/CompanyProfileDeleteSocialModal', () => ({
+    CompanyProfileDeleteSocialModal: ({ isOpen, onConfirm, onCancel }: any) =>
+        isOpen ? (
+            <div data-testid="delete-social-modal">
+                <button data-testid="confirm-delete" onClick={onConfirm}>
+                    Так
+                </button>
+                <button data-testid="cancel-delete" onClick={onCancel}>
+                    Ні
+                </button>
+            </div>
+        ) : null,
+}));
+
 const Wrapper = (props: { disabled: boolean; defaultValues?: Partial<CompanyProfileFormValues> }) => {
     const methods = useForm<CompanyProfileFormValues>({
         defaultValues: { ...COMPANY_PROFILE_FORM_DEFAULTS, ...(props.defaultValues ?? {}) },
         mode: 'onBlur',
     });
-
     return (
         <FormProvider {...methods}>
             <CompanyProfileSocialMediaTab disabled={props.disabled} />
@@ -66,7 +79,7 @@ describe('CompanyProfileSocialMediaTab', () => {
         expect(screen.queryByTestId('add-platform-btn')).not.toBeInTheDocument();
     });
 
-    it('allows deleting social contact when disabled=false', () => {
+    it('does not show delete button when only one contact exists', () => {
         render(
             <Wrapper
                 disabled={false}
@@ -75,12 +88,55 @@ describe('CompanyProfileSocialMediaTab', () => {
                 }}
             />,
         );
+        expect(screen.queryByLabelText('Delete social contact')).not.toBeInTheDocument();
+    });
+
+    it('opens confirmation modal on delete click and removes contact on confirm', () => {
+        render(
+            <Wrapper
+                disabled={false}
+                defaultValues={{
+                    socialContacts: [
+                        { platform: 'Instagram', url: 'https://instagram.com/test' },
+                        { platform: 'Facebook', url: 'https://facebook.com/test' },
+                    ],
+                }}
+            />,
+        );
+
+        expect(screen.getAllByTestId(/^social-url-socialContacts\./)).toHaveLength(2);
+        expect(screen.queryByTestId('delete-social-modal')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getAllByLabelText('Delete social contact')[0]);
+
+        expect(screen.getByTestId('delete-social-modal')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('confirm-delete'));
 
         expect(screen.getAllByTestId(/^social-url-socialContacts\./)).toHaveLength(1);
+        expect(screen.queryByTestId('delete-social-modal')).not.toBeInTheDocument();
+    });
 
-        fireEvent.click(screen.getByLabelText('Delete social contact'));
+    it('closes modal without deleting on cancel', () => {
+        render(
+            <Wrapper
+                disabled={false}
+                defaultValues={{
+                    socialContacts: [
+                        { platform: 'Instagram', url: 'https://instagram.com/test' },
+                        { platform: 'Facebook', url: 'https://facebook.com/test' },
+                    ],
+                }}
+            />,
+        );
 
-        expect(screen.queryAllByTestId(/^social-url-socialContacts\./)).toHaveLength(0);
+        fireEvent.click(screen.getAllByLabelText('Delete social contact')[0]);
+        expect(screen.getByTestId('delete-social-modal')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('cancel-delete'));
+
+        expect(screen.queryByTestId('delete-social-modal')).not.toBeInTheDocument();
+        expect(screen.getAllByTestId(/^social-url-socialContacts\./)).toHaveLength(2);
     });
 
     it('disables add button when 4 contacts reached', () => {
@@ -97,7 +153,6 @@ describe('CompanyProfileSocialMediaTab', () => {
                 }}
             />,
         );
-
         expect(screen.getByTestId('add-platform-btn')).toBeDisabled();
         expect(screen.getByText(COMPANY_PROFILE_TEXT.SOCIAL_MEDIA_TAB.LIMIT_MESSAGE)).toBeInTheDocument();
     });

--- a/src/pages/admin/company-profile/components/company-profile-social-media-tab/CompanyProfileSocialMediaTab.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-social-media-tab/CompanyProfileSocialMediaTab.tsx
@@ -1,4 +1,5 @@
 import { useFormContext, Controller, useFieldArray } from 'react-hook-form';
+import { useState } from 'react';
 import { CustomFormGroup } from '../company-profile-form-group/CompanyProfileFormGroup';
 import { COMPANY_PROFILE_TEXT } from '@/const/admin/company-profile';
 import styles from './CompanyProfileSocialMediaTab.module.scss';
@@ -8,6 +9,7 @@ import { IconButton } from '@/components/admin/icon-button/IconButton';
 import { ACTION_ICONS } from '@/const/common/action-icons';
 import { ButtonTooltip } from '@/components/admin/button-tooltip/ButtonTooltip';
 import { CompanyProfileFormValues, SocialPlatform } from '@/types/admin/company-profile';
+import { CompanyProfileDeleteSocialModal } from '../company-profile-delete-social-modal/CompanyProfileDeleteSocialModal';
 
 interface CompanyProfileSocialMediaTabProps {
     disabled: boolean;
@@ -37,6 +39,8 @@ export const CompanyProfileSocialMediaTab = ({ disabled }: CompanyProfileSocialM
         control,
         name: 'socialContacts',
     });
+
+    const [deleteIndex, setDeleteIndex] = useState<number | null>(null);
 
     const watchedSocialContacts = watch('socialContacts');
 
@@ -73,6 +77,21 @@ export const CompanyProfileSocialMediaTab = ({ disabled }: CompanyProfileSocialM
     const handleAddPlatform = (opt: SelectOption) => {
         if (disabled || isLimitReached) return;
         append({ platform: opt.id, url: '' });
+    };
+
+    const handleDeleteClick = (index: number) => {
+        setDeleteIndex(index);
+    };
+
+    const handleConfirmDelete = () => {
+        if (deleteIndex !== null) {
+            remove(deleteIndex);
+            setDeleteIndex(null);
+        }
+    };
+
+    const handleCancelDelete = () => {
+        setDeleteIndex(null);
     };
 
     const showCounter = !disabled;
@@ -115,17 +134,19 @@ export const CompanyProfileSocialMediaTab = ({ disabled }: CompanyProfileSocialM
                                 <span className={styles['social-media-contact-label-text']}>{field.platform}</span>
                             </div>
 
-                            <div className={styles['social-media-contact-actions']}>
-                                <IconButton
-                                    type="button"
-                                    className={styles['social-media-contact-icon-btn']}
-                                    onClick={() => remove(index)}
-                                    aria-label="Delete social contact"
-                                    disabled={disabled}
-                                    DefaultIcon={ACTION_ICONS.delete.default}
-                                    FilledIcon={ACTION_ICONS.delete.hover}
-                                />
-                            </div>
+                            {fields.length > 1 && (
+                                <div className={styles['social-media-contact-actions']}>
+                                    <IconButton
+                                        type="button"
+                                        className={styles['social-media-contact-icon-btn']}
+                                        onClick={() => handleDeleteClick(index)}
+                                        aria-label="Delete social contact"
+                                        disabled={disabled}
+                                        DefaultIcon={ACTION_ICONS.delete.default}
+                                        FilledIcon={ACTION_ICONS.delete.hover}
+                                    />
+                                </div>
+                            )}
                         </div>
 
                         <Controller
@@ -148,6 +169,12 @@ export const CompanyProfileSocialMediaTab = ({ disabled }: CompanyProfileSocialM
                     </div>
                 ))}
             </div>
+
+            <CompanyProfileDeleteSocialModal
+                isOpen={deleteIndex !== null}
+                onConfirm={handleConfirmDelete}
+                onCancel={handleCancelDelete}
+            />
         </div>
     );
 };

--- a/src/pages/admin/company-profile/components/company-profile-toolbar/CompanyProfileToolbar.module.scss
+++ b/src/pages/admin/company-profile/components/company-profile-toolbar/CompanyProfileToolbar.module.scss
@@ -1,3 +1,4 @@
+@use '@/assets/sass/variables/colors' as c;
 @use '@/assets/sass/mixins/typography.mixins' as type;
 
 .profileToolbarActions {
@@ -9,4 +10,10 @@
 .profileToolbarActions :global(button) {
     @include type.subtitle-1-regular;
     padding: 16px 24px;
+}
+
+.profileToolbarActions :global(button:disabled) {
+    background-color: c.$blue-100;
+    border-color: c.$blue-100;
+    color: c.$white;
 }

--- a/src/services/api/admin/company-profile/company-profile-api.test.ts
+++ b/src/services/api/admin/company-profile/company-profile-api.test.ts
@@ -2,6 +2,30 @@ import { CompanyProfileApi } from './company-profile-api';
 import { mockCompanyProfile, mockCompanyProfileLanguages } from '@/utils/mock-data/admin/company-profile';
 import type { CompanyProfilePatch } from '@/utils/functions/mappers/admin/company-profile/company-profile-mappers';
 
+const createMockPatch = (socialLinks: any[] = []): CompanyProfilePatch => ({
+    contact: {
+        phone: '+380000000000',
+        address: 'New UA address',
+        email: 'new@email.com',
+        correspondenceEmail: 'new-office@email.com',
+        motto: 'New motto',
+        localizations: [
+            { languageCode: 'uk', address: 'New UA address', motto: 'New motto' },
+            { languageCode: 'en', address: 'New EN address', motto: 'New EN motto' },
+        ],
+    },
+    requisite: {
+        recipient: 'New recipient UA',
+        edrpou: '87654321',
+        address: 'New UA req address',
+        localizations: [
+            { languageCode: 'uk', recipient: 'New recipient UA', address: 'New UA req address' },
+            { languageCode: 'en', recipient: 'New recipient EN', address: 'New EN req address' },
+        ],
+    },
+    socialLinks,
+});
+
 describe('CompanyProfileApi', () => {
     beforeEach(() => {
         jest.useFakeTimers();
@@ -26,31 +50,9 @@ describe('CompanyProfileApi', () => {
     });
 
     it('publish should update stored profile and be returned by subsequent get()', async () => {
-        const patch: CompanyProfilePatch = {
-            contact: {
-                phone: '+380000000000',
-                address: 'New UA address',
-                email: 'new@email.com',
-                correspondenceEmail: 'new-office@email.com',
-                motto: 'New motto',
-                localizations: [
-                    { languageCode: 'uk', address: 'New UA address', motto: 'New motto' },
-                    { languageCode: 'en', address: 'New EN address', motto: 'New EN motto' },
-                ],
-            },
-            requisite: {
-                recipient: 'New recipient UA',
-                edrpou: '87654321',
-                address: 'New UA req address',
-                localizations: [
-                    { languageCode: 'uk', recipient: 'New recipient UA', address: 'New UA req address' },
-                    { languageCode: 'en', recipient: 'New recipient EN', address: 'New EN req address' },
-                ],
-            },
-            socialLinks: [{ socialPlatform: 'Instagram', url: 'https://instagram.com/new' }],
-        };
-
+        const patch = createMockPatch([{ socialPlatform: 'Instagram', url: 'https://instagram.com/new' }]);
         const publishPromise = CompanyProfileApi.publish({} as any, patch);
+
         jest.advanceTimersByTime(200);
         const published = await publishPromise;
 
@@ -60,6 +62,7 @@ describe('CompanyProfileApi', () => {
         expect(published.profile.socialLinks[0]?.url).toBe('https://instagram.com/new');
 
         const getPromise = CompanyProfileApi.get({} as any);
+
         jest.advanceTimersByTime(200);
         const afterGet = await getPromise;
 
@@ -69,37 +72,16 @@ describe('CompanyProfileApi', () => {
     });
 
     it('__resetMocks should restore initial mock profile', async () => {
-        const patch: CompanyProfilePatch = {
-            contact: {
-                phone: '+380000000000',
-                address: 'New UA address',
-                email: 'new@email.com',
-                correspondenceEmail: 'new-office@email.com',
-                motto: 'New motto',
-                localizations: [
-                    { languageCode: 'uk', address: 'New UA address', motto: 'New motto' },
-                    { languageCode: 'en', address: 'New EN address', motto: 'New EN motto' },
-                ],
-            },
-            requisite: {
-                recipient: 'New recipient UA',
-                edrpou: '87654321',
-                address: 'New UA req address',
-                localizations: [
-                    { languageCode: 'uk', recipient: 'New recipient UA', address: 'New UA req address' },
-                    { languageCode: 'en', recipient: 'New recipient EN', address: 'New EN req address' },
-                ],
-            },
-            socialLinks: [],
-        };
-
+        const patch = createMockPatch([]);
         const publishPromise = CompanyProfileApi.publish({} as any, patch);
+
         jest.advanceTimersByTime(200);
         await publishPromise;
 
         CompanyProfileApi.__resetMocks();
 
         const getPromise = CompanyProfileApi.get({} as any);
+
         jest.advanceTimersByTime(200);
         const result = await getPromise;
 

--- a/src/services/api/admin/company-profile/company-profile-api.test.ts
+++ b/src/services/api/admin/company-profile/company-profile-api.test.ts
@@ -1,9 +1,11 @@
 import { CompanyProfileApi } from './company-profile-api';
 import { mockCompanyProfile, mockCompanyProfileLanguages } from '@/utils/mock-data/admin/company-profile';
+import type { CompanyProfilePatch } from '@/utils/functions/mappers/admin/company-profile/company-profile-mappers';
 
 describe('CompanyProfileApi', () => {
     beforeEach(() => {
         jest.useFakeTimers();
+        CompanyProfileApi.__resetMocks();
     });
 
     afterEach(() => {
@@ -23,19 +25,85 @@ describe('CompanyProfileApi', () => {
         });
     });
 
-    it('should resolve only after artificial delay', async () => {
-        let resolved = false;
+    it('publish should update stored profile and be returned by subsequent get()', async () => {
+        const patch: CompanyProfilePatch = {
+            contact: {
+                phone: '+380000000000',
+                address: 'New UA address',
+                email: 'new@email.com',
+                correspondenceEmail: 'new-office@email.com',
+                motto: 'New motto',
+                localizations: [
+                    { languageCode: 'uk', address: 'New UA address', motto: 'New motto' },
+                    { languageCode: 'en', address: 'New EN address', motto: 'New EN motto' },
+                ],
+            },
+            requisite: {
+                recipient: 'New recipient UA',
+                edrpou: '87654321',
+                address: 'New UA req address',
+                localizations: [
+                    { languageCode: 'uk', recipient: 'New recipient UA', address: 'New UA req address' },
+                    { languageCode: 'en', recipient: 'New recipient EN', address: 'New EN req address' },
+                ],
+            },
+            socialLinks: [{ socialPlatform: 'Instagram', url: 'https://instagram.com/new' }],
+        };
 
-        const promise = CompanyProfileApi.get({} as any).then(() => {
-            resolved = true;
-        });
+        const publishPromise = CompanyProfileApi.publish({} as any, patch);
+        jest.advanceTimersByTime(200);
+        const published = await publishPromise;
 
-        jest.advanceTimersByTime(199);
-        await Promise.resolve();
-        expect(resolved).toBe(false);
+        expect(published.profile.contact.phone).toBe('+380000000000');
+        expect(published.profile.contact.email).toBe('new@email.com');
+        expect(published.profile.requisite.edrpou).toBe('87654321');
+        expect(published.profile.socialLinks[0]?.url).toBe('https://instagram.com/new');
 
-        jest.advanceTimersByTime(1);
-        await promise;
-        expect(resolved).toBe(true);
+        const getPromise = CompanyProfileApi.get({} as any);
+        jest.advanceTimersByTime(200);
+        const afterGet = await getPromise;
+
+        expect(afterGet.profile.contact.phone).toBe('+380000000000');
+        expect(afterGet.profile.requisite.edrpou).toBe('87654321');
+        expect(afterGet.profile.socialLinks[0]?.url).toBe('https://instagram.com/new');
+    });
+
+    it('__resetMocks should restore initial mock profile', async () => {
+        const patch: CompanyProfilePatch = {
+            contact: {
+                phone: '+380000000000',
+                address: 'New UA address',
+                email: 'new@email.com',
+                correspondenceEmail: 'new-office@email.com',
+                motto: 'New motto',
+                localizations: [
+                    { languageCode: 'uk', address: 'New UA address', motto: 'New motto' },
+                    { languageCode: 'en', address: 'New EN address', motto: 'New EN motto' },
+                ],
+            },
+            requisite: {
+                recipient: 'New recipient UA',
+                edrpou: '87654321',
+                address: 'New UA req address',
+                localizations: [
+                    { languageCode: 'uk', recipient: 'New recipient UA', address: 'New UA req address' },
+                    { languageCode: 'en', recipient: 'New recipient EN', address: 'New EN req address' },
+                ],
+            },
+            socialLinks: [],
+        };
+
+        const publishPromise = CompanyProfileApi.publish({} as any, patch);
+        jest.advanceTimersByTime(200);
+        await publishPromise;
+
+        CompanyProfileApi.__resetMocks();
+
+        const getPromise = CompanyProfileApi.get({} as any);
+        jest.advanceTimersByTime(200);
+        const result = await getPromise;
+
+        expect(result.profile).toEqual(mockCompanyProfile);
+        expect(result.languages).toEqual(mockCompanyProfileLanguages);
     });
 });

--- a/src/services/api/admin/company-profile/company-profile-api.ts
+++ b/src/services/api/admin/company-profile/company-profile-api.ts
@@ -1,13 +1,81 @@
 import { AxiosInstance } from 'axios';
 import { CompanyProfile, LocalizationLanguage } from '@/types/admin/company-profile';
 import { mockCompanyProfile, mockCompanyProfileLanguages } from '@/utils/mock-data/admin/company-profile';
+import { CompanyProfilePatch } from '@/utils/functions/mappers/admin/company-profile/company-profile-mappers';
+
+const deepClone = <T>(v: T): T => JSON.parse(JSON.stringify(v));
+
+let storedProfile: CompanyProfile = deepClone(mockCompanyProfile);
+let storedLanguages: LocalizationLanguage[] | undefined = deepClone(mockCompanyProfileLanguages);
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 export const CompanyProfileApi = {
     get: async (_client: AxiosInstance): Promise<{ profile: CompanyProfile; languages?: LocalizationLanguage[] }> => {
-        await new Promise((r) => setTimeout(r, 200));
+        await delay(200);
         return {
-            profile: mockCompanyProfile,
-            languages: mockCompanyProfileLanguages,
+            profile: storedProfile,
+            languages: storedLanguages,
         };
+    },
+
+    publish: async (
+        _client: AxiosInstance,
+        patch: CompanyProfilePatch,
+    ): Promise<{ profile: CompanyProfile; languages?: LocalizationLanguage[] }> => {
+        await delay(200);
+
+        storedProfile = {
+            ...storedProfile,
+            contact: {
+                ...storedProfile.contact,
+                phone: patch.contact.phone,
+                address: patch.contact.address,
+                email: patch.contact.email,
+                correspondenceEmail: patch.contact.correspondenceEmail,
+                motto: patch.contact.motto ?? '',
+                localizations: storedProfile.contact.localizations.map((loc: any) => {
+                    const langCode = loc.language?.code;
+                    const locPatch = patch.contact.localizations.find((l) => l.languageCode === langCode);
+                    if (!locPatch) return loc;
+
+                    return {
+                        ...loc,
+                        address: locPatch.address,
+                        motto: locPatch.motto ?? '',
+                    };
+                }),
+            },
+            requisite: {
+                ...storedProfile.requisite,
+                recipient: patch.requisite.recipient,
+                edrpou: patch.requisite.edrpou,
+                address: patch.requisite.address,
+                localizations: storedProfile.requisite.localizations.map((loc: any) => {
+                    const langCode = loc.language?.code;
+                    const locPatch = patch.requisite.localizations.find((l) => l.languageCode === langCode);
+                    if (!locPatch) return loc;
+
+                    return {
+                        ...loc,
+                        recipient: locPatch.recipient,
+                        address: locPatch.address,
+                    };
+                }),
+            },
+            socialLinks: patch.socialLinks.map((l, idx) => ({
+                id: storedProfile.socialLinks[idx]?.id ?? idx + 1,
+                profileId: storedProfile.id,
+                socialPlatform: l.socialPlatform,
+                url: l.url,
+            })),
+        };
+
+        return { profile: storedProfile, languages: storedLanguages };
+    },
+
+    __resetMocks: () => {
+        storedProfile = deepClone(mockCompanyProfile);
+        storedLanguages = deepClone(mockCompanyProfileLanguages);
     },
 };


### PR DESCRIPTION
## Github ticker

* Epic https://github.com/ita-social-projects/VictoryCenter-Back/issues/916

## Description

This PR completes the Company Profile admin page flow with mock data. The base structure was already in place; this PR finalizes the full feature set covering view, edit, publish, cancel, tooltip display, and social media management (view, add, delete with confirmation).

Covers the following User Stories:

[#915](https://github.com/ita-social-projects/VictoryCenter-Back/issues/915) - View company details
[#917](https://github.com/ita-social-projects/VictoryCenter-Back/issues/917) - Validation company details
[#918](https://github.com/ita-social-projects/VictoryCenter-Back/issues/918) - Edit company details
[#919](https://github.com/ita-social-projects/VictoryCenter-Back/issues/919) - Publish company details
[#920](https://github.com/ita-social-projects/VictoryCenter-Back/issues/920) - Edit social media contact
[#924](https://github.com/ita-social-projects/VictoryCenter-Back/issues/924) - Cancel changes
[#958](https://github.com/ita-social-projects/VictoryCenter-Back/issues/958) - Apply info tooltip
[#961](https://github.com/ita-social-projects/VictoryCenter-Back/issues/961) - Add social media
[#962](https://github.com/ita-social-projects/VictoryCenter-Back/issues/962) - Delete social media contact

> **Note:** All functionality is implemented with mock data. 
> Real API integration will be done in a separate task once the backend endpoints are merged and available.

## How it looks

https://github.com/user-attachments/assets/2f4765c1-52eb-482d-9115-e600e325d1b1

## Summary of change

- `CompanyProfileSocialMediaTab` - added delete confirmation modal flow; hide Delete icon when only 1 contact remains
- `CompanyProfileDeleteSocialModal` - new component, confirmation modal for social contact deletion ("Видалити соц мережу?")
`company-profile.ts` - added `DELETE_SOCIAL_TITLE` constant to `MODAL`
- `CustomFormGroup` - fixed tooltip visibility: now rendered in both view and edit modes (removed `disabled` condition)
- `CompanyProfileSocialMediaTab.test.tsx` - updated tests: added modal mock, split delete test into confirm/cancel scenarios, added test for hidden Delete button at 1 contact
- `CompanyProfileFormGroup.test.tsx` - updated tooltip tests to reflect correct behavior (visible in both modes)
- `CustomFormGroup`- tooltip icon moved outside the input to a dedicated slot on the right (`custom-form-group-tooltip-slot`) to avoid overlap with the clear icon in edit mode; a fixed `32px` right padding is applied to all counter rows to keep alignment consistent across fields with and without tooltip
- `InputWithCharacterLimit` - reverted changes from previous PR and used `InputErrorWithCharacterCount` instead in `CustomFormGroup`

## How to recreate changes

> **Testing note:** The page runs on mock data - no real API calls are made. 
> Data persists within the session but resets on page refresh.

1. Navigate to **Профіль** in the admin sidebar
2. Verify all fields are visible and non-editable in view mode; tooltips are shown on hover for relevant fields
3. Click **Редагувати сторінку** - edit mode activates
4. Verify tooltips remain visible in edit mode
5. Open tab **Соціальні мережі**:
   - Add contacts via dropdown (up to 4); verify limit message appears at 4
   - Click Delete icon on a contact - confirmation modal appears
   - Click **Ні** - modal closes, contact remains
   - Click Delete again -> **Так** - contact is removed, platform returns to dropdown
   - Verify Delete icon is hidden when only 1 contact remains
6. Make changes and click **Опублікувати** - confirm in modal -> toast "Зміни успішно опубліковано" appears for 3s, page returns to view mode
7. Click **Відмінити** with unsaved changes - confirmation modal appears; confirm to discard

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [x]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added publish confirmation modal with success notification.
  * Added confirmation modal for deleting social network contacts.
  * Added a publish API flow that persists published changes.

* **Improvements**
  * Redesigned form layout, tooltip, error and counter placement; delete control shown only when multiple contacts exist.
  * Publish flow now confirms, preserves/restores saved form state, and refreshes languages after publish.
  * Updated disabled button styling and new dropdown color tokens.

* **Bug Fixes**
  * Character counter rendering and accessibility behavior consolidated.

* **Tests**
  * Updated/added tests covering publish, delete modal, layout and counter behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->