### PR TITLE
Feature/issue-1589: Add ability to delete funds/expenses records

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -139,6 +139,8 @@ export const FUNDS_EXPENDITURES_TEXT = {
         RECORD_CREATE_FAILED_RETRY: 'Не вдалося додати запис. Спробуйте ще раз',
         RECORD_UPDATED_SUCCESSFULLY: 'Зміни збережено успішно',
         RECORD_UPDATE_FAILED_RETRY: 'Виникла помилка, спробуйте ще раз',
+        RECORD_DELETED_SUCCESSFULLY: 'Запис успішно видалено',
+        RECORD_DELETE_FAILED_RETRY: 'Не вдалося видалити запис. Спробуйте ще раз',
     },
     MODAL: {
         SHARED: {
@@ -147,6 +149,9 @@ export const FUNDS_EXPENDITURES_TEXT = {
             AMOUNT_UAH_LABEL: 'Сума (UAH)',
             AMOUNT_USD_LABEL: 'Сума (USD)',
             CONFIRM_CLOSE_TITLE: 'Зміни будуть втрачені. Бажаєте продовжити?',
+        },
+        DELETE: {
+            TITLE: 'Видалити запис?',
         },
         INCOME: {
             TITLE: 'Додати надходження',

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
@@ -197,11 +197,27 @@ jest.mock('./components/funds-expenditures-table/FundsExpendituresTable', () => 
         isEditing,
         onRecordSave,
         onRowEditModeChange,
+        onDeleteRecord,
     }: {
-        records: unknown[];
+        records: Array<{
+            id: number;
+            categoryId: number;
+            type: 'income' | 'expense';
+            reportingYear: string;
+            amountUah: string;
+            amountUsd: string;
+        }>;
         isEditing?: boolean;
         onRecordSave?: (recordId: number, data: { categoryId: number; amountUah: string; amountUsd: string }) => void;
         onRowEditModeChange?: (isRowEditMode: boolean) => void;
+        onDeleteRecord?: (record: {
+            id: number;
+            categoryId: number;
+            type: 'income' | 'expense';
+            reportingYear: string;
+            amountUah: string;
+            amountUsd: string;
+        }) => void;
     }) => (
         <div data-testid="funds-table" data-record-count={records.length} data-editing={String(isEditing ?? false)}>
             <button
@@ -221,6 +237,13 @@ jest.mock('./components/funds-expenditures-table/FundsExpendituresTable', () => 
             </button>
             <button data-testid="row-edit-off" onClick={() => onRowEditModeChange?.(false)}>
                 Row edit off
+            </button>
+            <button
+                data-testid="trigger-record-delete"
+                onClick={() => onDeleteRecord?.(records[0])}
+                disabled={!isEditing || records.length === 0}
+            >
+                Delete row
             </button>
         </div>
     ),
@@ -267,6 +290,7 @@ jest.mock('./components/common/add-income-modal/AddIncomeModal', () => ({
 const mockUpdateRecord = jest.fn();
 const mockCreateRecord = jest.fn();
 const mockUpdateSettings = jest.fn();
+const mockDeleteRecord = jest.fn();
 jest.mock('@/services/api/admin/reports/funds-expenditures-api', () => ({
     FundsExpendituresApi: {
         getSettings: jest.fn(),
@@ -276,7 +300,36 @@ jest.mock('@/services/api/admin/reports/funds-expenditures-api', () => ({
         updateSettings: (...args: unknown[]) => mockUpdateSettings(...args),
         createRecord: (...args: unknown[]) => mockCreateRecord(...args),
         updateRecord: (...args: unknown[]) => mockUpdateRecord(...args),
+        deleteRecord: (...args: unknown[]) => mockDeleteRecord(...args),
     },
+}));
+
+jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
+    ConfirmationModal: ({
+        isOpen,
+        onConfirm,
+        onCancel,
+        onClose,
+        isButtonsDisabled,
+    }: {
+        isOpen: boolean;
+        onConfirm: () => void;
+        onCancel: () => void;
+        onClose: () => void;
+        isButtonsDisabled?: boolean;
+    }) => (
+        <div data-testid="delete-confirmation-modal" data-open={String(isOpen)}>
+            <button data-testid="confirm-delete-record" onClick={onConfirm} disabled={isButtonsDisabled}>
+                Confirm delete
+            </button>
+            <button data-testid="cancel-delete-record" onClick={onCancel}>
+                Cancel delete
+            </button>
+            <button data-testid="close-delete-record" onClick={onClose}>
+                Close delete
+            </button>
+        </div>
+    ),
 }));
 
 const setupMockDataFetch = (
@@ -735,6 +788,72 @@ describe('FundsExpenditureSection', () => {
                 FUNDS_EXPENDITURES_TEXT.MESSAGE.RECORD_CREATE_FAILED_RETRY,
                 'error',
             );
+        });
+
+        it('should delete record after confirmation and show success toast', async () => {
+            mockDeleteRecord.mockResolvedValueOnce(undefined);
+
+            render(<FundsExpenditureSection />);
+
+            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
+            expect(screen.getByTestId('funds-table')).toHaveAttribute(
+                'data-record-count',
+                String(MOCK_FUNDS_EXPENDITURES_RECORDS.length),
+            );
+
+            fireEvent.click(screen.getByTestId('trigger-record-delete'));
+            expect(screen.getByTestId('delete-confirmation-modal')).toHaveAttribute('data-open', 'true');
+
+            fireEvent.click(screen.getByTestId('confirm-delete-record'));
+
+            await waitFor(() => {
+                expect(mockDeleteRecord).toHaveBeenCalledWith({}, 1);
+                expect(mockAddToast).toHaveBeenCalledWith(
+                    FUNDS_EXPENDITURES_TEXT.MESSAGE.RECORD_DELETED_SUCCESSFULLY,
+                    'success',
+                );
+                expect(screen.getByTestId('funds-table')).toHaveAttribute(
+                    'data-record-count',
+                    String(MOCK_FUNDS_EXPENDITURES_RECORDS.length - 1),
+                );
+                expect(screen.getByTestId('delete-confirmation-modal')).toHaveAttribute('data-open', 'false');
+            });
+        });
+
+        it('should show delete error toast and keep modal open when delete fails', async () => {
+            mockDeleteRecord.mockRejectedValueOnce(new Error('delete failed'));
+
+            render(<FundsExpenditureSection />);
+
+            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
+            fireEvent.click(screen.getByTestId('trigger-record-delete'));
+            fireEvent.click(screen.getByTestId('confirm-delete-record'));
+
+            await waitFor(() => {
+                expect(mockDeleteRecord).toHaveBeenCalledWith({}, 1);
+                expect(mockAddToast).toHaveBeenCalledWith(
+                    FUNDS_EXPENDITURES_TEXT.MESSAGE.RECORD_DELETE_FAILED_RETRY,
+                    'error',
+                );
+                expect(screen.getByTestId('delete-confirmation-modal')).toHaveAttribute('data-open', 'true');
+                expect(screen.getByTestId('funds-table')).toHaveAttribute(
+                    'data-record-count',
+                    String(MOCK_FUNDS_EXPENDITURES_RECORDS.length),
+                );
+            });
+        });
+
+        it('should close delete confirmation modal on cancel', () => {
+            render(<FundsExpenditureSection />);
+
+            fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
+            fireEvent.click(screen.getByTestId('trigger-record-delete'));
+
+            expect(screen.getByTestId('delete-confirmation-modal')).toHaveAttribute('data-open', 'true');
+
+            fireEvent.click(screen.getByTestId('cancel-delete-record'));
+
+            expect(screen.getByTestId('delete-confirmation-modal')).toHaveAttribute('data-open', 'false');
         });
     });
 });

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
@@ -304,34 +304,6 @@ jest.mock('@/services/api/admin/reports/funds-expenditures-api', () => ({
     },
 }));
 
-jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
-    ConfirmationModal: ({
-        isOpen,
-        onConfirm,
-        onCancel,
-        onClose,
-        isButtonsDisabled,
-    }: {
-        isOpen: boolean;
-        onConfirm: () => void;
-        onCancel: () => void;
-        onClose: () => void;
-        isButtonsDisabled?: boolean;
-    }) => (
-        <div data-testid="delete-confirmation-modal" data-open={String(isOpen)}>
-            <button data-testid="confirm-delete-record" onClick={onConfirm} disabled={isButtonsDisabled}>
-                Confirm delete
-            </button>
-            <button data-testid="cancel-delete-record" onClick={onCancel}>
-                Cancel delete
-            </button>
-            <button data-testid="close-delete-record" onClick={onClose}>
-                Close delete
-            </button>
-        </div>
-    ),
-}));
-
 const setupMockDataFetch = (
     settings: ReportFundsExpendituresSettings | null = MOCK_FUNDS_EXPENDITURES_SETTINGS,
     categories: ReportFundsExpendituresCategory[] = MOCK_FUNDS_EXPENDITURES_CATEGORIES,
@@ -802,9 +774,9 @@ describe('FundsExpenditureSection', () => {
             );
 
             fireEvent.click(screen.getByTestId('trigger-record-delete'));
-            expect(screen.getByTestId('delete-confirmation-modal')).toHaveAttribute('data-open', 'true');
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE.TITLE)).toBeInTheDocument();
 
-            fireEvent.click(screen.getByTestId('confirm-delete-record'));
+            fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.YES));
 
             await waitFor(() => {
                 expect(mockDeleteRecord).toHaveBeenCalledWith({}, 1);
@@ -816,7 +788,7 @@ describe('FundsExpenditureSection', () => {
                     'data-record-count',
                     String(MOCK_FUNDS_EXPENDITURES_RECORDS.length - 1),
                 );
-                expect(screen.getByTestId('delete-confirmation-modal')).toHaveAttribute('data-open', 'false');
+                expect(screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE.TITLE)).not.toBeInTheDocument();
             });
         });
 
@@ -827,7 +799,7 @@ describe('FundsExpenditureSection', () => {
 
             fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
             fireEvent.click(screen.getByTestId('trigger-record-delete'));
-            fireEvent.click(screen.getByTestId('confirm-delete-record'));
+            fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.YES));
 
             await waitFor(() => {
                 expect(mockDeleteRecord).toHaveBeenCalledWith({}, 1);
@@ -835,7 +807,7 @@ describe('FundsExpenditureSection', () => {
                     FUNDS_EXPENDITURES_TEXT.MESSAGE.RECORD_DELETE_FAILED_RETRY,
                     'error',
                 );
-                expect(screen.getByTestId('delete-confirmation-modal')).toHaveAttribute('data-open', 'true');
+                expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE.TITLE)).toBeInTheDocument();
                 expect(screen.getByTestId('funds-table')).toHaveAttribute(
                     'data-record-count',
                     String(MOCK_FUNDS_EXPENDITURES_RECORDS.length),
@@ -849,11 +821,11 @@ describe('FundsExpenditureSection', () => {
             fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
             fireEvent.click(screen.getByTestId('trigger-record-delete'));
 
-            expect(screen.getByTestId('delete-confirmation-modal')).toHaveAttribute('data-open', 'true');
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE.TITLE)).toBeInTheDocument();
 
-            fireEvent.click(screen.getByTestId('cancel-delete-record'));
+            fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.NO));
 
-            expect(screen.getByTestId('delete-confirmation-modal')).toHaveAttribute('data-open', 'false');
+            expect(screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE.TITLE)).not.toBeInTheDocument();
         });
     });
 });

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -30,8 +30,8 @@ import {
 } from './components/funds-expenditures-toolbar/FundsExpendituresToolbar';
 import { EnrichedRecord, FundsExpendituresTable } from './components/funds-expenditures-table/FundsExpendituresTable';
 import { AddIncomeModal } from './components/common/add-income-modal/AddIncomeModal';
+import { DeleteRecordModal } from './components/common/delete-record-modal/DeleteRecordModal';
 import styles from './FundsExpendituresSection.module.scss';
-import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
 
 const enrichRecords = (
     records: ReportFundsExpendituresRecord[],
@@ -444,15 +444,15 @@ export const FundsExpenditureSection = () => {
                 onSubmit={handleCreateRecord}
             />
 
-            <ConfirmationModal
+            <DeleteRecordModal
                 isOpen={isDeleteModalOpen}
                 title={FUNDS_EXPENDITURES_TEXT.MODAL.DELETE.TITLE}
                 confirmText={COMMON_TEXT_ADMIN.BUTTON.YES}
                 cancelText={COMMON_TEXT_ADMIN.BUTTON.NO}
+                isButtonsDisabled={isDeletingRecord}
                 onConfirm={handleConfirmDelete}
                 onCancel={() => setIsDeleteModalOpen(false)}
                 onClose={() => setIsDeleteModalOpen(false)}
-                isButtonsDisabled={isDeletingRecord}
             />
         </div>
     );

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -31,6 +31,7 @@ import {
 import { EnrichedRecord, FundsExpendituresTable } from './components/funds-expenditures-table/FundsExpendituresTable';
 import { AddIncomeModal } from './components/common/add-income-modal/AddIncomeModal';
 import styles from './FundsExpendituresSection.module.scss';
+import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
 
 const enrichRecords = (
     records: ReportFundsExpendituresRecord[],
@@ -58,6 +59,10 @@ export const FundsExpenditureSection = () => {
     const [recordsState, setRecordsState] = useState<ReportFundsExpendituresRecord[]>([]);
     const [isRowEditMode, setIsRowEditMode] = useState(false);
     const [isAddIncomeModalOpen, setIsAddIncomeModalOpen] = useState(false);
+
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+    const [recordToDelete, setRecordToDelete] = useState<ReportFundsExpendituresRecord | null>(null);
+    const [isDeletingRecord, setIsDeletingRecord] = useState(false);
 
     const handleEdit = useCallback(() => setIsEditing(true), []);
     const handleCancel = useCallback(() => {
@@ -268,6 +273,28 @@ export const FundsExpenditureSection = () => {
         [addToast, adminClient, refetchSummary],
     );
 
+    const handleDeleteClick = (record: ReportFundsExpendituresRecord) => {
+        setRecordToDelete(record);
+        setIsDeleteModalOpen(true);
+    };
+
+    const handleConfirmDelete = useCallback(async () => {
+        if (!recordToDelete) return;
+
+        setIsDeletingRecord(true);
+        try {
+            await FundsExpendituresApi.deleteRecord(adminClient, recordToDelete.id);
+            setRecordsState((prev) => prev.filter((r) => r.id !== recordToDelete.id));
+            refetchSummary();
+            addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.RECORD_DELETED_SUCCESSFULLY, ToastType.Success);
+            setIsDeleteModalOpen(false);
+        } catch {
+            addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.RECORD_DELETE_FAILED_RETRY, ToastType.Error);
+        } finally {
+            setIsDeletingRecord(false);
+        }
+    }, [recordToDelete, adminClient, addToast, refetchSummary]);
+
     const handlePublish = useCallback(async () => {
         try {
             const updatedSettings = await FundsExpendituresApi.updateSettings(adminClient, {
@@ -389,6 +416,7 @@ export const FundsExpenditureSection = () => {
                 isRowActionsDisabled={hasExchangeRateError}
                 onRowEditModeChange={setIsRowEditMode}
                 onRecordSave={handleRecordSave}
+                onDeleteRecord={handleDeleteClick}
             />
 
             {isEditing && (
@@ -414,6 +442,17 @@ export const FundsExpenditureSection = () => {
                 records={recordsState}
                 exchangeRate={currentExchangeRate}
                 onSubmit={handleCreateRecord}
+            />
+
+            <ConfirmationModal
+                isOpen={isDeleteModalOpen}
+                title={FUNDS_EXPENDITURES_TEXT.MODAL.DELETE.TITLE}
+                confirmText={COMMON_TEXT_ADMIN.BUTTON.YES}
+                cancelText={COMMON_TEXT_ADMIN.BUTTON.NO}
+                onConfirm={handleConfirmDelete}
+                onCancel={() => setIsDeleteModalOpen(false)}
+                onClose={() => setIsDeleteModalOpen(false)}
+                isButtonsDisabled={isDeletingRecord}
             />
         </div>
     );

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-record-modal/DeleteRecordModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-record-modal/DeleteRecordModal.module.scss
@@ -1,0 +1,14 @@
+.delete-record-modal {
+    max-width: 600px;
+}
+
+.delete-record-actions {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    width: 100%;
+
+    button {
+        width: 45%;
+    }
+}

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-record-modal/DeleteRecordModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-record-modal/DeleteRecordModal.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { DeleteRecordModal } from './DeleteRecordModal';
+
+describe('DeleteRecordModal', () => {
+    it('should render title and default button labels when open', () => {
+        render(
+            <DeleteRecordModal
+                isOpen
+                title="Delete record?"
+                onConfirm={jest.fn()}
+                onCancel={jest.fn()}
+                onClose={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('Delete record?')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Ні' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Так' })).toBeInTheDocument();
+    });
+
+    it('should use provided button labels', () => {
+        render(
+            <DeleteRecordModal
+                isOpen
+                title="Delete record?"
+                confirmText="Confirm"
+                cancelText="Cancel"
+                onConfirm={jest.fn()}
+                onCancel={jest.fn()}
+                onClose={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
+    });
+
+    it('should call onConfirm when confirm button is clicked', () => {
+        const onConfirm = jest.fn();
+
+        render(
+            <DeleteRecordModal
+                isOpen
+                title="Delete record?"
+                onConfirm={onConfirm}
+                onCancel={jest.fn()}
+                onClose={jest.fn()}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Так' }));
+
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onCancel when cancel button is clicked', () => {
+        const onCancel = jest.fn();
+
+        render(
+            <DeleteRecordModal
+                isOpen
+                title="Delete record?"
+                onConfirm={jest.fn()}
+                onCancel={onCancel}
+                onClose={jest.fn()}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Ні' }));
+
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('should disable both buttons when isButtonsDisabled is true', () => {
+        render(
+            <DeleteRecordModal
+                isOpen
+                title="Delete record?"
+                isButtonsDisabled
+                onConfirm={jest.fn()}
+                onCancel={jest.fn()}
+                onClose={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByRole('button', { name: 'Ні' })).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Так' })).toBeDisabled();
+    });
+
+    it('should not render when closed', () => {
+        render(
+            <DeleteRecordModal
+                isOpen={false}
+                title="Delete record?"
+                onConfirm={jest.fn()}
+                onCancel={jest.fn()}
+                onClose={jest.fn()}
+            />,
+        );
+
+        expect(screen.queryByText('Delete record?')).not.toBeInTheDocument();
+    });
+});

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-record-modal/DeleteRecordModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-record-modal/DeleteRecordModal.tsx
@@ -1,0 +1,42 @@
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { Button } from '@/components/admin/button/Button';
+import { Modal } from '@/components/common/modal/Modal';
+import styles from './DeleteRecordModal.module.scss';
+
+export interface DeleteRecordModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    title: string;
+    confirmText?: string;
+    cancelText?: string;
+    onConfirm: () => void;
+    onCancel: () => void;
+    isButtonsDisabled?: boolean;
+}
+
+export const DeleteRecordModal = ({
+    isOpen,
+    onClose,
+    title,
+    confirmText,
+    cancelText,
+    onConfirm,
+    onCancel,
+    isButtonsDisabled = false,
+}: DeleteRecordModalProps) => {
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} className={styles['delete-record-modal']}>
+            <Modal.Title>{title}</Modal.Title>
+            <Modal.Actions>
+                <div className={styles['delete-record-actions']}>
+                    <Button buttonStyle="secondary" onClick={onCancel} disabled={isButtonsDisabled}>
+                        {cancelText || COMMON_TEXT_ADMIN.BUTTON.NO}
+                    </Button>
+                    <Button buttonStyle="primary" onClick={onConfirm} disabled={isButtonsDisabled}>
+                        {confirmText || COMMON_TEXT_ADMIN.BUTTON.YES}
+                    </Button>
+                </div>
+            </Modal.Actions>
+        </Modal>
+    );
+};

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
@@ -183,7 +183,23 @@
 .action-icon {
     width: 20px;
     height: 20px;
-    color: c.$blue-500;
+    transition: color 0.15s ease;
+}
+
+.edit-icon-button,
+.delete-icon-button {
+    display: inline-grid;
+    place-items: center;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+
+    :global(.icon-default),
+    :global(.icon-filled) {
+        width: 24px;
+        height: 24px;
+        flex-shrink: 0;
+    }
 }
 
 .accept-icon-button {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
@@ -201,6 +201,16 @@ describe('FundsExpendituresTable', () => {
         expect(screen.getAllByTestId('delete-icon')).toHaveLength(MOCK_RECORDS.length);
     });
 
+    it('should call onDeleteRecord with the selected row when delete is clicked', () => {
+        const onDeleteRecord = jest.fn();
+
+        renderTable({ isEditing: true, onDeleteRecord });
+
+        fireEvent.click(screen.getByLabelText('Delete record 1'));
+
+        expect(onDeleteRecord).toHaveBeenCalledWith(MOCK_RECORDS[0]);
+    });
+
     it('should render empty state row when records is empty', () => {
         renderTable({ records: [] });
 

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
@@ -7,10 +7,10 @@ import {
 } from '@/types/admin/reports';
 import { ReactComponent as NotFoundIcon } from '@/assets/icons/not-found.svg';
 import { ReactComponent as ArrowUpIcon } from '@/assets/icons/arrow-up.svg';
-import { ReactComponent as EditIcon } from '@/assets/icons/edit.svg';
-import { ReactComponent as DeleteIcon } from '@/assets/icons/delete.svg';
 import { ReactComponent as CheckmarkIcon } from '@/assets/icons/checkmark.svg';
 import { ReactComponent as CrossIcon } from '@/assets/icons/cross.svg';
+import { IconButton } from '@/components/admin/icon-button/IconButton';
+import { ACTION_ICONS } from '@/const/common/action-icons';
 import { Select } from '@/components/common/select/Select';
 import { SortIcon } from '@/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/components/sort-icon';
 import {
@@ -722,24 +722,30 @@ export const FundsExpendituresTable = ({
                                                         </>
                                                     ) : (
                                                         <>
-                                                            <button
+                                                            <IconButton
                                                                 type="button"
-                                                                className={styles['icon-button']}
+                                                                className={cn(
+                                                                    styles['icon-button'],
+                                                                    styles['edit-icon-button'],
+                                                                )}
                                                                 aria-label={`Edit record ${record.id}`}
                                                                 onClick={() => handleStartRowEdit(record)}
                                                                 disabled={isAnotherRowEditing}
-                                                            >
-                                                                <EditIcon className={styles['action-icon']} />
-                                                            </button>
-                                                            <button
+                                                                DefaultIcon={ACTION_ICONS.edit.default}
+                                                                FilledIcon={ACTION_ICONS.edit.hover}
+                                                            />
+                                                            <IconButton
                                                                 type="button"
-                                                                className={styles['icon-button']}
+                                                                className={cn(
+                                                                    styles['icon-button'],
+                                                                    styles['delete-icon-button'],
+                                                                )}
                                                                 aria-label={`Delete record ${record.id}`}
                                                                 onClick={() => onDeleteRecord?.(record)}
                                                                 disabled={isAnotherRowEditing}
-                                                            >
-                                                                <DeleteIcon className={styles['action-icon']} />
-                                                            </button>
+                                                                DefaultIcon={ACTION_ICONS.delete.default}
+                                                                FilledIcon={ACTION_ICONS.delete.hover}
+                                                            />
                                                         </>
                                                     )}
                                                 </div>

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
@@ -48,6 +48,7 @@ interface FundsExpendituresTableProps {
         recordId: number,
         data: { categoryId: number; amountUah: string; amountUsd: string },
     ) => boolean | Promise<boolean>;
+    onDeleteRecord?: (record: EnrichedRecord) => void;
 }
 
 interface RowEditState {
@@ -144,6 +145,7 @@ export const FundsExpendituresTable = ({
     isRowActionsDisabled = false,
     onRowEditModeChange,
     onRecordSave,
+    onDeleteRecord,
 }: FundsExpendituresTableProps) => {
     const [sort, setSort] = useState<ColumnSort>({ column: null, direction: null });
     const [rowEditState, setRowEditState] = useState<RowEditState | null>(null);
@@ -733,6 +735,7 @@ export const FundsExpendituresTable = ({
                                                                 type="button"
                                                                 className={styles['icon-button']}
                                                                 aria-label={`Delete record ${record.id}`}
+                                                                onClick={() => onDeleteRecord?.(record)}
                                                                 disabled={isAnotherRowEditing}
                                                             >
                                                                 <DeleteIcon className={styles['action-icon']} />


### PR DESCRIPTION
## Github ticker

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1589

## Description

This PR introduces the ability for an Admin to delete records from the funds/expenses list in the "Доходи та витрати" tab.

## How it looks


https://github.com/user-attachments/assets/2886e0ef-5b40-4405-84f8-d93fe295ad85


## Summary of change

Implemented hover state for the delete icon according to the mock-up
Added confirmation modal ("Видалити запис?")
Implemented deletion logic:
  - Removes the selected record from the system
  - Updates the UI list after deletion
  - Recalculates totals in summary cards
  - Handled cancel action (no changes when "НІ" is clicked)


## How to recreate changes

1. Open Admin panel
2. Navigate to "Доходи та витрати" tab
3. Locate any record in the list
4. Hover over the Delete icon → verify hover state
5. Click the Delete icon
6. In the confirmation modal:
  - Click "НІ" → ensure modal closes and record remains
  - Click "ТАК" → verify:
    - Modal closes
    - Record is removed from the list
    - Totals in summary cards are updated accordingly

## CHECK LIST
- [x]  New tests was added or existing was modified
- [x]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now delete individual records from the funds expenditures management table with a delete confirmation modal.
  * Implemented delete operation notifications with success and error messages, fully supporting Ukrainian language.

* **Style**
  * Enhanced delete and edit action button styling with improved visual consistency, sizing, and interactive hover transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->