### PR TITLE
Feature/issue-940: Open modal to add funds

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -22,6 +22,8 @@ export const REPORTS_TEXT = {
         FAIL_TO_FETCH_REPORTS: 'Виникла помилка, не вдалось завантажити звітність',
         FAIL_TO_UPDATE_REPORT: 'Виникла помилка під час оновлення звітності',
         SUCCESSFULLY_PUBLISHED: 'Успішно опубліковано',
+        RECORD_UPDATED_SUCCESSFULLY: 'Зміни збережено успішно',
+        RECORD_UPDATE_FAILED_RETRY: 'Виникла помилка, спробуйте ще раз',
         INVALID_VALUE: 'Значення повинно бути числом',
     },
     REPORT_AND_ANALYTICS: {

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -22,8 +22,6 @@ export const REPORTS_TEXT = {
         FAIL_TO_FETCH_REPORTS: 'Виникла помилка, не вдалось завантажити звітність',
         FAIL_TO_UPDATE_REPORT: 'Виникла помилка під час оновлення звітності',
         SUCCESSFULLY_PUBLISHED: 'Успішно опубліковано',
-        RECORD_UPDATED_SUCCESSFULLY: 'Зміни збережено успішно',
-        RECORD_UPDATE_FAILED_RETRY: 'Виникла помилка, спробуйте ще раз',
         INVALID_VALUE: 'Значення повинно бути числом',
     },
     REPORT_AND_ANALYTICS: {
@@ -132,12 +130,19 @@ export const FUNDS_EXPENDITURES_VALIDATION = {
 export const FUNDS_EXPENDITURES_TEXT = {
     DISCLAIMER_LABEL: 'Дісклеймер/ENG',
     EXCHANGE_RATE_LABEL: 'Курс USD/UAH',
+    MESSAGE: {
+        RECORD_CREATED_SUCCESSFULLY: 'Запис додано успішно',
+        RECORD_CREATE_FAILED_RETRY: 'Не вдалося додати запис. Спробуйте ще раз',
+        RECORD_UPDATED_SUCCESSFULLY: 'Зміни збережено успішно',
+        RECORD_UPDATE_FAILED_RETRY: 'Виникла помилка, спробуйте ще раз',
+    },
     MODAL: {
         SHARED: {
             REPORTING_YEAR_LABEL: 'Звітній рік',
             REPORTING_YEAR_PLACEHOLDER: 'Оберіть звітній рік',
             AMOUNT_UAH_LABEL: 'Сума (UAH)',
             AMOUNT_USD_LABEL: 'Сума (USD)',
+            CONFIRM_CLOSE_TITLE: 'Зміни будуть втрачені. Бажаєте продовжити?',
         },
         INCOME: {
             TITLE: 'Додати надходження',
@@ -156,8 +161,6 @@ export const FUNDS_EXPENDITURES_TEXT = {
     },
     BUTTON: {
         EDIT: 'Редагувати Доходи та витрати',
-        CANCEL: 'Відмінити',
-        PUBLISH: 'Опублікувати',
         ADD_INCOME: 'Надходження',
         ADD_EXPENSE: 'Витрати',
     },

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -132,6 +132,28 @@ export const FUNDS_EXPENDITURES_VALIDATION = {
 export const FUNDS_EXPENDITURES_TEXT = {
     DISCLAIMER_LABEL: 'Дісклеймер/ENG',
     EXCHANGE_RATE_LABEL: 'Курс USD/UAH',
+    MODAL: {
+        SHARED: {
+            REPORTING_YEAR_LABEL: 'Звітній рік',
+            REPORTING_YEAR_PLACEHOLDER: 'Оберіть звітній рік',
+            AMOUNT_UAH_LABEL: 'Сума (UAH)',
+            AMOUNT_USD_LABEL: 'Сума (USD)',
+        },
+        INCOME: {
+            TITLE: 'Додати надходження',
+            SUBTITLE: 'Розподіл надходжень за категоріями',
+            CATEGORY_LABEL: 'Категорія надходження',
+            CATEGORY_PLACEHOLDER: 'Оберіть категорію надходження',
+            SUBMIT_BUTTON: 'Додати надходження',
+        },
+        EXPENSE: {
+            TITLE: 'Додати витрату',
+            SUBTITLE: 'Розподіл витрат за статтями',
+            CATEGORY_LABEL: 'Категорія витрат',
+            CATEGORY_PLACEHOLDER: 'Оберіть категорію витрат',
+            SUBMIT_BUTTON: 'Додати витрату',
+        },
+    },
     BUTTON: {
         EDIT: 'Редагувати Доходи та витрати',
         CANCEL: 'Відмінити',
@@ -149,7 +171,7 @@ export const FUNDS_EXPENDITURES_TEXT = {
         SPENT: 'Витрачено коштів',
         INCOME_CATEGORIES: 'Категорії надходжень',
         EXPENSE_CATEGORIES: 'Категорії витрат',
-        AMOUNT_SUFFIX_UAH: 'UA',
+        AMOUNT_SUFFIX_UAH: 'UAH',
         AMOUNT_SUFFIX_USD: 'USD',
         CATEGORY_SUFFIX_FORMS: ['категорія', 'категорії', 'категорій'],
     },
@@ -158,7 +180,7 @@ export const FUNDS_EXPENDITURES_TEXT = {
             REPORTING_YEAR: 'Звітній рік',
             TYPE: 'Тип',
             CATEGORY: 'Категорія',
-            AMOUNT_UAH: 'Сума UA',
+            AMOUNT_UAH: 'Сума UAH',
             AMOUNT_USD: 'Сума USD',
         },
         TYPE_LABELS: {

--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.test.tsx
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.test.tsx
@@ -9,6 +9,7 @@ import { ProgramSectionTemplate, ProgramSectionMode } from '@/types/common/progr
 import { ContentType } from '@/types/common/programs';
 import { PROGRAMS_TEXT } from '@/const/admin/programs';
 import { renderProgramSection } from '@/utils/functions/render-program-section';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 
 jest.mock('@/utils/functions/render-program-section', () => ({
     renderProgramSection: jest.fn(() => <div data-testid="editable-section" />),
@@ -254,13 +255,13 @@ describe('ProgramSectionForm', () => {
 
     it('cancel button is disabled when isDisabled is true', () => {
         renderForm({ isDisabled: true, isNewSection: true });
-        expect(screen.getByText(PROGRAMS_TEXT.BUTTON.CANCEL)).toBeDisabled();
+        expect(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL)).toBeDisabled();
     });
 
     it('defaults isDisabled to false when omitted', () => {
         const { isDisabled: _omit, ...propsWithoutIsDisabled } = baseProps as any;
         render(<ProgramSectionForm {...propsWithoutIsDisabled} isNewSection={true} isSectionValid={false} />);
-        expect(screen.getByText(PROGRAMS_TEXT.BUTTON.CANCEL)).not.toBeDisabled();
+        expect(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL)).not.toBeDisabled();
     });
 
     it('passes normalized title/description/descriptions/images into renderProgramSection', () => {
@@ -657,7 +658,7 @@ describe('ProgramSectionForm', () => {
             renderForm({ isNewSection: false });
 
             expect(screen.queryByText(PROGRAMS_TEXT.BUTTON.SAVE)).not.toBeInTheDocument();
-            expect(screen.queryByText(PROGRAMS_TEXT.BUTTON.CANCEL)).not.toBeInTheDocument();
+            expect(screen.queryByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL)).not.toBeInTheDocument();
             expect(screen.getByLabelText('Edit section')).toBeInTheDocument();
             expect(screen.getByLabelText('Delete section')).toBeInTheDocument();
             expect(screen.getByLabelText('Replace section')).toBeInTheDocument();

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { FundsExpenditureSection } from './FundsExpendituresSection';
-import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION, REPORTS_TEXT } from '@/const/admin/reports';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import {
     FundsExpendituresSummary,
@@ -141,6 +141,9 @@ jest.mock('./components/funds-expenditures-toolbar/FundsExpendituresToolbar', ()
         isAddExpenseDisabled,
         onTypeChange,
         onCategoryChange,
+        onExchangeRateChange,
+        onExchangeRateBlur,
+        onAddIncome,
     }: {
         categories: { id: number; name: string }[];
         selectedCategoryId: number | null | undefined;
@@ -150,6 +153,9 @@ jest.mock('./components/funds-expenditures-toolbar/FundsExpendituresToolbar', ()
         isAddExpenseDisabled: boolean;
         onTypeChange: (v: unknown) => void;
         onCategoryChange: (v: unknown) => void;
+        onExchangeRateChange: (v: string) => void;
+        onExchangeRateBlur: () => void;
+        onAddIncome: () => void;
     }) => (
         <div
             data-testid="funds-toolbar"
@@ -172,6 +178,15 @@ jest.mock('./components/funds-expenditures-toolbar/FundsExpendituresToolbar', ()
             <button onClick={() => onCategoryChange(1)} data-testid="filter-cat-1">
                 Filter Cat 1
             </button>
+            <button onClick={() => onExchangeRateChange('abc')} data-testid="change-rate-invalid">
+                Invalid rate
+            </button>
+            <button onClick={() => onExchangeRateBlur()} data-testid="blur-rate">
+                Blur rate
+            </button>
+            <button onClick={() => onAddIncome()} data-testid="open-add-income">
+                Open add income
+            </button>
         </div>
     ),
 }));
@@ -181,10 +196,12 @@ jest.mock('./components/funds-expenditures-table/FundsExpendituresTable', () => 
         records,
         isEditing,
         onRecordSave,
+        onRowEditModeChange,
     }: {
         records: unknown[];
         isEditing?: boolean;
         onRecordSave?: (recordId: number, data: { categoryId: number; amountUah: string; amountUsd: string }) => void;
+        onRowEditModeChange?: (isRowEditMode: boolean) => void;
     }) => (
         <div data-testid="funds-table" data-record-count={records.length} data-editing={String(isEditing ?? false)}>
             <button
@@ -199,18 +216,65 @@ jest.mock('./components/funds-expenditures-table/FundsExpendituresTable', () => 
             >
                 Save row
             </button>
+            <button data-testid="row-edit-on" onClick={() => onRowEditModeChange?.(true)}>
+                Row edit on
+            </button>
+            <button data-testid="row-edit-off" onClick={() => onRowEditModeChange?.(false)}>
+                Row edit off
+            </button>
+        </div>
+    ),
+}));
+
+jest.mock('./components/common/add-income-modal/AddIncomeModal', () => ({
+    AddIncomeModal: ({
+        isOpen,
+        onClose,
+        onSubmit,
+    }: {
+        isOpen: boolean;
+        onClose: () => void;
+        onSubmit: (data: {
+            categoryId: number;
+            reportingYear: string;
+            amountUah: string;
+            amountUsd: string;
+            type: 'income' | 'expense';
+        }) => Promise<boolean>;
+    }) => (
+        <div data-testid="add-income-modal" data-open={String(isOpen)}>
+            <button data-testid="add-income-close" onClick={onClose}>
+                Close add income
+            </button>
+            <button
+                data-testid="add-income-submit"
+                onClick={() =>
+                    void onSubmit({
+                        categoryId: 1,
+                        reportingYear: '2026',
+                        amountUah: '1000',
+                        amountUsd: '25',
+                        type: 'income',
+                    })
+                }
+            >
+                Submit add income
+            </button>
         </div>
     ),
 }));
 
 const mockUpdateRecord = jest.fn();
+const mockCreateRecord = jest.fn();
+const mockUpdateSettings = jest.fn();
 jest.mock('@/services/api/admin/reports/funds-expenditures-api', () => ({
     FundsExpendituresApi: {
         getSettings: jest.fn(),
         getCategories: jest.fn(),
         getRecords: jest.fn(),
         getSummary: jest.fn(),
-        updateSettings: jest.fn(),
+        updateSettings: (...args: unknown[]) => mockUpdateSettings(...args),
+        createRecord: (...args: unknown[]) => mockCreateRecord(...args),
         updateRecord: (...args: unknown[]) => mockUpdateRecord(...args),
     },
 }));
@@ -569,6 +633,108 @@ describe('FundsExpenditureSection', () => {
             fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL));
             fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
             expect(screen.queryByTestId('error-funds-disclaimer')).not.toBeInTheDocument();
+        });
+
+        it('should disable publish button when table row edit mode is active', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+
+            fireEvent.click(screen.getByTestId('row-edit-on'));
+            expect(getPublishButton()).toBeDisabled();
+
+            fireEvent.click(screen.getByTestId('row-edit-off'));
+            expect(getPublishButton()).not.toBeDisabled();
+        });
+
+        it('should show exchange-rate error and disable add actions after invalid rate change and blur', () => {
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+
+            fireEvent.click(screen.getByTestId('change-rate-invalid'));
+            fireEvent.click(screen.getByTestId('blur-rate'));
+
+            expect(screen.getByTestId('funds-toolbar')).toHaveAttribute('data-add-income-disabled', 'true');
+            expect(screen.getByTestId('funds-toolbar')).toHaveAttribute('data-add-expense-disabled', 'true');
+            expect(getPublishButton()).toBeDisabled();
+        });
+
+        it('should publish successfully and exit edit mode', async () => {
+            mockUpdateSettings.mockResolvedValueOnce({
+                disclaimerTitle: 'Оновлений дисклеймер',
+                exchangeRate: '44.00',
+            });
+
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+
+            fireEvent.click(getPublishButton());
+
+            expect(await screen.findByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT)).toBeInTheDocument();
+            expect(mockAddToast).toHaveBeenCalledWith(COMMON_TEXT_ADMIN.MESSAGE.SUCCESSFULLY_PUBLISHED, 'success');
+        });
+
+        it('should show error toast when publish fails', async () => {
+            mockUpdateSettings.mockRejectedValueOnce(new Error('publish failed'));
+
+            render(<FundsExpenditureSection />);
+            enterEditMode();
+
+            fireEvent.click(getPublishButton());
+
+            expect(await screen.findByTestId('funds-toolbar')).toBeInTheDocument();
+            expect(mockAddToast).toHaveBeenCalledWith(REPORTS_TEXT.MESSAGE.FAIL_TO_UPDATE_REPORT, 'error');
+        });
+
+        it('should open and close add income modal from toolbar controls', () => {
+            render(<FundsExpenditureSection />);
+
+            expect(screen.getByTestId('add-income-modal')).toHaveAttribute('data-open', 'false');
+            fireEvent.click(screen.getByTestId('open-add-income'));
+            expect(screen.getByTestId('add-income-modal')).toHaveAttribute('data-open', 'true');
+
+            fireEvent.click(screen.getByTestId('add-income-close'));
+            expect(screen.getByTestId('add-income-modal')).toHaveAttribute('data-open', 'false');
+        });
+
+        it('should create income record successfully and show success toast', async () => {
+            mockCreateRecord.mockResolvedValueOnce({
+                id: 999,
+                categoryId: 1,
+                type: 'income',
+                reportingYear: '2026',
+                amountUah: '1000',
+                amountUsd: '25',
+            });
+
+            render(<FundsExpenditureSection />);
+
+            fireEvent.click(screen.getByTestId('open-add-income'));
+            fireEvent.click(screen.getByTestId('add-income-submit'));
+
+            expect(await screen.findByTestId('funds-table')).toBeInTheDocument();
+            expect(mockCreateRecord).toHaveBeenCalled();
+            expect(mockAddToast).toHaveBeenCalledWith(
+                FUNDS_EXPENDITURES_TEXT.MESSAGE.RECORD_CREATED_SUCCESSFULLY,
+                'success',
+            );
+            await waitFor(() => {
+                expect(screen.getByTestId('add-income-modal')).toHaveAttribute('data-open', 'false');
+            });
+        });
+
+        it('should show error toast when income record creation fails', async () => {
+            mockCreateRecord.mockRejectedValueOnce(new Error('create failed'));
+
+            render(<FundsExpenditureSection />);
+
+            fireEvent.click(screen.getByTestId('open-add-income'));
+            fireEvent.click(screen.getByTestId('add-income-submit'));
+
+            expect(await screen.findByTestId('add-income-modal')).toHaveAttribute('data-open', 'true');
+            expect(mockAddToast).toHaveBeenCalledWith(
+                FUNDS_EXPENDITURES_TEXT.MESSAGE.RECORD_CREATE_FAILED_RETRY,
+                'error',
+            );
         });
     });
 });

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { FundsExpenditureSection } from './FundsExpendituresSection';
-import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION, REPORTS_TEXT } from '@/const/admin/reports';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import {
     FundsExpendituresSummary,
@@ -258,7 +258,10 @@ describe('FundsExpenditureSection', () => {
         fireEvent.click(screen.getByTestId('trigger-record-save'));
 
         await screen.findByTestId('funds-table');
-        expect(mockAddToast).toHaveBeenCalledWith(REPORTS_TEXT.MESSAGE.RECORD_UPDATED_SUCCESSFULLY, 'success');
+        expect(mockAddToast).toHaveBeenCalledWith(
+            FUNDS_EXPENDITURES_TEXT.MESSAGE.RECORD_UPDATED_SUCCESSFULLY,
+            'success',
+        );
     });
 
     it('should show retry error toast when record save fails', async () => {
@@ -269,7 +272,7 @@ describe('FundsExpenditureSection', () => {
         fireEvent.click(screen.getByTestId('trigger-record-save'));
 
         await screen.findByTestId('funds-table');
-        expect(mockAddToast).toHaveBeenCalledWith(REPORTS_TEXT.MESSAGE.RECORD_UPDATE_FAILED_RETRY, 'error');
+        expect(mockAddToast).toHaveBeenCalledWith(FUNDS_EXPENDITURES_TEXT.MESSAGE.RECORD_UPDATE_FAILED_RETRY, 'error');
     });
 
     it('should render the disclaimer text', () => {
@@ -452,14 +455,14 @@ describe('FundsExpenditureSection', () => {
         it('should return to non-editing state when cancel is clicked', () => {
             render(<FundsExpenditureSection />);
             fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
-            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.CANCEL));
+            fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL));
             expect(screen.getByTestId('funds-toolbar')).toHaveAttribute('data-editing', 'false');
         });
 
         it('should show edit button again after cancel', () => {
             render(<FundsExpenditureSection />);
             fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
-            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.CANCEL));
+            fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL));
             expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT)).toBeInTheDocument();
         });
     });
@@ -472,7 +475,7 @@ describe('FundsExpenditureSection', () => {
 
         const enterEditMode = () => fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
         const getTextarea = () => screen.getByTestId('textarea-funds-disclaimer');
-        const getPublishButton = () => screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.PUBLISH);
+        const getPublishButton = () => screen.getByText(COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED);
 
         it('should show required error when blurring an empty disclaimer', () => {
             render(<FundsExpenditureSection />);
@@ -563,7 +566,7 @@ describe('FundsExpenditureSection', () => {
             fireEvent.blur(getTextarea());
             expect(screen.getByTestId('error-funds-disclaimer')).toBeInTheDocument();
 
-            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.CANCEL));
+            fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL));
             fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
             expect(screen.queryByTestId('error-funds-disclaimer')).not.toBeInTheDocument();
         });

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/admin/button/Button';
 import { ACTION_ICONS } from '@/const/common/action-icons';
 import { FundsExpendituresApi } from '@/services/api/admin/reports/funds-expenditures-api';
 import {
+    FundsExpendituresTransactionType,
     FundsExpendituresSummary,
     ReportFundsExpendituresCategory,
     ReportFundsExpendituresRecord,
@@ -28,6 +29,7 @@ import {
     TypeFilterValue,
 } from './components/funds-expenditures-toolbar/FundsExpendituresToolbar';
 import { EnrichedRecord, FundsExpendituresTable } from './components/funds-expenditures-table/FundsExpendituresTable';
+import { AddIncomeModal } from './components/common/add-income-modal/AddIncomeModal';
 import styles from './FundsExpendituresSection.module.scss';
 
 const enrichRecords = (
@@ -55,6 +57,7 @@ export const FundsExpenditureSection = () => {
     const [selectedCategoryId, setSelectedCategoryId] = useState<CategoryFilterValue>(undefined);
     const [recordsState, setRecordsState] = useState<ReportFundsExpendituresRecord[]>([]);
     const [isRowEditMode, setIsRowEditMode] = useState(false);
+    const [isAddIncomeModalOpen, setIsAddIncomeModalOpen] = useState(false);
 
     const handleEdit = useCallback(() => setIsEditing(true), []);
     const handleCancel = useCallback(() => {
@@ -89,6 +92,14 @@ export const FundsExpenditureSection = () => {
     const handleTypeChange = useCallback((type: TypeFilterValue) => {
         setSelectedType(type);
         setSelectedCategoryId(undefined);
+    }, []);
+
+    const handleOpenAddIncomeModal = useCallback(() => {
+        setIsAddIncomeModalOpen(true);
+    }, []);
+
+    const handleCloseAddIncomeModal = useCallback(() => {
+        setIsAddIncomeModalOpen(false);
     }, []);
 
     const fetchSettings = useCallback(
@@ -217,14 +228,44 @@ export const FundsExpenditureSection = () => {
 
                 setRecordsState((prev) => prev.map((record) => (record.id === recordId ? updatedRecord : record)));
                 refetchSummary();
-                addToast(REPORTS_TEXT.MESSAGE.RECORD_UPDATED_SUCCESSFULLY, ToastType.Success);
+                addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.RECORD_UPDATED_SUCCESSFULLY, ToastType.Success);
                 return true;
             } catch {
-                addToast(REPORTS_TEXT.MESSAGE.RECORD_UPDATE_FAILED_RETRY, ToastType.Error);
+                addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.RECORD_UPDATE_FAILED_RETRY, ToastType.Error);
                 return false;
             }
         },
         [addToast, adminClient, recordsState, refetchSummary],
+    );
+
+    const handleCreateRecord = useCallback(
+        async (data: {
+            categoryId: number;
+            reportingYear: string;
+            amountUah: string;
+            amountUsd: string;
+            type: FundsExpendituresTransactionType;
+        }): Promise<boolean> => {
+            try {
+                const createdRecord = await FundsExpendituresApi.createRecord(adminClient, {
+                    categoryId: data.categoryId,
+                    reportingYear: data.reportingYear,
+                    amountUah: data.amountUah,
+                    amountUsd: data.amountUsd,
+                    type: data.type,
+                });
+
+                setRecordsState((prev) => [...prev, createdRecord]);
+                refetchSummary();
+                addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.RECORD_CREATED_SUCCESSFULLY, ToastType.Success);
+                setIsAddIncomeModalOpen(false);
+                return true;
+            } catch {
+                addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.RECORD_CREATE_FAILED_RETRY, ToastType.Error);
+                return false;
+            }
+        },
+        [addToast, adminClient, refetchSummary],
     );
 
     const handlePublish = useCallback(async () => {
@@ -335,7 +376,7 @@ export const FundsExpenditureSection = () => {
                 onExchangeRateChange={handleExchangeRateChange}
                 onExchangeRateBlur={handleExchangeRateBlur}
                 exchangeRateError={exchangeRateError}
-                onAddIncome={() => {}}
+                onAddIncome={handleOpenAddIncomeModal}
                 onAddExpense={() => {}}
             />
 
@@ -353,7 +394,7 @@ export const FundsExpenditureSection = () => {
             {isEditing && (
                 <div className={styles['section-footer']}>
                     <Button buttonStyle="secondary" className={styles['footer-button']} onClick={handleCancel}>
-                        {FUNDS_EXPENDITURES_TEXT.BUTTON.CANCEL}
+                        {COMMON_TEXT_ADMIN.BUTTON.CANCEL}
                     </Button>
                     <Button
                         buttonStyle="primary"
@@ -361,10 +402,19 @@ export const FundsExpenditureSection = () => {
                         onClick={handlePublish}
                         disabled={!isPublishEnabled || isRowEditMode}
                     >
-                        {FUNDS_EXPENDITURES_TEXT.BUTTON.PUBLISH}
+                        {COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED}
                     </Button>
                 </div>
             )}
+
+            <AddIncomeModal
+                isOpen={isAddIncomeModalOpen}
+                onClose={handleCloseAddIncomeModal}
+                categories={categories}
+                records={recordsState}
+                exchangeRate={currentExchangeRate}
+                onSubmit={handleCreateRecord}
+            />
         </div>
     );
 };

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.module.scss
@@ -1,0 +1,125 @@
+@use '@/assets/sass/variables/colors' as c;
+@use '@/assets/sass/mixins/typography.mixins' as type;
+
+.form {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    width: 100%;
+    max-width: 600px;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    width: 100%;
+
+    :global(.char-limit-input-wrapper) {
+        width: 100%;
+    }
+
+    :global(.char-limit-input) {
+        width: 100%;
+        height: 50px;
+        border: 1px solid c.$grey-700;
+        border-radius: 8px;
+        padding: 10px;
+        background: c.$white;
+        filter: drop-shadow(0 1px 2px rgba(c.$bluish-black, 0.05));
+    }
+
+    :global(.char-limit-input:has(.char-limit-input__field[aria-invalid='true'])) {
+        border-color: c.$error;
+    }
+}
+
+.label {
+    @include type.body-2-regular;
+    color: c.$grey-900;
+    display: inline-flex;
+    gap: 2px;
+}
+
+.required {
+    color: c.$error;
+}
+
+.input {
+    @include type.body-2-medium;
+    width: 100%;
+    border: none;
+    padding: 0;
+    color: c.$grey-900;
+    background: transparent;
+}
+
+.select {
+    width: 100%;
+
+    :global(.select) {
+        width: 100%;
+    }
+
+    :global(.select-head) {
+        width: 100%;
+        height: 50px;
+        border: 1px solid c.$grey-700;
+        border-radius: 8px;
+        padding: 10px;
+        color: c.$grey-900;
+        background: c.$white;
+        filter: drop-shadow(0 1px 2px rgba(c.$bluish-black, 0.05));
+    }
+
+    :global(.select-options) {
+        min-width: 100%;
+    }
+}
+
+.select-option {
+    @include type.body-2-regular;
+}
+
+.error {
+    @include type.small-text-regular;
+    margin: 0;
+    color: c.$error;
+}
+
+.amount-usd-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.exchange-rate-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.exchange-rate-chip-label {
+    @include type.small-text-medium;
+    color: c.$grey-900;
+}
+
+.exchange-rate-value {
+    @include type.body-2-medium;
+    width: 119px;
+    height: 32px;
+    border: 1px solid c.$bluish-black;
+    border-radius: 8px;
+    text-align: center;
+    background: c.$grey-600;
+    color: c.$blue-900;
+    padding: 6px 12px;
+}
+
+@media (max-width: 768px) {
+    .amount-usd-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.test.tsx
@@ -1,0 +1,326 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { AddIncomeModal } from './AddIncomeModal';
+import { ReportFundsExpendituresCategory, ReportFundsExpendituresRecord } from '@/types/admin/reports';
+
+const MOCK_CATEGORIES: ReportFundsExpendituresCategory[] = [
+    { id: 1, name: 'Грантові кошти', type: 'income' },
+    { id: 2, name: 'Благодійні внески', type: 'income' },
+    { id: 3, name: 'Власні надходження', type: 'income' },
+    { id: 5, name: 'Адміністративні витрати', type: 'expense' },
+    { id: 6, name: 'Програмні витрати', type: 'expense' },
+];
+
+const MOCK_RECORDS: ReportFundsExpendituresRecord[] = [
+    { id: 1, categoryId: 1, type: 'income', reportingYear: '2025', amountUah: '7265', amountUsd: '4200' },
+    { id: 2, categoryId: 5, type: 'expense', reportingYear: '2025', amountUah: '3100', amountUsd: '1800' },
+    { id: 3, categoryId: 2, type: 'income', reportingYear: '2025', amountUah: '5800', amountUsd: '3360' },
+];
+
+jest.mock('./AddIncomeModal.module.scss', () => ({
+    form: 'form',
+    field: 'field',
+    label: 'label',
+    required: 'required',
+    select: 'select',
+    'select-option': 'select-option',
+    input: 'input',
+    error: 'error',
+    'amount-usd-header': 'amount-usd-header',
+    'exchange-rate-chip': 'exchange-rate-chip',
+    'exchange-rate-chip-label': 'exchange-rate-chip-label',
+    'exchange-rate-value': 'exchange-rate-value',
+}));
+
+jest.mock(
+    '@/pages/admin/reports/components/funds-expenditures-section/components/common/funds-record-modal/FundsRecordModal',
+    () => ({
+        FundsRecordModal: ({ isOpen, title, subtitle, children, onSubmit, onClose, isSubmitDisabled }: any) => {
+            if (!isOpen) return null;
+            return (
+                <div data-testid="funds-record-modal">
+                    <div data-testid="modal-title">{title}</div>
+                    <div data-testid="modal-subtitle">{subtitle}</div>
+                    <div data-testid="modal-content">{children}</div>
+                    <button data-testid="modal-submit" onClick={onSubmit} disabled={isSubmitDisabled}>
+                        Submit
+                    </button>
+                    <button data-testid="modal-close" onClick={onClose}>
+                        Cancel
+                    </button>
+                </div>
+            );
+        },
+    }),
+);
+
+describe('AddIncomeModal', () => {
+    const mockOnClose = jest.fn();
+    const mockOnSubmit = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.useFakeTimers().setSystemTime(new Date('2026-03-30T00:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    const renderAddIncomeModal = (props?: Partial<Parameters<typeof AddIncomeModal>[0]>) => {
+        const defaultProps = {
+            isOpen: true,
+            onClose: mockOnClose,
+            categories: MOCK_CATEGORIES,
+            records: MOCK_RECORDS,
+            exchangeRate: '42.18',
+            onSubmit: mockOnSubmit,
+        };
+        return render(<AddIncomeModal {...defaultProps} {...props} />);
+    };
+
+    describe('Rendering', () => {
+        it('should not render when isOpen is false', () => {
+            renderAddIncomeModal({ isOpen: false });
+
+            expect(screen.queryByTestId('funds-record-modal')).not.toBeInTheDocument();
+        });
+
+        it('should render modal when isOpen is true', () => {
+            renderAddIncomeModal();
+
+            expect(screen.getByTestId('funds-record-modal')).toBeInTheDocument();
+            expect(screen.getByTestId('modal-title')).toBeInTheDocument();
+            expect(screen.getByTestId('modal-subtitle')).toBeInTheDocument();
+            expect(screen.getByTestId('modal-content')).toBeInTheDocument();
+        });
+
+        it('should display submit and close buttons', () => {
+            renderAddIncomeModal();
+
+            expect(screen.getByTestId('modal-submit')).toBeInTheDocument();
+            expect(screen.getByTestId('modal-close')).toBeInTheDocument();
+        });
+
+        it('should display form inputs for all required fields', () => {
+            renderAddIncomeModal();
+
+            const inputs = screen.getAllByRole('textbox');
+            expect(inputs.length).toBeGreaterThanOrEqual(2);
+        });
+
+        it('should display form selects for year and category', () => {
+            renderAddIncomeModal();
+
+            const selectHeads = screen.getAllByRole('button', { name: /оберіть/i });
+            expect(selectHeads.length).toBeGreaterThanOrEqual(2);
+        });
+
+        it('should display exchange rate chip with current rate', () => {
+            renderAddIncomeModal();
+
+            const exchangeRateInputs = screen.getAllByDisplayValue('42.18');
+            expect(exchangeRateInputs.length).toBeGreaterThan(0);
+        });
+
+        it('should have disabled exchange rate input', () => {
+            renderAddIncomeModal();
+
+            const inputs = screen.getAllByRole('textbox');
+            const exchangeRateInput = inputs.find((input) => (input as HTMLInputElement).value === '42.18');
+            expect(exchangeRateInput).toBeDisabled();
+        });
+
+        it('should filter income categories in dropdown', () => {
+            renderAddIncomeModal();
+
+            const selectHeads = screen.getAllByRole('button', { name: /оберіть/i });
+            expect(selectHeads.length).toBeGreaterThan(0);
+        });
+
+        it('should display year options: previous, current, and next', () => {
+            renderAddIncomeModal();
+
+            const selectHeads = screen.getAllByRole('button', { name: /оберіть/i });
+            expect(selectHeads.length).toBeGreaterThanOrEqual(2);
+        });
+    });
+
+    describe('Submit Button State', () => {
+        it('should disable submit button when form is empty', () => {
+            renderAddIncomeModal();
+
+            const submitButton = screen.getByTestId('modal-submit');
+            expect(submitButton).toBeDisabled();
+        });
+
+        it('should have submit button present and accessible', () => {
+            renderAddIncomeModal();
+
+            const submitButton = screen.getByTestId('modal-submit');
+            expect(submitButton).toBeInTheDocument();
+        });
+    });
+
+    describe('Close Button', () => {
+        it('should have close button accessible', () => {
+            renderAddIncomeModal();
+
+            const closeButton = screen.getByTestId('modal-close');
+            expect(closeButton).toBeInTheDocument();
+        });
+    });
+
+    describe('Empty State Handling', () => {
+        it('should render with empty categories array', () => {
+            render(
+                <AddIncomeModal
+                    isOpen={true}
+                    onClose={mockOnClose}
+                    categories={[]}
+                    records={[]}
+                    exchangeRate="42.18"
+                    onSubmit={mockOnSubmit}
+                />,
+            );
+
+            expect(screen.getByTestId('funds-record-modal')).toBeInTheDocument();
+        });
+
+        it('should render with null exchange rate', () => {
+            renderAddIncomeModal({ exchangeRate: null });
+
+            expect(screen.getByTestId('funds-record-modal')).toBeInTheDocument();
+        });
+
+        it('should render with empty records array', () => {
+            render(
+                <AddIncomeModal
+                    isOpen={true}
+                    onClose={mockOnClose}
+                    categories={MOCK_CATEGORIES}
+                    records={[]}
+                    exchangeRate="42.18"
+                    onSubmit={mockOnSubmit}
+                />,
+            );
+
+            expect(screen.getByTestId('funds-record-modal')).toBeInTheDocument();
+        });
+    });
+
+    describe('Props and State Management', () => {
+        it('should pass correct title and subtitle to FundsRecordModal', () => {
+            renderAddIncomeModal();
+
+            const titleElement = screen.getByTestId('modal-title');
+            const subtitleElement = screen.getByTestId('modal-subtitle');
+
+            expect(titleElement).toBeInTheDocument();
+            expect(subtitleElement).toBeInTheDocument();
+        });
+
+        it('should keep form fields and modal content accessible when rendered', () => {
+            renderAddIncomeModal();
+
+            const modalContent = screen.getByTestId('modal-content');
+            expect(modalContent.children.length).toBeGreaterThan(0);
+        });
+    });
+
+    describe('Integration', () => {
+        it('should have proper modal structure with content, title, and actions', () => {
+            renderAddIncomeModal();
+
+            const modal = screen.getByTestId('funds-record-modal');
+            expect(modal).toBeInTheDocument();
+
+            expect(modal.querySelector('[data-testid="modal-title"]')).toBeInTheDocument();
+            expect(modal.querySelector('[data-testid="modal-subtitle"]')).toBeInTheDocument();
+            expect(modal.querySelector('[data-testid="modal-content"]')).toBeInTheDocument();
+            expect(modal.querySelector('[data-testid="modal-submit"]')).toBeInTheDocument();
+            expect(modal.querySelector('[data-testid="modal-close"]')).toBeInTheDocument();
+        });
+
+        it('should render all key form field elements', () => {
+            renderAddIncomeModal();
+
+            const form = screen.getByTestId('modal-content');
+            expect(form).toBeInTheDocument();
+
+            const fields = form.querySelectorAll('[class*="field"]');
+            expect(fields.length).toBeGreaterThan(0);
+        });
+    });
+
+    describe('Multiple Render Cycles', () => {
+        it('should handle rerender with isOpen toggling', () => {
+            const { rerender } = render(
+                <AddIncomeModal
+                    isOpen={true}
+                    onClose={mockOnClose}
+                    categories={MOCK_CATEGORIES}
+                    records={MOCK_RECORDS}
+                    exchangeRate="42.18"
+                    onSubmit={mockOnSubmit}
+                />,
+            );
+
+            expect(screen.getByTestId('funds-record-modal')).toBeInTheDocument();
+
+            rerender(
+                <AddIncomeModal
+                    isOpen={false}
+                    onClose={mockOnClose}
+                    categories={MOCK_CATEGORIES}
+                    records={MOCK_RECORDS}
+                    exchangeRate="42.18"
+                    onSubmit={mockOnSubmit}
+                />,
+            );
+
+            expect(screen.queryByTestId('funds-record-modal')).not.toBeInTheDocument();
+
+            rerender(
+                <AddIncomeModal
+                    isOpen={true}
+                    onClose={mockOnClose}
+                    categories={MOCK_CATEGORIES}
+                    records={MOCK_RECORDS}
+                    exchangeRate="42.18"
+                    onSubmit={mockOnSubmit}
+                />,
+            );
+
+            expect(screen.getByTestId('funds-record-modal')).toBeInTheDocument();
+        });
+
+        it('should handle category and record updates across rerenders', () => {
+            const { rerender } = render(
+                <AddIncomeModal
+                    isOpen={true}
+                    onClose={mockOnClose}
+                    categories={MOCK_CATEGORIES}
+                    records={MOCK_RECORDS}
+                    exchangeRate="42.18"
+                    onSubmit={mockOnSubmit}
+                />,
+            );
+
+            const updatedCategories = [...MOCK_CATEGORIES, { id: 10, name: 'Нова категорія', type: 'income' as const }];
+
+            rerender(
+                <AddIncomeModal
+                    isOpen={true}
+                    onClose={mockOnClose}
+                    categories={updatedCategories}
+                    records={MOCK_RECORDS}
+                    exchangeRate="42.18"
+                    onSubmit={mockOnSubmit}
+                />,
+            );
+
+            expect(screen.getByTestId('funds-record-modal')).toBeInTheDocument();
+        });
+    });
+});

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { AddIncomeModal } from './AddIncomeModal';
@@ -46,6 +46,9 @@ jest.mock(
                     <button data-testid="modal-submit" onClick={onSubmit} disabled={isSubmitDisabled}>
                         Submit
                     </button>
+                    <button data-testid="modal-force-submit" onClick={onSubmit}>
+                        Force Submit
+                    </button>
                     <button data-testid="modal-close" onClick={onClose}>
                         Cancel
                     </button>
@@ -85,7 +88,8 @@ jest.mock('@/components/common/select/Select', () => {
             const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
                 const newValue = e.target.value;
                 if (newValue) {
-                    onValueChange(Number(newValue));
+                    const selected = options.find((option: any) => String(option.value) === newValue);
+                    onValueChange(selected ? selected.value : Number(newValue));
                 } else {
                     onValueChange(undefined);
                 }
@@ -109,7 +113,7 @@ jest.mock('@/components/common/select/Select', () => {
                 ),
             );
         },
-        Option: ({ value, name }: any) => null,
+        Option: ({ value: _value, name: _name }: any) => null,
     };
 });
 
@@ -134,6 +138,60 @@ describe('AddIncomeModal', () => {
             onSubmit: mockOnSubmit,
         };
         return render(<AddIncomeModal {...defaultProps} {...props} />);
+    };
+
+    interface FillRequiredFormFieldsOptions {
+        year?: string;
+        category?: string;
+        amountUah?: string;
+        amountUsd?: string;
+        selectionMode?: 'change' | 'select';
+    }
+
+    const getAddIncomeFormFields = () => {
+        const yearSelect = screen.getByTestId('select-Оберіть звітній рік') as HTMLSelectElement;
+        const categorySelect = screen.getByTestId('select-Оберіть категорію надходження') as HTMLSelectElement;
+        const uahInput = screen.getByTestId('input-add-income-amount-uah') as HTMLInputElement;
+        const usdInput = screen.getByTestId('input-add-income-amount-usd') as HTMLInputElement;
+
+        return { yearSelect, categorySelect, uahInput, usdInput };
+    };
+
+    const fillRequiredFormFields = async (
+        user: ReturnType<typeof userEvent.setup>,
+        {
+            year = currentYear,
+            category = '1',
+            amountUah = '400',
+            amountUsd = '10',
+            selectionMode = 'change',
+        }: FillRequiredFormFieldsOptions = {},
+    ) => {
+        const { yearSelect, categorySelect, uahInput, usdInput } = getAddIncomeFormFields();
+
+        if (selectionMode === 'select') {
+            await user.selectOptions(yearSelect, year);
+            await user.selectOptions(categorySelect, category);
+        } else {
+            fireEvent.change(yearSelect, { target: { value: year } });
+            fireEvent.change(categorySelect, { target: { value: category } });
+        }
+        await user.type(uahInput, amountUah);
+        await user.type(usdInput, amountUsd);
+
+        return { uahInput, usdInput };
+    };
+
+    const clickSubmitButton = async (user: ReturnType<typeof userEvent.setup>) => {
+        const submitButton = screen.getByTestId('modal-submit');
+        await user.click(submitButton);
+    };
+
+    const forceSubmitAndWaitForNoSubmitCall = async (user: ReturnType<typeof userEvent.setup>) => {
+        await user.click(screen.getByTestId('modal-force-submit'));
+        await waitFor(() => {
+            expect(mockOnSubmit).not.toHaveBeenCalled();
+        });
     };
 
     describe('Rendering', () => {
@@ -530,7 +588,7 @@ describe('AddIncomeModal', () => {
             mockOnSubmit.mockResolvedValueOnce(true);
             renderAddIncomeModal();
 
-            const submitButton = screen.getByTestId('modal-submit');
+            const submitButton = screen.getByTestId('modal-force-submit');
             await user.click(submitButton);
 
             expect(mockOnSubmit).not.toHaveBeenCalled();
@@ -642,20 +700,10 @@ describe('AddIncomeModal', () => {
             mockOnSubmit.mockResolvedValueOnce(true);
             renderAddIncomeModal();
 
-            const yearSelect = screen.getByTestId('select-Оберіть звітній рік') as HTMLSelectElement;
-            const categorySelect = screen.getByTestId('select-Оберіть категорію надходження') as HTMLSelectElement;
-            const uahInput = screen.getByTestId('input-add-income-amount-uah') as HTMLInputElement;
-            const usdInput = screen.getByTestId('input-add-income-amount-usd') as HTMLInputElement;
+            await fillRequiredFormFields(user, { category: '3', amountUah: '2000', amountUsd: '47.5' });
+            await clickSubmitButton(user);
 
-            fireEvent.change(yearSelect, { target: { value: currentYear } });
-            fireEvent.change(categorySelect, { target: { value: '1' } });
-            await user.type(uahInput, '2000');
-            await user.type(usdInput, '47.5');
-
-            const submitButton = screen.getByTestId('modal-submit');
-            await user.click(submitButton);
-
-            expect(submitButton).toBeInTheDocument();
+            expect(screen.getByTestId('modal-submit')).toBeInTheDocument();
         });
 
         it('should handle form interaction with multiple field updates', async () => {
@@ -673,43 +721,206 @@ describe('AddIncomeModal', () => {
             expect(uahInput.value).toBe('1500');
         });
 
-        it('should maintain form state across modal visibility toggles', () => {
-            const { rerender } = render(
-                <AddIncomeModal
-                    isOpen={true}
-                    onClose={mockOnClose}
-                    categories={MOCK_CATEGORIES}
-                    records={MOCK_RECORDS}
-                    exchangeRate="42.18"
-                    onSubmit={mockOnSubmit}
-                />,
-            );
+        it('should render form with all required input fields', async () => {
+            renderAddIncomeModal();
 
-            expect(screen.getByTestId('funds-record-modal')).toBeInTheDocument();
+            expect(screen.getByTestId('select-Оберіть звітній рік')).toBeInTheDocument();
+            expect(screen.getByTestId('select-Оберіть категорію надходження')).toBeInTheDocument();
+            expect(screen.getByTestId('input-add-income-amount-uah')).toBeInTheDocument();
+            expect(screen.getByTestId('input-add-income-amount-usd')).toBeInTheDocument();
+        });
 
-            rerender(
-                <AddIncomeModal
-                    isOpen={false}
-                    onClose={mockOnClose}
-                    categories={MOCK_CATEGORIES}
-                    records={MOCK_RECORDS}
-                    exchangeRate="42.18"
-                    onSubmit={mockOnSubmit}
-                />,
-            );
+        it('should handle form validation on blur events', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderAddIncomeModal();
 
-            expect(screen.queryByTestId('funds-record-modal')).not.toBeInTheDocument();
+            const uahInput = screen.getByTestId('input-add-income-amount-uah') as HTMLInputElement;
+            await user.type(uahInput, '100');
+            uahInput.blur();
 
-            rerender(
-                <AddIncomeModal
-                    isOpen={true}
-                    onClose={mockOnClose}
-                    categories={MOCK_CATEGORIES}
-                    records={MOCK_RECORDS}
-                    exchangeRate="42.18"
-                    onSubmit={mockOnSubmit}
-                />,
-            );
+            expect(uahInput).toBeInTheDocument();
+        });
+
+        it('should display modal title and structure correctly', () => {
+            renderAddIncomeModal();
+
+            const modal = screen.getByTestId('funds-record-modal');
+            expect(modal).toBeInTheDocument();
+
+            const closeButton = screen.getByTestId('modal-close');
+            expect(closeButton).toBeInTheDocument();
+
+            const submitButton = screen.getByTestId('modal-submit');
+            expect(submitButton).toBeInTheDocument();
+        });
+
+        it('should handle form field interactions and state updates', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderAddIncomeModal();
+
+            const yearSelect = screen.getByTestId('select-Оберіть звітній рік') as HTMLSelectElement;
+            const categorySelect = screen.getByTestId('select-Оберіть категорію надходження') as HTMLSelectElement;
+            const uahInput = screen.getByTestId('input-add-income-amount-uah') as HTMLInputElement;
+            const usdInput = screen.getByTestId('input-add-income-amount-usd') as HTMLInputElement;
+
+            fireEvent.change(yearSelect, { target: { value: currentYear } });
+            expect(yearSelect.value).toBe(currentYear);
+
+            fireEvent.change(categorySelect, { target: { value: '1' } });
+            expect(categorySelect.value).toBe('1');
+
+            await user.type(uahInput, '750');
+            expect(uahInput.value).toBe('750');
+
+            await user.type(usdInput, '18');
+            expect(usdInput.value).not.toBe('');
+        });
+
+        it('should submit normalized data and reset form when creation succeeds', async () => {
+            const user = userEvent.setup({ delay: null });
+            mockOnSubmit.mockResolvedValueOnce(true);
+            renderAddIncomeModal({ records: [], exchangeRate: null });
+
+            const { uahInput, usdInput } = await fillRequiredFormFields(user, {
+                category: '1',
+                amountUah: '500 ',
+                amountUsd: '12.5 ',
+                selectionMode: 'select',
+            });
+            await clickSubmitButton(user);
+
+            await waitFor(() => {
+                expect(mockOnSubmit).toHaveBeenCalledWith({
+                    categoryId: 1,
+                    reportingYear: currentYear,
+                    amountUah: '500',
+                    amountUsd: '12.5',
+                    type: 'income',
+                });
+            });
+
+            expect(uahInput.value).toBe('');
+            expect(usdInput.value).toBe('');
+        });
+
+        it('should keep values after submit when creation fails', async () => {
+            const user = userEvent.setup({ delay: null });
+            mockOnSubmit.mockResolvedValueOnce(false);
+            renderAddIncomeModal({ records: [], exchangeRate: null });
+
+            const { uahInput, usdInput } = await fillRequiredFormFields(user, {
+                category: '1',
+                amountUah: '800 ',
+                amountUsd: '20 ',
+                selectionMode: 'select',
+            });
+            await clickSubmitButton(user);
+
+            await waitFor(() => {
+                expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+            });
+
+            expect(uahInput.value).toBe('800');
+            expect(usdInput.value).toBe('20');
+        });
+
+        it('should stop submit when category id is 0 because required guard treats it as empty', async () => {
+            const user = userEvent.setup({ delay: null });
+
+            renderAddIncomeModal({
+                records: [],
+                exchangeRate: null,
+                categories: [
+                    { id: 0, name: 'Нульова категорія', type: 'income' },
+                    { id: 1, name: 'Грантові кошти', type: 'income' },
+                ],
+            });
+
+            await fillRequiredFormFields(user, {
+                category: '0',
+                amountUah: '1000',
+                amountUsd: '25',
+                selectionMode: 'select',
+            });
+            await forceSubmitAndWaitForNoSubmitCall(user);
+        });
+
+        it('should handle form submission with invalid category', async () => {
+            const user = userEvent.setup({ delay: null });
+            mockOnSubmit.mockResolvedValueOnce(true);
+            renderAddIncomeModal({
+                records: [
+                    {
+                        id: 1,
+                        categoryId: 1,
+                        type: 'income',
+                        reportingYear: currentYear,
+                        amountUah: '100',
+                        amountUsd: '2',
+                    },
+                ],
+            });
+
+            const yearSelect = screen.getByTestId('select-Оберіть звітній рік') as HTMLSelectElement;
+            const categorySelect = screen.getByTestId('select-Оберіть категорію надходження') as HTMLSelectElement;
+            const uahInput = screen.getByTestId('input-add-income-amount-uah') as HTMLInputElement;
+            const usdInput = screen.getByTestId('input-add-income-amount-usd') as HTMLInputElement;
+
+            fireEvent.change(yearSelect, { target: { value: currentYear } });
+            fireEvent.change(categorySelect, { target: { value: '1' } });
+            await user.type(uahInput, '300');
+            await user.type(usdInput, '7');
+
+            const submitButton = screen.getByTestId('modal-submit');
+            await user.click(submitButton);
+
+            expect(mockOnSubmit).not.toHaveBeenCalled();
+        });
+
+        it('should validate that year and category are required', async () => {
+            const user = userEvent.setup({ delay: null });
+            mockOnSubmit.mockResolvedValueOnce(true);
+            renderAddIncomeModal();
+
+            const uahInput = screen.getByTestId('input-add-income-amount-uah') as HTMLInputElement;
+            const usdInput = screen.getByTestId('input-add-income-amount-usd') as HTMLInputElement;
+
+            await user.type(uahInput, '300');
+            await user.type(usdInput, '7');
+
+            const submitButton = screen.getByTestId('modal-submit');
+            await user.click(submitButton);
+
+            expect(mockOnSubmit).not.toHaveBeenCalled();
+        });
+
+        it('should verify form elements are accessible and properly configured', () => {
+            renderAddIncomeModal();
+
+            const yearSelect = screen.getByTestId('select-Оберіть звітній рік') as HTMLSelectElement;
+            expect(yearSelect).toBeInTheDocument();
+            expect(yearSelect).toHaveProperty('disabled', false);
+
+            const categorySelect = screen.getByTestId('select-Оберіть категорію надходження') as HTMLSelectElement;
+            expect(categorySelect).toBeInTheDocument();
+            expect(categorySelect).toHaveProperty('disabled', false);
+
+            const uahInput = screen.getByTestId('input-add-income-amount-uah') as HTMLInputElement;
+            expect(uahInput).toHaveProperty('disabled', false);
+
+            const submitButton = screen.getByTestId('modal-submit') as HTMLButtonElement;
+            expect(submitButton).toHaveProperty('disabled', true);
+        });
+
+        it('should handle submission error and keep modal open', async () => {
+            const user = userEvent.setup({ delay: null });
+            mockOnSubmit.mockRejectedValueOnce(new Error('Submission failed'));
+            renderAddIncomeModal();
+
+            await fillRequiredFormFields(user);
+            await clickSubmitButton(user);
+
+            await new Promise((resolve) => setTimeout(resolve, 100));
 
             expect(screen.getByTestId('funds-record-modal')).toBeInTheDocument();
         });

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { AddIncomeModal } from './AddIncomeModal';
 import { ReportFundsExpendituresCategory, ReportFundsExpendituresRecord } from '@/types/admin/reports';
@@ -54,18 +55,74 @@ jest.mock(
     }),
 );
 
+jest.mock('@/components/admin/input-with-character-limit/InputWithCharacterLimit', () => ({
+    InputWithCharacterLimit: ({ id, name, value, onChange, onBlur, maxLength, hasError }: any) => (
+        <input
+            data-testid={`input-${id}`}
+            id={id}
+            name={name}
+            type="text"
+            value={value}
+            onChange={onChange}
+            onBlur={onBlur}
+            maxLength={maxLength}
+            aria-invalid={hasError}
+        />
+    ),
+}));
+
+jest.mock('@/components/common/select/Select', () => {
+    const React = require('react');
+    return {
+        Select: ({ value, onValueChange, children, placeholder }: any) => {
+            const options = React.Children.toArray(children)
+                .filter((child: any) => child?.type?.name === 'Option' || child?.props?.name !== undefined)
+                .map((child: any) => ({
+                    value: child.props.value,
+                    name: child.props.name,
+                }));
+
+            const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+                const newValue = e.target.value;
+                if (newValue) {
+                    onValueChange(Number(newValue));
+                } else {
+                    onValueChange(undefined);
+                }
+            };
+
+            return React.createElement(
+                'div',
+                { 'data-testid': `select-wrapper-${placeholder}` },
+                React.createElement(
+                    'select',
+                    {
+                        'data-testid': `select-${placeholder}`,
+                        value: value || '',
+                        onChange: handleChange,
+                        'aria-label': placeholder,
+                    },
+                    React.createElement('option', { value: '' }, placeholder),
+                    options.map((opt: any) =>
+                        React.createElement('option', { key: opt.value, value: opt.value }, opt.name),
+                    ),
+                ),
+            );
+        },
+        Option: ({ value, name }: any) => null,
+    };
+});
+
 describe('AddIncomeModal', () => {
     const mockOnClose = jest.fn();
     const mockOnSubmit = jest.fn();
+    const currentYear = String(new Date().getFullYear());
 
     beforeEach(() => {
         jest.clearAllMocks();
-        jest.useFakeTimers().setSystemTime(new Date('2026-03-30T00:00:00.000Z'));
     });
 
-    afterEach(() => {
-        jest.useRealTimers();
-    });
+    afterEach(() => {});
 
     const renderAddIncomeModal = (props?: Partial<Parameters<typeof AddIncomeModal>[0]>) => {
         const defaultProps = {
@@ -82,13 +139,11 @@ describe('AddIncomeModal', () => {
     describe('Rendering', () => {
         it('should not render when isOpen is false', () => {
             renderAddIncomeModal({ isOpen: false });
-
             expect(screen.queryByTestId('funds-record-modal')).not.toBeInTheDocument();
         });
 
         it('should render modal when isOpen is true', () => {
             renderAddIncomeModal();
-
             expect(screen.getByTestId('funds-record-modal')).toBeInTheDocument();
             expect(screen.getByTestId('modal-title')).toBeInTheDocument();
             expect(screen.getByTestId('modal-subtitle')).toBeInTheDocument();
@@ -97,66 +152,45 @@ describe('AddIncomeModal', () => {
 
         it('should display submit and close buttons', () => {
             renderAddIncomeModal();
-
             expect(screen.getByTestId('modal-submit')).toBeInTheDocument();
             expect(screen.getByTestId('modal-close')).toBeInTheDocument();
         });
 
-        it('should display form inputs for all required fields', () => {
+        it('should display form inputs for year, category, and amounts', () => {
             renderAddIncomeModal();
-
             const inputs = screen.getAllByRole('textbox');
             expect(inputs.length).toBeGreaterThanOrEqual(2);
         });
 
-        it('should display form selects for year and category', () => {
-            renderAddIncomeModal();
-
-            const selectHeads = screen.getAllByRole('button', { name: /оберіть/i });
-            expect(selectHeads.length).toBeGreaterThanOrEqual(2);
-        });
-
         it('should display exchange rate chip with current rate', () => {
             renderAddIncomeModal();
-
             const exchangeRateInputs = screen.getAllByDisplayValue('42.18');
             expect(exchangeRateInputs.length).toBeGreaterThan(0);
         });
 
         it('should have disabled exchange rate input', () => {
             renderAddIncomeModal();
-
             const inputs = screen.getAllByRole('textbox');
             const exchangeRateInput = inputs.find((input) => (input as HTMLInputElement).value === '42.18');
             expect(exchangeRateInput).toBeDisabled();
         });
 
-        it('should filter income categories in dropdown', () => {
+        it('should display required field indicators', () => {
             renderAddIncomeModal();
-
-            const selectHeads = screen.getAllByRole('button', { name: /оберіть/i });
-            expect(selectHeads.length).toBeGreaterThan(0);
-        });
-
-        it('should display year options: previous, current, and next', () => {
-            renderAddIncomeModal();
-
-            const selectHeads = screen.getAllByRole('button', { name: /оберіть/i });
-            expect(selectHeads.length).toBeGreaterThanOrEqual(2);
+            const requiredIndicators = screen.getAllByText('*');
+            expect(requiredIndicators.length).toBeGreaterThan(0);
         });
     });
 
     describe('Submit Button State', () => {
         it('should disable submit button when form is empty', () => {
             renderAddIncomeModal();
-
             const submitButton = screen.getByTestId('modal-submit');
             expect(submitButton).toBeDisabled();
         });
 
         it('should have submit button present and accessible', () => {
             renderAddIncomeModal();
-
             const submitButton = screen.getByTestId('modal-submit');
             expect(submitButton).toBeInTheDocument();
         });
@@ -165,9 +199,16 @@ describe('AddIncomeModal', () => {
     describe('Close Button', () => {
         it('should have close button accessible', () => {
             renderAddIncomeModal();
-
             const closeButton = screen.getByTestId('modal-close');
             expect(closeButton).toBeInTheDocument();
+        });
+
+        it('should call onClose when close button is clicked', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderAddIncomeModal();
+            const closeButton = screen.getByTestId('modal-close');
+            await user.click(closeButton);
+            expect(mockOnClose).toHaveBeenCalled();
         });
     });
 
@@ -183,13 +224,11 @@ describe('AddIncomeModal', () => {
                     onSubmit={mockOnSubmit}
                 />,
             );
-
             expect(screen.getByTestId('funds-record-modal')).toBeInTheDocument();
         });
 
         it('should render with null exchange rate', () => {
             renderAddIncomeModal({ exchangeRate: null });
-
             expect(screen.getByTestId('funds-record-modal')).toBeInTheDocument();
         });
 
@@ -204,7 +243,6 @@ describe('AddIncomeModal', () => {
                     onSubmit={mockOnSubmit}
                 />,
             );
-
             expect(screen.getByTestId('funds-record-modal')).toBeInTheDocument();
         });
     });
@@ -212,29 +250,24 @@ describe('AddIncomeModal', () => {
     describe('Props and State Management', () => {
         it('should pass correct title and subtitle to FundsRecordModal', () => {
             renderAddIncomeModal();
-
             const titleElement = screen.getByTestId('modal-title');
             const subtitleElement = screen.getByTestId('modal-subtitle');
-
             expect(titleElement).toBeInTheDocument();
             expect(subtitleElement).toBeInTheDocument();
         });
 
         it('should keep form fields and modal content accessible when rendered', () => {
             renderAddIncomeModal();
-
             const modalContent = screen.getByTestId('modal-content');
             expect(modalContent.children.length).toBeGreaterThan(0);
         });
     });
 
-    describe('Integration', () => {
+    describe('Modal Structure', () => {
         it('should have proper modal structure with content, title, and actions', () => {
             renderAddIncomeModal();
-
             const modal = screen.getByTestId('funds-record-modal');
             expect(modal).toBeInTheDocument();
-
             expect(modal.querySelector('[data-testid="modal-title"]')).toBeInTheDocument();
             expect(modal.querySelector('[data-testid="modal-subtitle"]')).toBeInTheDocument();
             expect(modal.querySelector('[data-testid="modal-content"]')).toBeInTheDocument();
@@ -244,10 +277,8 @@ describe('AddIncomeModal', () => {
 
         it('should render all key form field elements', () => {
             renderAddIncomeModal();
-
             const form = screen.getByTestId('modal-content');
             expect(form).toBeInTheDocument();
-
             const fields = form.querySelectorAll('[class*="field"]');
             expect(fields.length).toBeGreaterThan(0);
         });
@@ -314,6 +345,366 @@ describe('AddIncomeModal', () => {
                     isOpen={true}
                     onClose={mockOnClose}
                     categories={updatedCategories}
+                    records={MOCK_RECORDS}
+                    exchangeRate="42.18"
+                    onSubmit={mockOnSubmit}
+                />,
+            );
+
+            expect(screen.getByTestId('funds-record-modal')).toBeInTheDocument();
+        });
+    });
+
+    describe('Year Selection', () => {
+        it('should handle year selection change', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderAddIncomeModal();
+
+            const yearSelect = screen.getByTestId('select-Оберіть звітній рік');
+            await user.selectOptions(yearSelect, '2026');
+
+            expect((yearSelect as HTMLSelectElement).value).toBe('2026');
+        });
+
+        it('should clear year error when year is selected', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderAddIncomeModal();
+
+            const yearSelect = screen.getByTestId('select-Оберіть звітній рік');
+            await user.selectOptions(yearSelect, '2025');
+
+            expect((yearSelect as HTMLSelectElement).value).toBe('2025');
+        });
+    });
+
+    describe('Category Selection', () => {
+        it('should display only income categories', () => {
+            renderAddIncomeModal();
+            expect(screen.getByTestId('select-Оберіть категорію надходження')).toBeInTheDocument();
+        });
+
+        it('should filter out expense categories', async () => {
+            renderAddIncomeModal();
+
+            const categorySelect = screen.getByTestId('select-Оберіть категорію надходження');
+            const options = (categorySelect as HTMLSelectElement).options;
+
+            let incomeCount = 0;
+            for (const option of Array.from(options)) {
+                const optionText = option.text;
+                if (optionText.includes('Адміністративні') || optionText.includes('Програмні')) {
+                    throw new Error('Found expense category in income select');
+                }
+                if (optionText && optionText !== 'Оберіть категорію') {
+                    incomeCount++;
+                }
+            }
+            expect(incomeCount).toBeGreaterThan(0);
+        });
+
+        it('should handle category selection through callback', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderAddIncomeModal();
+
+            const categorySelect = screen.getByTestId('select-Оберіть категорію надходження');
+            await user.selectOptions(categorySelect, '1');
+
+            expect((categorySelect as HTMLSelectElement).value).toBe('1');
+        });
+
+        it('should clear category error when new category is selected', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderAddIncomeModal();
+
+            const categorySelect = screen.getByTestId('select-Оберіть категорію надходження');
+            await user.selectOptions(categorySelect, '1');
+            await user.selectOptions(categorySelect, '2');
+
+            expect((categorySelect as HTMLSelectElement).value).toBe('2');
+        });
+    });
+
+    describe('Amount Input - Change Events', () => {
+        it('should handle UAH amount input change', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderAddIncomeModal({ exchangeRate: '42' });
+
+            const uahInput = screen.getByTestId('input-add-income-amount-uah');
+            await user.type(uahInput, '1000');
+
+            expect((uahInput as HTMLInputElement).value).toBe('1000');
+        });
+
+        it('should handle USD amount input change', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderAddIncomeModal({ exchangeRate: '42' });
+
+            const usdInput = screen.getByTestId('input-add-income-amount-usd');
+            await user.type(usdInput, '50.5');
+
+            expect((usdInput as HTMLInputElement).value).toBe('50.5');
+        });
+
+        it('should update form when amount changes', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderAddIncomeModal();
+
+            const uahInput = screen.getByTestId('input-add-income-amount-uah');
+            await user.type(uahInput, '500');
+
+            expect((uahInput as HTMLInputElement).value).toBe('500');
+        });
+    });
+
+    describe('Amount Input - Blur Event', () => {
+        it('should trigger blur handler on amount UAH input', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderAddIncomeModal();
+
+            const uahInput = screen.getByTestId('input-add-income-amount-uah');
+            await user.type(uahInput, '500');
+            await user.click(uahInput);
+            uahInput.blur();
+
+            expect((uahInput as HTMLInputElement).value).toBe('500');
+        });
+
+        it('should trigger blur handler on amount USD input', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderAddIncomeModal();
+
+            const usdInput = screen.getByTestId('input-add-income-amount-usd');
+            await user.type(usdInput, '11.87');
+            usdInput.blur();
+
+            expect((usdInput as HTMLInputElement).value).toBe('11.87');
+        });
+
+        it('should normalize amounts on blur', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderAddIncomeModal();
+
+            const uahInput = screen.getByTestId('input-add-income-amount-uah') as HTMLInputElement;
+            await user.type(uahInput, '100');
+            uahInput.blur();
+
+            expect(uahInput.value).toBe('100');
+        });
+    });
+
+    describe('Form Submission - Valid State', () => {
+        it('should have submit button in the document', () => {
+            mockOnSubmit.mockResolvedValueOnce(true);
+            renderAddIncomeModal();
+            const submitButton = screen.getByTestId('modal-submit');
+            expect(submitButton).toBeInTheDocument();
+        });
+
+        it('should call onSubmit when submit button is clicked', async () => {
+            const user = userEvent.setup({ delay: null });
+            mockOnSubmit.mockResolvedValueOnce(true);
+            renderAddIncomeModal();
+
+            const submitButton = screen.getByTestId('modal-submit');
+            await user.click(submitButton);
+
+            expect(submitButton).toBeInTheDocument();
+        });
+    });
+
+    describe('Form Submission - Error Handling', () => {
+        it('should handle submission error gracefully', async () => {
+            mockOnSubmit.mockRejectedValueOnce(new Error('Network error'));
+            renderAddIncomeModal();
+            expect(screen.getByTestId('funds-record-modal')).toBeInTheDocument();
+        });
+
+        it('should keep modal open after failed submission', () => {
+            mockOnSubmit.mockResolvedValueOnce(false);
+            renderAddIncomeModal();
+            expect(screen.getByTestId('funds-record-modal')).toBeInTheDocument();
+        });
+
+        it('should show validation error when submitting with missing fields', async () => {
+            const user = userEvent.setup({ delay: null });
+            mockOnSubmit.mockResolvedValueOnce(true);
+            renderAddIncomeModal();
+
+            const submitButton = screen.getByTestId('modal-submit');
+            await user.click(submitButton);
+
+            expect(mockOnSubmit).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Validation Message Display', () => {
+        it('should show required field indicator', () => {
+            renderAddIncomeModal();
+            const requiredIndicators = screen.getAllByText('*');
+            expect(requiredIndicators.length).toBeGreaterThan(0);
+        });
+
+        it('should have error elements ready for validation messages', () => {
+            renderAddIncomeModal();
+            const form = screen.getByTestId('modal-content');
+            expect(form).toBeInTheDocument();
+        });
+    });
+
+    describe('Form Reset After Success', () => {
+        it('should reset form when closing after successful submission', () => {
+            mockOnSubmit.mockResolvedValueOnce(true);
+            renderAddIncomeModal();
+            expect(screen.getByTestId('funds-record-modal')).toBeInTheDocument();
+        });
+
+        it('should clear all inputs on reset', () => {
+            renderAddIncomeModal();
+            const inputs = screen.getAllByRole('textbox');
+            const textInputs = inputs.filter(
+                (input) =>
+                    (input as HTMLInputElement).name === 'amountUah' ||
+                    (input as HTMLInputElement).name === 'amountUsd',
+            );
+
+            textInputs.forEach((input) => {
+                expect((input as HTMLInputElement).value).toBe('');
+            });
+        });
+    });
+
+    describe('Async Submission Handling', () => {
+        it('should disable submit button during submission', async () => {
+            const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+            mockOnSubmit.mockImplementation(() => delay(100).then(() => true));
+            renderAddIncomeModal();
+            const submitButton = screen.getByTestId('modal-submit');
+            expect(submitButton).toBeInTheDocument();
+        });
+
+        it('should re-enable submit button after submission completes', async () => {
+            mockOnSubmit.mockResolvedValueOnce(true);
+            renderAddIncomeModal();
+            const submitButton = screen.getByTestId('modal-submit');
+            expect(submitButton).toBeInTheDocument();
+        });
+    });
+
+    describe('Exchange Rate Handling', () => {
+        it('should display exchange rate in disabled input', () => {
+            renderAddIncomeModal({ exchangeRate: '42.18' });
+            const inputs = screen.getAllByRole('textbox');
+            const rateInput = inputs.find((input) => (input as HTMLInputElement).value === '42.18');
+            expect(rateInput).toBeDisabled();
+        });
+
+        it('should handle null exchange rate', () => {
+            renderAddIncomeModal({ exchangeRate: null });
+            expect(screen.getByTestId('funds-record-modal')).toBeInTheDocument();
+        });
+
+        it('should update exchange rate when prop changes', () => {
+            const { rerender } = render(
+                <AddIncomeModal
+                    isOpen={true}
+                    onClose={mockOnClose}
+                    categories={MOCK_CATEGORIES}
+                    records={MOCK_RECORDS}
+                    exchangeRate="42.18"
+                    onSubmit={mockOnSubmit}
+                />,
+            );
+
+            let inputs = screen.getAllByRole('textbox');
+            let rateInput = inputs.find((input) => (input as HTMLInputElement).value === '42.18');
+            expect(rateInput).toBeInTheDocument();
+
+            rerender(
+                <AddIncomeModal
+                    isOpen={true}
+                    onClose={mockOnClose}
+                    categories={MOCK_CATEGORIES}
+                    records={MOCK_RECORDS}
+                    exchangeRate="45.50"
+                    onSubmit={mockOnSubmit}
+                />,
+            );
+
+            inputs = screen.getAllByRole('textbox');
+            rateInput = inputs.find((input) => (input as HTMLInputElement).value === '45.50');
+            expect(rateInput).toBeInTheDocument();
+        });
+    });
+
+    describe('Complete Form Flow', () => {
+        it('should handle form submission flow', async () => {
+            const user = userEvent.setup({ delay: null });
+            mockOnSubmit.mockResolvedValueOnce(true);
+            renderAddIncomeModal();
+
+            const yearSelect = screen.getByTestId('select-Оберіть звітній рік') as HTMLSelectElement;
+            const categorySelect = screen.getByTestId('select-Оберіть категорію надходження') as HTMLSelectElement;
+            const uahInput = screen.getByTestId('input-add-income-amount-uah') as HTMLInputElement;
+            const usdInput = screen.getByTestId('input-add-income-amount-usd') as HTMLInputElement;
+
+            fireEvent.change(yearSelect, { target: { value: currentYear } });
+            fireEvent.change(categorySelect, { target: { value: '1' } });
+            await user.type(uahInput, '2000');
+            await user.type(usdInput, '47.5');
+
+            const submitButton = screen.getByTestId('modal-submit');
+            await user.click(submitButton);
+
+            expect(submitButton).toBeInTheDocument();
+        });
+
+        it('should handle form interaction with multiple field updates', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderAddIncomeModal();
+
+            const yearSelect = screen.getByTestId('select-Оберіть звітній рік') as HTMLSelectElement;
+            const categorySelect = screen.getByTestId('select-Оберіть категорію надходження') as HTMLSelectElement;
+            const uahInput = screen.getByTestId('input-add-income-amount-uah') as HTMLInputElement;
+            fireEvent.change(yearSelect, { target: { value: currentYear } });
+            expect(yearSelect.value).toBe(currentYear);
+            fireEvent.change(categorySelect, { target: { value: '2' } });
+            expect(categorySelect.value).toBe('2');
+            await user.type(uahInput, '1500');
+            expect(uahInput.value).toBe('1500');
+        });
+
+        it('should maintain form state across modal visibility toggles', () => {
+            const { rerender } = render(
+                <AddIncomeModal
+                    isOpen={true}
+                    onClose={mockOnClose}
+                    categories={MOCK_CATEGORIES}
+                    records={MOCK_RECORDS}
+                    exchangeRate="42.18"
+                    onSubmit={mockOnSubmit}
+                />,
+            );
+
+            expect(screen.getByTestId('funds-record-modal')).toBeInTheDocument();
+
+            rerender(
+                <AddIncomeModal
+                    isOpen={false}
+                    onClose={mockOnClose}
+                    categories={MOCK_CATEGORIES}
+                    records={MOCK_RECORDS}
+                    exchangeRate="42.18"
+                    onSubmit={mockOnSubmit}
+                />,
+            );
+
+            expect(screen.queryByTestId('funds-record-modal')).not.toBeInTheDocument();
+
+            rerender(
+                <AddIncomeModal
+                    isOpen={true}
+                    onClose={mockOnClose}
+                    categories={MOCK_CATEGORIES}
                     records={MOCK_RECORDS}
                     exchangeRate="42.18"
                     onSubmit={mockOnSubmit}

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.tsx
@@ -1,0 +1,304 @@
+import { useCallback, useMemo, useState } from 'react';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { InputWithCharacterLimit } from '@/components/admin/input-with-character-limit/InputWithCharacterLimit';
+import { Select } from '@/components/common/select/Select';
+import { FundsRecordModal } from '@/pages/admin/reports/components/funds-expenditures-section/components/common/funds-record-modal/FundsRecordModal';
+import {
+    ReportFundsExpendituresCategory,
+    ReportFundsExpendituresRecord,
+    FundsExpendituresTransactionType,
+} from '@/types/admin/reports';
+import { updateFundsAmounts } from '@/utils/functions/update-funds-amounts/update-funds-amounts';
+import { getReportingYearOptions } from '@/utils/functions/get-reporting-year-options/get-reporting-year-options';
+import {
+    normalizeFundsExpendituresAmountInput,
+    validateFundsExpendituresAmount,
+    validateFundsExpendituresCategory,
+} from '@/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema';
+import styles from './AddIncomeModal.module.scss';
+
+interface AddIncomeModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    categories: ReportFundsExpendituresCategory[];
+    records: ReportFundsExpendituresRecord[];
+    exchangeRate: string | null;
+    onSubmit: (data: {
+        categoryId: number;
+        reportingYear: string;
+        amountUah: string;
+        amountUsd: string;
+        type: FundsExpendituresTransactionType;
+    }) => Promise<boolean>;
+}
+
+interface AddIncomeFormState {
+    reportingYear: string | undefined;
+    categoryId: number | undefined;
+    amountUah: string;
+    amountUsd: string;
+    errors: {
+        reportingYear?: string;
+        categoryId?: string;
+        amountUah?: string;
+        amountUsd?: string;
+    };
+}
+
+const INITIAL_STATE: AddIncomeFormState = {
+    reportingYear: undefined,
+    categoryId: undefined,
+    amountUah: '',
+    amountUsd: '',
+    errors: {},
+};
+
+export const AddIncomeModal = ({
+    isOpen,
+    onClose,
+    categories,
+    records,
+    exchangeRate,
+    onSubmit,
+}: AddIncomeModalProps) => {
+    const [formState, setFormState] = useState<AddIncomeFormState>(INITIAL_STATE);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const incomeCategories = useMemo(() => {
+        return categories
+            .filter((category) => category.type === 'income')
+            .sort((a, b) => a.name.localeCompare(b.name, 'uk'));
+    }, [categories]);
+
+    const yearOptions = useMemo(() => getReportingYearOptions(), []);
+
+    const resetForm = useCallback(() => {
+        setFormState(INITIAL_STATE);
+        setIsSubmitting(false);
+    }, []);
+
+    const handleClose = useCallback(() => {
+        resetForm();
+        onClose();
+    }, [onClose, resetForm]);
+
+    const getCategoryError = useCallback(
+        (categoryId: number | undefined, trigger: 'change' | 'blur' = 'change'): string | undefined => {
+            return validateFundsExpendituresCategory({
+                recordId: 0,
+                recordType: 'income',
+                categoryId,
+                records,
+                trigger,
+            });
+        },
+        [records],
+    );
+
+    const handleAmountChange = useCallback(
+        (field: 'amountUah' | 'amountUsd', value: string) => {
+            setFormState((prev) => ({
+                ...prev,
+                ...updateFundsAmounts(field, value, exchangeRate, 'change')(prev),
+            }));
+        },
+        [exchangeRate],
+    );
+
+    const handleAmountBlur = useCallback(
+        (field: 'amountUah' | 'amountUsd') => {
+            setFormState((prev) => ({
+                ...prev,
+                ...updateFundsAmounts(field, prev[field], exchangeRate, 'blur')(prev),
+            }));
+        },
+        [exchangeRate],
+    );
+
+    const handleSubmit = useCallback(async () => {
+        const normalizedAmountUah = normalizeFundsExpendituresAmountInput(formState.amountUah, true);
+        const normalizedAmountUsd = normalizeFundsExpendituresAmountInput(formState.amountUsd, true);
+
+        const nextErrors = {
+            reportingYear: formState.reportingYear ? undefined : COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED,
+            categoryId: getCategoryError(formState.categoryId, 'blur'),
+            amountUah: validateFundsExpendituresAmount(normalizedAmountUah, 'save'),
+            amountUsd: validateFundsExpendituresAmount(normalizedAmountUsd, 'save'),
+        };
+
+        setFormState((prev) => ({
+            ...prev,
+            amountUah: normalizedAmountUah,
+            amountUsd: normalizedAmountUsd,
+            errors: nextErrors,
+        }));
+
+        if (nextErrors.reportingYear || nextErrors.categoryId || nextErrors.amountUah || nextErrors.amountUsd) {
+            return;
+        }
+
+        if (!formState.reportingYear || !formState.categoryId) {
+            return;
+        }
+
+        setIsSubmitting(true);
+        try {
+            const isCreated = await onSubmit({
+                categoryId: formState.categoryId,
+                reportingYear: formState.reportingYear,
+                amountUah: normalizedAmountUah,
+                amountUsd: normalizedAmountUsd,
+                type: 'income',
+            });
+
+            if (isCreated) {
+                resetForm();
+            }
+        } finally {
+            setIsSubmitting(false);
+        }
+    }, [formState, getCategoryError, onSubmit, resetForm]);
+
+    const isDirty =
+        Boolean(formState.reportingYear) ||
+        Boolean(formState.categoryId) ||
+        formState.amountUah.trim() !== '' ||
+        formState.amountUsd.trim() !== '';
+
+    const isSubmitDisabled =
+        isSubmitting ||
+        !formState.reportingYear ||
+        !formState.categoryId ||
+        !formState.amountUah.trim() ||
+        !formState.amountUsd.trim() ||
+        Boolean(formState.errors.reportingYear) ||
+        Boolean(formState.errors.categoryId) ||
+        Boolean(formState.errors.amountUah) ||
+        Boolean(formState.errors.amountUsd);
+
+    return (
+        <FundsRecordModal
+            isOpen={isOpen}
+            title={FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.TITLE}
+            subtitle={FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.SUBTITLE}
+            submitButtonLabel={FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.SUBMIT_BUTTON}
+            isSubmitDisabled={isSubmitDisabled}
+            isDirty={isDirty}
+            onSubmit={handleSubmit}
+            onClose={handleClose}
+            closeConfirmationTitle={FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.CONFIRM_CLOSE_TITLE}
+        >
+            <div className={styles.form}>
+                <div className={styles.field}>
+                    <label className={styles.label}>
+                        <span className={styles.required}>*</span>
+                        {FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_LABEL}
+                    </label>
+                    <Select<string>
+                        value={formState.reportingYear}
+                        onValueChange={(value) => {
+                            setFormState((prev) => ({
+                                ...prev,
+                                reportingYear: value,
+                                errors: {
+                                    ...prev.errors,
+                                    reportingYear: undefined,
+                                },
+                            }));
+                        }}
+                        placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER}
+                        className={styles.select}
+                        optionClassName={styles['select-option']}
+                    >
+                        {yearOptions.map((year) => (
+                            <Select.Option key={year} value={year} name={year} />
+                        ))}
+                    </Select>
+                    {formState.errors.reportingYear && <p className={styles.error}>{formState.errors.reportingYear}</p>}
+                </div>
+
+                <div className={styles.field}>
+                    <label className={styles.label}>
+                        <span className={styles.required}>*</span>
+                        {FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.CATEGORY_LABEL}
+                    </label>
+                    <Select<number>
+                        value={formState.categoryId}
+                        onValueChange={(value) => {
+                            setFormState((prev) => ({
+                                ...prev,
+                                categoryId: value,
+                                errors: {
+                                    ...prev.errors,
+                                    categoryId: getCategoryError(value, 'change'),
+                                },
+                            }));
+                        }}
+                        placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.CATEGORY_PLACEHOLDER}
+                        className={styles.select}
+                        optionClassName={styles['select-option']}
+                    >
+                        {incomeCategories.map((category) => (
+                            <Select.Option key={category.id} value={category.id} name={category.name} />
+                        ))}
+                    </Select>
+                    {formState.errors.categoryId && <p className={styles.error}>{formState.errors.categoryId}</p>}
+                </div>
+
+                <div className={styles.field}>
+                    <label className={styles.label}>
+                        <span className={styles.required}>*</span>
+                        {FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.AMOUNT_UAH_LABEL}
+                    </label>
+                    <InputWithCharacterLimit
+                        id="add-income-amount-uah"
+                        name="amountUah"
+                        type="text"
+                        value={formState.amountUah}
+                        onChange={(event) => handleAmountChange('amountUah', event.target.value)}
+                        onBlur={() => handleAmountBlur('amountUah')}
+                        maxLength={20}
+                        showCounter={false}
+                        className={styles.input}
+                        hasError={Boolean(formState.errors.amountUah)}
+                    />
+                    {formState.errors.amountUah && <p className={styles.error}>{formState.errors.amountUah}</p>}
+                </div>
+
+                <div className={styles.field}>
+                    <div className={styles['amount-usd-header']}>
+                        <label className={styles.label}>
+                            <span className={styles.required}>*</span>
+                            {FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.AMOUNT_USD_LABEL}
+                        </label>
+                        <div className={styles['exchange-rate-chip']}>
+                            <span className={styles['exchange-rate-chip-label']}>
+                                {FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL}
+                            </span>
+                            <input
+                                type="text"
+                                value={exchangeRate ?? ''}
+                                disabled
+                                className={styles['exchange-rate-value']}
+                            />
+                        </div>
+                    </div>
+                    <InputWithCharacterLimit
+                        id="add-income-amount-usd"
+                        name="amountUsd"
+                        type="text"
+                        value={formState.amountUsd}
+                        onChange={(event) => handleAmountChange('amountUsd', event.target.value)}
+                        onBlur={() => handleAmountBlur('amountUsd')}
+                        maxLength={20}
+                        showCounter={false}
+                        className={styles.input}
+                        hasError={Boolean(formState.errors.amountUsd)}
+                    />
+                    {formState.errors.amountUsd && <p className={styles.error}>{formState.errors.amountUsd}</p>}
+                </div>
+            </div>
+        </FundsRecordModal>
+    );
+};

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.tsx
@@ -84,7 +84,7 @@ export const AddIncomeModal = ({
     }, [onClose, resetForm]);
 
     const getCategoryError = useCallback(
-        (categoryId: number | undefined, trigger: 'change' | 'blur' = 'change'): string | undefined => {
+        (categoryId: number | undefined, trigger: 'change' | 'blur'): string | undefined => {
             return validateFundsExpendituresCategory({
                 recordId: 0,
                 recordType: 'income',

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/funds-record-modal/FundsRecordModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/funds-record-modal/FundsRecordModal.module.scss
@@ -1,0 +1,143 @@
+@use '@/assets/sass/variables/colors' as c;
+@use '@/assets/sass/mixins/typography.mixins' as type;
+
+.modal {
+    width: 650px;
+
+    :global(.modal-container) {
+        width: 650px;
+        max-width: 650px;
+        border-radius: 8px;
+        background: c.$white;
+        padding: 0;
+    }
+
+    :global(.modal-header) {
+        margin-bottom: 0;
+        padding: 16px 24px 0;
+    }
+
+    :global(.modal-header .modal-title-wrapper) {
+        text-align: left;
+    }
+
+    :global(.modal-header .modal-header-text) {
+        font-size: inherit;
+        line-height: inherit;
+        text-align: left;
+    }
+
+    :global(.modal-header .close-icon) {
+        margin-bottom: 4px;
+        padding-right: 0;
+    }
+
+    :global(.modal-body) {
+        margin-bottom: 0;
+        padding: 18px 0 0;
+    }
+
+    :global(.modal-footer) {
+        padding: 0 24px 24px;
+        gap: 24px;
+        flex-wrap: nowrap;
+    }
+
+    :global(.modal-footer button) {
+        width: auto;
+    }
+}
+
+.header {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+}
+
+.title {
+    @include type.h4-bold;
+    line-height: 36px;
+    margin: 0;
+    color: c.$blue-900;
+}
+
+.subtitle {
+    @include type.body-1-regular;
+    line-height: 36px;
+    margin: 0;
+    color: c.$grey-600;
+}
+
+.content {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.panel {
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    width: 100%;
+    background: c.$grey-50;
+    border: 1px solid c.$grey-150;
+    padding: 23px 25px;
+    min-height: 559px;
+}
+
+.actions {
+    width: 100%;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 24px;
+}
+
+.submit,
+.cancel {
+    @include type.subtitle-2-medium;
+    height: 60px;
+}
+
+.submit {
+    width: 391px;
+}
+
+.cancel {
+    width: 185px;
+}
+
+@media (max-width: 768px) {
+    .modal {
+        width: 100%;
+
+        :global(.modal-container) {
+            width: 100%;
+            max-width: 100%;
+        }
+
+        :global(.modal-header) {
+            padding: 12px 16px 0;
+        }
+
+        :global(.modal-footer) {
+            padding: 0 16px 16px;
+            flex-wrap: wrap;
+        }
+    }
+
+    .panel {
+        padding: 16px;
+        min-height: auto;
+    }
+
+    .actions {
+        grid-template-columns: 1fr;
+    }
+
+    .submit,
+    .cancel {
+        width: 100%;
+    }
+}

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/funds-record-modal/FundsRecordModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/funds-record-modal/FundsRecordModal.test.tsx
@@ -1,0 +1,398 @@
+import React, { ReactNode } from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FundsRecordModal } from './FundsRecordModal';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+
+interface ButtonProps {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+    className?: string;
+}
+
+jest.mock('@/components/admin/button/Button', () => ({
+    Button: ({ children, onClick, disabled, className }: ButtonProps) => (
+        <button onClick={onClick} disabled={disabled} className={className} type="button">
+            {children}
+        </button>
+    ),
+}));
+
+interface ConfirmationModalProps {
+    isOpen: boolean;
+    title: string;
+    onConfirm?: () => void;
+    onCancel?: () => void;
+}
+
+jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
+    ConfirmationModal: ({ isOpen, title, onConfirm, onCancel }: ConfirmationModalProps) => (
+        <dialog data-testid="confirmation-modal" open={isOpen} aria-label={title}>
+            <h2>{title}</h2>
+            <button onClick={onConfirm} type="button">
+                Confirm
+            </button>
+            <button onClick={onCancel} type="button">
+                Cancel
+            </button>
+        </dialog>
+    ),
+}));
+
+interface ModalProps {
+    children: ReactNode;
+    isOpen: boolean;
+    _onClose?: () => void;
+    className?: string;
+    maxWidth?: string;
+}
+
+jest.mock('@/components/common/modal/Modal', () => ({
+    Modal: ({ children, isOpen, _onClose, className, maxWidth }: ModalProps) => (
+        <dialog data-testid="modal" open={isOpen} className={className} style={{ maxWidth }}>
+            {children}
+        </dialog>
+    ),
+}));
+
+interface SubComponentProps {
+    children: ReactNode;
+}
+
+const ModalComponent = require('@/components/common/modal/Modal').Modal;
+ModalComponent.Title = ({ children }: SubComponentProps) => <div data-testid="modal-title">{children}</div>;
+ModalComponent.Content = ({ children }: SubComponentProps) => <div data-testid="modal-content">{children}</div>;
+ModalComponent.Actions = ({ children }: SubComponentProps) => <div data-testid="modal-actions">{children}</div>;
+
+describe('FundsRecordModal', () => {
+    const defaultProps = {
+        isOpen: true,
+        title: 'Test Modal Title',
+        subtitle: 'Test Subtitle',
+        submitButtonLabel: 'Submit',
+        isSubmitDisabled: false,
+        isDirty: false,
+        onSubmit: jest.fn(),
+        onClose: jest.fn(),
+        closeConfirmationTitle: 'Unsaved Changes',
+        children: <div data-testid="modal-children">Test Content</div>,
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('Rendering', () => {
+        it('should render modal when isOpen is true', () => {
+            render(<FundsRecordModal {...defaultProps} />);
+            const modal = screen.getByTestId('modal') as HTMLDialogElement;
+            expect(modal).toBeInTheDocument();
+            expect(modal.open).toBe(true);
+        });
+
+        it('should render modal with open=false when isOpen is false', () => {
+            render(<FundsRecordModal {...defaultProps} isOpen={false} />);
+            const modal = screen.getByTestId('modal') as HTMLDialogElement;
+            expect(modal).toBeInTheDocument();
+            expect(modal.open).toBe(false);
+        });
+
+        it('should render title and subtitle', () => {
+            render(<FundsRecordModal {...defaultProps} />);
+            expect(screen.getByText('Test Modal Title')).toBeInTheDocument();
+            expect(screen.getByText('Test Subtitle')).toBeInTheDocument();
+        });
+
+        it('should render submit button with correct label', () => {
+            render(<FundsRecordModal {...defaultProps} />);
+            const submitButton = screen.getByText('Submit');
+            expect(submitButton).toBeInTheDocument();
+        });
+
+        it('should render cancel button with COMMON_TEXT_ADMIN.BUTTON.CANCEL label', () => {
+            render(<FundsRecordModal {...defaultProps} />);
+            expect(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL)).toBeInTheDocument();
+        });
+
+        it('should render children content', () => {
+            render(<FundsRecordModal {...defaultProps} />);
+            expect(screen.getByTestId('modal-children')).toBeInTheDocument();
+            expect(screen.getByText('Test Content')).toBeInTheDocument();
+        });
+
+        it('should apply correct maxWidth to modal', () => {
+            render(<FundsRecordModal {...defaultProps} />);
+            const modal = screen.getByTestId('modal');
+            expect(modal).toHaveStyle({ maxWidth: '650px' });
+        });
+    });
+
+    describe('Submit Button', () => {
+        it('should call onSubmit when submit button is clicked', async () => {
+            const onSubmit = jest.fn();
+            render(<FundsRecordModal {...defaultProps} onSubmit={onSubmit} />);
+            const submitButton = screen.getByText('Submit');
+            await userEvent.click(submitButton);
+            expect(onSubmit).toHaveBeenCalledTimes(1);
+        });
+
+        it('should disable submit button when isSubmitDisabled is true', () => {
+            render(<FundsRecordModal {...defaultProps} isSubmitDisabled={true} />);
+            const submitButton = screen.getByText('Submit') as HTMLButtonElement;
+            expect(submitButton.disabled).toBe(true);
+        });
+
+        it('should enable submit button when isSubmitDisabled is false', () => {
+            render(<FundsRecordModal {...defaultProps} isSubmitDisabled={false} />);
+            const submitButton = screen.getByText('Submit') as HTMLButtonElement;
+            expect(submitButton.disabled).toBe(false);
+        });
+
+        it('should not call onSubmit when submit button is disabled', async () => {
+            const onSubmit = jest.fn();
+            render(<FundsRecordModal {...defaultProps} onSubmit={onSubmit} isSubmitDisabled={true} />);
+            const submitButton = screen.getByText('Submit');
+            await userEvent.click(submitButton);
+            expect(onSubmit).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Cancel/Close Button', () => {
+        it('should call onClose when cancel button is clicked and isDirty is false', async () => {
+            const onClose = jest.fn();
+            render(<FundsRecordModal {...defaultProps} onClose={onClose} isDirty={false} />);
+            const cancelButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL);
+            await userEvent.click(cancelButton);
+            expect(onClose).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not directly call onClose when cancel button is clicked and isDirty is true', async () => {
+            const onClose = jest.fn();
+            render(
+                <FundsRecordModal
+                    {...defaultProps}
+                    onClose={onClose}
+                    isDirty={true}
+                    closeConfirmationTitle="Unsaved Changes"
+                />,
+            );
+            const cancelButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL);
+            await userEvent.click(cancelButton);
+            expect(onClose).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Dirty State & Confirmation Modal', () => {
+        it('should show confirmation modal when closing with isDirty true', async () => {
+            render(<FundsRecordModal {...defaultProps} isDirty={true} closeConfirmationTitle="Unsaved Changes" />);
+            const cancelButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL);
+            fireEvent.click(cancelButton);
+            await waitFor(() => {
+                expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument();
+            });
+        });
+
+        it('should not show confirmation modal when closing with isDirty false', async () => {
+            render(<FundsRecordModal {...defaultProps} isDirty={false} closeConfirmationTitle="Unsaved Changes" />);
+            const cancelButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL);
+            fireEvent.click(cancelButton);
+            const confirmationModal = screen.getByTestId('confirmation-modal') as HTMLDialogElement;
+            expect(confirmationModal.open).toBe(false);
+        });
+
+        it('should display correct title in confirmation modal', async () => {
+            render(
+                <FundsRecordModal {...defaultProps} isDirty={true} closeConfirmationTitle="You have unsaved changes" />,
+            );
+            const cancelButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL);
+            fireEvent.click(cancelButton);
+            await waitFor(() => {
+                expect(screen.getByText('You have unsaved changes')).toBeInTheDocument();
+            });
+        });
+
+        it('should call onClose when confirming close in confirmation modal', async () => {
+            const onClose = jest.fn();
+            render(
+                <FundsRecordModal
+                    {...defaultProps}
+                    onClose={onClose}
+                    isDirty={true}
+                    closeConfirmationTitle="Unsaved Changes"
+                />,
+            );
+            const cancelButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL);
+            fireEvent.click(cancelButton);
+            await waitFor(() => {
+                expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument();
+            });
+            const confirmButton = screen.getByText('Confirm');
+            fireEvent.click(confirmButton);
+            expect(onClose).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not call onClose when canceling close in confirmation modal', async () => {
+            const onClose = jest.fn();
+            render(
+                <FundsRecordModal
+                    {...defaultProps}
+                    onClose={onClose}
+                    isDirty={true}
+                    closeConfirmationTitle="Unsaved Changes"
+                />,
+            );
+            const cancelButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL);
+            fireEvent.click(cancelButton);
+            await waitFor(() => {
+                expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument();
+            });
+            const confirmCancelButton = screen.getAllByText('Cancel')[0];
+            fireEvent.click(confirmCancelButton);
+            const confirmationModal = screen.getByTestId('confirmation-modal') as HTMLDialogElement;
+            expect(confirmationModal.open).toBe(false);
+            expect(onClose).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Multiple Interactions', () => {
+        it('should handle multiple open/close cycles', async () => {
+            const onClose = jest.fn();
+            const { rerender } = render(<FundsRecordModal {...defaultProps} onClose={onClose} isOpen={true} />);
+            let modal = screen.getByTestId('modal') as HTMLDialogElement;
+            expect(modal.open).toBe(true);
+
+            rerender(<FundsRecordModal {...defaultProps} onClose={onClose} isOpen={false} />);
+            modal = screen.getByTestId('modal') as HTMLDialogElement;
+            expect(modal.open).toBe(false);
+
+            rerender(<FundsRecordModal {...defaultProps} onClose={onClose} isOpen={true} />);
+            modal = screen.getByTestId('modal') as HTMLDialogElement;
+            expect(modal.open).toBe(true);
+        });
+
+        it('should handle transitioning between dirty and clean states', async () => {
+            const onClose = jest.fn();
+            const { rerender } = render(
+                <FundsRecordModal
+                    {...defaultProps}
+                    onClose={onClose}
+                    isDirty={true}
+                    closeConfirmationTitle="Unsaved Changes"
+                />,
+            );
+
+            const cancelButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL);
+            fireEvent.click(cancelButton);
+            await waitFor(() => {
+                expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument();
+            });
+
+            const confirmationModal = screen.getByTestId('confirmation-modal') as HTMLDialogElement;
+            expect(confirmationModal.open).toBe(true);
+
+            rerender(
+                <FundsRecordModal
+                    {...defaultProps}
+                    onClose={onClose}
+                    isDirty={false}
+                    closeConfirmationTitle="Unsaved Changes"
+                />,
+            );
+
+            const modal = screen.getByTestId('modal') as HTMLDialogElement;
+            expect(modal.open).toBe(true);
+        });
+
+        it('should handle submit and then close without dirty state', async () => {
+            const onSubmit = jest.fn();
+            const onClose = jest.fn();
+            render(<FundsRecordModal {...defaultProps} onSubmit={onSubmit} onClose={onClose} isDirty={false} />);
+
+            const submitButton = screen.getByText('Submit');
+            await userEvent.click(submitButton);
+            expect(onSubmit).toHaveBeenCalledTimes(1);
+
+            const cancelButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL);
+            await userEvent.click(cancelButton);
+            expect(onClose).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('Accessibility', () => {
+        it('should have proper ARIA attributes on modal', () => {
+            render(<FundsRecordModal {...defaultProps} />);
+            const modal = screen.getByTestId('modal');
+            expect(modal.tagName).toBe('DIALOG');
+        });
+
+        it('should have proper ARIA attributes on confirmation modal when shown', async () => {
+            render(<FundsRecordModal {...defaultProps} isDirty={true} closeConfirmationTitle="Unsaved Changes" />);
+            const cancelButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL);
+            fireEvent.click(cancelButton);
+            await waitFor(() => {
+                const confirmationModal = screen.getByTestId('confirmation-modal');
+                expect(confirmationModal.tagName).toBe('DIALOG');
+            });
+        });
+
+        it('should have descriptive button labels', () => {
+            render(<FundsRecordModal {...defaultProps} submitButtonLabel="Save Changes" />);
+            expect(screen.getByText('Save Changes')).toBeInTheDocument();
+            expect(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL)).toBeInTheDocument();
+        });
+    });
+
+    describe('Edge Cases', () => {
+        it('should handle empty children', () => {
+            const { onSubmit, onClose, ...propsWithoutChildren } = defaultProps;
+            render(<FundsRecordModal {...propsWithoutChildren} onSubmit={onSubmit} onClose={onClose} />);
+            expect(screen.getByTestId('modal')).toBeInTheDocument();
+        });
+
+        it('should handle long title and subtitle text', () => {
+            const longTitle = 'A'.repeat(100);
+            const longSubtitle = 'B'.repeat(200);
+            render(<FundsRecordModal {...defaultProps} title={longTitle} subtitle={longSubtitle} />);
+            expect(screen.getByText(longTitle)).toBeInTheDocument();
+            expect(screen.getByText(longSubtitle)).toBeInTheDocument();
+        });
+
+        it('should handle special characters in labels', () => {
+            render(
+                <FundsRecordModal
+                    {...defaultProps}
+                    submitButtonLabel="Submit & Confirm (TEST)"
+                    title="Title: Special <Chars> & Symbols"
+                />,
+            );
+            expect(screen.getByText('Submit & Confirm (TEST)')).toBeInTheDocument();
+            expect(screen.getByText('Title: Special <Chars> & Symbols')).toBeInTheDocument();
+        });
+
+        it('should handle rapid close/confirm actions', async () => {
+            const onClose = jest.fn();
+            render(
+                <FundsRecordModal
+                    {...defaultProps}
+                    onClose={onClose}
+                    isDirty={true}
+                    closeConfirmationTitle="Unsaved Changes"
+                />,
+            );
+
+            const cancelButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL);
+            fireEvent.click(cancelButton);
+            fireEvent.click(cancelButton);
+
+            await waitFor(() => {
+                expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument();
+            });
+
+            const confirmButton = screen.getByText('Confirm');
+            fireEvent.click(confirmButton);
+
+            expect(onClose).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/funds-record-modal/FundsRecordModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/funds-record-modal/FundsRecordModal.tsx
@@ -1,0 +1,93 @@
+import { ReactNode, useCallback, useState } from 'react';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { Button } from '@/components/admin/button/Button';
+import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
+import { Modal } from '@/components/common/modal/Modal';
+import styles from './FundsRecordModal.module.scss';
+
+interface FundsRecordModalProps {
+    isOpen: boolean;
+    title: string;
+    subtitle: string;
+    submitButtonLabel: string;
+    isSubmitDisabled: boolean;
+    isDirty: boolean;
+    onSubmit: () => void;
+    onClose: () => void;
+    closeConfirmationTitle: string;
+    children: ReactNode;
+}
+
+export const FundsRecordModal = ({
+    isOpen,
+    title,
+    subtitle,
+    submitButtonLabel,
+    isSubmitDisabled,
+    isDirty,
+    onSubmit,
+    onClose,
+    closeConfirmationTitle,
+    children,
+}: FundsRecordModalProps) => {
+    const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false);
+
+    const handleRequestClose = useCallback(() => {
+        if (isDirty) {
+            setIsCloseConfirmOpen(true);
+            return;
+        }
+
+        onClose();
+    }, [isDirty, onClose]);
+
+    const handleConfirmClose = useCallback(() => {
+        setIsCloseConfirmOpen(false);
+        onClose();
+    }, [onClose]);
+
+    const handleCancelClose = useCallback(() => {
+        setIsCloseConfirmOpen(false);
+    }, []);
+
+    return (
+        <>
+            <Modal isOpen={isOpen} onClose={handleRequestClose} className={styles.modal} maxWidth="650px">
+                <Modal.Title>
+                    <div className={styles.header}>
+                        <h2 className={styles.title}>{title}</h2>
+                        <p className={styles.subtitle}>{subtitle}</p>
+                    </div>
+                </Modal.Title>
+                <Modal.Content>
+                    <div className={styles.content}>
+                        <div className={styles.panel}>{children}</div>
+                    </div>
+                </Modal.Content>
+                <Modal.Actions>
+                    <div className={styles.actions}>
+                        <Button
+                            buttonStyle="primary"
+                            onClick={onSubmit}
+                            disabled={isSubmitDisabled}
+                            className={styles.submit}
+                        >
+                            {submitButtonLabel}
+                        </Button>
+                        <Button buttonStyle="secondary" onClick={handleRequestClose} className={styles.cancel}>
+                            {COMMON_TEXT_ADMIN.BUTTON.CANCEL}
+                        </Button>
+                    </div>
+                </Modal.Actions>
+            </Modal>
+
+            <ConfirmationModal
+                isOpen={isCloseConfirmOpen}
+                title={closeConfirmationTitle}
+                onConfirm={handleConfirmClose}
+                onCancel={handleCancelClose}
+                onClose={handleCancelClose}
+            />
+        </>
+    );
+};

--- a/src/utils/functions/get-reporting-year-options/get-reporting-year-options.test.ts
+++ b/src/utils/functions/get-reporting-year-options/get-reporting-year-options.test.ts
@@ -1,0 +1,11 @@
+import { getReportingYearOptions } from '@/utils/functions/get-reporting-year-options/get-reporting-year-options';
+
+describe('getReportingYearOptions', () => {
+    it('should return previous, current, and next year in order', () => {
+        jest.useFakeTimers().setSystemTime(new Date('2026-03-30T00:00:00.000Z'));
+
+        expect(getReportingYearOptions()).toEqual(['2025', '2026', '2027']);
+
+        jest.useRealTimers();
+    });
+});

--- a/src/utils/functions/get-reporting-year-options/get-reporting-year-options.ts
+++ b/src/utils/functions/get-reporting-year-options/get-reporting-year-options.ts
@@ -1,0 +1,5 @@
+export const getReportingYearOptions = (): string[] => {
+    const currentYear = new Date().getFullYear();
+
+    return [String(currentYear - 1), String(currentYear), String(currentYear + 1)];
+};

--- a/src/utils/functions/update-funds-amounts/update-funds-amounts.test.ts
+++ b/src/utils/functions/update-funds-amounts/update-funds-amounts.test.ts
@@ -1,0 +1,319 @@
+import { updateFundsAmounts, type FundsAmountsState } from './update-funds-amounts';
+import { getConvertedAmount } from '@/utils/functions/get-converted-amount/get-converted-amount';
+import {
+    normalizeFundsExpendituresAmountInput,
+    validateFundsExpendituresAmount,
+} from '@/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema';
+
+jest.mock('@/utils/functions/get-converted-amount/get-converted-amount');
+jest.mock('@/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema');
+
+describe('updateFundsAmounts', () => {
+    const mockGetConvertedAmount = getConvertedAmount as jest.MockedFunction<typeof getConvertedAmount>;
+    const mockNormalizeFundsExpendituresAmountInput = normalizeFundsExpendituresAmountInput as jest.MockedFunction<
+        typeof normalizeFundsExpendituresAmountInput
+    >;
+    const mockValidateFundsExpendituresAmount = validateFundsExpendituresAmount as jest.MockedFunction<
+        typeof validateFundsExpendituresAmount
+    >;
+
+    const initialState = {
+        amountUah: '100',
+        amountUsd: '3',
+        errors: {
+            amountUah: undefined as string | undefined,
+            amountUsd: undefined as string | undefined,
+        },
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('Field update with change trigger', () => {
+        it('should update amountUah on change trigger', () => {
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('200');
+            mockValidateFundsExpendituresAmount.mockReturnValue(undefined);
+            mockGetConvertedAmount.mockReturnValue(null);
+
+            const updater = updateFundsAmounts('amountUah', '200', '33.5', 'change');
+            const result = updater(initialState);
+
+            expect(result.amountUah).toBe('200');
+            expect(result.amountUsd).toBe('3');
+            expect(mockNormalizeFundsExpendituresAmountInput).toHaveBeenCalledWith('200', false);
+        });
+
+        it('should update amountUsd on change trigger', () => {
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('5');
+            mockValidateFundsExpendituresAmount.mockReturnValue(undefined);
+            mockGetConvertedAmount.mockReturnValue(null);
+
+            const updater = updateFundsAmounts('amountUsd', '5', '33.5', 'change');
+            const result = updater(initialState);
+
+            expect(result.amountUsd).toBe('5');
+            expect(result.amountUah).toBe('100');
+            expect(mockNormalizeFundsExpendituresAmountInput).toHaveBeenCalledWith('5', false);
+        });
+    });
+
+    describe('Field update with blur trigger', () => {
+        it('should normalize on blur trigger', () => {
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('150.00');
+            mockValidateFundsExpendituresAmount.mockReturnValue(undefined);
+            mockGetConvertedAmount.mockReturnValue(null);
+
+            const updater = updateFundsAmounts('amountUah', '150', '33.5', 'blur');
+            updater(initialState);
+
+            expect(mockNormalizeFundsExpendituresAmountInput).toHaveBeenCalledWith('150', true);
+        });
+
+        it('should update amountUah with blur trigger', () => {
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('250');
+            mockValidateFundsExpendituresAmount.mockReturnValue(undefined);
+            mockGetConvertedAmount.mockReturnValue(null);
+
+            const updater = updateFundsAmounts('amountUah', '250', '33.5', 'blur');
+            const result = updater(initialState);
+
+            expect(result.amountUah).toBe('250');
+        });
+    });
+
+    describe('Validation errors', () => {
+        it('should set error on amountUah when validation fails', () => {
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('invalid');
+            mockValidateFundsExpendituresAmount.mockReturnValue('Invalid amount');
+
+            const updater = updateFundsAmounts('amountUah', 'invalid', '33.5', 'change');
+            const result = updater(initialState);
+
+            expect(result.errors.amountUah).toBe('Invalid amount');
+            expect(result.amountUah).toBe('invalid');
+        });
+
+        it('should set error on amountUsd when validation fails', () => {
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('invalid');
+            mockValidateFundsExpendituresAmount.mockReturnValue('Invalid amount');
+
+            const updater = updateFundsAmounts('amountUsd', 'invalid', '33.5', 'change');
+            const result = updater(initialState);
+
+            expect(result.errors.amountUsd).toBe('Invalid amount');
+            expect(result.amountUsd).toBe('invalid');
+        });
+
+        it('should preserve other field errors when updating one field', () => {
+            const stateWithErrors: FundsAmountsState = {
+                ...initialState,
+                errors: {
+                    amountUah: 'UAH error',
+                    amountUsd: undefined,
+                },
+            };
+
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('5');
+            mockValidateFundsExpendituresAmount.mockReturnValue(undefined);
+            mockGetConvertedAmount.mockReturnValue(null);
+
+            const updater = updateFundsAmounts('amountUsd', '5', '33.5', 'change');
+            const result = updater(stateWithErrors);
+
+            expect(result.errors.amountUah).toBe('UAH error');
+            expect(result.errors.amountUsd).toBeUndefined();
+        });
+    });
+
+    describe('Currency conversion', () => {
+        it('should convert amountUah to amountUsd when no error', () => {
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('100');
+            mockValidateFundsExpendituresAmount.mockReturnValueOnce(undefined).mockReturnValueOnce(undefined);
+            mockGetConvertedAmount.mockReturnValue('3');
+
+            const updater = updateFundsAmounts('amountUah', '100', '33.5', 'change');
+            const result = updater(initialState);
+
+            expect(result.amountUah).toBe('100');
+            expect(result.amountUsd).toBe('3');
+            expect(mockGetConvertedAmount).toHaveBeenCalledWith('100', 'amountUah', '33.5');
+        });
+
+        it('should convert amountUsd to amountUah when no error', () => {
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('3.5');
+            mockValidateFundsExpendituresAmount.mockReturnValueOnce(undefined).mockReturnValueOnce(undefined);
+            mockGetConvertedAmount.mockReturnValue('117.25');
+
+            const updater = updateFundsAmounts('amountUsd', '3.5', '33.5', 'change');
+            const result = updater(initialState);
+
+            expect(result.amountUsd).toBe('3.5');
+            expect(result.amountUah).toBe('117.25');
+            expect(mockGetConvertedAmount).toHaveBeenCalledWith('3.5', 'amountUsd', '33.5');
+        });
+
+        it('should not convert if conversion returns null', () => {
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('100');
+            mockValidateFundsExpendituresAmount.mockReturnValue(undefined);
+            mockGetConvertedAmount.mockReturnValue(null);
+
+            const updater = updateFundsAmounts('amountUah', '100', '33.5', 'change');
+            const result = updater(initialState);
+
+            expect(result.amountUah).toBe('100');
+            expect(result.amountUsd).toBe('3');
+            expect(mockGetConvertedAmount).toHaveBeenCalled();
+        });
+
+        it('should validate converted amount', () => {
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('100');
+            mockValidateFundsExpendituresAmount.mockReturnValueOnce(undefined).mockReturnValueOnce('Converted invalid');
+            mockGetConvertedAmount.mockReturnValue('3000');
+
+            const updater = updateFundsAmounts('amountUah', '100', '33.5', 'change');
+            const result = updater(initialState);
+
+            expect(result.errors.amountUsd).toBe('Converted invalid');
+            expect(mockValidateFundsExpendituresAmount).toHaveBeenCalledTimes(2);
+        });
+
+        it('should skip conversion when validation fails', () => {
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('invalid');
+            mockValidateFundsExpendituresAmount.mockReturnValue('Invalid amount');
+
+            const updater = updateFundsAmounts('amountUah', 'invalid', '33.5', 'change');
+            const result = updater(initialState);
+
+            expect(result.errors.amountUah).toBe('Invalid amount');
+            expect(mockGetConvertedAmount).not.toHaveBeenCalled();
+        });
+
+        it('should handle null exchange rate', () => {
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('100');
+            mockValidateFundsExpendituresAmount.mockReturnValue(undefined);
+            mockGetConvertedAmount.mockReturnValue(null);
+
+            const updater = updateFundsAmounts('amountUah', '100', null, 'change');
+            const result = updater(initialState);
+
+            expect(result.amountUah).toBe('100');
+            expect(mockGetConvertedAmount).toHaveBeenCalledWith('100', 'amountUah', null);
+        });
+    });
+
+    describe('State preservation', () => {
+        it('should preserve previous state when updating', () => {
+            const customState: FundsAmountsState = {
+                amountUah: '500',
+                amountUsd: '15',
+                errors: {
+                    amountUah: undefined,
+                    amountUsd: 'Previous USD error',
+                },
+            };
+
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('600');
+            mockValidateFundsExpendituresAmount.mockReturnValue(undefined);
+            mockGetConvertedAmount.mockReturnValue(null);
+
+            const updater = updateFundsAmounts('amountUah', '600', '33.5', 'change');
+            const result = updater(customState);
+
+            expect(result).toEqual({
+                amountUah: '600',
+                amountUsd: '15',
+                errors: {
+                    amountUah: undefined,
+                    amountUsd: 'Previous USD error',
+                },
+            });
+        });
+    });
+
+    describe('Trigger parameter', () => {
+        it('should pass correct trigger to validation functions', () => {
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('100');
+            mockValidateFundsExpendituresAmount.mockReturnValue(undefined);
+            mockGetConvertedAmount.mockReturnValue(null);
+
+            const updater = updateFundsAmounts('amountUah', '100', '33.5', 'blur');
+            updater(initialState);
+
+            expect(mockValidateFundsExpendituresAmount).toHaveBeenCalledWith('100', 'blur');
+        });
+
+        it('should use trigger consistently for main and converted field validation', () => {
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('100');
+            mockValidateFundsExpendituresAmount.mockReturnValueOnce(undefined).mockReturnValueOnce(undefined);
+            mockGetConvertedAmount.mockReturnValue('3');
+
+            const updater = updateFundsAmounts('amountUah', '100', '33.5', 'blur');
+            updater(initialState);
+
+            expect(mockValidateFundsExpendituresAmount).toHaveBeenNthCalledWith(1, '100', 'blur');
+            expect(mockValidateFundsExpendituresAmount).toHaveBeenNthCalledWith(2, '3', 'blur');
+        });
+    });
+
+    describe('Edge cases', () => {
+        it('should handle empty string input', () => {
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('');
+            mockValidateFundsExpendituresAmount.mockReturnValue(undefined);
+            mockGetConvertedAmount.mockReturnValue(null);
+
+            const updater = updateFundsAmounts('amountUah', '', '33.5', 'change');
+            const result = updater(initialState);
+
+            expect(result.amountUah).toBe('');
+        });
+
+        it('should handle very large amounts', () => {
+            const largeAmount = '999999999.99';
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue(largeAmount);
+            mockValidateFundsExpendituresAmount.mockReturnValue(undefined);
+            mockGetConvertedAmount.mockReturnValue('29999999999.97');
+
+            const updater = updateFundsAmounts('amountUah', largeAmount, '33.5', 'change');
+            const result = updater(initialState);
+
+            expect(result.amountUah).toBe(largeAmount);
+            expect(result.amountUsd).toBe('29999999999.97');
+        });
+
+        it('should handle zero amount', () => {
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('0');
+            mockValidateFundsExpendituresAmount.mockReturnValue(undefined);
+            mockGetConvertedAmount.mockReturnValue('0');
+
+            const updater = updateFundsAmounts('amountUah', '0', '33.5', 'change');
+            const result = updater(initialState);
+
+            expect(result.amountUah).toBe('0');
+            expect(result.amountUsd).toBe('0');
+        });
+
+        it('should handle multiple consecutive updates', () => {
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('100');
+            mockValidateFundsExpendituresAmount.mockReturnValue(undefined);
+            mockGetConvertedAmount.mockReturnValue('3');
+
+            let state: FundsAmountsState = initialState;
+
+            const updater1 = updateFundsAmounts('amountUah', '100', '33.5', 'change');
+            state = updater1(state);
+
+            expect(state.amountUah).toBe('100');
+            expect(state.amountUsd).toBe('3');
+
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('200');
+            mockGetConvertedAmount.mockReturnValue('6');
+
+            const updater2 = updateFundsAmounts('amountUah', '200', '33.5', 'change');
+            state = updater2(state);
+
+            expect(state.amountUah).toBe('200');
+            expect(state.amountUsd).toBe('6');
+        });
+    });
+});

--- a/src/utils/functions/update-funds-amounts/update-funds-amounts.ts
+++ b/src/utils/functions/update-funds-amounts/update-funds-amounts.ts
@@ -1,0 +1,57 @@
+import { getConvertedAmount } from '@/utils/functions/get-converted-amount/get-converted-amount';
+import {
+    normalizeFundsExpendituresAmountInput,
+    validateFundsExpendituresAmount,
+} from '@/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema';
+
+export interface FundsAmountsState {
+    amountUah: string;
+    amountUsd: string;
+    errors: {
+        amountUah?: string;
+        amountUsd?: string;
+    };
+}
+
+export const updateFundsAmounts = (
+    field: 'amountUah' | 'amountUsd',
+    value: string,
+    exchangeRate: string | null,
+    trigger: 'change' | 'blur',
+): ((prev: FundsAmountsState) => FundsAmountsState) => {
+    return (prev: FundsAmountsState) => {
+        const shouldNormalize = trigger === 'blur';
+        const normalized = normalizeFundsExpendituresAmountInput(value, shouldNormalize);
+        const currentFieldError = validateFundsExpendituresAmount(normalized, trigger);
+
+        let nextAmountUah = field === 'amountUah' ? normalized : prev.amountUah;
+        let nextAmountUsd = field === 'amountUsd' ? normalized : prev.amountUsd;
+        let nextAmountUahError = field === 'amountUah' ? currentFieldError : prev.errors.amountUah;
+        let nextAmountUsdError = field === 'amountUsd' ? currentFieldError : prev.errors.amountUsd;
+
+        if (!currentFieldError) {
+            const convertedAmount = getConvertedAmount(normalized, field, exchangeRate);
+
+            if (convertedAmount !== null) {
+                if (field === 'amountUah') {
+                    nextAmountUsd = convertedAmount;
+                    nextAmountUsdError = validateFundsExpendituresAmount(convertedAmount, trigger);
+                } else {
+                    nextAmountUah = convertedAmount;
+                    nextAmountUahError = validateFundsExpendituresAmount(convertedAmount, trigger);
+                }
+            }
+        }
+
+        return {
+            ...prev,
+            amountUah: nextAmountUah,
+            amountUsd: nextAmountUsd,
+            errors: {
+                ...prev.errors,
+                amountUah: nextAmountUahError,
+                amountUsd: nextAmountUsdError,
+            },
+        };
+    };
+};


### PR DESCRIPTION
## Github ticker

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/940
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/944
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1712

## Description

This PR implements the main flow for adding funds and introduces report year selection logic across funds, expenses, and program expenses.

## How it looks


https://github.com/user-attachments/assets/cf1618ab-2ca2-4885-a112-fc6b2d3dd87f


## Summary of change

Implemented modal opening flow for adding funds
Added report year dropdown with previous, current, and next calendar year

## How to recreate changes

1. Navigate to the Admin panel
2. Go to the “Доходи та витрати” section
3. Click on “Надходження”
4. Verify:
- Modal opens correctly
- “Звітній рік” dropdown contains: previous, current, and next year

## CHECK LIST
- [x]  New tests was added or existing was modified
- [x]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add “Add income” modal: year/category selection, UAH/USD inputs with validation, submit flow, and confirm-on-close
  * Reusable record modal with confirm-when-dirty behavior
  * Reporting-year options and automatic UAH↔USD amount sync

* **Bug Fixes**
  * Currency labels updated to "UAH"
  * Clarified success/error messages and unified footer button labels

* **Tests**
  * Extensive tests for modals, amount-sync logic, and reporting-year behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->