### PR TITLE
Feature/Issue-1755: Add Program Expenses Section with related components

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -182,3 +182,25 @@ export const FUNDS_EXPENDITURES_TEXT = {
         EXCHANGE_RATE_MAX_DIGITS: "Не більше 9 цифр, 6 після ','",
     },
 };
+
+export const PROGRAM_EXPENSES_TEXT = {
+    SUMMARY_CARD: {
+        TITLE: 'Всього програмні витрати',
+        AMOUNT_SUFFIX_UAH: 'UAH',
+        AMOUNT_SUFFIX_USD: 'USD',
+    },
+    FILTER: {
+        ALL_OPTION: 'Всі',
+        PLACEHOLDER: 'Програма',
+    },
+    TABLE: {
+        TYPE_LABEL: 'Програми',
+        COLUMNS: {
+            REPORTING_YEAR: 'Звітній рік',
+            TYPE: 'Тип',
+            PROGRAM: 'Програма',
+            AMOUNT_UAH: 'Сума UAH',
+            AMOUNT_USD: 'Сума USD',
+        },
+    },
+};

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -160,7 +160,7 @@ export const FUNDS_EXPENDITURES_TEXT = {
             REPORTING_YEAR: 'Звітній рік',
             TYPE: 'Тип',
             CATEGORY: 'Категорія',
-            AMOUNT_UAH: 'Сума UA',
+            AMOUNT_UAH: 'Сума UAH',
             AMOUNT_USD: 'Сума USD',
         },
         TYPE_LABELS: {
@@ -186,21 +186,10 @@ export const FUNDS_EXPENDITURES_TEXT = {
 export const PROGRAM_EXPENSES_TEXT = {
     SUMMARY_CARD: {
         TITLE: 'Всього програмні витрати',
-        AMOUNT_SUFFIX_UAH: 'UAH',
-        AMOUNT_SUFFIX_USD: 'USD',
-    },
-    FILTER: {
-        ALL_OPTION: 'Всі',
-        PLACEHOLDER: 'Програма',
     },
     TABLE: {
-        TYPE_LABEL: 'Програми',
         COLUMNS: {
-            REPORTING_YEAR: 'Звітній рік',
-            TYPE: 'Тип',
             PROGRAM: 'Програма',
-            AMOUNT_UAH: 'Сума UAH',
-            AMOUNT_USD: 'Сума USD',
         },
     },
 };

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -151,7 +151,7 @@ export const FUNDS_EXPENDITURES_TEXT = {
         SPENT: 'Витрачено коштів',
         INCOME_CATEGORIES: 'Категорії надходжень',
         EXPENSE_CATEGORIES: 'Категорії витрат',
-        AMOUNT_SUFFIX_UAH: 'UA',
+        AMOUNT_SUFFIX_UAH: 'UAH',
         AMOUNT_SUFFIX_USD: 'USD',
         CATEGORY_SUFFIX_FORMS: ['категорія', 'категорії', 'категорій'],
     },

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.module.scss
@@ -1,0 +1,34 @@
+.section {
+    display: flex;
+    flex-direction: column;
+    gap: 40px;
+    width: 100%;
+    max-width: 1440px;
+    padding: 0 50px;
+}
+
+.loader-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 220px;
+}
+
+.filters {
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
+    width: 100%;
+}
+
+@media (max-width: 1200px) {
+    .section {
+        max-width: none;
+    }
+}
+
+@media (max-width: 900px) {
+    .section {
+        padding: 0 24px;
+    }
+}

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
@@ -1,0 +1,202 @@
+import { ChangeEvent, ReactNode } from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ProgramExpensesSection } from './ProgramExpensesSection';
+import { PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+import { ProgramExpensesReadOnlyData } from '@/types/admin/reports';
+import { ProgramExpensesApi } from '@/services/api/admin/reports/program-expenses-api';
+
+const MOCK_PROGRAM_EXPENSES_DATA: ProgramExpensesReadOnlyData = {
+    exchangeRate: '41.25',
+    programs: [
+        { id: 1, name: 'Program A' },
+        { id: 2, name: 'Program B' },
+    ],
+    summary: {
+        totalAmountUah: 125000,
+        totalAmountUsd: 3000,
+    },
+    records: [
+        {
+            id: 1,
+            programId: 1,
+            programName: 'Program A',
+            type: 'expense',
+            reportingYear: '2025',
+            amountUah: '50000',
+            amountUsd: '1200',
+        },
+        {
+            id: 2,
+            programId: 1,
+            programName: 'Program A',
+            type: 'expense',
+            reportingYear: '2024',
+            amountUah: '25000',
+            amountUsd: '600',
+        },
+        {
+            id: 3,
+            programId: 2,
+            programName: 'Program B',
+            type: 'expense',
+            reportingYear: '2025',
+            amountUah: '50000',
+            amountUsd: '1200',
+        },
+    ],
+};
+
+jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
+    useAdminClient: () => ({}),
+}));
+
+const mockGetReadOnlyData = jest.fn();
+jest.mock('@/services/api/admin/reports/program-expenses-api', () => ({
+    ProgramExpensesApi: {
+        getReadOnlyData: (...args: unknown[]) => mockGetReadOnlyData(...args),
+    },
+}));
+
+let mockUseDataFetchResult = {
+    data: MOCK_PROGRAM_EXPENSES_DATA,
+    isLoading: false,
+};
+
+const mockUseDataFetch = jest.fn();
+jest.mock('@/hooks/common/use-data-fetch/useDataFetch', () => ({
+    useDataFetch: (props: unknown) => mockUseDataFetch(props),
+}));
+
+jest.mock('@/components/common/inline-loader/InlineLoader', () => ({
+    InlineLoader: ({ size }: { size?: number }) => <div data-testid="inline-loader">loader-{size ?? 2}</div>,
+}));
+
+jest.mock('@/assets/icons/not-found.svg', () => ({
+    ReactComponent: () => <svg data-testid="not-found-icon" />,
+}));
+
+jest.mock('@/components/common/select/Select', () => {
+    const React = require('react') as typeof import('react');
+
+    interface MockSelectProps<TValue> {
+        value: TValue;
+        onValueChange: (value: TValue) => void;
+        children: ReactNode;
+        placeholder?: string;
+    }
+
+    interface MockSelectOptionProps<TValue> {
+        value: TValue;
+        name: string;
+    }
+
+    const Option = <TValue,>(_props: MockSelectOptionProps<TValue>) => null;
+
+    const Select = <TValue,>({ value, onValueChange, children, placeholder }: MockSelectProps<TValue>) => {
+        const options = React.Children.toArray(children) as React.ReactElement<MockSelectOptionProps<TValue>>[];
+        const normalizedValue = value === undefined ? '' : String(value);
+
+        return (
+            <select
+                data-testid="program-select"
+                aria-label={placeholder}
+                value={normalizedValue}
+                onChange={(event: ChangeEvent<HTMLSelectElement>) => {
+                    const nextValue = event.target.value === '' ? undefined : Number(event.target.value);
+                    onValueChange(nextValue as TValue);
+                }}
+            >
+                {options.map((option) => (
+                    <option
+                        key={String(option.props.value)}
+                        value={option.props.value === undefined ? '' : String(option.props.value)}
+                    >
+                        {option.props.name}
+                    </option>
+                ))}
+            </select>
+        );
+    };
+
+    Select.Option = Option;
+
+    return { Select };
+});
+
+describe('ProgramExpensesSection', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseDataFetchResult = {
+            data: MOCK_PROGRAM_EXPENSES_DATA,
+            isLoading: false,
+        };
+        mockUseDataFetch.mockImplementation(() => mockUseDataFetchResult);
+    });
+
+    it('should render loader during initial loading', () => {
+        mockUseDataFetchResult = {
+            data: {
+                exchangeRate: null,
+                programs: [],
+                summary: {
+                    totalAmountUah: 0,
+                    totalAmountUsd: 0,
+                },
+                records: [],
+            },
+            isLoading: true,
+        };
+
+        render(<ProgramExpensesSection />);
+
+        expect(screen.getByTestId('inline-loader')).toBeInTheDocument();
+        expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    });
+
+    it('should render summary, toolbar and all records by default', () => {
+        render(<ProgramExpensesSection />);
+
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.SUMMARY_CARD.TITLE)).toBeInTheDocument();
+        expect(screen.getByText('41.25')).toBeInTheDocument();
+
+        const table = screen.getByRole('table');
+        const rows = within(table).getAllByRole('row');
+
+        expect(rows).toHaveLength(4);
+        expect(within(table).getAllByText('Program A')).toHaveLength(2);
+        expect(within(table).getByText('Program B')).toBeInTheDocument();
+    });
+
+    it('should filter table records by selected program', () => {
+        render(<ProgramExpensesSection />);
+
+        fireEvent.change(screen.getByTestId('program-select'), {
+            target: { value: '2' },
+        });
+
+        const table = screen.getByRole('table');
+        const rows = within(table).getAllByRole('row');
+
+        expect(rows).toHaveLength(2);
+        expect(within(table).getByText('Program B')).toBeInTheDocument();
+        expect(within(table).queryByText('2024')).not.toBeInTheDocument();
+    });
+
+    it('should pass fetch handler that calls ProgramExpensesApi.getReadOnlyData', async () => {
+        mockGetReadOnlyData.mockResolvedValue(MOCK_PROGRAM_EXPENSES_DATA);
+
+        render(<ProgramExpensesSection />);
+
+        const useDataFetchProps = mockUseDataFetch.mock.calls[0][0] as {
+            fetchHandler: (options?: unknown) => Promise<ProgramExpensesReadOnlyData>;
+        };
+
+        await useDataFetchProps.fetchHandler();
+        await useDataFetchProps.fetchHandler({ test: true });
+
+        expect(mockGetReadOnlyData).toHaveBeenCalledWith({}, {});
+        expect(ProgramExpensesApi.getReadOnlyData).toBeDefined();
+        expect(mockGetReadOnlyData).toHaveBeenCalledWith({}, { test: true });
+    });
+});

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
@@ -77,7 +77,7 @@ jest.mock('@/assets/icons/not-found.svg', () => ({
 }));
 
 jest.mock('@/components/common/select/Select', () => {
-    const React = require('react') as typeof import('react');
+    const React = require('react');
 
     interface MockSelectProps<TValue> {
         value: TValue;

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
@@ -1,0 +1,71 @@
+import { useCallback, useMemo, useState } from 'react';
+import { InlineLoader } from '@/components/common/inline-loader/InlineLoader';
+import { useDataFetch } from '@/hooks/common/use-data-fetch/useDataFetch';
+import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
+import { ProgramExpensesApi } from '@/services/api/admin/reports/program-expenses-api';
+import { ProgramExpensesReadOnlyData } from '@/types/admin/reports';
+import { ProgramExpensesToolbar } from './components/program-expenses-toolbar/ProgramExpensesToolbar';
+import { ProgramExpensesSummaryCard } from './components/program-expenses-summary-card/ProgramExpensesSummaryCard';
+import { ProgramExpensesTable } from './components/program-expenses-table/ProgramExpensesTable';
+import styles from './ProgramExpensesSection.module.scss';
+
+const INITIAL_PROGRAM_EXPENSES_DATA: ProgramExpensesReadOnlyData = {
+    exchangeRate: null,
+    programs: [],
+    summary: {
+        totalAmountUah: 0,
+        totalAmountUsd: 0,
+    },
+    records: [],
+};
+
+export const ProgramExpensesSection = () => {
+    const adminClient = useAdminClient();
+    const [selectedProgramId, setSelectedProgramId] = useState<number | undefined>(undefined);
+
+    const fetchReadOnlyData = useCallback(
+        (options = {}) => ProgramExpensesApi.getReadOnlyData(adminClient, options),
+        [adminClient],
+    );
+
+    const { data, isLoading } = useDataFetch<ProgramExpensesReadOnlyData>({
+        initialData: INITIAL_PROGRAM_EXPENSES_DATA,
+        fetchHandler: fetchReadOnlyData,
+    });
+
+    const filteredRecords = useMemo(() => {
+        if (!selectedProgramId) {
+            return data.records;
+        }
+
+        return data.records.filter((record) => record.programId === selectedProgramId);
+    }, [data.records, selectedProgramId]);
+
+    const isInitialLoading = isLoading && data.records.length === 0 && data.programs.length === 0;
+
+    if (isInitialLoading) {
+        return (
+            <div className={styles.section}>
+                <div className={styles['loader-container']}>
+                    <InlineLoader size={3} />
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className={styles.section}>
+            <ProgramExpensesSummaryCard summary={data.summary} />
+
+            <div className={styles.filters}>
+                <ProgramExpensesToolbar
+                    programs={data.programs}
+                    selectedProgramId={selectedProgramId}
+                    exchangeRate={data.exchangeRate}
+                    onProgramChange={setSelectedProgramId}
+                />
+                <ProgramExpensesTable records={filteredRecords} />
+            </div>
+        </div>
+    );
+};

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-summary-card/ProgramExpensesSummaryCard.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-summary-card/ProgramExpensesSummaryCard.module.scss
@@ -1,0 +1,51 @@
+@use '@/assets/sass/variables/colors' as c;
+@use '@/assets/sass/variables/typography' as t;
+
+.summary-card {
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-start;
+    gap: 20px;
+    width: 271px;
+    min-width: 200px;
+    min-height: 163px;
+    padding: 20px;
+    background: c.$white;
+    border-radius: 16px;
+    box-shadow: 0 24px 48px -12px rgba(c.$bluish-black, 0.2);
+}
+
+.summary-title {
+    display: flex;
+    align-items: center;
+    width: 240px;
+    min-height: 56px;
+    font-family: t.$font-family-base;
+    font-weight: t.$fw-semibold;
+    font-size: 22px;
+    line-height: 28px;
+    letter-spacing: t.$sub2-spacing;
+    color: c.$graphite-black;
+    text-transform: uppercase;
+}
+
+.summary-amounts {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    width: 240px;
+}
+
+.summary-amount {
+    display: flex;
+    align-items: center;
+    min-height: 20px;
+    font-family: t.$font-family-base;
+    font-weight: t.$fw-regular;
+    font-size: t.$sub2-size;
+    line-height: 20px;
+    letter-spacing: t.$sub2-spacing;
+    color: c.$graphite-black;
+}

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-summary-card/ProgramExpensesSummaryCard.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-summary-card/ProgramExpensesSummaryCard.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ProgramExpensesSummaryCard } from './ProgramExpensesSummaryCard';
-import { PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
 
 describe('ProgramExpensesSummaryCard', () => {
     const normalizeText = (value: string) => value.replaceAll('\u00A0', ' ').replaceAll(/\s+/g, ' ').trim();
@@ -34,11 +34,11 @@ describe('ProgramExpensesSummaryCard', () => {
             .map((element) => normalizeText(element.textContent ?? ''))
             .filter(
                 (text) =>
-                    text.includes(PROGRAM_EXPENSES_TEXT.SUMMARY_CARD.AMOUNT_SUFFIX_UAH) ||
-                    text.includes(PROGRAM_EXPENSES_TEXT.SUMMARY_CARD.AMOUNT_SUFFIX_USD),
+                    text.includes(FUNDS_EXPENDITURES_TEXT.SUMMARY_CARDS.AMOUNT_SUFFIX_UAH) ||
+                    text.includes(FUNDS_EXPENDITURES_TEXT.SUMMARY_CARDS.AMOUNT_SUFFIX_USD),
             );
 
-        expect(amountTexts).toContain(`7 265 ${PROGRAM_EXPENSES_TEXT.SUMMARY_CARD.AMOUNT_SUFFIX_UAH}`);
-        expect(amountTexts).toContain(`4 200 ${PROGRAM_EXPENSES_TEXT.SUMMARY_CARD.AMOUNT_SUFFIX_USD}`);
+        expect(amountTexts).toContain(`7 265 ${FUNDS_EXPENDITURES_TEXT.SUMMARY_CARDS.AMOUNT_SUFFIX_UAH}`);
+        expect(amountTexts).toContain(`4 200 ${FUNDS_EXPENDITURES_TEXT.SUMMARY_CARDS.AMOUNT_SUFFIX_USD}`);
     });
 });

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-summary-card/ProgramExpensesSummaryCard.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-summary-card/ProgramExpensesSummaryCard.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ProgramExpensesSummaryCard } from './ProgramExpensesSummaryCard';
+import { PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+
+describe('ProgramExpensesSummaryCard', () => {
+    const normalizeText = (value: string) => value.replaceAll('\u00A0', ' ').replaceAll(/\s+/g, ' ').trim();
+
+    it('should render summary title', () => {
+        render(
+            <ProgramExpensesSummaryCard
+                summary={{
+                    totalAmountUah: 7265,
+                    totalAmountUsd: 4200,
+                }}
+            />,
+        );
+
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.SUMMARY_CARD.TITLE)).toBeInTheDocument();
+    });
+
+    it('should render formatted amounts with suffixes', () => {
+        const { container } = render(
+            <ProgramExpensesSummaryCard
+                summary={{
+                    totalAmountUah: 7265,
+                    totalAmountUsd: 4200,
+                }}
+            />,
+        );
+
+        const amountElements = container.querySelectorAll('span');
+        const amountTexts = Array.from(amountElements)
+            .map((element) => normalizeText(element.textContent ?? ''))
+            .filter(
+                (text) =>
+                    text.includes(PROGRAM_EXPENSES_TEXT.SUMMARY_CARD.AMOUNT_SUFFIX_UAH) ||
+                    text.includes(PROGRAM_EXPENSES_TEXT.SUMMARY_CARD.AMOUNT_SUFFIX_USD),
+            );
+
+        expect(amountTexts).toContain(`7 265 ${PROGRAM_EXPENSES_TEXT.SUMMARY_CARD.AMOUNT_SUFFIX_UAH}`);
+        expect(amountTexts).toContain(`4 200 ${PROGRAM_EXPENSES_TEXT.SUMMARY_CARD.AMOUNT_SUFFIX_USD}`);
+    });
+});

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-summary-card/ProgramExpensesSummaryCard.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-summary-card/ProgramExpensesSummaryCard.tsx
@@ -1,4 +1,4 @@
-import { PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
 import { ProgramExpensesSummary } from '@/types/admin/reports';
 import { formatSummaryAmount } from '@/utils/functions/format-summary-amount/format-summary-amount';
 import styles from './ProgramExpensesSummaryCard.module.scss';
@@ -13,10 +13,12 @@ export const ProgramExpensesSummaryCard = ({ summary }: ProgramExpensesSummaryCa
             <span className={styles['summary-title']}>{PROGRAM_EXPENSES_TEXT.SUMMARY_CARD.TITLE}</span>
             <div className={styles['summary-amounts']}>
                 <span className={styles['summary-amount']}>
-                    {formatSummaryAmount(summary.totalAmountUah)} {PROGRAM_EXPENSES_TEXT.SUMMARY_CARD.AMOUNT_SUFFIX_UAH}
+                    {formatSummaryAmount(summary.totalAmountUah)}{' '}
+                    {FUNDS_EXPENDITURES_TEXT.SUMMARY_CARDS.AMOUNT_SUFFIX_UAH}
                 </span>
                 <span className={styles['summary-amount']}>
-                    {formatSummaryAmount(summary.totalAmountUsd)} {PROGRAM_EXPENSES_TEXT.SUMMARY_CARD.AMOUNT_SUFFIX_USD}
+                    {formatSummaryAmount(summary.totalAmountUsd)}{' '}
+                    {FUNDS_EXPENDITURES_TEXT.SUMMARY_CARDS.AMOUNT_SUFFIX_USD}
                 </span>
             </div>
         </div>

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-summary-card/ProgramExpensesSummaryCard.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-summary-card/ProgramExpensesSummaryCard.tsx
@@ -1,0 +1,24 @@
+import { PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+import { ProgramExpensesSummary } from '@/types/admin/reports';
+import { formatSummaryAmount } from '@/utils/functions/format-summary-amount/format-summary-amount';
+import styles from './ProgramExpensesSummaryCard.module.scss';
+
+interface ProgramExpensesSummaryCardProps {
+    summary: ProgramExpensesSummary;
+}
+
+export const ProgramExpensesSummaryCard = ({ summary }: ProgramExpensesSummaryCardProps) => {
+    return (
+        <div className={styles['summary-card']}>
+            <span className={styles['summary-title']}>{PROGRAM_EXPENSES_TEXT.SUMMARY_CARD.TITLE}</span>
+            <div className={styles['summary-amounts']}>
+                <span className={styles['summary-amount']}>
+                    {formatSummaryAmount(summary.totalAmountUah)} {PROGRAM_EXPENSES_TEXT.SUMMARY_CARD.AMOUNT_SUFFIX_UAH}
+                </span>
+                <span className={styles['summary-amount']}>
+                    {formatSummaryAmount(summary.totalAmountUsd)} {PROGRAM_EXPENSES_TEXT.SUMMARY_CARD.AMOUNT_SUFFIX_USD}
+                </span>
+            </div>
+        </div>
+    );
+};

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.module.scss
@@ -1,0 +1,118 @@
+@use '@/assets/sass/variables/colors' as c;
+@use '@/assets/sass/mixins/typography.mixins' as type;
+@use '@/assets/sass/variables/typography' as t;
+
+.table-wrapper {
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 347px;
+    overflow-x: auto;
+    background: c.$light-blue-25;
+    border: 1px solid c.$grey-500;
+    border-radius: 16px;
+    box-shadow: 0 24px 48px -12px rgba(c.$bluish-black, 0.2);
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+    table-layout: fixed;
+
+    thead tr {
+        height: 88px;
+    }
+}
+
+.column-year {
+    width: 19%;
+}
+
+.column-type {
+    width: 18%;
+}
+
+.column-program {
+    width: 24%;
+}
+
+.column-amount {
+    width: 19.5%;
+}
+
+.th {
+    @include type.subtitle-1-medium;
+    padding: 30px 20px;
+    text-align: left;
+    line-height: 24px;
+    color: rgba(c.$graphite-black, 0.88);
+    white-space: nowrap;
+}
+
+.tr {
+    height: 65px;
+    background: c.$white;
+    border-top: 1px solid c.$grey-500;
+}
+
+.td {
+    @include type.subtitle-2-medium;
+    box-sizing: border-box;
+    height: 65px;
+    padding: 13px 20px;
+    vertical-align: middle;
+    font-weight: 400;
+    line-height: 24px;
+    color: c.$graphite-black;
+    white-space: nowrap;
+}
+
+.type-chip {
+    box-sizing: border-box;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    min-width: 106px;
+    height: 24px;
+    padding: 0 10px;
+    border: 1px solid rgba(c.$error, 0.6);
+    border-radius: 50px;
+    background: rgba(c.$error, 0.5);
+    font-family: t.$font-family-base;
+    font-weight: t.$fw-light;
+    color: c.$white;
+    font-size: 13px;
+    line-height: 15px;
+    letter-spacing: t.$small-spacing;
+    text-align: center;
+}
+
+.empty-cell {
+    padding: 48px 20px;
+    text-align: center;
+}
+
+.empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+}
+
+.empty-state-image {
+    width: 180px;
+    height: auto;
+}
+
+.empty-state-message {
+    @include type.subtitle-2-medium;
+    margin: 0;
+    font-weight: 400;
+    line-height: 24px;
+    color: c.$graphite-black;
+}
+
+@media (max-width: 1200px) {
+    .table {
+        min-width: 1200px;
+    }
+}

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { ProgramExpensesTable } from './ProgramExpensesTable';
 import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
 
@@ -34,11 +35,11 @@ describe('ProgramExpensesTable', () => {
     it('should render table headers', () => {
         render(<ProgramExpensesTable records={records} />);
 
-        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.REPORTING_YEAR)).toBeInTheDocument();
-        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.TYPE)).toBeInTheDocument();
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.REPORTING_YEAR)).toBeInTheDocument();
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.TYPE)).toBeInTheDocument();
         expect(screen.getByText(PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.PROGRAM)).toBeInTheDocument();
-        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.AMOUNT_UAH)).toBeInTheDocument();
-        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.AMOUNT_USD)).toBeInTheDocument();
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_UAH)).toBeInTheDocument();
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_USD)).toBeInTheDocument();
     });
 
     it('should render formatted record values', () => {
@@ -47,7 +48,7 @@ describe('ProgramExpensesTable', () => {
 
         expect(within(table).getByText('2025')).toBeInTheDocument();
         expect(within(table).getByText('Program A')).toBeInTheDocument();
-        expect(within(table).getAllByText(PROGRAM_EXPENSES_TEXT.TABLE.TYPE_LABEL)).toHaveLength(2);
+        expect(within(table).getAllByText(COMMON_TEXT_ADMIN.TAB.PROGRAMS)).toHaveLength(2);
 
         const normalizedText = normalizeText(container.textContent ?? '');
         expect(normalizedText).toContain('7 265');

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ProgramExpensesTable } from './ProgramExpensesTable';
+import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+
+jest.mock('@/assets/icons/not-found.svg', () => ({
+    ReactComponent: () => <svg data-testid="not-found-icon" />,
+}));
+
+describe('ProgramExpensesTable', () => {
+    const records = [
+        {
+            id: 1,
+            programId: 100,
+            programName: 'Program A',
+            type: 'expense' as const,
+            reportingYear: '2025',
+            amountUah: '7 265',
+            amountUsd: '4 200.5',
+        },
+        {
+            id: 2,
+            programId: 101,
+            programName: 'Program B',
+            type: 'expense' as const,
+            reportingYear: '2024',
+            amountUah: '3000',
+            amountUsd: '1250',
+        },
+    ];
+
+    const normalizeText = (value: string) => value.replaceAll('\u00A0', ' ').replaceAll(/\s+/g, ' ').trim();
+
+    it('should render table headers', () => {
+        render(<ProgramExpensesTable records={records} />);
+
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.REPORTING_YEAR)).toBeInTheDocument();
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.TYPE)).toBeInTheDocument();
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.PROGRAM)).toBeInTheDocument();
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.AMOUNT_UAH)).toBeInTheDocument();
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.AMOUNT_USD)).toBeInTheDocument();
+    });
+
+    it('should render formatted record values', () => {
+        const { container } = render(<ProgramExpensesTable records={records} />);
+        const table = screen.getByRole('table');
+
+        expect(within(table).getByText('2025')).toBeInTheDocument();
+        expect(within(table).getByText('Program A')).toBeInTheDocument();
+        expect(within(table).getAllByText(PROGRAM_EXPENSES_TEXT.TABLE.TYPE_LABEL)).toHaveLength(2);
+
+        const normalizedText = normalizeText(container.textContent ?? '');
+        expect(normalizedText).toContain('7 265');
+        expect(normalizedText).toContain('4 200');
+    });
+
+    it('should render empty state when records are missing', () => {
+        render(<ProgramExpensesTable records={[]} />);
+
+        expect(screen.getByTestId('not-found-icon')).toBeInTheDocument();
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.MESSAGE)).toBeInTheDocument();
+    });
+});

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.tsx
@@ -1,3 +1,4 @@
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
 import { ProgramExpensesRecord } from '@/types/admin/reports';
 import { ReactComponent as NotFoundIcon } from '@/assets/icons/not-found.svg';
@@ -22,11 +23,11 @@ export const ProgramExpensesTable = ({ records }: ProgramExpensesTableProps) => 
                 </colgroup>
                 <thead>
                     <tr>
-                        <th className={styles.th}>{PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.REPORTING_YEAR}</th>
-                        <th className={styles.th}>{PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.TYPE}</th>
+                        <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.REPORTING_YEAR}</th>
+                        <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.TYPE}</th>
                         <th className={styles.th}>{PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.PROGRAM}</th>
-                        <th className={styles.th}>{PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.AMOUNT_UAH}</th>
-                        <th className={styles.th}>{PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.AMOUNT_USD}</th>
+                        <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_UAH}</th>
+                        <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_USD}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -46,9 +47,7 @@ export const ProgramExpensesTable = ({ records }: ProgramExpensesTableProps) => 
                             <tr key={record.id} className={styles.tr}>
                                 <td className={styles.td}>{record.reportingYear}</td>
                                 <td className={styles.td}>
-                                    <span className={styles['type-chip']}>
-                                        {PROGRAM_EXPENSES_TEXT.TABLE.TYPE_LABEL}
-                                    </span>
+                                    <span className={styles['type-chip']}>{COMMON_TEXT_ADMIN.TAB.PROGRAMS}</span>
                                 </td>
                                 <td className={styles.td}>{record.programName}</td>
                                 <td className={styles.td}>{formatSummaryAmount(parseAmount(record.amountUah))}</td>

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.tsx
@@ -1,0 +1,63 @@
+import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+import { ProgramExpensesRecord } from '@/types/admin/reports';
+import { ReactComponent as NotFoundIcon } from '@/assets/icons/not-found.svg';
+import { formatSummaryAmount } from '@/utils/functions/format-summary-amount/format-summary-amount';
+import { parseAmount } from '@/utils/functions/parse-amount/parse-amount';
+import styles from './ProgramExpensesTable.module.scss';
+
+interface ProgramExpensesTableProps {
+    records: ProgramExpensesRecord[];
+}
+
+export const ProgramExpensesTable = ({ records }: ProgramExpensesTableProps) => {
+    return (
+        <div className={styles['table-wrapper']}>
+            <table className={styles.table}>
+                <colgroup>
+                    <col className={styles['column-year']} />
+                    <col className={styles['column-type']} />
+                    <col className={styles['column-program']} />
+                    <col className={styles['column-amount']} />
+                    <col className={styles['column-amount']} />
+                </colgroup>
+                <thead>
+                    <tr>
+                        <th className={styles.th}>{PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.REPORTING_YEAR}</th>
+                        <th className={styles.th}>{PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.TYPE}</th>
+                        <th className={styles.th}>{PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.PROGRAM}</th>
+                        <th className={styles.th}>{PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.AMOUNT_UAH}</th>
+                        <th className={styles.th}>{PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.AMOUNT_USD}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {records.length === 0 ? (
+                        <tr>
+                            <td className={styles['empty-cell']} colSpan={5}>
+                                <div className={styles['empty-state']}>
+                                    <NotFoundIcon className={styles['empty-state-image']} />
+                                    <p className={styles['empty-state-message']}>
+                                        {FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.MESSAGE}
+                                    </p>
+                                </div>
+                            </td>
+                        </tr>
+                    ) : (
+                        records.map((record) => (
+                            <tr key={record.id} className={styles.tr}>
+                                <td className={styles.td}>{record.reportingYear}</td>
+                                <td className={styles.td}>
+                                    <span className={styles['type-chip']}>
+                                        {PROGRAM_EXPENSES_TEXT.TABLE.TYPE_LABEL}
+                                    </span>
+                                </td>
+                                <td className={styles.td}>{record.programName}</td>
+                                <td className={styles.td}>{formatSummaryAmount(parseAmount(record.amountUah))}</td>
+                                <td className={styles.td}>{formatSummaryAmount(parseAmount(record.amountUsd))}</td>
+                            </tr>
+                        ))
+                    )}
+                </tbody>
+            </table>
+        </div>
+    );
+};

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.module.scss
@@ -82,6 +82,7 @@
 
 .program-option {
     @include type.body-2-regular;
+
     min-height: 56px;
     padding: 8px 12px;
     color: c.$dropdown-text;
@@ -107,6 +108,7 @@
 
 .exchange-rate-label {
     @include type.small-text-medium;
+
     display: flex;
     align-items: center;
     letter-spacing: 0.1px;
@@ -115,6 +117,7 @@
 
 .exchange-rate-value {
     @include type.small-text-medium;
+
     box-sizing: border-box;
     display: inline-flex;
     justify-content: center;

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.module.scss
@@ -1,0 +1,121 @@
+@use '@/assets/sass/variables/colors' as c;
+@use '@/assets/sass/mixins/typography.mixins' as type;
+@use '@/assets/sass/variables/typography' as t;
+
+.toolbar-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 24px;
+    width: 100%;
+    min-height: 60px;
+}
+
+.program-select {
+    width: 200px;
+
+    :global(.select-options) {
+        top: 60px;
+        width: 200px;
+        min-width: 200px;
+        border: 1px solid c.$blue-900;
+        border-radius: 12px;
+        box-shadow: 0 24px 48px -12px rgba(c.$bluish-black, 0.2);
+        overflow: hidden;
+    }
+}
+
+.program-select-head {
+    box-sizing: border-box;
+    width: 200px;
+    height: 60px;
+    padding: 8px 10px;
+    border: 1px solid c.$blue-900;
+    border-radius: 12px;
+    background: c.$white;
+    font-family: t.$font-family-base;
+    font-weight: t.$fw-semibold;
+    font-size: t.$sub2-size;
+    color: c.$blue-900;
+    line-height: 30px;
+    letter-spacing: t.$sub2-spacing;
+
+    &:hover {
+        background: c.$white;
+    }
+
+    span {
+        display: inline-flex;
+        align-items: center;
+        width: 94px;
+        text-align: center;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    svg {
+        width: 26px;
+        height: 26px;
+        flex-shrink: 0;
+    }
+}
+
+.program-option {
+    height: 60px;
+    padding: 8px 10px;
+    font-family: t.$font-family-base;
+    font-weight: t.$fw-semibold;
+    font-size: t.$sub2-size;
+    color: c.$blue-900;
+    line-height: 30px;
+    letter-spacing: t.$sub2-spacing;
+
+    &:global(.select-options-selected) {
+        background-color: c.$blue-50;
+    }
+}
+
+.exchange-rate {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 8px;
+    margin-left: auto;
+}
+
+.exchange-rate-label {
+    @include type.small-text-medium;
+    display: flex;
+    align-items: center;
+    letter-spacing: 0.1px;
+    color: c.$grey-900;
+}
+
+.exchange-rate-value {
+    @include type.small-text-medium;
+    box-sizing: border-box;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    min-width: 119px;
+    height: 32px;
+    padding: 6px 12px;
+    border: 1px solid c.$bluish-black;
+    border-radius: 8px;
+    background: c.$grey-600;
+    letter-spacing: 0.1px;
+    color: c.$blue-900;
+}
+
+@media (max-width: 1200px) {
+    .toolbar-row {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .exchange-rate {
+        align-items: flex-start;
+        margin-left: 0;
+    }
+}

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.module.scss
@@ -15,13 +15,33 @@
     width: 200px;
 
     :global(.select-options) {
-        top: 60px;
+        top: calc(100% + 4px);
         width: 200px;
-        min-width: 200px;
-        border: 1px solid c.$blue-900;
-        border-radius: 12px;
-        box-shadow: 0 24px 48px -12px rgba(c.$bluish-black, 0.2);
-        overflow: hidden;
+        max-height: 244px;
+        padding: 8px 0;
+        border: none;
+        border-radius: 4px;
+        box-shadow:
+            0 1px 2px rgba(c.$black, 0.3),
+            0 2px 6px 2px rgba(c.$black, 0.15);
+        overflow-y: auto;
+        scrollbar-width: thin;
+        scrollbar-color: c.$grey-800 transparent;
+
+        &::-webkit-scrollbar {
+            width: 12px;
+        }
+
+        &::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        &::-webkit-scrollbar-thumb {
+            background: c.$grey-800;
+            border: 4px solid transparent;
+            border-radius: 100px;
+            background-clip: content-box;
+        }
     }
 }
 
@@ -47,7 +67,6 @@
     span {
         display: inline-flex;
         align-items: center;
-        width: 94px;
         text-align: center;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -62,17 +81,19 @@
 }
 
 .program-option {
-    height: 60px;
-    padding: 8px 10px;
-    font-family: t.$font-family-base;
-    font-weight: t.$fw-semibold;
-    font-size: t.$sub2-size;
-    color: c.$blue-900;
-    line-height: 30px;
-    letter-spacing: t.$sub2-spacing;
+    @include type.body-2-regular;
+    min-height: 56px;
+    padding: 8px 12px;
+    color: c.$dropdown-text;
+    letter-spacing: 0.5px;
 
     &:global(.select-options-selected) {
-        background-color: c.$blue-50;
+        background-color: c.$dropdown-hover;
+
+        span {
+            color: c.$dropdown-text;
+            border-bottom: none;
+        }
     }
 }
 

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ProgramExpensesToolbar } from './ProgramExpensesToolbar';
+import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+
+jest.mock('@/components/common/select/Select', () => {
+    const SelectOption = (_props: { value: unknown; name: string }) => null;
+
+    const MockSelect = ({
+        onValueChange,
+        placeholder,
+    }: {
+        onValueChange: (value: unknown) => void;
+        placeholder?: string;
+    }) => {
+        return (
+            <div data-testid="program-expenses-select">
+                <span>{placeholder}</span>
+                <button type="button" data-testid="program-filter-all" onClick={() => onValueChange(undefined)}>
+                    All
+                </button>
+                <button type="button" data-testid="program-filter-1" onClick={() => onValueChange(1)}>
+                    Program 1
+                </button>
+            </div>
+        );
+    };
+
+    MockSelect.Option = SelectOption;
+
+    return { Select: MockSelect };
+});
+
+describe('ProgramExpensesToolbar', () => {
+    const defaultProps = {
+        programs: [
+            { id: 1, name: 'Program 1' },
+            { id: 2, name: 'Program 2' },
+        ],
+        selectedProgramId: undefined,
+        exchangeRate: '42.15',
+        onProgramChange: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should render program filter placeholder', () => {
+        render(<ProgramExpensesToolbar {...defaultProps} />);
+
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.FILTER.PLACEHOLDER)).toBeInTheDocument();
+    });
+
+    it('should render exchange rate label and value', () => {
+        render(<ProgramExpensesToolbar {...defaultProps} />);
+
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL)).toBeInTheDocument();
+        expect(screen.getByText('42.15')).toBeInTheDocument();
+    });
+
+    it('should render fallback value when exchange rate is null', () => {
+        render(<ProgramExpensesToolbar {...defaultProps} exchangeRate={null} />);
+
+        expect(screen.getByText('-')).toBeInTheDocument();
+    });
+
+    it('should call onProgramChange when program is selected', () => {
+        render(<ProgramExpensesToolbar {...defaultProps} />);
+
+        fireEvent.click(screen.getByTestId('program-filter-1'));
+
+        expect(defaultProps.onProgramChange).toHaveBeenCalledWith(1);
+    });
+
+    it('should call onProgramChange with undefined for all option', () => {
+        render(<ProgramExpensesToolbar {...defaultProps} />);
+
+        fireEvent.click(screen.getByTestId('program-filter-all'));
+
+        expect(defaultProps.onProgramChange).toHaveBeenCalledWith(undefined);
+    });
+});

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.test.tsx
@@ -49,7 +49,7 @@ describe('ProgramExpensesToolbar', () => {
     it('should render program filter placeholder', () => {
         render(<ProgramExpensesToolbar {...defaultProps} />);
 
-        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.FILTER.PLACEHOLDER)).toBeInTheDocument();
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.PROGRAM)).toBeInTheDocument();
     });
 
     it('should render exchange rate label and value', () => {

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.tsx
@@ -24,9 +24,9 @@ export const ProgramExpensesToolbar = ({
                 className={styles['program-select']}
                 headClassName={styles['program-select-head']}
                 optionClassName={styles['program-option']}
-                placeholder={PROGRAM_EXPENSES_TEXT.FILTER.PLACEHOLDER}
+                placeholder={PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.PROGRAM}
             >
-                <Select.Option value={undefined} name={PROGRAM_EXPENSES_TEXT.FILTER.ALL_OPTION} />
+                <Select.Option value={undefined} name={FUNDS_EXPENDITURES_TEXT.FILTER.ALL_OPTION} />
                 {programs.map((program) => (
                     <Select.Option key={program.id} value={program.id} name={program.name} />
                 ))}

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.tsx
@@ -1,0 +1,41 @@
+import { Select } from '@/components/common/select/Select';
+import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+import { ProgramExpensesProgram } from '@/types/admin/reports';
+import styles from './ProgramExpensesToolbar.module.scss';
+
+interface ProgramExpensesToolbarProps {
+    programs: ProgramExpensesProgram[];
+    selectedProgramId: number | undefined;
+    exchangeRate: string | null;
+    onProgramChange: (value: number | undefined) => void;
+}
+
+export const ProgramExpensesToolbar = ({
+    programs,
+    selectedProgramId,
+    exchangeRate,
+    onProgramChange,
+}: ProgramExpensesToolbarProps) => {
+    return (
+        <div className={styles['toolbar-row']}>
+            <Select<number | undefined>
+                value={selectedProgramId}
+                onValueChange={onProgramChange}
+                className={styles['program-select']}
+                headClassName={styles['program-select-head']}
+                optionClassName={styles['program-option']}
+                placeholder={PROGRAM_EXPENSES_TEXT.FILTER.PLACEHOLDER}
+            >
+                <Select.Option value={undefined} name={PROGRAM_EXPENSES_TEXT.FILTER.ALL_OPTION} />
+                {programs.map((program) => (
+                    <Select.Option key={program.id} value={program.id} name={program.name} />
+                ))}
+            </Select>
+
+            <div className={styles['exchange-rate']}>
+                <span className={styles['exchange-rate-label']}>{FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL}</span>
+                <span className={styles['exchange-rate-value']}>{exchangeRate ?? '-'}</span>
+            </div>
+        </div>
+    );
+};

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
@@ -5,6 +5,7 @@ import styles from './ReportAnalytics.module.scss';
 import './ReportAnalytics.scss';
 import { PdfFilesSection } from '../pdf-files-section/PdfFilesSection';
 import { FundsExpenditureSection } from '../funds-expenditures-section/FundsExpendituresSection';
+import { ProgramExpensesSection } from '../program-expenses-section/ProgramExpensesSection';
 
 interface ReportAnalyticsTab {
     id: 'income-expenses' | 'program-expenses' | 'pdf-files';
@@ -12,9 +13,9 @@ interface ReportAnalyticsTab {
 }
 
 const ANALYTICS_TABS: ReportAnalyticsTab[] = [
-    { id: 'income-expenses', label: 'Доходи та витрати' },
-    { id: 'program-expenses', label: 'Програмні витрати' },
-    { id: 'pdf-files', label: 'PDF Файли' },
+    { id: 'income-expenses', label: REPORTS_TEXT.REPORT_AND_ANALYTICS.TAB.INCOME_EXPENSES },
+    { id: 'program-expenses', label: REPORTS_TEXT.REPORT_AND_ANALYTICS.TAB.PROGRAM_EXPENSES },
+    { id: 'pdf-files', label: REPORTS_TEXT.REPORT_AND_ANALYTICS.TAB.PDF_FILES },
 ];
 
 export const ReportAnalytics = () => {
@@ -34,7 +35,7 @@ export const ReportAnalytics = () => {
             <div className={styles['tab-content']}>
                 {activeTab.id === 'pdf-files' && <PdfFilesSection />}
                 {activeTab.id === 'income-expenses' && <FundsExpenditureSection />}
-                {activeTab.id === 'program-expenses' && <div></div>}
+                {activeTab.id === 'program-expenses' && <ProgramExpensesSection />}
             </div>
         </div>
     );

--- a/src/services/api/admin/reports/program-expenses-api.test.ts
+++ b/src/services/api/admin/reports/program-expenses-api.test.ts
@@ -1,0 +1,144 @@
+import { AxiosInstance } from 'axios';
+import { ProgramExpensesRecord } from '@/types/admin/reports';
+
+const loadProgramExpensesApi = (
+    records: Array<ProgramExpensesRecord & { isPublished: boolean }>,
+    exchangeRate = '42.15',
+) => {
+    jest.resetModules();
+    jest.doMock('@/utils/mock-data/admin/reports/program-expenses', () => ({
+        MOCK_PROGRAM_EXPENSES_EXCHANGE_RATE: exchangeRate,
+        MOCK_PROGRAM_EXPENSES_RECORDS: records,
+    }));
+
+    let api: typeof import('./program-expenses-api').ProgramExpensesApi;
+
+    jest.isolateModules(() => {
+        api = require('./program-expenses-api').ProgramExpensesApi;
+    });
+
+    return api!;
+};
+
+describe('ProgramExpensesApi', () => {
+    afterEach(() => {
+        jest.resetModules();
+        jest.dontMock('@/utils/mock-data/admin/reports/program-expenses');
+    });
+
+    it('should return only published records with computed programs and summary', async () => {
+        const api = loadProgramExpensesApi([
+            {
+                id: 1,
+                programId: 2,
+                programName: 'Program B',
+                type: 'expense',
+                reportingYear: '2025',
+                amountUah: '1 500',
+                amountUsd: '1000',
+                isPublished: true,
+            },
+            {
+                id: 2,
+                programId: 1,
+                programName: 'Program A',
+                type: 'expense',
+                reportingYear: '2025',
+                amountUah: '250',
+                amountUsd: '100.5',
+                isPublished: true,
+            },
+            {
+                id: 3,
+                programId: 1,
+                programName: 'Program A',
+                type: 'expense',
+                reportingYear: '2024',
+                amountUah: '2000',
+                amountUsd: '800',
+                isPublished: true,
+            },
+            {
+                id: 4,
+                programId: 3,
+                programName: 'Program C',
+                type: 'expense',
+                reportingYear: '2025',
+                amountUah: '999',
+                amountUsd: '999',
+                isPublished: false,
+            },
+        ]);
+
+        const result = await api.getReadOnlyData({} as AxiosInstance);
+
+        expect(result.exchangeRate).toBe('42.15');
+        expect(result.records).toEqual([
+            {
+                id: 2,
+                programId: 1,
+                programName: 'Program A',
+                type: 'expense',
+                reportingYear: '2025',
+                amountUah: '250',
+                amountUsd: '100.5',
+            },
+            {
+                id: 1,
+                programId: 2,
+                programName: 'Program B',
+                type: 'expense',
+                reportingYear: '2025',
+                amountUah: '1 500',
+                amountUsd: '1000',
+            },
+            {
+                id: 3,
+                programId: 1,
+                programName: 'Program A',
+                type: 'expense',
+                reportingYear: '2024',
+                amountUah: '2000',
+                amountUsd: '800',
+            },
+        ]);
+        expect(result.programs).toEqual([
+            { id: 1, name: 'Program A' },
+            { id: 2, name: 'Program B' },
+        ]);
+        expect(result.summary).toEqual({
+            totalAmountUah: 3750,
+            totalAmountUsd: 1900.5,
+        });
+    });
+
+    it('should return empty collections and zero summary when no records are published', async () => {
+        const api = loadProgramExpensesApi(
+            [
+                {
+                    id: 10,
+                    programId: 5,
+                    programName: 'Hidden Program',
+                    type: 'expense',
+                    reportingYear: '2025',
+                    amountUah: '100',
+                    amountUsd: '10',
+                    isPublished: false,
+                },
+            ],
+            '39.00',
+        );
+
+        const result = await api.getReadOnlyData({} as AxiosInstance);
+
+        expect(result).toEqual({
+            exchangeRate: '39.00',
+            programs: [],
+            summary: {
+                totalAmountUah: 0,
+                totalAmountUsd: 0,
+            },
+            records: [],
+        });
+    });
+});

--- a/src/services/api/admin/reports/program-expenses-api.ts
+++ b/src/services/api/admin/reports/program-expenses-api.ts
@@ -60,11 +60,11 @@ export const ProgramExpensesApi = {
         _client: AxiosInstance,
         _options: RequestOptions = {},
     ): Promise<ProgramExpensesReadOnlyData> => {
-        return Promise.resolve({
+        return {
             exchangeRate: MOCK_PROGRAM_EXPENSES_EXCHANGE_RATE,
             programs: PROGRAM_EXPENSES_PROGRAMS,
             summary: PROGRAM_EXPENSES_SUMMARY,
             records: PUBLISHED_PROGRAM_EXPENSES_RECORDS,
-        });
+        };
     },
 };

--- a/src/services/api/admin/reports/program-expenses-api.ts
+++ b/src/services/api/admin/reports/program-expenses-api.ts
@@ -1,0 +1,70 @@
+import { RequestOptions } from '@/types/common/api';
+import { ProgramExpensesProgram, ProgramExpensesReadOnlyData, ProgramExpensesSummary } from '@/types/admin/reports';
+import {
+    MOCK_PROGRAM_EXPENSES_EXCHANGE_RATE,
+    MOCK_PROGRAM_EXPENSES_RECORDS,
+} from '@/utils/mock-data/admin/reports/program-expenses';
+import { AxiosInstance } from 'axios';
+import { parseAmount } from '@/utils/functions/parse-amount/parse-amount';
+
+const getPublishedProgramExpensesRecords = () =>
+    MOCK_PROGRAM_EXPENSES_RECORDS.filter((record) => record.isPublished).sort((firstRecord, secondRecord) => {
+        const yearDifference =
+            Number.parseInt(secondRecord.reportingYear, 10) - Number.parseInt(firstRecord.reportingYear, 10);
+
+        if (yearDifference !== 0) {
+            return yearDifference;
+        }
+
+        return firstRecord.programName.localeCompare(secondRecord.programName, 'uk');
+    });
+
+const getPrograms = (): ProgramExpensesProgram[] => {
+    const uniqueProgramsMap = new Map<number, ProgramExpensesProgram>();
+
+    getPublishedProgramExpensesRecords().forEach((record) => {
+        uniqueProgramsMap.set(record.programId, {
+            id: record.programId,
+            name: record.programName,
+        });
+    });
+
+    return Array.from(uniqueProgramsMap.values()).sort((firstProgram, secondProgram) =>
+        firstProgram.name.localeCompare(secondProgram.name, 'uk'),
+    );
+};
+
+const getSummary = (): ProgramExpensesSummary => {
+    return getPublishedProgramExpensesRecords().reduce<ProgramExpensesSummary>(
+        (summary, record) => ({
+            totalAmountUah: summary.totalAmountUah + parseAmount(record.amountUah),
+            totalAmountUsd: summary.totalAmountUsd + parseAmount(record.amountUsd),
+        }),
+        {
+            totalAmountUah: 0,
+            totalAmountUsd: 0,
+        },
+    );
+};
+
+const PUBLISHED_PROGRAM_EXPENSES_RECORDS = getPublishedProgramExpensesRecords().map(
+    ({ isPublished: _isPublished, ...record }) => record,
+);
+
+const PROGRAM_EXPENSES_PROGRAMS = getPrograms();
+
+const PROGRAM_EXPENSES_SUMMARY = getSummary();
+
+export const ProgramExpensesApi = {
+    getReadOnlyData: async (
+        _client: AxiosInstance,
+        _options: RequestOptions = {},
+    ): Promise<ProgramExpensesReadOnlyData> => {
+        return Promise.resolve({
+            exchangeRate: MOCK_PROGRAM_EXPENSES_EXCHANGE_RATE,
+            programs: PROGRAM_EXPENSES_PROGRAMS,
+            summary: PROGRAM_EXPENSES_SUMMARY,
+            records: PUBLISHED_PROGRAM_EXPENSES_RECORDS,
+        });
+    },
+};

--- a/src/types/admin/reports.ts
+++ b/src/types/admin/reports.ts
@@ -169,3 +169,30 @@ export interface FundsExpendituresSummary {
     incomeCategories: number;
     expenseCategories: number;
 }
+
+export interface ProgramExpensesProgram {
+    id: number;
+    name: string;
+}
+
+export interface ProgramExpensesRecord {
+    id: number;
+    programId: number;
+    programName: string;
+    type: FundsExpendituresTransactionType;
+    reportingYear: string;
+    amountUah: string;
+    amountUsd: string;
+}
+
+export interface ProgramExpensesSummary {
+    totalAmountUah: number;
+    totalAmountUsd: number;
+}
+
+export interface ProgramExpensesReadOnlyData {
+    exchangeRate: string | null;
+    programs: ProgramExpensesProgram[];
+    summary: ProgramExpensesSummary;
+    records: ProgramExpensesRecord[];
+}

--- a/src/utils/mock-data/admin/reports/program-expenses.ts
+++ b/src/utils/mock-data/admin/reports/program-expenses.ts
@@ -1,0 +1,60 @@
+import { ProgramExpensesRecord } from '@/types/admin/reports';
+
+interface MockProgramExpensesRecord extends ProgramExpensesRecord {
+    isPublished: boolean;
+}
+
+export const MOCK_PROGRAM_EXPENSES_EXCHANGE_RATE = '42.15';
+
+export const MOCK_PROGRAM_EXPENSES_RECORDS: MockProgramExpensesRecord[] = [
+    {
+        id: 1,
+        programId: 101,
+        programName: 'Лікування дітей',
+        type: 'expense',
+        reportingYear: '2025',
+        amountUah: '1500',
+        amountUsd: '1000',
+        isPublished: true,
+    },
+    {
+        id: 2,
+        programId: 101,
+        programName: 'Лікування дітей',
+        type: 'expense',
+        reportingYear: '2025',
+        amountUah: '1765',
+        amountUsd: '1200',
+        isPublished: true,
+    },
+    {
+        id: 3,
+        programId: 101,
+        programName: 'Лікування дітей',
+        type: 'expense',
+        reportingYear: '2025',
+        amountUah: '2000',
+        amountUsd: '1000',
+        isPublished: true,
+    },
+    {
+        id: 4,
+        programId: 101,
+        programName: 'Лікування дітей',
+        type: 'expense',
+        reportingYear: '2025',
+        amountUah: '2000',
+        amountUsd: '1000',
+        isPublished: true,
+    },
+    {
+        id: 5,
+        programId: 102,
+        programName: 'Реабілітація ветеранів',
+        type: 'expense',
+        reportingYear: '2025',
+        amountUah: '900',
+        amountUsd: '400',
+        isPublished: false,
+    },
+];


### PR DESCRIPTION
## JIRA or Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1755

## Description

Added the read-only Program Expenses sub-tab to Reports.
Implemented the Figma-based layout with a summary card, program filter, exchange rate display, and table with published records only.
Used mocked data for this UI until the backend endpoint is ready.

## How it looks
<img width="1459" height="712" alt="image" src="https://github.com/user-attachments/assets/2430e5f3-e325-4ea5-bf91-ed4a4268a952" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Program Expenses" reporting section with summary card (UAH & USD), program filter, exchange-rate display, and a detailed expenses table grouped by reporting year and type.

* **UI Copy**
  * Updated UAH currency label/suffix from "UA" to "UAH" across summary and table headers.

* **Tests**
  * Added comprehensive tests covering the new UI components, toolbar behavior, table/empty state, summary rendering, and read-only API outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->