### PR TITLE
Fix/issue 2073: [Single Program] Clean-up icon does not disappear after clicking (T3, T5, T6), text not wrapping in description (T7)

### DIFF
--- a/src/components/admin/input-with-character-limit/InputWithCharacterLimit.scss
+++ b/src/components/admin/input-with-character-limit/InputWithCharacterLimit.scss
@@ -27,7 +27,7 @@
 
     &__field {
         flex: 1;
-        padding: 0;
+        padding: 0 0.25rem 0 0;
         border: none;
         outline: none;
         background: none;
@@ -51,17 +51,12 @@
         background: none;
         cursor: pointer;
         flex-shrink: 0;
-        opacity: 0;
-        pointer-events: none;
         transition: opacity 0.2s ease;
         display: flex;
         align-items: center;
         justify-content: center;
-
-        &--visible {
-            opacity: 1;
-            pointer-events: auto;
-        }
+        opacity: 1;
+        contain: layout paint;
 
         svg {
             width: 100%;
@@ -76,11 +71,18 @@
         &--error svg {
             filter: invert(41%) sepia(59%) saturate(2297%) hue-rotate(334deg) brightness(90%) contrast(110%);
         }
+
+        &--hidden {
+            opacity: 0;
+            pointer-events: none;
+        }
     }
 
     &__counter {
         white-space: nowrap;
         color: colors.$grey-900;
         flex-shrink: 0;
+        text-align: right;
+        contain: layout paint;
     }
 }

--- a/src/components/admin/input-with-character-limit/InputWithCharacterLimit.test.tsx
+++ b/src/components/admin/input-with-character-limit/InputWithCharacterLimit.test.tsx
@@ -110,26 +110,19 @@ describe('InputWithCharacterLimit', () => {
         );
     });
 
-    it('hides clear button when value becomes empty after clearing', () => {
-        const onChange = jest.fn();
+    it('hides clear button when value is empty', () => {
+        const { rerender } = renderInputWithCharacterLimit({ value: 'Hello' });
 
-        const { rerender } = render(
-            <InputWithCharacterLimit value="Hello" onChange={onChange} name="testName" id="test-id" maxLength={50} />,
+        focusInput();
+        expect(screen.getByRole('button', { name: /clear input/i })).not.toHaveClass(
+            'char-limit-input__clear-button--hidden',
         );
 
-        let btn = screen.getByRole('button', { name: /clear input/i });
+        rerender(<InputWithCharacterLimit {...defaultProps} value="" />);
 
-        fireEvent.focus(screen.getByRole('textbox'));
-
-        // Button should be visible (not have --hidden class) when focused with value
-        expect(btn).not.toHaveClass('char-limit-input__clear-button--hidden');
-
-        // Rerender with empty value (simulating parent updating prop after clear)
-        rerender(<InputWithCharacterLimit value="" onChange={onChange} name="testName" id="test-id" maxLength={50} />);
-
-        // Button should have --hidden class when value is empty
-        btn = screen.getByRole('button', { name: /clear input/i });
-        expect(btn).toHaveClass('char-limit-input__clear-button--hidden');
+        expect(screen.getByRole('button', { name: /clear input/i })).toHaveClass(
+            'char-limit-input__clear-button--hidden',
+        );
     });
 
     it('sets aria-invalid when current length exceeds maxLength', () => {

--- a/src/components/admin/input-with-character-limit/InputWithCharacterLimit.test.tsx
+++ b/src/components/admin/input-with-character-limit/InputWithCharacterLimit.test.tsx
@@ -19,7 +19,7 @@ describe('InputWithCharacterLimit', () => {
 
     const getInput = () => screen.getByRole('textbox');
     const getCharacterCounter = (current: number, max: number) => screen.getByText(`${current}/${max}`);
-    const getWrapper = () => getInput().parentElement!;
+    const getWrapper = () => getInput().closest('.char-limit-input')!;
 
     const focusInput = () => fireEvent.focus(getInput());
     const blurInput = () => fireEvent.blur(getInput());
@@ -108,6 +108,28 @@ describe('InputWithCharacterLimit', () => {
                 }),
             }),
         );
+    });
+
+    it('hides clear button when value becomes empty after clearing', () => {
+        const onChange = jest.fn();
+
+        const { rerender } = render(
+            <InputWithCharacterLimit value="Hello" onChange={onChange} name="testName" id="test-id" maxLength={50} />,
+        );
+
+        let btn = screen.getByRole('button', { name: /clear input/i });
+
+        fireEvent.focus(screen.getByRole('textbox'));
+
+        // Button should be visible (not have --hidden class) when focused with value
+        expect(btn).not.toHaveClass('char-limit-input__clear-button--hidden');
+
+        // Rerender with empty value (simulating parent updating prop after clear)
+        rerender(<InputWithCharacterLimit value="" onChange={onChange} name="testName" id="test-id" maxLength={50} />);
+
+        // Button should have --hidden class when value is empty
+        btn = screen.getByRole('button', { name: /clear input/i });
+        expect(btn).toHaveClass('char-limit-input__clear-button--hidden');
     });
 
     it('sets aria-invalid when current length exceeds maxLength', () => {

--- a/src/components/admin/input-with-character-limit/InputWithCharacterLimit.test.tsx
+++ b/src/components/admin/input-with-character-limit/InputWithCharacterLimit.test.tsx
@@ -160,7 +160,6 @@ describe('InputWithCharacterLimit', () => {
         renderInputWithCharacterLimit({ value: 'abc', hasError: true });
         focusInput();
         const btn = screen.getByRole('button', { name: /clear input/i });
-        expect(btn).toHaveClass('char-limit-input__clear-button--visible');
         expect(btn).toHaveClass('char-limit-input__clear-button--error');
     });
 

--- a/src/components/admin/input-with-character-limit/InputWithCharacterLimit.tsx
+++ b/src/components/admin/input-with-character-limit/InputWithCharacterLimit.tsx
@@ -126,13 +126,14 @@ export const InputWithCharacterLimit = ({
             <button
                 type="button"
                 className={cn('char-limit-input__clear-button', {
-                    'char-limit-input__clear-button--visible': showClearButton,
+                    'char-limit-input__clear-button--hidden': !showClearButton || disabled,
                     'char-limit-input__clear-button--error': hasError || !!localWarning,
                 })}
                 onMouseDown={(e) => e.preventDefault()}
                 onClick={handleClear}
                 aria-label="Clear input"
-                tabIndex={showClearButton ? 0 : -1}
+                tabIndex={showClearButton && !disabled ? 0 : -1}
+                disabled={!showClearButton || disabled}
             >
                 <RemoveIcon />
             </button>

--- a/src/components/common/program-section-templates/single-image-right/SingleImageRight.module.scss
+++ b/src/components/common/program-section-templates/single-image-right/SingleImageRight.module.scss
@@ -15,6 +15,7 @@
 .left-section {
     display: flex;
     flex: 0 0 50%;
+    min-width: 0;
     flex-direction: column;
     justify-content: center;
     align-items: center;
@@ -24,6 +25,7 @@
 
 .title-section {
     display: flex;
+    min-width: 0;
     align-items: start;
     width: 100%;
     > div {
@@ -42,12 +44,14 @@
     font-size: 30px;
     font-weight: bold;
     line-height: 1.2;
-    word-wrap: break-word;
+    overflow-wrap: break-word;
+    white-space: pre-wrap;
 }
 
 .description-section {
     width: 100%;
     display: flex;
+    min-width: 0;
     align-items: start;
     > div {
         flex: 1;
@@ -61,7 +65,7 @@
 }
 
 .description {
-    word-wrap: break-word;
+    overflow-wrap: break-word;
     white-space: pre-wrap;
 }
 

--- a/src/components/common/program-section-templates/single-image-right/SingleImageRight.module.scss
+++ b/src/components/common/program-section-templates/single-image-right/SingleImageRight.module.scss
@@ -51,6 +51,14 @@
     align-items: start;
     > div {
         flex: 1;
+        width: 100%;
+
+        textarea {
+            word-wrap: break-word;
+            word-break: break-word;
+            overflow-wrap: break-word;
+            white-space: pre-wrap;
+        }
     }
 }
 

--- a/src/components/common/program-section-templates/single-image-right/SingleImageRight.module.scss
+++ b/src/components/common/program-section-templates/single-image-right/SingleImageRight.module.scss
@@ -54,8 +54,6 @@
         width: 100%;
 
         textarea {
-            word-wrap: break-word;
-            word-break: break-word;
             overflow-wrap: break-word;
             white-space: pre-wrap;
         }

--- a/src/components/common/program-section-templates/single-image-right/ViewSingleImageRight.module.scss
+++ b/src/components/common/program-section-templates/single-image-right/ViewSingleImageRight.module.scss
@@ -28,6 +28,7 @@ $img-height: 600px;
 .left-section {
     display: flex;
     flex: 1;
+    min-width: 0;
     flex-direction: column;
     justify-content: center;
     align-items: center;
@@ -36,6 +37,7 @@ $img-height: 600px;
 
 .title-section {
     display: flex;
+    min-width: 0;
     align-items: start;
     width: 100%;
 }
@@ -43,11 +45,15 @@ $img-height: 600px;
 .title {
     @include type.h3-semibold-uppercase;
     word-wrap: break-word;
+    overflow-wrap: break-word;
+    white-space: pre-wrap;
+    word-break: break-word;
 }
 
 .description-section {
     width: 100%;
     display: flex;
+    min-width: 0;
     align-items: start;
     > div {
         flex: 1;
@@ -58,6 +64,7 @@ $img-height: 600px;
     @include type.body-1-medium;
     overflow-wrap: break-word;
     white-space: pre-wrap;
+    word-break: break-word;
 }
 
 .right-section {

--- a/src/components/common/program-section-templates/single-image-right/ViewSingleImageRight.module.scss
+++ b/src/components/common/program-section-templates/single-image-right/ViewSingleImageRight.module.scss
@@ -56,9 +56,7 @@ $img-height: 600px;
 
 .description {
     @include type.body-1-medium;
-    word-wrap: break-word;
     overflow-wrap: break-word;
-    word-break: break-word;
     white-space: pre-wrap;
 }
 

--- a/src/components/common/program-section-templates/single-image-right/ViewSingleImageRight.module.scss
+++ b/src/components/common/program-section-templates/single-image-right/ViewSingleImageRight.module.scss
@@ -79,7 +79,7 @@ $img-height: 600px;
 }
 
 .image {
-    width: auto;
+    width: 100%;
     object-fit: cover;
     max-width: 100%;
 }

--- a/src/components/common/program-section-templates/single-image-right/ViewSingleImageRight.module.scss
+++ b/src/components/common/program-section-templates/single-image-right/ViewSingleImageRight.module.scss
@@ -57,6 +57,8 @@ $img-height: 600px;
 .description {
     @include type.body-1-medium;
     word-wrap: break-word;
+    overflow-wrap: break-word;
+    word-break: break-word;
     white-space: pre-wrap;
 }
 


### PR DESCRIPTION
## Github ticker

* [2073](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2073)
* [2074](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2074)
* [2075](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2075)
* [1899](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1899)

## Description

First bug:
After clicking clean-up (X) icon text cleared, but the button remains visible even though the field is empty

Second bug:
When entering the "Description" field in the program section T7 template, the text does not wrap.

## How it looks

First bugfix:
https://github.com/user-attachments/assets/8d2543b8-f02d-488a-bd47-2e2318ff0f0d

Second bugfix:
https://github.com/user-attachments/assets/f9bbd5d7-7bce-427a-acc0-c519c07a7bcb

## Summary of change

FIxed InputWithCharacterLimit component, fix styling in SIngleRightImageComponent

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Clear button visibility and interactivity now properly reflect the input's disabled state
  * Improved text wrapping and whitespace handling in program section descriptions
  * Enhanced image sizing and responsive behavior in program templates
  * Refined keyboard navigation and focus management for inputs with character limits
<!-- end of auto-generated comment: release notes by coderabbit.ai -->