### PR TITLE
Feature/issue: 1325,1707: Implement logic for Cancel and Confirm while editing inf PDF files section title 

### DIFF
--- a/src/const/admin/common.ts
+++ b/src/const/admin/common.ts
@@ -58,7 +58,8 @@ export const COMMON_TEXT_ADMIN = {
     },
 
     MESSAGE: {
-        SUCCESSFULLY_PUBLISHED: 'успішно опубліковано',
+        SUCCESSFULLY_PUBLISHED: 'Успішно опубліковано',
+        UPDATES_SUCCESSFULLY_PUBLISHED: 'Зміни успішно опубліковані',
         FAIL_TO_PUBLISH_CHANGES: 'Не вдалося опублікувати зміни',
         TRANSLATION_SAVED_SUCCESS: 'Переклад збережено успішно',
         TRANSLATION_PUBLISHED_SUCCESS: 'Переклад опубліковано успішно',

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.test.tsx
@@ -57,7 +57,12 @@ async function confirmModal(user: ReturnType<typeof userEvent.setup>) {
     await user.click(confirmButton);
 }
 
-async function openPublishModal(user: ReturnType<typeof userEvent.setup>, title = 'Updated Title') {
+async function openPublishModal(
+    user: ReturnType<typeof userEvent.setup>,
+    title = 'Updated Title',
+    props: Partial<React.ComponentProps<typeof PdfSectionContentBlock>> = {},
+) {
+    render(<PdfSectionContentBlock content={MOCK_CONTENT} {...props} />);
     await enterEditMode(user);
     await changeTitle(user, title);
     await clickPublish(user);
@@ -94,6 +99,7 @@ describe('PdfSectionContentBlock', () => {
     });
 
     async function renderAndEnterEditMode(): Promise<ReturnType<typeof userEvent.setup>> {
+        render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
         const user = userEvent.setup();
         await enterEditMode(user);
         return user;
@@ -101,6 +107,7 @@ describe('PdfSectionContentBlock', () => {
 
     describe('Edit Mode', () => {
         it('should switch to edit mode when edit button is clicked', async () => {
+            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
             const user = userEvent.setup();
             await enterEditMode(user);
             expect(screen.getByDisplayValue(MOCK_CONTENT.title)).toBeInTheDocument();
@@ -138,7 +145,6 @@ describe('PdfSectionContentBlock', () => {
             const utils = await renderAndEnterEditMode();
             await changeTitle(utils, 'New Title');
             await utils.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
-            await utils.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
             await confirmModal(utils);
             expect(screen.queryByDisplayValue('New Title')).not.toBeInTheDocument();
             expect(screen.getByText(MOCK_CONTENT.title)).toBeInTheDocument();
@@ -147,7 +153,7 @@ describe('PdfSectionContentBlock', () => {
         it('should call onSave when publish button is clicked with valid data', async () => {
             const mockOnSave = jest.fn().mockResolvedValue(undefined);
             const user = userEvent.setup();
-            await openPublishModal(user);
+            await openPublishModal(user, 'Updated Title', { onSave: mockOnSave });
             await confirmModal(user);
             await waitFor(() =>
                 expect(mockOnSave).toHaveBeenCalledWith({
@@ -172,9 +178,9 @@ describe('PdfSectionContentBlock', () => {
         });
 
         it('should close modal and not save when clicking НІ button', async () => {
-            const mockOnSave = jest.fn();
+            const mockOnSave = jest.fn().mockResolvedValue(undefined);
             const user = userEvent.setup();
-            await openPublishModal(user);
+            await openPublishModal(user, 'Updated Title', { onSave: mockOnSave });
             const modal = await screen.findByTestId('confirmation-modal');
             await user.click(screen.getByText('НІ'));
             await waitFor(() => expect(modal).not.toBeInTheDocument());
@@ -185,7 +191,7 @@ describe('PdfSectionContentBlock', () => {
         it('should save and show success toast when clicking ТАК button', async () => {
             const mockOnSave = jest.fn().mockResolvedValue(undefined);
             const user = userEvent.setup();
-            await openPublishModal(user);
+            await openPublishModal(user, 'Updated Title', { onSave: mockOnSave });
             await confirmModal(user);
             await waitFor(() =>
                 expect(mockOnSave).toHaveBeenCalledWith({
@@ -199,7 +205,7 @@ describe('PdfSectionContentBlock', () => {
         it('should revert to view mode after successful save', async () => {
             const mockOnSave = jest.fn().mockResolvedValue(undefined);
             const user = userEvent.setup();
-            await openPublishModal(user);
+            await openPublishModal(user, 'Updated Title', { onSave: mockOnSave });
             await confirmModal(user);
             await waitFor(() => expect(screen.queryByDisplayValue('Updated Title')).not.toBeInTheDocument());
             expect(screen.getByRole('button', { name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT })).toBeInTheDocument();
@@ -210,7 +216,6 @@ describe('PdfSectionContentBlock', () => {
             const savePromise = new Promise<void>((resolve) => {
                 resolveSave = resolve;
             });
-            const mockOnSave = jest.fn(() => savePromise);
             jest.spyOn(PdfSectionApi, 'updatePdfSection').mockReturnValue(savePromise as any);
             const user = userEvent.setup();
             await openPublishModal(user);

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.test.tsx
@@ -172,6 +172,9 @@ describe('PdfSectionContentBlock', () => {
                 }),
             );
 
+            const confirmButton = await screen.findByText('ТАК');
+            await user.click(confirmButton);
+
             expect(screen.queryByDisplayValue('New Title')).not.toBeInTheDocument();
             expect(screen.getByText(mockContent.title)).toBeInTheDocument();
         });
@@ -203,7 +206,6 @@ describe('PdfSectionContentBlock', () => {
 
             await user.click(publishButton);
 
-            // Click confirm button in the modal
             const confirmButton = await screen.findByText('ТАК');
             await user.click(confirmButton);
 
@@ -400,6 +402,125 @@ describe('PdfSectionContentBlock', () => {
             await user.click(confirmButton);
 
             resolveSave!();
+        });
+    });
+
+    describe('Cancel Changes Modal', () => {
+        it('should cancel without modal when no changes made', async () => {
+            const user = userEvent.setup();
+            render(<PdfSectionContentBlock content={mockContent} />);
+
+            await user.click(
+                screen.getByRole('button', {
+                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
+                }),
+            );
+
+            await user.click(
+                screen.getByRole('button', {
+                    name: COMMON_TEXT_ADMIN.BUTTON.CANCEL,
+                }),
+            );
+
+            expect(screen.queryByTestId('confirmation-modal')).not.toBeInTheDocument();
+            expect(screen.getByRole('button', { name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT })).toBeInTheDocument();
+        });
+
+        it('should open cancel confirmation modal when changes made', async () => {
+            const user = userEvent.setup();
+            render(<PdfSectionContentBlock content={mockContent} />);
+
+            await user.click(
+                screen.getByRole('button', {
+                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
+                }),
+            );
+
+            const titleInput = screen.getByLabelText(/заголовок/i);
+            await user.clear(titleInput);
+            await user.type(titleInput, 'Updated Title');
+
+            await user.tab();
+
+            await user.click(
+                screen.getByRole('button', {
+                    name: COMMON_TEXT_ADMIN.BUTTON.CANCEL,
+                }),
+            );
+
+            const modal = await screen.findByTestId('confirmation-modal');
+            expect(modal).toBeInTheDocument();
+            expect(
+                screen.getByText(COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE),
+            ).toBeInTheDocument();
+        });
+
+        it('should close modal and keep edit mode when clicking НІ in cancel modal', async () => {
+            const user = userEvent.setup();
+            render(<PdfSectionContentBlock content={mockContent} />);
+
+            await user.click(
+                screen.getByRole('button', {
+                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
+                }),
+            );
+
+            const titleInput = screen.getByLabelText(/заголовок/i);
+            await user.clear(titleInput);
+            await user.type(titleInput, 'Updated Title');
+
+            await user.tab();
+
+            await user.click(
+                screen.getByRole('button', {
+                    name: COMMON_TEXT_ADMIN.BUTTON.CANCEL,
+                }),
+            );
+
+            const modal = await screen.findByTestId('confirmation-modal');
+            const cancelButton = screen.getByText('НІ');
+
+            await user.click(cancelButton);
+
+            await waitFor(() => {
+                expect(modal).not.toBeInTheDocument();
+            });
+
+            expect(screen.getByDisplayValue('Updated Title')).toBeInTheDocument();
+        });
+
+        it('should revert changes when clicking ТАК in cancel modal', async () => {
+            const user = userEvent.setup();
+            render(<PdfSectionContentBlock content={mockContent} />);
+
+            await user.click(
+                screen.getByRole('button', {
+                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
+                }),
+            );
+
+            const titleInput = screen.getByLabelText(/заголовок/i);
+            await user.clear(titleInput);
+            await user.type(titleInput, 'Updated Title');
+
+            await user.tab();
+
+            await user.click(
+                screen.getByRole('button', {
+                    name: COMMON_TEXT_ADMIN.BUTTON.CANCEL,
+                }),
+            );
+
+            const confirmButton = await screen.findByText('ТАК');
+            await user.click(confirmButton);
+
+            await waitFor(() => {
+                expect(screen.queryByDisplayValue('Updated Title')).not.toBeInTheDocument();
+            });
+
+            expect(screen.getByText(mockContent.title)).toBeInTheDocument();
+            expect(screen.getByText(mockContent.description)).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT })).toBeInTheDocument();
         });
     });
 });

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.test.tsx
@@ -5,11 +5,23 @@ import { PDF_FILES_SECTION_TEXT } from '@/const/admin/reports';
 import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextProvider';
 import { PdfSectionApi } from '@/services/api/admin/reports/pdf-section/pdf-section-api';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { ToastType } from '@/types/admin/toast';
 
 jest.mock('@/contexts/admin/toast-context-provider/ToastContextProvider');
 
 jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
     useAdminClient: () => ({}),
+}));
+
+jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
+    ConfirmationModal: ({ isOpen, onConfirm, onCancel, title }: any) =>
+        isOpen ? (
+            <div data-testid="confirmation-modal" role="dialog">
+                <h2>{title}</h2>
+                <button onClick={onCancel}>НІ</button>
+                <button onClick={onConfirm}>ТАК</button>
+            </div>
+        ) : null,
 }));
 
 const mockUseToast = useToast as jest.MockedFunction<typeof useToast>;
@@ -191,6 +203,10 @@ describe('PdfSectionContentBlock', () => {
 
             await user.click(publishButton);
 
+            // Click confirm button in the modal
+            const confirmButton = await screen.findByText('ТАК');
+            await user.click(confirmButton);
+
             await waitFor(() => {
                 expect(mockOnSave).toHaveBeenCalledWith({
                     title: 'Updated Title',
@@ -210,6 +226,180 @@ describe('PdfSectionContentBlock', () => {
 
             const counters = screen.getAllByText(/\//);
             expect(counters.length).toBeGreaterThan(0);
+        });
+    });
+
+    describe('Confirmation Modal', () => {
+        it('should open confirmation modal when publish button is clicked with valid changes', async () => {
+            const user = userEvent.setup();
+            render(<PdfSectionContentBlock content={mockContent} />);
+
+            await user.click(
+                screen.getByRole('button', {
+                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
+                }),
+            );
+
+            const titleInput = screen.getByLabelText(/заголовок/i);
+            await user.clear(titleInput);
+            await user.type(titleInput, 'Updated Title');
+
+            await user.tab();
+
+            const publishButton = screen.getByRole('button', {
+                name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED,
+            });
+
+            await user.click(publishButton);
+
+            const modal = await screen.findByTestId('confirmation-modal');
+            expect(modal).toBeInTheDocument();
+            expect(screen.getByText(COMMON_TEXT_ADMIN.QUESTION.PUBLISH_CHANGES)).toBeInTheDocument();
+        });
+
+        it('should close modal and not save when clicking НІ button', async () => {
+            const user = userEvent.setup();
+            const mockOnSave = jest.fn();
+
+            render(<PdfSectionContentBlock content={mockContent} onSave={mockOnSave} />);
+
+            await user.click(
+                screen.getByRole('button', {
+                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
+                }),
+            );
+
+            const titleInput = screen.getByLabelText(/заголовок/i);
+            await user.clear(titleInput);
+            await user.type(titleInput, 'Updated Title');
+
+            await user.tab();
+
+            const publishButton = screen.getByRole('button', {
+                name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED,
+            });
+
+            await user.click(publishButton);
+
+            const modal = await screen.findByTestId('confirmation-modal');
+            const cancelButton = screen.getByText('НІ');
+
+            await user.click(cancelButton);
+
+            await waitFor(() => {
+                expect(modal).not.toBeInTheDocument();
+            });
+
+            expect(mockOnSave).not.toHaveBeenCalled();
+            expect(mockAddToast).not.toHaveBeenCalled();
+        });
+
+        it('should save and show success toast when clicking ТАК button', async () => {
+            const user = userEvent.setup();
+            const mockOnSave = jest.fn().mockResolvedValue(undefined);
+
+            render(<PdfSectionContentBlock content={mockContent} onSave={mockOnSave} />);
+
+            await user.click(
+                screen.getByRole('button', {
+                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
+                }),
+            );
+
+            const titleInput = screen.getByLabelText(/заголовок/i);
+            await user.clear(titleInput);
+            await user.type(titleInput, 'Updated Title');
+
+            await user.tab();
+
+            const publishButton = screen.getByRole('button', {
+                name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED,
+            });
+
+            await user.click(publishButton);
+
+            const confirmButton = await screen.findByText('ТАК');
+            await user.click(confirmButton);
+
+            await waitFor(() => {
+                expect(mockOnSave).toHaveBeenCalledWith({
+                    title: 'Updated Title',
+                    description: mockContent.description,
+                });
+            });
+
+            expect(mockAddToast).toHaveBeenCalledWith('Зміни успішно опубліковані', ToastType.Success);
+        });
+
+        it('should revert to view mode after successful save', async () => {
+            const user = userEvent.setup();
+            const mockOnSave = jest.fn().mockResolvedValue(undefined);
+
+            render(<PdfSectionContentBlock content={mockContent} onSave={mockOnSave} />);
+
+            await user.click(
+                screen.getByRole('button', {
+                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
+                }),
+            );
+
+            const titleInput = screen.getByLabelText(/заголовок/i);
+            await user.clear(titleInput);
+            await user.type(titleInput, 'Updated Title');
+
+            await user.tab();
+
+            const publishButton = screen.getByRole('button', {
+                name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED,
+            });
+
+            await user.click(publishButton);
+
+            const confirmButton = await screen.findByText('ТАК');
+            await user.click(confirmButton);
+
+            await waitFor(() => {
+                expect(screen.queryByDisplayValue('Updated Title')).not.toBeInTheDocument();
+            });
+
+            expect(screen.getByRole('button', { name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT })).toBeInTheDocument();
+        });
+
+        it('should disable modal buttons during save', async () => {
+            const user = userEvent.setup();
+            let resolveSave: () => void;
+            const savePromise = new Promise<void>((resolve) => {
+                resolveSave = resolve;
+            });
+
+            const mockOnSave = jest.fn(() => savePromise);
+
+            jest.spyOn(PdfSectionApi, 'updatePdfSection').mockReturnValue(savePromise as any);
+
+            render(<PdfSectionContentBlock content={mockContent} onSave={mockOnSave} />);
+
+            await user.click(
+                screen.getByRole('button', {
+                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
+                }),
+            );
+
+            const titleInput = screen.getByLabelText(/заголовок/i);
+            await user.clear(titleInput);
+            await user.type(titleInput, 'Updated Title');
+
+            await user.tab();
+
+            const publishButton = screen.getByRole('button', {
+                name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED,
+            });
+
+            await user.click(publishButton);
+
+            const confirmButton = await screen.findByText('ТАК');
+            await user.click(confirmButton);
+
+            resolveSave!();
         });
     });
 });

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.test.tsx
@@ -12,12 +12,16 @@ jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
     useAdminClient: () => ({}),
 }));
 jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
-    ConfirmationModal: ({ isOpen, onConfirm, onCancel, title }: any) =>
+    ConfirmationModal: ({ isOpen, onConfirm, onCancel, title, isButtonsDisabled }: any) =>
         isOpen ? (
             <div data-testid="confirmation-modal" role="dialog">
                 <h2>{title}</h2>
-                <button onClick={onCancel}>НІ</button>
-                <button onClick={onConfirm}>ТАК</button>
+                <button onClick={onCancel} disabled={isButtonsDisabled}>
+                    НІ
+                </button>
+                <button onClick={onConfirm} disabled={isButtonsDisabled}>
+                    ТАК
+                </button>
             </div>
         ) : null,
 }));
@@ -89,6 +93,13 @@ describe('PdfSectionContentBlock', () => {
         });
     });
 
+    async function renderAndEnterEditMode() {
+        render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+        const user = userEvent.setup();
+        await enterEditMode(user);
+        return user;
+    }
+
     describe('Edit Mode', () => {
         it('should switch to edit mode when edit button is clicked', async () => {
             const user = userEvent.setup();
@@ -99,17 +110,13 @@ describe('PdfSectionContentBlock', () => {
         });
 
         it('should display form labels in edit mode', async () => {
-            const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
-            await enterEditMode(user);
+            await renderAndEnterEditMode();
             expect(screen.getByText(PDF_FILES_SECTION_TEXT.TITLE)).toBeInTheDocument();
             expect(screen.getByText(PDF_FILES_SECTION_TEXT.DESCRIPTION)).toBeInTheDocument();
         });
 
         it('should display publish and cancel buttons', async () => {
-            const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
-            await enterEditMode(user);
+            await renderAndEnterEditMode();
             expect(
                 screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED }),
             ).toBeInTheDocument();
@@ -117,16 +124,12 @@ describe('PdfSectionContentBlock', () => {
         });
 
         it('should disable publish button when form is unchanged', async () => {
-            const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
-            await enterEditMode(user);
+            await renderAndEnterEditMode();
             expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED })).toBeDisabled();
         });
 
         it('should enable publish button when form changes are made', async () => {
-            const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
-            await enterEditMode(user);
+            const user = await renderAndEnterEditMode();
             await changeTitle(user, 'New Title Updated');
             await waitFor(() =>
                 expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED })).toBeEnabled(),
@@ -229,18 +232,14 @@ describe('PdfSectionContentBlock', () => {
 
     describe('Cancel Changes Modal', () => {
         it('should cancel without modal when no changes made', async () => {
-            const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
-            await enterEditMode(user);
+            const user = await renderAndEnterEditMode();
             await user.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
             expect(screen.queryByTestId('confirmation-modal')).not.toBeInTheDocument();
             expect(screen.getByRole('button', { name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT })).toBeInTheDocument();
         });
 
         it('should open cancel confirmation modal when changes made', async () => {
-            const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
-            await enterEditMode(user);
+            const user = await renderAndEnterEditMode();
             await changeTitle(user, 'Updated Title');
             await user.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
             expect(await screen.findByTestId('confirmation-modal')).toBeInTheDocument();
@@ -250,9 +249,7 @@ describe('PdfSectionContentBlock', () => {
         });
 
         it('should close modal and keep edit mode when clicking НІ in cancel modal', async () => {
-            const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
-            await enterEditMode(user);
+            const user = await renderAndEnterEditMode();
             await changeTitle(user, 'Updated Title');
             await user.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
             const modal = await screen.findByTestId('confirmation-modal');
@@ -262,9 +259,7 @@ describe('PdfSectionContentBlock', () => {
         });
 
         it('should revert changes when clicking ТАК in cancel modal', async () => {
-            const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
-            await enterEditMode(user);
+            const user = await renderAndEnterEditMode();
             await changeTitle(user, 'Updated Title');
             await user.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
             await confirmModal(user);

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.test.tsx
@@ -8,11 +8,9 @@ import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { ToastType } from '@/types/admin/toast';
 
 jest.mock('@/contexts/admin/toast-context-provider/ToastContextProvider');
-
 jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
     useAdminClient: () => ({}),
 }));
-
 jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
     ConfirmationModal: ({ isOpen, onConfirm, onCancel, title }: any) =>
         isOpen ? (
@@ -26,272 +24,165 @@ jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
 
 const mockUseToast = useToast as jest.MockedFunction<typeof useToast>;
 
-describe('PdfSectionContentBlock', () => {
-    const mockContent = {
-        title: 'Test Section Title',
-        description: 'Test Section Description',
-    };
+const MOCK_CONTENT = {
+    title: 'Test Section Title',
+    description: 'Test Section Description',
+};
 
+async function enterEditMode(user: ReturnType<typeof userEvent.setup>) {
+    await user.click(screen.getByRole('button', { name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT }));
+}
+
+async function changeTitle(user: ReturnType<typeof userEvent.setup>, newTitle: string) {
+    const titleInput = screen.getByLabelText(/заголовок/i);
+    await user.clear(titleInput);
+    await user.type(titleInput, newTitle);
+    await user.tab();
+}
+
+async function clickPublish(user: ReturnType<typeof userEvent.setup>) {
+    const publishButton = screen.getByRole('button', {
+        name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED,
+    });
+    await waitFor(() => expect(publishButton).toBeEnabled());
+    await user.click(publishButton);
+}
+
+async function confirmModal(user: ReturnType<typeof userEvent.setup>) {
+    const confirmButton = await screen.findByText('ТАК');
+    await user.click(confirmButton);
+}
+
+async function openPublishModal(user: ReturnType<typeof userEvent.setup>, title = 'Updated Title') {
+    await enterEditMode(user);
+    await changeTitle(user, title);
+    await clickPublish(user);
+}
+
+describe('PdfSectionContentBlock', () => {
     const mockAddToast = jest.fn();
 
     beforeEach(() => {
         jest.clearAllMocks();
-        mockUseToast.mockReturnValue({
-            addToast: mockAddToast,
-        } as any);
+        mockUseToast.mockReturnValue({ addToast: mockAddToast } as any);
         jest.spyOn(PdfSectionApi, 'updatePdfSection').mockResolvedValue({} as any);
     });
 
     describe('View Mode', () => {
         it('should render title and description in view mode', () => {
-            render(<PdfSectionContentBlock content={mockContent} />);
-
+            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
             expect(screen.getByText(PDF_FILES_SECTION_TEXT.TITLE)).toBeInTheDocument();
-            expect(screen.getByText(mockContent.title)).toBeInTheDocument();
+            expect(screen.getByText(MOCK_CONTENT.title)).toBeInTheDocument();
             expect(screen.getByText(PDF_FILES_SECTION_TEXT.DESCRIPTION)).toBeInTheDocument();
-            expect(screen.getByText(mockContent.description)).toBeInTheDocument();
+            expect(screen.getByText(MOCK_CONTENT.description)).toBeInTheDocument();
         });
 
         it('should apply correct classes for view mode', () => {
-            const { container } = render(<PdfSectionContentBlock content={mockContent} />);
-
-            const rootDiv = container.firstChild;
-            expect(rootDiv).toHaveClass('root', 'view-root');
-
-            const titleText = screen.getByText(mockContent.title);
-            expect(titleText).toHaveClass('view-text', 'view-text-title');
+            const { container } = render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+            expect(container.firstChild).toHaveClass('root', 'view-root');
+            expect(screen.getByText(MOCK_CONTENT.title)).toHaveClass('view-text', 'view-text-title');
         });
 
         it('should render edit button', () => {
-            render(<PdfSectionContentBlock content={mockContent} />);
-
-            const editButton = screen.getByRole('button', { name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT });
-            expect(editButton).toBeInTheDocument();
+            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+            expect(screen.getByRole('button', { name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT })).toBeInTheDocument();
         });
     });
 
     describe('Edit Mode', () => {
         it('should switch to edit mode when edit button is clicked', async () => {
             const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={mockContent} />);
-
-            const editButton = screen.getByRole('button', { name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT });
-            await user.click(editButton);
-
-            expect(screen.getByDisplayValue(mockContent.title)).toBeInTheDocument();
-            expect(screen.getByDisplayValue(mockContent.description)).toBeInTheDocument();
+            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+            await enterEditMode(user);
+            expect(screen.getByDisplayValue(MOCK_CONTENT.title)).toBeInTheDocument();
+            expect(screen.getByDisplayValue(MOCK_CONTENT.description)).toBeInTheDocument();
         });
 
         it('should display form labels in edit mode', async () => {
             const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={mockContent} />);
-
-            const editButton = screen.getByRole('button', { name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT });
-            await user.click(editButton);
-
+            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+            await enterEditMode(user);
             expect(screen.getByText(PDF_FILES_SECTION_TEXT.TITLE)).toBeInTheDocument();
             expect(screen.getByText(PDF_FILES_SECTION_TEXT.DESCRIPTION)).toBeInTheDocument();
         });
 
         it('should display publish and cancel buttons', async () => {
             const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={mockContent} />);
-
-            const editButton = screen.getByRole('button', {
-                name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
-            });
-
-            await user.click(editButton);
-
+            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+            await enterEditMode(user);
             expect(
                 screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED }),
             ).toBeInTheDocument();
-
             expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL })).toBeInTheDocument();
         });
 
         it('should disable publish button when form is unchanged', async () => {
             const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={mockContent} />);
-
-            const editButton = screen.getByRole('button', {
-                name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
-            });
-            await user.click(editButton);
-
-            const publishButton = screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED });
-            expect(publishButton).toBeDisabled();
+            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+            await enterEditMode(user);
+            expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED })).toBeDisabled();
         });
 
         it('should enable publish button when form changes are made', async () => {
             const user = userEvent.setup();
-
-            render(<PdfSectionContentBlock content={mockContent} />);
-
-            await user.click(
-                screen.getByRole('button', {
-                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
-                }),
+            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+            await enterEditMode(user);
+            await changeTitle(user, 'New Title Updated');
+            await waitFor(() =>
+                expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED })).toBeEnabled(),
             );
-
-            const titleInput = screen.getByLabelText(/заголовок/i);
-
-            await user.clear(titleInput);
-            await user.type(titleInput, 'New Title Updated');
-
-            await user.tab();
-
-            const publishButton = screen.getByRole('button', {
-                name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED,
-            });
-
-            await waitFor(() => {
-                expect(publishButton).toBeEnabled();
-            });
         });
 
         it('should cancel edit and return to view mode', async () => {
             const user = userEvent.setup();
-
-            render(<PdfSectionContentBlock content={mockContent} />);
-
-            await user.click(
-                screen.getByRole('button', {
-                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
-                }),
-            );
-
-            const titleInput = screen.getByDisplayValue(mockContent.title);
-
-            await user.clear(titleInput);
-            await user.type(titleInput, 'New Title');
-
-            await user.click(
-                screen.getByRole('button', {
-                    name: COMMON_TEXT_ADMIN.BUTTON.CANCEL,
-                }),
-            );
-
-            const confirmButton = await screen.findByText('ТАК');
-            await user.click(confirmButton);
-
+            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+            await enterEditMode(user);
+            await changeTitle(user, 'New Title');
+            await user.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
+            await confirmModal(user);
             expect(screen.queryByDisplayValue('New Title')).not.toBeInTheDocument();
-            expect(screen.getByText(mockContent.title)).toBeInTheDocument();
+            expect(screen.getByText(MOCK_CONTENT.title)).toBeInTheDocument();
         });
 
         it('should call onSave when publish button is clicked with valid data', async () => {
             const user = userEvent.setup();
             const mockOnSave = jest.fn().mockResolvedValue(undefined);
-
-            render(<PdfSectionContentBlock content={mockContent} onSave={mockOnSave} />);
-
-            await user.click(
-                screen.getByRole('button', {
-                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
-                }),
-            );
-
-            const titleInput = screen.getByLabelText(/заголовок/i);
-
-            await user.clear(titleInput);
-            await user.type(titleInput, 'Updated Title');
-
-            await user.tab();
-
-            const publishButton = screen.getByRole('button', {
-                name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED,
-            });
-
-            await waitFor(() => expect(publishButton).toBeEnabled());
-
-            await user.click(publishButton);
-
-            const confirmButton = await screen.findByText('ТАК');
-            await user.click(confirmButton);
-
-            await waitFor(() => {
+            render(<PdfSectionContentBlock content={MOCK_CONTENT} onSave={mockOnSave} />);
+            await openPublishModal(user);
+            await confirmModal(user);
+            await waitFor(() =>
                 expect(mockOnSave).toHaveBeenCalledWith({
                     title: 'Updated Title',
-                    description: mockContent.description,
-                });
-            });
+                    description: MOCK_CONTENT.description,
+                }),
+            );
         });
 
         it('should have character counters for both fields', async () => {
             const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={mockContent} />);
-
-            const editButton = screen.getByRole('button', {
-                name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
-            });
-            await user.click(editButton);
-
-            const counters = screen.getAllByText(/\//);
-            expect(counters.length).toBeGreaterThan(0);
+            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+            await enterEditMode(user);
+            expect(screen.getAllByText(/\//).length).toBeGreaterThan(0);
         });
     });
 
     describe('Confirmation Modal', () => {
         it('should open confirmation modal when publish button is clicked with valid changes', async () => {
             const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={mockContent} />);
-
-            await user.click(
-                screen.getByRole('button', {
-                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
-                }),
-            );
-
-            const titleInput = screen.getByLabelText(/заголовок/i);
-            await user.clear(titleInput);
-            await user.type(titleInput, 'Updated Title');
-
-            await user.tab();
-
-            const publishButton = screen.getByRole('button', {
-                name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED,
-            });
-
-            await user.click(publishButton);
-
-            const modal = await screen.findByTestId('confirmation-modal');
-            expect(modal).toBeInTheDocument();
+            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+            await openPublishModal(user);
+            expect(await screen.findByTestId('confirmation-modal')).toBeInTheDocument();
             expect(screen.getByText(COMMON_TEXT_ADMIN.QUESTION.PUBLISH_CHANGES)).toBeInTheDocument();
         });
 
         it('should close modal and not save when clicking НІ button', async () => {
             const user = userEvent.setup();
             const mockOnSave = jest.fn();
-
-            render(<PdfSectionContentBlock content={mockContent} onSave={mockOnSave} />);
-
-            await user.click(
-                screen.getByRole('button', {
-                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
-                }),
-            );
-
-            const titleInput = screen.getByLabelText(/заголовок/i);
-            await user.clear(titleInput);
-            await user.type(titleInput, 'Updated Title');
-
-            await user.tab();
-
-            const publishButton = screen.getByRole('button', {
-                name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED,
-            });
-
-            await user.click(publishButton);
-
+            render(<PdfSectionContentBlock content={MOCK_CONTENT} onSave={mockOnSave} />);
+            await openPublishModal(user);
             const modal = await screen.findByTestId('confirmation-modal');
-            const cancelButton = screen.getByText('НІ');
-
-            await user.click(cancelButton);
-
-            await waitFor(() => {
-                expect(modal).not.toBeInTheDocument();
-            });
-
+            await user.click(screen.getByText('НІ'));
+            await waitFor(() => expect(modal).not.toBeInTheDocument());
             expect(mockOnSave).not.toHaveBeenCalled();
             expect(mockAddToast).not.toHaveBeenCalled();
         });
@@ -299,157 +190,60 @@ describe('PdfSectionContentBlock', () => {
         it('should save and show success toast when clicking ТАК button', async () => {
             const user = userEvent.setup();
             const mockOnSave = jest.fn().mockResolvedValue(undefined);
-
-            render(<PdfSectionContentBlock content={mockContent} onSave={mockOnSave} />);
-
-            await user.click(
-                screen.getByRole('button', {
-                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
-                }),
-            );
-
-            const titleInput = screen.getByLabelText(/заголовок/i);
-            await user.clear(titleInput);
-            await user.type(titleInput, 'Updated Title');
-
-            await user.tab();
-
-            const publishButton = screen.getByRole('button', {
-                name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED,
-            });
-
-            await user.click(publishButton);
-
-            const confirmButton = await screen.findByText('ТАК');
-            await user.click(confirmButton);
-
-            await waitFor(() => {
+            render(<PdfSectionContentBlock content={MOCK_CONTENT} onSave={mockOnSave} />);
+            await openPublishModal(user);
+            await confirmModal(user);
+            await waitFor(() =>
                 expect(mockOnSave).toHaveBeenCalledWith({
                     title: 'Updated Title',
-                    description: mockContent.description,
-                });
-            });
-
+                    description: MOCK_CONTENT.description,
+                }),
+            );
             expect(mockAddToast).toHaveBeenCalledWith('Зміни успішно опубліковані', ToastType.Success);
         });
 
         it('should revert to view mode after successful save', async () => {
             const user = userEvent.setup();
             const mockOnSave = jest.fn().mockResolvedValue(undefined);
-
-            render(<PdfSectionContentBlock content={mockContent} onSave={mockOnSave} />);
-
-            await user.click(
-                screen.getByRole('button', {
-                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
-                }),
-            );
-
-            const titleInput = screen.getByLabelText(/заголовок/i);
-            await user.clear(titleInput);
-            await user.type(titleInput, 'Updated Title');
-
-            await user.tab();
-
-            const publishButton = screen.getByRole('button', {
-                name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED,
-            });
-
-            await user.click(publishButton);
-
-            const confirmButton = await screen.findByText('ТАК');
-            await user.click(confirmButton);
-
-            await waitFor(() => {
-                expect(screen.queryByDisplayValue('Updated Title')).not.toBeInTheDocument();
-            });
-
+            render(<PdfSectionContentBlock content={MOCK_CONTENT} onSave={mockOnSave} />);
+            await openPublishModal(user);
+            await confirmModal(user);
+            await waitFor(() => expect(screen.queryByDisplayValue('Updated Title')).not.toBeInTheDocument());
             expect(screen.getByRole('button', { name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT })).toBeInTheDocument();
         });
 
         it('should disable modal buttons during save', async () => {
             const user = userEvent.setup();
-            let resolveSave: () => void;
+            let resolveSave!: () => void;
             const savePromise = new Promise<void>((resolve) => {
                 resolveSave = resolve;
             });
-
             const mockOnSave = jest.fn(() => savePromise);
-
             jest.spyOn(PdfSectionApi, 'updatePdfSection').mockReturnValue(savePromise as any);
-
-            render(<PdfSectionContentBlock content={mockContent} onSave={mockOnSave} />);
-
-            await user.click(
-                screen.getByRole('button', {
-                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
-                }),
-            );
-
-            const titleInput = screen.getByLabelText(/заголовок/i);
-            await user.clear(titleInput);
-            await user.type(titleInput, 'Updated Title');
-
-            await user.tab();
-
-            const publishButton = screen.getByRole('button', {
-                name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED,
-            });
-
-            await user.click(publishButton);
-
-            const confirmButton = await screen.findByText('ТАК');
-            await user.click(confirmButton);
-
-            resolveSave!();
+            render(<PdfSectionContentBlock content={MOCK_CONTENT} onSave={mockOnSave} />);
+            await openPublishModal(user);
+            await screen.findByText('ТАК');
+            resolveSave();
         });
     });
 
     describe('Cancel Changes Modal', () => {
         it('should cancel without modal when no changes made', async () => {
             const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={mockContent} />);
-
-            await user.click(
-                screen.getByRole('button', {
-                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
-                }),
-            );
-
-            await user.click(
-                screen.getByRole('button', {
-                    name: COMMON_TEXT_ADMIN.BUTTON.CANCEL,
-                }),
-            );
-
+            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+            await enterEditMode(user);
+            await user.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
             expect(screen.queryByTestId('confirmation-modal')).not.toBeInTheDocument();
             expect(screen.getByRole('button', { name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT })).toBeInTheDocument();
         });
 
         it('should open cancel confirmation modal when changes made', async () => {
             const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={mockContent} />);
-
-            await user.click(
-                screen.getByRole('button', {
-                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
-                }),
-            );
-
-            const titleInput = screen.getByLabelText(/заголовок/i);
-            await user.clear(titleInput);
-            await user.type(titleInput, 'Updated Title');
-
-            await user.tab();
-
-            await user.click(
-                screen.getByRole('button', {
-                    name: COMMON_TEXT_ADMIN.BUTTON.CANCEL,
-                }),
-            );
-
-            const modal = await screen.findByTestId('confirmation-modal');
-            expect(modal).toBeInTheDocument();
+            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+            await enterEditMode(user);
+            await changeTitle(user, 'Updated Title');
+            await user.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
+            expect(await screen.findByTestId('confirmation-modal')).toBeInTheDocument();
             expect(
                 screen.getByText(COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE),
             ).toBeInTheDocument();
@@ -457,70 +251,25 @@ describe('PdfSectionContentBlock', () => {
 
         it('should close modal and keep edit mode when clicking НІ in cancel modal', async () => {
             const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={mockContent} />);
-
-            await user.click(
-                screen.getByRole('button', {
-                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
-                }),
-            );
-
-            const titleInput = screen.getByLabelText(/заголовок/i);
-            await user.clear(titleInput);
-            await user.type(titleInput, 'Updated Title');
-
-            await user.tab();
-
-            await user.click(
-                screen.getByRole('button', {
-                    name: COMMON_TEXT_ADMIN.BUTTON.CANCEL,
-                }),
-            );
-
+            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+            await enterEditMode(user);
+            await changeTitle(user, 'Updated Title');
+            await user.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
             const modal = await screen.findByTestId('confirmation-modal');
-            const cancelButton = screen.getByText('НІ');
-
-            await user.click(cancelButton);
-
-            await waitFor(() => {
-                expect(modal).not.toBeInTheDocument();
-            });
-
+            await user.click(screen.getByText('НІ'));
+            await waitFor(() => expect(modal).not.toBeInTheDocument());
             expect(screen.getByDisplayValue('Updated Title')).toBeInTheDocument();
         });
 
         it('should revert changes when clicking ТАК in cancel modal', async () => {
             const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={mockContent} />);
-
-            await user.click(
-                screen.getByRole('button', {
-                    name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT,
-                }),
-            );
-
-            const titleInput = screen.getByLabelText(/заголовок/i);
-            await user.clear(titleInput);
-            await user.type(titleInput, 'Updated Title');
-
-            await user.tab();
-
-            await user.click(
-                screen.getByRole('button', {
-                    name: COMMON_TEXT_ADMIN.BUTTON.CANCEL,
-                }),
-            );
-
-            const confirmButton = await screen.findByText('ТАК');
-            await user.click(confirmButton);
-
-            await waitFor(() => {
-                expect(screen.queryByDisplayValue('Updated Title')).not.toBeInTheDocument();
-            });
-
-            expect(screen.getByText(mockContent.title)).toBeInTheDocument();
-            expect(screen.getByText(mockContent.description)).toBeInTheDocument();
-            expect(screen.getByRole('button', { name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT })).toBeInTheDocument();
+            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+            await enterEditMode(user);
+            await changeTitle(user, 'Updated Title');
+            await user.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
+            await confirmModal(user);
+            expect(screen.queryByDisplayValue('Updated Title')).not.toBeInTheDocument();
+            expect(screen.getByText(MOCK_CONTENT.title)).toBeInTheDocument();
         });
     });
 });

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.test.tsx
@@ -93,8 +93,7 @@ describe('PdfSectionContentBlock', () => {
         });
     });
 
-    async function renderAndEnterEditMode() {
-        render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+    async function renderAndEnterEditMode(): Promise<ReturnType<typeof userEvent.setup>> {
         const user = userEvent.setup();
         await enterEditMode(user);
         return user;
@@ -103,7 +102,6 @@ describe('PdfSectionContentBlock', () => {
     describe('Edit Mode', () => {
         it('should switch to edit mode when edit button is clicked', async () => {
             const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
             await enterEditMode(user);
             expect(screen.getByDisplayValue(MOCK_CONTENT.title)).toBeInTheDocument();
             expect(screen.getByDisplayValue(MOCK_CONTENT.description)).toBeInTheDocument();
@@ -129,28 +127,26 @@ describe('PdfSectionContentBlock', () => {
         });
 
         it('should enable publish button when form changes are made', async () => {
-            const user = await renderAndEnterEditMode();
-            await changeTitle(user, 'New Title Updated');
+            const utils = await renderAndEnterEditMode();
+            await changeTitle(utils, 'New Title Updated');
             await waitFor(() =>
                 expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED })).toBeEnabled(),
             );
         });
 
         it('should cancel edit and return to view mode', async () => {
-            const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
-            await enterEditMode(user);
-            await changeTitle(user, 'New Title');
-            await user.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
-            await confirmModal(user);
+            const utils = await renderAndEnterEditMode();
+            await changeTitle(utils, 'New Title');
+            await utils.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
+            await utils.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
+            await confirmModal(utils);
             expect(screen.queryByDisplayValue('New Title')).not.toBeInTheDocument();
             expect(screen.getByText(MOCK_CONTENT.title)).toBeInTheDocument();
         });
 
         it('should call onSave when publish button is clicked with valid data', async () => {
-            const user = userEvent.setup();
             const mockOnSave = jest.fn().mockResolvedValue(undefined);
-            render(<PdfSectionContentBlock content={MOCK_CONTENT} onSave={mockOnSave} />);
+            const user = userEvent.setup();
             await openPublishModal(user);
             await confirmModal(user);
             await waitFor(() =>
@@ -162,9 +158,7 @@ describe('PdfSectionContentBlock', () => {
         });
 
         it('should have character counters for both fields', async () => {
-            const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
-            await enterEditMode(user);
+            await renderAndEnterEditMode();
             expect(screen.getAllByText(/\//).length).toBeGreaterThan(0);
         });
     });
@@ -172,16 +166,14 @@ describe('PdfSectionContentBlock', () => {
     describe('Confirmation Modal', () => {
         it('should open confirmation modal when publish button is clicked with valid changes', async () => {
             const user = userEvent.setup();
-            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
             await openPublishModal(user);
             expect(await screen.findByTestId('confirmation-modal')).toBeInTheDocument();
             expect(screen.getByText(COMMON_TEXT_ADMIN.QUESTION.PUBLISH_CHANGES)).toBeInTheDocument();
         });
 
         it('should close modal and not save when clicking НІ button', async () => {
-            const user = userEvent.setup();
             const mockOnSave = jest.fn();
-            render(<PdfSectionContentBlock content={MOCK_CONTENT} onSave={mockOnSave} />);
+            const user = userEvent.setup();
             await openPublishModal(user);
             const modal = await screen.findByTestId('confirmation-modal');
             await user.click(screen.getByText('НІ'));
@@ -191,9 +183,8 @@ describe('PdfSectionContentBlock', () => {
         });
 
         it('should save and show success toast when clicking ТАК button', async () => {
-            const user = userEvent.setup();
             const mockOnSave = jest.fn().mockResolvedValue(undefined);
-            render(<PdfSectionContentBlock content={MOCK_CONTENT} onSave={mockOnSave} />);
+            const user = userEvent.setup();
             await openPublishModal(user);
             await confirmModal(user);
             await waitFor(() =>
@@ -206,9 +197,8 @@ describe('PdfSectionContentBlock', () => {
         });
 
         it('should revert to view mode after successful save', async () => {
-            const user = userEvent.setup();
             const mockOnSave = jest.fn().mockResolvedValue(undefined);
-            render(<PdfSectionContentBlock content={MOCK_CONTENT} onSave={mockOnSave} />);
+            const user = userEvent.setup();
             await openPublishModal(user);
             await confirmModal(user);
             await waitFor(() => expect(screen.queryByDisplayValue('Updated Title')).not.toBeInTheDocument());
@@ -216,14 +206,13 @@ describe('PdfSectionContentBlock', () => {
         });
 
         it('should disable modal buttons during save', async () => {
-            const user = userEvent.setup();
             let resolveSave!: () => void;
             const savePromise = new Promise<void>((resolve) => {
                 resolveSave = resolve;
             });
             const mockOnSave = jest.fn(() => savePromise);
             jest.spyOn(PdfSectionApi, 'updatePdfSection').mockReturnValue(savePromise as any);
-            render(<PdfSectionContentBlock content={MOCK_CONTENT} onSave={mockOnSave} />);
+            const user = userEvent.setup();
             await openPublishModal(user);
             await screen.findByText('ТАК');
             resolveSave();
@@ -232,16 +221,16 @@ describe('PdfSectionContentBlock', () => {
 
     describe('Cancel Changes Modal', () => {
         it('should cancel without modal when no changes made', async () => {
-            const user = await renderAndEnterEditMode();
-            await user.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
+            const utils = await renderAndEnterEditMode();
+            await utils.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
             expect(screen.queryByTestId('confirmation-modal')).not.toBeInTheDocument();
             expect(screen.getByRole('button', { name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT })).toBeInTheDocument();
         });
 
         it('should open cancel confirmation modal when changes made', async () => {
-            const user = await renderAndEnterEditMode();
-            await changeTitle(user, 'Updated Title');
-            await user.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
+            const utils = await renderAndEnterEditMode();
+            await changeTitle(utils, 'Updated Title');
+            await utils.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
             expect(await screen.findByTestId('confirmation-modal')).toBeInTheDocument();
             expect(
                 screen.getByText(COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE),
@@ -249,20 +238,20 @@ describe('PdfSectionContentBlock', () => {
         });
 
         it('should close modal and keep edit mode when clicking НІ in cancel modal', async () => {
-            const user = await renderAndEnterEditMode();
-            await changeTitle(user, 'Updated Title');
-            await user.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
+            const utils = await renderAndEnterEditMode();
+            await changeTitle(utils, 'Updated Title');
+            await utils.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
             const modal = await screen.findByTestId('confirmation-modal');
-            await user.click(screen.getByText('НІ'));
+            await utils.click(screen.getByText('НІ'));
             await waitFor(() => expect(modal).not.toBeInTheDocument());
             expect(screen.getByDisplayValue('Updated Title')).toBeInTheDocument();
         });
 
         it('should revert changes when clicking ТАК in cancel modal', async () => {
-            const user = await renderAndEnterEditMode();
-            await changeTitle(user, 'Updated Title');
-            await user.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
-            await confirmModal(user);
+            const utils = await renderAndEnterEditMode();
+            await changeTitle(utils, 'Updated Title');
+            await utils.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
+            await confirmModal(utils);
             expect(screen.queryByDisplayValue('Updated Title')).not.toBeInTheDocument();
             expect(screen.getByText(MOCK_CONTENT.title)).toBeInTheDocument();
         });

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.tsx
@@ -30,10 +30,13 @@ interface PdfSectionContentBlockProps {
     onSave?: (data: PdfSectionContent) => Promise<void>;
 }
 
+type ConfirmationModalType = 'publish' | 'cancel' | null;
+
 export const PdfSectionContentBlock: React.FC<PdfSectionContentBlockProps> = ({ content, onSave }) => {
     const client = useAdminClient();
     const [isEditMode, setIsEditMode] = useState(false);
     const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
+    const [confirmationModalType, setConfirmationModalType] = useState<ConfirmationModalType>(null);
     const [formData, setFormData] = useState<PdfSectionFormData>({
         title: content.title,
         description: content.description,
@@ -73,7 +76,20 @@ export const PdfSectionContentBlock: React.FC<PdfSectionContentBlockProps> = ({ 
         getNormalizedInputText(formData.title) !== getNormalizedInputText(content.title) ||
         getNormalizedInputText(formData.description) !== getNormalizedInputText(content.description);
 
-    const handleCancel = useCallback(() => {
+    const handleCancelClick = useCallback(() => {
+        if (hasChanges) {
+            setConfirmationModalType('cancel');
+            setIsConfirmationModalOpen(true);
+        } else {
+            setFormData({ title: content.title, description: content.description });
+            setErrors({});
+            setIsEditMode(false);
+        }
+    }, [content, hasChanges]);
+
+    const handleCancelConfirmed = useCallback(() => {
+        setIsConfirmationModalOpen(false);
+        setConfirmationModalType(null);
         setFormData({ title: content.title, description: content.description });
         setErrors({});
         setIsEditMode(false);
@@ -104,6 +120,7 @@ export const PdfSectionContentBlock: React.FC<PdfSectionContentBlockProps> = ({ 
 
     const handleConfirmPublish = useCallback(() => {
         setIsConfirmationModalOpen(false);
+        setConfirmationModalType(null);
         handleSaveConfirmed();
     }, [handleSaveConfirmed]);
 
@@ -117,6 +134,7 @@ export const PdfSectionContentBlock: React.FC<PdfSectionContentBlockProps> = ({ 
             return;
         }
 
+        setConfirmationModalType('publish');
         setIsConfirmationModalOpen(true);
     };
 
@@ -159,7 +177,7 @@ export const PdfSectionContentBlock: React.FC<PdfSectionContentBlockProps> = ({ 
                                 buttonStyle="secondary"
                                 type="button"
                                 className={cn(styles.button, styles['cancel-button'])}
-                                onClick={handleCancel}
+                                onClick={handleCancelClick}
                                 disabled={isSaving}
                             >
                                 {COMMON_TEXT_ADMIN.BUTTON.CANCEL}
@@ -207,15 +225,36 @@ export const PdfSectionContentBlock: React.FC<PdfSectionContentBlockProps> = ({ 
         );
     };
 
+    const getModalConfig = () => {
+        if (confirmationModalType === 'cancel') {
+            return {
+                title: COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE,
+                onConfirm: handleCancelConfirmed,
+            };
+        }
+        return {
+            title: COMMON_TEXT_ADMIN.QUESTION.PUBLISH_CHANGES,
+            onConfirm: handleConfirmPublish,
+        };
+    };
+
+    const modalConfig = getModalConfig();
+
     return (
         <>
             {renderContent()}
             <ConfirmationModal
                 isOpen={isConfirmationModalOpen}
-                onClose={() => setIsConfirmationModalOpen(false)}
-                title={COMMON_TEXT_ADMIN.QUESTION.PUBLISH_CHANGES}
-                onConfirm={handleConfirmPublish}
-                onCancel={() => setIsConfirmationModalOpen(false)}
+                onClose={() => {
+                    setIsConfirmationModalOpen(false);
+                    setConfirmationModalType(null);
+                }}
+                title={modalConfig.title}
+                onConfirm={modalConfig.onConfirm}
+                onCancel={() => {
+                    setIsConfirmationModalOpen(false);
+                    setConfirmationModalType(null);
+                }}
                 isButtonsDisabled={isSaving}
             />
         </>

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { PDF_FILES_SECTION_TEXT, PDF_FILES_SECTION_VALIDATION, REPORTS_TEXT } from '@/const/admin/reports';
+import { PDF_FILES_SECTION_TEXT, PDF_FILES_SECTION_VALIDATION } from '@/const/admin/reports';
 import {
     PDF_SECTION_FIELD_VALIDATORS,
     PdfSectionFormData,
@@ -12,6 +12,7 @@ import { PdfSectionApi } from '@/services/api/admin/reports/pdf-section/pdf-sect
 import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
 import { TextAreaWithCharacterLimitGroup } from '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup';
 import { Button } from '@/components/admin/button/Button';
+import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
 import styles from './PdfSectionContentBlock.module.scss';
 import './PdfSectionContentBlock.scss';
 import cn from 'classnames';
@@ -32,6 +33,7 @@ interface PdfSectionContentBlockProps {
 export const PdfSectionContentBlock: React.FC<PdfSectionContentBlockProps> = ({ content, onSave }) => {
     const client = useAdminClient();
     const [isEditMode, setIsEditMode] = useState(false);
+    const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
     const [formData, setFormData] = useState<PdfSectionFormData>({
         title: content.title,
         description: content.description,
@@ -77,16 +79,7 @@ export const PdfSectionContentBlock: React.FC<PdfSectionContentBlockProps> = ({ 
         setIsEditMode(false);
     }, [content]);
 
-    const handleSave = async () => {
-        const titleError = PDF_SECTION_FIELD_VALIDATORS.validateTitle(formData.title);
-        const descriptionError = PDF_SECTION_FIELD_VALIDATORS.validateDescription(formData.description);
-        const newErrors = { title: titleError, description: descriptionError };
-        setErrors(newErrors);
-
-        if (titleError || descriptionError) {
-            return;
-        }
-
+    const handleSaveConfirmed = useCallback(async () => {
         setIsSaving(true);
         try {
             const normalizedData = {
@@ -101,94 +94,130 @@ export const PdfSectionContentBlock: React.FC<PdfSectionContentBlockProps> = ({ 
             }
 
             setIsEditMode(false);
-            addToast(REPORTS_TEXT.MESSAGE.RECORD_UPDATED_SUCCESSFULLY, ToastType.Success);
+            addToast(COMMON_TEXT_ADMIN.MESSAGE.UPDATES_SUCCESSFULLY_PUBLISHED, ToastType.Success);
         } catch {
-            addToast(REPORTS_TEXT.MESSAGE.RECORD_UPDATE_FAILED_RETRY, ToastType.Error);
+            addToast(COMMON_TEXT_ADMIN.MESSAGE.FAIL_TO_PUBLISH_CHANGES, ToastType.Error);
         } finally {
             setIsSaving(false);
         }
+    }, [formData.title, formData.description, client, onSave, addToast]);
+
+    const handleConfirmPublish = useCallback(() => {
+        setIsConfirmationModalOpen(false);
+        handleSaveConfirmed();
+    }, [handleSaveConfirmed]);
+
+    const handleSave = async () => {
+        const titleError = PDF_SECTION_FIELD_VALIDATORS.validateTitle(formData.title);
+        const descriptionError = PDF_SECTION_FIELD_VALIDATORS.validateDescription(formData.description);
+        const newErrors = { title: titleError, description: descriptionError };
+        setErrors(newErrors);
+
+        if (titleError || descriptionError) {
+            return;
+        }
+
+        setIsConfirmationModalOpen(true);
     };
 
     const isSaveDisabled = hasErrors || !hasChanges || isSaving;
 
-    if (isEditMode) {
+    const renderContent = () => {
+        if (isEditMode) {
+            return (
+                <div className={cn(styles.root, styles['edit-root'])}>
+                    <form className={styles['edit-form']}>
+                        <InputWithCharacterLimitGroup
+                            id="pdf-section-title"
+                            name="title"
+                            className="pdf-section-input"
+                            label={PDF_FILES_SECTION_TEXT.TITLE}
+                            value={formData.title}
+                            onChange={handleTitleChange}
+                            onBlur={handleTitleBlur}
+                            maxLength={PDF_FILES_SECTION_VALIDATION.title.max}
+                            placeholder="Введіть заголовок"
+                            error={errors.title}
+                            isRequired
+                        />
+                        <TextAreaWithCharacterLimitGroup
+                            id="pdf-section-description"
+                            name="description"
+                            className="pdf-section-textarea"
+                            label={PDF_FILES_SECTION_TEXT.DESCRIPTION}
+                            value={formData.description}
+                            onChange={handleDescriptionChange}
+                            onBlur={handleDescriptionBlur}
+                            maxLength={PDF_FILES_SECTION_VALIDATION.description.max}
+                            placeholder="Введіть опис"
+                            error={errors.description}
+                            isRequired
+                            rows={2}
+                        />
+                        <div className={styles['edit-actions']}>
+                            <Button
+                                buttonStyle="secondary"
+                                type="button"
+                                className={cn(styles.button, styles['cancel-button'])}
+                                onClick={handleCancel}
+                                disabled={isSaving}
+                            >
+                                {COMMON_TEXT_ADMIN.BUTTON.CANCEL}
+                            </Button>
+                            <Button
+                                buttonStyle="primary"
+                                type="button"
+                                className={cn(styles.button, styles['save-button'])}
+                                onClick={handleSave}
+                                disabled={isSaveDisabled}
+                            >
+                                {COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED}
+                            </Button>
+                        </div>
+                    </form>
+                </div>
+            );
+        }
+
         return (
-            <div className={cn(styles.root, styles['edit-root'])}>
-                <form className={styles['edit-form']}>
-                    <InputWithCharacterLimitGroup
-                        id="pdf-section-title"
-                        name="title"
-                        className="pdf-section-input"
-                        label={PDF_FILES_SECTION_TEXT.TITLE}
-                        value={formData.title}
-                        onChange={handleTitleChange}
-                        onBlur={handleTitleBlur}
-                        maxLength={PDF_FILES_SECTION_VALIDATION.title.max}
-                        placeholder="Введіть заголовок"
-                        error={errors.title}
-                        isRequired
+            <div className={cn(styles.root, styles['view-root'])}>
+                <div className={styles['edit-button-container']}>
+                    <IconButton
+                        aria-label={PDF_FILES_SECTION_TEXT.ACTIONS.EDIT}
+                        type="button"
+                        onClick={handleEditClick}
+                        className={styles['edit-button']}
+                        DefaultIcon={ACTION_ICONS.edit.default}
+                        FilledIcon={ACTION_ICONS.edit.hover}
                     />
-                    <TextAreaWithCharacterLimitGroup
-                        id="pdf-section-description"
-                        name="description"
-                        className="pdf-section-textarea"
-                        label={PDF_FILES_SECTION_TEXT.DESCRIPTION}
-                        value={formData.description}
-                        onChange={handleDescriptionChange}
-                        onBlur={handleDescriptionBlur}
-                        maxLength={PDF_FILES_SECTION_VALIDATION.description.max}
-                        placeholder="Введіть опис"
-                        error={errors.description}
-                        isRequired
-                        rows={2}
-                    />
-                    <div className={styles['edit-actions']}>
-                        <Button
-                            buttonStyle="secondary"
-                            type="button"
-                            className={cn(styles.button, styles['cancel-button'])}
-                            onClick={handleCancel}
-                            disabled={isSaving}
-                        >
-                            {COMMON_TEXT_ADMIN.BUTTON.CANCEL}
-                        </Button>
-                        <Button
-                            buttonStyle="primary"
-                            type="button"
-                            className={cn(styles.button, styles['save-button'])}
-                            onClick={handleSave}
-                            disabled={isSaveDisabled}
-                        >
-                            {COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED}
-                        </Button>
+                </div>
+                <div className={styles['content-container']}>
+                    <div className={styles['view-field']}>
+                        <label className={styles['view-label']}>{PDF_FILES_SECTION_TEXT.TITLE}</label>
+                        <p className={cn(styles['view-text'], styles['view-text-title'])}>{formData.title}</p>
                     </div>
-                </form>
+                    <div className={styles['view-field']}>
+                        <label className={styles['view-label']}>{PDF_FILES_SECTION_TEXT.DESCRIPTION}</label>
+                        <p className={cn(styles['view-text'], styles['view-text-description'])}>
+                            {formData.description}
+                        </p>
+                    </div>
+                </div>
             </div>
         );
-    }
+    };
 
     return (
-        <div className={cn(styles.root, styles['view-root'])}>
-            <div className={styles['edit-button-container']}>
-                <IconButton
-                    aria-label={PDF_FILES_SECTION_TEXT.ACTIONS.EDIT}
-                    type="button"
-                    onClick={handleEditClick}
-                    className={styles['edit-button']}
-                    DefaultIcon={ACTION_ICONS.edit.default}
-                    FilledIcon={ACTION_ICONS.edit.hover}
-                />
-            </div>
-            <div className={styles['content-container']}>
-                <div className={styles['view-field']}>
-                    <label className={styles['view-label']}>{PDF_FILES_SECTION_TEXT.TITLE}</label>
-                    <p className={cn(styles['view-text'], styles['view-text-title'])}>{formData.title}</p>
-                </div>
-                <div className={styles['view-field']}>
-                    <label className={styles['view-label']}>{PDF_FILES_SECTION_TEXT.DESCRIPTION}</label>
-                    <p className={cn(styles['view-text'], styles['view-text-description'])}>{formData.description}</p>
-                </div>
-            </div>
-        </div>
+        <>
+            {renderContent()}
+            <ConfirmationModal
+                isOpen={isConfirmationModalOpen}
+                onClose={() => setIsConfirmationModalOpen(false)}
+                title={COMMON_TEXT_ADMIN.QUESTION.PUBLISH_CHANGES}
+                onConfirm={handleConfirmPublish}
+                onCancel={() => setIsConfirmationModalOpen(false)}
+                isButtonsDisabled={isSaving}
+            />
+        </>
     );
 };

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.tsx
@@ -157,6 +157,7 @@ export const PdfSectionContentBlock: React.FC<PdfSectionContentBlockProps> = ({ 
                             placeholder="Введіть заголовок"
                             error={errors.title}
                             isRequired
+                            disabled={isSaving}
                         />
                         <TextAreaWithCharacterLimitGroup
                             id="pdf-section-description"
@@ -171,6 +172,7 @@ export const PdfSectionContentBlock: React.FC<PdfSectionContentBlockProps> = ({ 
                             error={errors.description}
                             isRequired
                             rows={2}
+                            disabled={isSaving}
                         />
                         <div className={styles['edit-actions']}>
                             <Button


### PR DESCRIPTION
## Github ticket

* [Ticket 1325](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1325)
* [Ticket 1707](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1707)

## Description

This PR refactors the `PdfSectionContentBlock` component to improve UX by introducing two separate confirmation modals — one for publishing changes and one for cancelling edits — replacing the previous single-modal flow. It also cleans up the component structure, aligns toast messages with shared admin constants, and significantly improves test coverage and readability.

## How it looks

<img width="980" height="325" alt="image" src="https://github.com/user-attachments/assets/871a7d23-c2be-4857-a8d9-1df13e67bec6" />
<img width="510" height="92" alt="image" src="https://github.com/user-attachments/assets/7126832c-7a70-4789-8d4b-d590011bdb7e" />
<img width="982" height="359" alt="image" src="https://github.com/user-attachments/assets/b91cd7ea-bca6-4d60-915b-0f31f32e4f8b" />

## Summary of change

- Added `ConfirmationModal` support for two distinct flows: **publish** and **cancel** (with `ConfirmationModalType = 'publish' | 'cancel' | null`)
- Replaced inline conditional rendering with a `renderContent()` helper and a `getModalConfig()` helper for cleaner JSX
- Extracted reusable test helpers (`enterEditMode`, `changeTitle`, `clickPublish`, `confirmModal`, `openPublishModal`, `renderAndEnterEditMode`) to reduce duplication in tests
- Replaced local `REPORTS_TEXT` toast messages with shared `COMMON_TEXT_ADMIN.MESSAGE` constants (`UPDATES_SUCCESSFULLY_PUBLISHED`, `FAIL_TO_PUBLISH_CHANGES`)
- Fixed capitalisation of `SUCCESSFULLY_PUBLISHED` constant in `common.ts`
- Added `COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE` and `PUBLISH_CHANGES` question constants
- Added `disabled` prop to form inputs during save to prevent editing while submitting
- Replaced `.scss` global import with `.module.scss` for better style scoping
- Reorganised and expanded test suite into focused `describe` blocks: `View Mode`, `Edit Mode`, `Confirmation Modal`, `Cancel Changes Modal`

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Confirmation modals added for publishing changes and for canceling edits in the PDF admin area; users confirm with ТАК or НІ.
  * Cancel: immediate reset when no edits, confirmation when changes exist.
  * Modals disable buttons during save to prevent duplicate actions.

* **Bug Fixes**
  * Ukrainian success message capitalized and a new distinct success message for published updates.

* **Tests**
  * Expanded tests covering modal flows, confirmations, disabled-state behavior, and edit/cancel scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->