### PR TITLE
Feature/issue-1714: Add confirmation modal for saving fund record

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -154,6 +154,7 @@ export const FUNDS_EXPENDITURES_TEXT = {
             CATEGORY_LABEL: 'Категорія надходження',
             CATEGORY_PLACEHOLDER: 'Оберіть категорію надходження',
             SUBMIT_BUTTON: 'Додати надходження',
+            CONFIRM_ADD_TITLE: 'Додати нове надходження?',
         },
         EXPENSE: {
             TITLE: 'Додати витрату',

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.test.tsx
@@ -58,6 +58,24 @@ jest.mock(
     }),
 );
 
+jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
+    ConfirmationModal: ({ isOpen, title, onConfirm, onCancel }: any) => {
+        if (!isOpen) return null;
+
+        return (
+            <div data-testid="add-income-confirmation-modal" data-open={String(isOpen)}>
+                <div data-testid="add-income-confirmation-title">{title}</div>
+                <button data-testid="confirm-add-income" onClick={onConfirm}>
+                    Yes
+                </button>
+                <button data-testid="cancel-add-income" onClick={onCancel}>
+                    No
+                </button>
+            </div>
+        );
+    },
+}));
+
 jest.mock('@/components/admin/input-with-character-limit/InputWithCharacterLimit', () => ({
     InputWithCharacterLimit: ({ id, name, value, onChange, onBlur, maxLength, hasError }: any) => (
         <input
@@ -185,6 +203,10 @@ describe('AddIncomeModal', () => {
     const clickSubmitButton = async (user: ReturnType<typeof userEvent.setup>) => {
         const submitButton = screen.getByTestId('modal-submit');
         await user.click(submitButton);
+        const confirmButton = screen.queryByTestId('confirm-add-income');
+        if (confirmButton) {
+            await user.click(confirmButton);
+        }
     };
 
     const forceSubmitAndWaitForNoSubmitCall = async (user: ReturnType<typeof userEvent.setup>) => {
@@ -567,6 +589,43 @@ describe('AddIncomeModal', () => {
             await user.click(submitButton);
 
             expect(submitButton).toBeInTheDocument();
+        });
+
+        it('should open add confirmation modal when submit button is clicked', async () => {
+            const user = userEvent.setup({ delay: null });
+
+            renderAddIncomeModal({ records: [], exchangeRate: null });
+
+            await fillRequiredFormFields(user, {
+                category: '3',
+                amountUah: '700',
+                amountUsd: '17',
+                selectionMode: 'select',
+            });
+
+            await user.click(screen.getByTestId('modal-submit'));
+
+            expect(screen.getByTestId('add-income-confirmation-modal')).toHaveAttribute('data-open', 'true');
+            expect(screen.getByTestId('add-income-confirmation-title')).toHaveTextContent('Додати нове надходження?');
+        });
+
+        it('should close confirmation without submit when clicking No', async () => {
+            const user = userEvent.setup({ delay: null });
+
+            renderAddIncomeModal({ records: [], exchangeRate: null });
+
+            await fillRequiredFormFields(user, {
+                category: '3',
+                amountUah: '700',
+                amountUsd: '17',
+                selectionMode: 'select',
+            });
+
+            await user.click(screen.getByTestId('modal-submit'));
+            await user.click(screen.getByTestId('cancel-add-income'));
+
+            expect(screen.queryByTestId('add-income-confirmation-modal')).not.toBeInTheDocument();
+            expect(mockOnSubmit).not.toHaveBeenCalled();
         });
     });
 

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.tsx
@@ -321,7 +321,7 @@ export const AddIncomeModal = ({
                 title={FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.CONFIRM_ADD_TITLE}
                 confirmText={COMMON_TEXT_ADMIN.BUTTON.YES}
                 cancelText={COMMON_TEXT_ADMIN.BUTTON.NO}
-                onConfirm={() => void handleConfirmAdd()}
+                onConfirm={() => handleConfirmAdd()}
                 onCancel={() => setIsAddConfirmationOpen(false)}
                 onClose={() => setIsAddConfirmationOpen(false)}
                 isButtonsDisabled={isSubmitting}

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
 import { InputWithCharacterLimit } from '@/components/admin/input-with-character-limit/InputWithCharacterLimit';
 import { Select } from '@/components/common/select/Select';
 import { FundsRecordModal } from '@/pages/admin/reports/components/funds-expenditures-section/components/common/funds-record-modal/FundsRecordModal';
@@ -64,6 +65,7 @@ export const AddIncomeModal = ({
 }: AddIncomeModalProps) => {
     const [formState, setFormState] = useState<AddIncomeFormState>(INITIAL_STATE);
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [isAddConfirmationOpen, setIsAddConfirmationOpen] = useState(false);
 
     const incomeCategories = useMemo(() => {
         return categories
@@ -79,6 +81,7 @@ export const AddIncomeModal = ({
     }, []);
 
     const handleClose = useCallback(() => {
+        setIsAddConfirmationOpen(false);
         resetForm();
         onClose();
     }, [onClose, resetForm]);
@@ -177,128 +180,152 @@ export const AddIncomeModal = ({
         Boolean(formState.errors.amountUah) ||
         Boolean(formState.errors.amountUsd);
 
+    const handleOpenAddConfirmation = useCallback(() => {
+        setIsAddConfirmationOpen(true);
+    }, []);
+
+    const handleConfirmAdd = useCallback(async () => {
+        setIsAddConfirmationOpen(false);
+        await handleSubmit();
+    }, [handleSubmit]);
+
     return (
-        <FundsRecordModal
-            isOpen={isOpen}
-            title={FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.TITLE}
-            subtitle={FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.SUBTITLE}
-            submitButtonLabel={FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.SUBMIT_BUTTON}
-            isSubmitDisabled={isSubmitDisabled}
-            isDirty={isDirty}
-            onSubmit={handleSubmit}
-            onClose={handleClose}
-            closeConfirmationTitle={FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.CONFIRM_CLOSE_TITLE}
-        >
-            <div className={styles.form}>
-                <div className={styles.field}>
-                    <label className={styles.label}>
-                        <span className={styles.required}>*</span>
-                        {FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_LABEL}
-                    </label>
-                    <Select<string>
-                        value={formState.reportingYear}
-                        onValueChange={(value) => {
-                            setFormState((prev) => ({
-                                ...prev,
-                                reportingYear: value,
-                                errors: {
-                                    ...prev.errors,
-                                    reportingYear: undefined,
-                                },
-                            }));
-                        }}
-                        placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER}
-                        className={styles.select}
-                        optionClassName={styles['select-option']}
-                    >
-                        {yearOptions.map((year) => (
-                            <Select.Option key={year} value={year} name={year} />
-                        ))}
-                    </Select>
-                    {formState.errors.reportingYear && <p className={styles.error}>{formState.errors.reportingYear}</p>}
-                </div>
-
-                <div className={styles.field}>
-                    <label className={styles.label}>
-                        <span className={styles.required}>*</span>
-                        {FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.CATEGORY_LABEL}
-                    </label>
-                    <Select<number>
-                        value={formState.categoryId}
-                        onValueChange={(value) => {
-                            setFormState((prev) => ({
-                                ...prev,
-                                categoryId: value,
-                                errors: {
-                                    ...prev.errors,
-                                    categoryId: getCategoryError(value, 'change'),
-                                },
-                            }));
-                        }}
-                        placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.CATEGORY_PLACEHOLDER}
-                        className={styles.select}
-                        optionClassName={styles['select-option']}
-                    >
-                        {incomeCategories.map((category) => (
-                            <Select.Option key={category.id} value={category.id} name={category.name} />
-                        ))}
-                    </Select>
-                    {formState.errors.categoryId && <p className={styles.error}>{formState.errors.categoryId}</p>}
-                </div>
-
-                <div className={styles.field}>
-                    <label className={styles.label}>
-                        <span className={styles.required}>*</span>
-                        {FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.AMOUNT_UAH_LABEL}
-                    </label>
-                    <InputWithCharacterLimit
-                        id="add-income-amount-uah"
-                        name="amountUah"
-                        type="text"
-                        value={formState.amountUah}
-                        onChange={(event) => handleAmountChange('amountUah', event.target.value)}
-                        onBlur={() => handleAmountBlur('amountUah')}
-                        maxLength={20}
-                        showCounter={false}
-                        className={styles.input}
-                        hasError={Boolean(formState.errors.amountUah)}
-                    />
-                    {formState.errors.amountUah && <p className={styles.error}>{formState.errors.amountUah}</p>}
-                </div>
-
-                <div className={styles.field}>
-                    <div className={styles['amount-usd-header']}>
+        <>
+            <FundsRecordModal
+                isOpen={isOpen}
+                title={FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.TITLE}
+                subtitle={FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.SUBTITLE}
+                submitButtonLabel={FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.SUBMIT_BUTTON}
+                isSubmitDisabled={isSubmitDisabled}
+                isDirty={isDirty}
+                onSubmit={handleOpenAddConfirmation}
+                onClose={handleClose}
+                closeConfirmationTitle={FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.CONFIRM_CLOSE_TITLE}
+            >
+                <div className={styles.form}>
+                    <div className={styles.field}>
                         <label className={styles.label}>
                             <span className={styles.required}>*</span>
-                            {FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.AMOUNT_USD_LABEL}
+                            {FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_LABEL}
                         </label>
-                        <div className={styles['exchange-rate-chip']}>
-                            <span className={styles['exchange-rate-chip-label']}>
-                                {FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL}
-                            </span>
-                            <input
-                                type="text"
-                                value={exchangeRate ?? ''}
-                                disabled
-                                className={styles['exchange-rate-value']}
-                            />
-                        </div>
+                        <Select<string>
+                            value={formState.reportingYear}
+                            onValueChange={(value) => {
+                                setFormState((prev) => ({
+                                    ...prev,
+                                    reportingYear: value,
+                                    errors: {
+                                        ...prev.errors,
+                                        reportingYear: undefined,
+                                    },
+                                }));
+                            }}
+                            placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER}
+                            className={styles.select}
+                            optionClassName={styles['select-option']}
+                        >
+                            {yearOptions.map((year) => (
+                                <Select.Option key={year} value={year} name={year} />
+                            ))}
+                        </Select>
+                        {formState.errors.reportingYear && (
+                            <p className={styles.error}>{formState.errors.reportingYear}</p>
+                        )}
                     </div>
-                    <InputWithCharacterLimit
-                        id="add-income-amount-usd"
-                        name="amountUsd"
-                        type="text"
-                        value={formState.amountUsd}
-                        onChange={(event) => handleAmountChange('amountUsd', event.target.value)}
-                        onBlur={() => handleAmountBlur('amountUsd')}
-                        maxLength={20}
-                        showCounter={false}
-                        className={styles.input}
-                        hasError={Boolean(formState.errors.amountUsd)}
-                    />
-                    {formState.errors.amountUsd && <p className={styles.error}>{formState.errors.amountUsd}</p>}
+
+                    <div className={styles.field}>
+                        <label className={styles.label}>
+                            <span className={styles.required}>*</span>
+                            {FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.CATEGORY_LABEL}
+                        </label>
+                        <Select<number>
+                            value={formState.categoryId}
+                            onValueChange={(value) => {
+                                setFormState((prev) => ({
+                                    ...prev,
+                                    categoryId: value,
+                                    errors: {
+                                        ...prev.errors,
+                                        categoryId: getCategoryError(value, 'change'),
+                                    },
+                                }));
+                            }}
+                            placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.CATEGORY_PLACEHOLDER}
+                            className={styles.select}
+                            optionClassName={styles['select-option']}
+                        >
+                            {incomeCategories.map((category) => (
+                                <Select.Option key={category.id} value={category.id} name={category.name} />
+                            ))}
+                        </Select>
+                        {formState.errors.categoryId && <p className={styles.error}>{formState.errors.categoryId}</p>}
+                    </div>
+
+                    <div className={styles.field}>
+                        <label className={styles.label}>
+                            <span className={styles.required}>*</span>
+                            {FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.AMOUNT_UAH_LABEL}
+                        </label>
+                        <InputWithCharacterLimit
+                            id="add-income-amount-uah"
+                            name="amountUah"
+                            type="text"
+                            value={formState.amountUah}
+                            onChange={(event) => handleAmountChange('amountUah', event.target.value)}
+                            onBlur={() => handleAmountBlur('amountUah')}
+                            maxLength={20}
+                            showCounter={false}
+                            className={styles.input}
+                            hasError={Boolean(formState.errors.amountUah)}
+                        />
+                        {formState.errors.amountUah && <p className={styles.error}>{formState.errors.amountUah}</p>}
+                    </div>
+
+                    <div className={styles.field}>
+                        <div className={styles['amount-usd-header']}>
+                            <label className={styles.label}>
+                                <span className={styles.required}>*</span>
+                                {FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.AMOUNT_USD_LABEL}
+                            </label>
+                            <div className={styles['exchange-rate-chip']}>
+                                <span className={styles['exchange-rate-chip-label']}>
+                                    {FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL}
+                                </span>
+                                <input
+                                    type="text"
+                                    value={exchangeRate ?? ''}
+                                    disabled
+                                    className={styles['exchange-rate-value']}
+                                />
+                            </div>
+                        </div>
+                        <InputWithCharacterLimit
+                            id="add-income-amount-usd"
+                            name="amountUsd"
+                            type="text"
+                            value={formState.amountUsd}
+                            onChange={(event) => handleAmountChange('amountUsd', event.target.value)}
+                            onBlur={() => handleAmountBlur('amountUsd')}
+                            maxLength={20}
+                            showCounter={false}
+                            className={styles.input}
+                            hasError={Boolean(formState.errors.amountUsd)}
+                        />
+                        {formState.errors.amountUsd && <p className={styles.error}>{formState.errors.amountUsd}</p>}
+                    </div>
                 </div>
-            </div>
-        </FundsRecordModal>
+            </FundsRecordModal>
+
+            <ConfirmationModal
+                isOpen={isAddConfirmationOpen}
+                title={FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.CONFIRM_ADD_TITLE}
+                confirmText={COMMON_TEXT_ADMIN.BUTTON.YES}
+                cancelText={COMMON_TEXT_ADMIN.BUTTON.NO}
+                onConfirm={() => void handleConfirmAdd()}
+                onCancel={() => setIsAddConfirmationOpen(false)}
+                onClose={() => setIsAddConfirmationOpen(false)}
+                isButtonsDisabled={isSubmitting}
+            />
+        </>
     );
 };


### PR DESCRIPTION
## Github ticker

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1714

## Description

Added a confirmation step before creating a new income record in Funds Expenditures.

## How it looks


https://github.com/user-attachments/assets/af712dee-d3df-4b60-a912-ac276a2642d4


## Summary of change

Added pre-submit confirmation flow for new income creation.

## How to recreate changes

1. Open Admin Panel.
2. Go to Reports section and Funds Expenditures tab.
3. Click Add Income.
4. Fill required fields (year, category, UAH, USD).
5. Click Save.
6. Verify confirmation modal appears with title:
 Додати нове надходження?
7. Click No and verify:
  Confirmation closes
  Data is not submitted
8. Click Save again, then click Yes and verify:
 Record is created
 List and totals are updated

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog when adding new income entries; users must confirm before the entry is finalized.
  * Confirmation dialog displays the title "Додати нове надходження?" and lets users cancel to abort submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->