### PR TITLE
fix/issue-1998: change image size in the modal window in program section template 5 and 6

### DIFF
--- a/src/components/common/program-section-templates/single-image-bottom/SingleImageBottom.module.scss
+++ b/src/components/common/program-section-templates/single-image-bottom/SingleImageBottom.module.scss
@@ -1,5 +1,5 @@
 @import '../shared/BaseSectionTemplate.module.scss';
-$img-width: 1440px;
+$img-width: 1330px;
 $img-height: 680px;
 
 .container {

--- a/src/components/common/program-section-templates/single-image-bottom/ViewSingleImageBottom.module.scss
+++ b/src/components/common/program-section-templates/single-image-bottom/ViewSingleImageBottom.module.scss
@@ -9,7 +9,7 @@
 }
 
 .image-wrapper {
-    aspect-ratio: 1440 / 680;
+    aspect-ratio: 1330 / 680;
     width: 100%;
 }
 

--- a/src/components/common/program-section-templates/single-image-top/SingleImageTop.module.scss
+++ b/src/components/common/program-section-templates/single-image-top/SingleImageTop.module.scss
@@ -1,7 +1,7 @@
 @use '@/assets/sass/mixins/typography.mixins' as type;
 @import '../shared/BaseSectionTemplate.module.scss';
 
-$img-width: 1440px;
+$img-width: 1330px;
 $img-height: 680px;
 
 .container {
@@ -59,7 +59,7 @@ $img-height: 680px;
 
     .image-wrapper {
         width: 100%;
-        max-width: 1440px;
+        max-width: 1330px;
         max-height: 680px;
 
         display: flex;

--- a/src/components/common/program-section-templates/single-image-top/ViewSingleImageTop.module.scss
+++ b/src/components/common/program-section-templates/single-image-top/ViewSingleImageTop.module.scss
@@ -7,7 +7,7 @@
 }
 
 .image-wrapper {
-    aspect-ratio: 1440 / 680;
+    aspect-ratio: 1330 / 680;
     width: 100%;
 }
 

--- a/src/const/admin/programs.ts
+++ b/src/const/admin/programs.ts
@@ -170,15 +170,15 @@ export const PROGRAM_SECTION_IMAGE_CONFIGS = {
         minHeight: 480,
     },
     SINGLE_IMAGE_TOP: {
-        cropWidth: 1440,
+        cropWidth: 1330,
         cropHeight: 680,
-        minWidth: 1440,
+        minWidth: 1330,
         minHeight: 680,
     },
     SINGLE_IMAGE_BOTTOM: {
-        cropWidth: 1440,
+        cropWidth: 1330,
         cropHeight: 680,
-        minWidth: 1440,
+        minWidth: 1330,
         minHeight: 680,
     },
     SINGLE_IMAGE_RIGHT: {


### PR DESCRIPTION
## Github ticker

* [1998](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1998)
* [1999](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1999)

## Description

The image size in program section template 5 and 6 in the modal window does not match the required dimensions according to the mockup (1330x680)

## How it looks

https://github.com/user-attachments/assets/9c248208-473f-4e88-a744-1a6dea2a7353

## Summary of change

Changed image size and aspect ration for template 5 and 6

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Adjusted image dimensions across program section templates by reducing width proportions from 1440px to 1330px, updating aspect ratios and sizing constraints accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->