### PR TITLE
Fix/issue-1931: Fix incorrect add block button label in single program form

### DIFF
--- a/src/components/common/program-section-templates/single-title-description-author-pairs/SingleTitleDescriptionAuthorPairs.test.tsx
+++ b/src/components/common/program-section-templates/single-title-description-author-pairs/SingleTitleDescriptionAuthorPairs.test.tsx
@@ -87,7 +87,7 @@ jest.mock('@/const/admin/programs', () => ({
             FORM: { TITLE: { TEXT: 'Title' } },
             CARD: {
                 FORM: { SAMPLE: { AUTHOR: 'SAMPLE_AUTHOR' } },
-                BUTTON: { ADD_CARD: 'Add card' },
+                BUTTON: { ADD_CARD: 'Add block' },
             },
             SINGLE_TITLE_DESCRIPTION_AUTHOR_PAIRS: {
                 TITLE_PLACEHOLDER: '',
@@ -283,7 +283,7 @@ describe('SingleTitleDescriptionAuthorPairs', () => {
 
     it('renders add button only in edit mode and respects canAddPair', () => {
         const view = renderComponent({ mode: ProgramSectionMode.View });
-        expect(screen.queryByRole('button', { name: 'Add card' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Add block' })).not.toBeInTheDocument();
         view.unmount();
 
         const onAddPair = jest.fn();
@@ -293,11 +293,11 @@ describe('SingleTitleDescriptionAuthorPairs', () => {
             onAddPair,
             canAddPair: false,
         });
-        expect(screen.getByRole('button', { name: 'Add card' })).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Add block' })).toBeDisabled();
         utils.unmount();
 
         renderComponent({ mode: ProgramSectionMode.Edit, onAddPair, canAddPair: true });
-        fireEvent.click(screen.getByRole('button', { name: 'Add card' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Add block' }));
         expect(onAddPair).toHaveBeenCalledTimes(1);
     });
 

--- a/src/const/admin/programs.ts
+++ b/src/const/admin/programs.ts
@@ -61,7 +61,7 @@ export const PROGRAMS_TEXT = {
         },
         CARD: {
             BUTTON: {
-                ADD_CARD: 'Додати карточку',
+                ADD_CARD: 'Додати блок',
             },
             FORM: {
                 TITLE: {


### PR DESCRIPTION
## JIRA or Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1931

## Description

Updated the button label in the Single Program admin form from Додати картку to Додати блок for the relevant content block section, matching the expected UI text.

## How it looks

<img width="1504" height="856" alt="image" src="https://github.com/user-attachments/assets/49e9e9ef-07d5-4cb7-84e1-16a4514a20cd" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated button label from 'Add card' to 'Add block' for improved clarity and consistency throughout the application interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->