### PR TITLE
Fix/issue 1925, 1997: [Single Program] Live character counter ignores consecutive spaces after the first one in text input fields

### DIFF
--- a/src/components/admin/input-error-with-character-counter/InputErrorWithCharacterCounter.tsx
+++ b/src/components/admin/input-error-with-character-counter/InputErrorWithCharacterCounter.tsx
@@ -1,5 +1,4 @@
 import styles from './InputErrorWithCharacterCounter.module.scss';
-import { getNormalizedInputText } from '@/utils/functions/formatters/text-formatters';
 import cn from 'classnames';
 
 export interface InputErrorWithCharacterCounterProps {
@@ -21,7 +20,7 @@ export const InputErrorWithCharacterCounter = ({
     isWhiteLabel,
     containerClassName,
 }: InputErrorWithCharacterCounterProps) => {
-    const normalizedLength = getNormalizedInputText(value).length;
+    const normalizedLength = value.length;
     return (
         <div className={cn(styles.container, containerClassName)}>
             <div className={styles['error-section']}>{error || ''}</div>

--- a/src/components/admin/textarea-with-bullets/TextAreaWithBulletBehavior.test.tsx
+++ b/src/components/admin/textarea-with-bullets/TextAreaWithBulletBehavior.test.tsx
@@ -266,12 +266,14 @@ describe('TextAreaWithBulletBehavior', () => {
         expect(handleChange.mock.calls.length).toBe(callCount);
     });
 
-    it('should handle whitespace-only lines correctly on blur', () => {
+    it('should trim whitespace-only lines to empty string on blur', () => {
         renderComponent('   \n   ');
         const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
 
         fireEvent.blur(textarea);
 
-        expect(handleChange).not.toHaveBeenCalled();
+        expect(handleChange).toHaveBeenCalledWith({
+            target: { value: '', name, id },
+        });
     });
 });

--- a/src/hooks/admin/use-input-with-character-limit/useInputWithCharacterLimit.test.ts
+++ b/src/hooks/admin/use-input-with-character-limit/useInputWithCharacterLimit.test.ts
@@ -1,6 +1,5 @@
 import { renderHook, act } from '@testing-library/react';
 import { useInputWithCharacterLimit } from './useInputWithCharacterLimit';
-import { getNormalizedInputText } from '@/utils/functions/formatters/text-formatters';
 import { useTemporaryWarning } from '@/hooks/admin/use-temporary-warning/useTemporaryWarning';
 
 jest.mock('@/hooks/admin/use-temporary-warning/useTemporaryWarning');
@@ -56,13 +55,13 @@ describe('useInputWithCharacterLimit', () => {
             expect(result.current.showClearButton).toBe(false);
         });
 
-        it('should calculate current length using getNormalizedInputText', () => {
+        it('should calculate current length using raw input length', () => {
             const testValue = '  test  ';
-            const normalizedLength = getNormalizedInputText(testValue).length;
+            const rawLength = testValue.length;
 
             const { result } = renderHook(() => useInputWithCharacterLimit({ ...defaultProps, value: testValue }));
 
-            expect(result.current.currentLength).toBe(normalizedLength);
+            expect(result.current.currentLength).toBe(rawLength);
         });
 
         it('should pass onWarningChange to useTemporaryWarning', () => {
@@ -74,7 +73,7 @@ describe('useInputWithCharacterLimit', () => {
 
     describe('handleChange', () => {
         describe('Valid input (within limit)', () => {
-            it('should call onChange when normalized length is within limit', () => {
+            it('should call onChange when input length is within limit', () => {
                 const inputValue = 'hello';
                 const { result } = renderHook(() => useInputWithCharacterLimit(defaultProps));
 
@@ -91,7 +90,7 @@ describe('useInputWithCharacterLimit', () => {
                 expect(mockShowTemporaryWarning).not.toHaveBeenCalled();
             });
 
-            it('should allow input with spaces when normalized length is within limit', () => {
+            it('should allow input with spaces when raw length is within limit', () => {
                 const inputValue = '  test  ';
                 const { result } = renderHook(() => useInputWithCharacterLimit(defaultProps));
 
@@ -126,7 +125,7 @@ describe('useInputWithCharacterLimit', () => {
         });
 
         describe('Invalid input (exceeds limit)', () => {
-            it('should prevent input when normalized length exceeds maxLength', () => {
+            it('should prevent input when length exceeds maxLength', () => {
                 const inputValue = 'this is a very long text that exceeds the limit';
                 const { result } = renderHook(() => useInputWithCharacterLimit(defaultProps));
 
@@ -157,7 +156,7 @@ describe('useInputWithCharacterLimit', () => {
                 expect(mockOnChange).not.toHaveBeenCalled();
             });
 
-            it('should block a trailing space when normalized length is already at maxLength', () => {
+            it('should block a trailing space when length exceeds maxLength', () => {
                 const warningMessage = 'Character limit exceeded';
                 const atLimitValue = 'a'.repeat(defaultProps.maxLength);
                 const { result } = renderHook(() =>
@@ -174,7 +173,7 @@ describe('useInputWithCharacterLimit', () => {
                 expect(mockOnChange).not.toHaveBeenCalled();
             });
 
-            it('should block a leading space when normalized length is already at maxLength', () => {
+            it('should block a leading space when length exceeds maxLength', () => {
                 const warningMessage = 'Character limit exceeded';
                 const atLimitValue = 'a'.repeat(defaultProps.maxLength);
                 const { result } = renderHook(() =>
@@ -277,14 +276,16 @@ describe('useInputWithCharacterLimit', () => {
             expect(mockOnChange).not.toHaveBeenCalled();
         });
 
-        it('should not call onChange on blur when value is whitespace-only', () => {
+        it('should trim whitespace-only value to empty string on blur', () => {
             const { result } = renderHook(() => useInputWithCharacterLimit({ ...defaultProps, value: '   \n   ' }));
 
             act(() => {
                 result.current.handleBlur({} as React.FocusEvent<HTMLInputElement>);
             });
 
-            expect(mockOnChange).not.toHaveBeenCalled();
+            expect(mockOnChange).toHaveBeenCalledWith({
+                target: { value: '', name: 'testInput', id: 'test-input' },
+            });
         });
     });
 
@@ -370,9 +371,9 @@ describe('useInputWithCharacterLimit', () => {
     describe('works with HTMLTextAreaElement', () => {
         it('should work with textarea element', () => {
             const inputValue = 'textarea';
-            const normalizedLength = getNormalizedInputText(inputValue).length;
+            const rawLength = inputValue.length;
 
-            expect(normalizedLength).toBeLessThanOrEqual(defaultProps.maxLength);
+            expect(rawLength).toBeLessThanOrEqual(defaultProps.maxLength);
 
             const { result } = renderHook(() => useInputWithCharacterLimit<HTMLTextAreaElement>(defaultProps as any));
 

--- a/src/hooks/admin/use-input-with-character-limit/useInputWithCharacterLimit.ts
+++ b/src/hooks/admin/use-input-with-character-limit/useInputWithCharacterLimit.ts
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { getNormalizedInputText } from '@/utils/functions/formatters/text-formatters';
 import { useTemporaryWarning } from '@/hooks/admin/use-temporary-warning/useTemporaryWarning';
 
 interface UseInputWithCharacterLimitProps<T extends HTMLInputElement | HTMLTextAreaElement> {
@@ -29,15 +28,14 @@ export const useInputWithCharacterLimit = <T extends HTMLInputElement | HTMLText
 }: UseInputWithCharacterLimitProps<T>) => {
     const [isFocused, setIsFocused] = useState(false);
     const { localWarning, showTemporaryWarning, clearWarning } = useTemporaryWarning({ onWarningChange });
-    const currentLength = getNormalizedInputText(value ?? '').length;
+    const currentLength = (value ?? '').length;
 
     const handleChange = (e: React.ChangeEvent<T>) => {
         let newValue = e.target.value;
-        const normalized = getNormalizedInputText(newValue ?? '');
 
         const isTruncatableField = name === 'title' || name === 'description';
 
-        if (normalized.length > maxLength) {
+        if (newValue.length > maxLength) {
             if (isTruncatableField) {
                 const truncatedValue = newValue.slice(0, maxLength);
 
@@ -48,16 +46,8 @@ export const useInputWithCharacterLimit = <T extends HTMLInputElement | HTMLText
                         value: truncatedValue,
                     },
                 });
-            } else {
-                if (maxLimitWarning) {
-                    showTemporaryWarning(maxLimitWarning);
-                }
-                return;
             }
-            return;
-        }
 
-        if (newValue.length > maxLength && normalized.length <= maxLength) {
             if (maxLimitWarning) {
                 showTemporaryWarning(maxLimitWarning);
             }
@@ -84,7 +74,7 @@ export const useInputWithCharacterLimit = <T extends HTMLInputElement | HTMLText
         setIsFocused(false);
 
         const trimmed = (value ?? '').trim();
-        if (trimmed !== value && trimmed.length > 0) {
+        if (trimmed !== value) {
             onChange({
                 target: { value: trimmed, name, id },
             } as React.ChangeEvent<T>);


### PR DESCRIPTION
## Github

*  [[Single program] Live character counter ignores consecutive spaces after the first one in text input fields](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1925)
* [[Single program] [Додати програму] [ Frame 633434] Live character counter ignores consecutive spaces after the first one in text input fields](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1997)

## Description

This pull request updates the character counting and input validation logic for input fields with character limits. The main change is that character limits are now enforced based on the raw input length, rather than a "normalized" version of the input (which previously may have trimmed or otherwise altered the input before counting). Related tests and component logic have been updated accordingly, and whitespace-only values are now trimmed to empty strings on blur.

## How it looks

https://github.com/user-attachments/assets/4acfeaec-0578-454e-8523-80210d0f4268


## Summary of change

* The `useInputWithCharacterLimit` hook now calculates input length using the raw value's length instead of a normalized version, affecting both validation and display (`useInputWithCharacterLimit.ts`, `InputErrorWithCharacterCounter.tsx`).
* On blur, if the input value consists only of whitespace, it is now trimmed to an empty string and the change handler is called with an empty value (`useInputWithCharacterLimit.ts`, `TextAreaWithBulletBehavior.test.tsx`).
* All tests for character counting and validation have been updated to use the raw input length rather than the normalized length, including test descriptions and expectations (`useInputWithCharacterLimit.test.ts`).

## How to recreate changes

- Navigate to https://localhost:3000/
- Go to the Programs admin page and click the "Додати програму" button
- Enter consecutive spaces and verify that they are counted as characters

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Character counter now calculates using the actual number of characters entered (raw length) instead of a normalized text length.
  * Textareas that contain only whitespace are trimmed to an empty string on blur, and this triggers the change handler.
  * Character limit enforcement now uses raw character count for validation and truncation, ensuring limits reflect actual input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->