### PR TITLE
Fix/issue 2030:  [Партнери] Image allowed by validation rules is not added to the "Фото" section

### DIFF
--- a/src/validation/admin/image-schema/image-schema.test.ts
+++ b/src/validation/admin/image-schema/image-schema.test.ts
@@ -12,8 +12,8 @@ const createTestFile = (size: number, type: string = 'image/jpeg', name: string 
 };
 
 describe('ImageValidationSchema', () => {
-    const MIN_WIDTH = 1920;
-    const MIN_HEIGHT = 1080;
+    const MIN_WIDTH = 1440;
+    const MIN_HEIGHT = 860;
     const MAX_SIZE_MB = 3;
     const validationSchema = getImageValidationSchema(MIN_WIDTH, MIN_HEIGHT, MAX_SIZE_MB);
 
@@ -92,7 +92,7 @@ describe('ImageValidationSchema', () => {
     });
 
     it('rejects an image with width smaller than minWidth', async () => {
-        mockImageDimensions(1919, 1080);
+        mockImageDimensions(1439, 860);
         const validFile = createTestFile(1000, 'image/jpeg');
 
         await expect(validationSchema.validate(validFile)).rejects.toThrow(
@@ -101,7 +101,7 @@ describe('ImageValidationSchema', () => {
     });
 
     it('rejects an image with height smaller than minHeight', async () => {
-        mockImageDimensions(1920, 1079);
+        mockImageDimensions(1440, 859);
         const validFile = createTestFile(1000, 'image/jpeg');
 
         await expect(validationSchema.validate(validFile)).rejects.toThrow(
@@ -153,7 +153,7 @@ describe('IMAGE_VALIDATION_FUNCTIONS', () => {
     });
 
     it('returns Yup ValidationError message when err instanceof Yup.ValidationError is true', async () => {
-        const validationErrorMessage = 'Image must be at least 1920x1080px';
+        const validationErrorMessage = 'Image must be at least 1440x860px';
         jest.spyOn(Yup.mixed.prototype, 'validate').mockImplementation(() => {
             throw new Yup.ValidationError(validationErrorMessage);
         });

--- a/src/validation/admin/image-schema/image-schema.ts
+++ b/src/validation/admin/image-schema/image-schema.ts
@@ -38,12 +38,7 @@ export const getImageValidationSchema = (minWidth: number, minHeight: number, ma
 };
 
 export const IMAGE_VALIDATION_FUNCTIONS = {
-    validateImage: async (
-        file: File,
-        minWidth = 1920,
-        minHeight = 1080,
-        maxSizeMB = 3,
-    ): Promise<string | undefined> => {
+    validateImage: async (file: File, minWidth = 1440, minHeight = 860, maxSizeMB = 3): Promise<string | undefined> => {
         try {
             const schema = getImageValidationSchema(minWidth, minHeight, maxSizeMB);
             await schema.validate(file, { abortEarly: true });


### PR DESCRIPTION
## JIRA or Github ticker

[* [JIRA or Github ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2030)

## Description

The previous validation logic incorrectly rejected images that met the minimum size requirements, resulting in the error message: "Розмір зображення менший за рекомендований".
This PR fixes the size validation logic, ensures valid images are successfully added to the "Photos" section.

## How it looks


https://github.com/user-attachments/assets/7a0acb8e-0a47-426c-9c6f-095b56cb34d9


## Summary of change

-Fixed an issue where valid images were not added to the "Photos" section.
-Images are now properly validated for minimum dimensions.
-Updated getImageValidationSchema to correctly handle image size checks.

## How to recreate changes

1. Log in as Admin.
2. Open the [Partners](https://victorycenter.online/admin-panel/partners) page.
3. Click on the field to add a photo.
4. Select an image that meets the valid size requirements.
5. Verify that the image is added without the error message "Розмір зображення менший за рекомендований".

## CHECK LIST
- [ ]  Code changes tested manually
- [ ]  Validation logic unit tests passing
- [ ]  No regressions for other image uploads


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted minimum image dimension requirements for validation. Minimum width reduced from 1920px to 1440px, and minimum height reduced from 1080px to 860px.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->