### PR TITLE
Fix/issue 2124: add confirmation modal for saving program section

### DIFF
--- a/src/pages/admin/programs/components/program-form/ProgramForm.test.tsx
+++ b/src/pages/admin/programs/components/program-form/ProgramForm.test.tsx
@@ -176,6 +176,7 @@ jest.mock('../program-section-form/ProgramSectionForm', () => ({
         isDisabled,
         isNewSection,
         isReplacingTemplate,
+        onRequestSaveSection,
     }: any) => (
         <div
             data-testid="program-section-form"
@@ -257,6 +258,14 @@ jest.mock('../program-section-form/ProgramSectionForm', () => ({
                     Move Down
                 </button>
             )}
+
+            <button
+                type="button"
+                data-testid={`request-save-section-${section.id ?? section.template}`}
+                onClick={() => onRequestSaveSection?.({ onConfirm: jest.fn() })}
+            >
+                Request Save
+            </button>
         </div>
     ),
 }));
@@ -937,6 +946,26 @@ describe('ProgramForm', () => {
             await waitFor(() => {
                 expect(screen.getAllByTestId('program-section-form')).toHaveLength(1);
             });
+        });
+    });
+
+    it('calls onRequestSaveSection when ProgramSectionForm requests save confirmation', async () => {
+        const onRequestSaveSection = jest.fn();
+        const initialData = createInitialData({
+            sections: [{ id: 101, template: 1, order: 0, contents: [] } as CreateHippotherapyProgramSectionDto],
+        });
+
+        renderProgramForm({ initialData, onRequestSaveSection });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('program-section-form')).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByTestId('request-save-section-101'));
+
+        expect(onRequestSaveSection).toHaveBeenCalledTimes(1);
+        expect(onRequestSaveSection).toHaveBeenCalledWith({
+            onConfirm: expect.any(Function),
         });
     });
 });

--- a/src/pages/admin/programs/components/program-form/ProgramForm.tsx
+++ b/src/pages/admin/programs/components/program-form/ProgramForm.tsx
@@ -70,6 +70,7 @@ export interface ProgramFormProps {
     selectedLanguage?: string;
     onLanguageChange?: (language: string) => void;
     onRequestCancelSection?: (request: { type: SectionCancelActionType; onDiscard: () => void }) => void;
+    onRequestSaveSection?: (request: { onConfirm: () => void }) => void;
 }
 
 interface SectionEditingState {
@@ -108,6 +109,7 @@ export const ProgramForm = forwardRef<ProgramFormRef, ProgramFormProps>(
             onAddSection,
             onReplaceSection,
             onRequestCancelSection,
+            onRequestSaveSection,
         }: ProgramFormProps,
         ref,
     ) => {
@@ -758,6 +760,7 @@ export const ProgramForm = forwardRef<ProgramFormRef, ProgramFormProps>(
                                             isLastSection={index === formState.sections.length - 1}
                                             onMoveUpSection={() => handleMoveUpSection(sectionKey)}
                                             onMoveDownSection={() => handleMoveDownSection(sectionKey)}
+                                            onRequestSaveSection={onRequestSaveSection}
                                         />
                                         {index === formState.sections.length - 1 && (
                                             <div className={styles['add-section-wrapper']}>

--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.test.tsx
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.test.tsx
@@ -1084,4 +1084,58 @@ describe('ProgramSectionForm', () => {
             expect(faqPair!.faqQuestion!.answerText).toBe('New Answer');
         });
     });
+
+    it('requests save confirmation (does not call onSave immediately) when onRequestSaveSection is provided and section is dirty', () => {
+        const onSave = jest.fn();
+        const onRequestSaveSection = jest.fn();
+
+        const { handlers } = renderWithHandlers({
+            isNewSection: true,
+            isSectionValid: true,
+            onSave,
+            onRequestSaveSection,
+        } as any);
+
+        act(() => {
+            handlers.onTitleChange('Dirty title');
+        });
+
+        fireEvent.click(screen.getByText(PROGRAMS_TEXT.BUTTON.SAVE));
+
+        expect(onRequestSaveSection).toHaveBeenCalledTimes(1);
+        expect(onRequestSaveSection).toHaveBeenCalledWith({
+            onConfirm: expect.any(Function),
+        });
+
+        expect(onSave).not.toHaveBeenCalled();
+    });
+
+    it('executes save after external confirmation callback is invoked', () => {
+        const onSave = jest.fn();
+        const onRequestSaveSection = jest.fn();
+
+        const { handlers } = renderWithHandlers({
+            isNewSection: true,
+            isSectionValid: true,
+            onSave,
+            onRequestSaveSection,
+        } as any);
+
+        act(() => {
+            handlers.onTitleChange('Dirty title');
+        });
+
+        fireEvent.click(screen.getByText(PROGRAMS_TEXT.BUTTON.SAVE));
+
+        const requestArg = onRequestSaveSection.mock.calls[0][0];
+        expect(requestArg.onConfirm).toEqual(expect.any(Function));
+
+        act(() => {
+            requestArg.onConfirm();
+        });
+
+        expect(onSave).toHaveBeenCalledTimes(1);
+        expect(screen.queryByText(PROGRAMS_TEXT.BUTTON.SAVE)).not.toBeInTheDocument();
+        expect(screen.getByLabelText('Edit section')).toBeInTheDocument();
+    });
 });

--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
@@ -43,6 +43,7 @@ export interface ProgramSectionFormProps {
     isLastSection: boolean;
     onMoveUpSection: () => void;
     onMoveDownSection: () => void;
+    onRequestSaveSection?: (request: { onConfirm: () => void }) => void;
 }
 
 export interface SectionCancelOptions {
@@ -69,6 +70,7 @@ export const ProgramSectionForm = ({
     isLastSection = false,
     onMoveDownSection,
     onMoveUpSection,
+    onRequestSaveSection,
 }: ProgramSectionFormProps) => {
     const [localSection, setLocalSection] = useState<CreateHippotherapyProgramSectionDto>(() =>
         ensureTitleContentAndOnePair(section),
@@ -549,12 +551,22 @@ export const ProgramSectionForm = ({
 
     const handleSaveClick = useCallback(() => {
         if (isDisabled || !isSectionSaveValid) return;
-        onSave();
-        setOriginalSection(localSection);
-        setIsDirty(false);
-        setSectionMode(ProgramSectionMode.View);
-        setValidationResetKey((prev) => prev + 1);
-    }, [isDisabled, isSectionSaveValid, onSave, localSection]);
+
+        const applySave = () => {
+            onSave();
+            setOriginalSection(localSection);
+            setIsDirty(false);
+            setSectionMode(ProgramSectionMode.View);
+            setValidationResetKey((prev) => prev + 1);
+        };
+
+        if (onRequestSaveSection && isDirty) {
+            onRequestSaveSection({ onConfirm: applySave });
+            return;
+        }
+
+        applySave();
+    }, [isDisabled, isSectionSaveValid, onSave, localSection, onRequestSaveSection, isDirty]);
 
     const CARD_TEMPLATES = [
         ProgramSectionTemplate.DualTitleDescriptionPairs,

--- a/src/pages/admin/programs/components/programs-page-modals/program-modal/ProgramModal.test.tsx
+++ b/src/pages/admin/programs/components/programs-page-modals/program-modal/ProgramModal.test.tsx
@@ -753,4 +753,40 @@ describe('ProgramModal', () => {
             expect(mockOnClose).not.toHaveBeenCalled();
         });
     });
+
+    it('opens save-confirmation modal when ProgramForm requests section save confirmation', () => {
+        render(<ProgramModal {...addModeProps} />);
+
+        const onConfirm = jest.fn();
+
+        act(() => {
+            capturedFormProps.onRequestSaveSection({ onConfirm });
+        });
+
+        expect(screen.getByTestId('question-modal')).toBeInTheDocument();
+        expect(screen.getByTestId('question-title')).toHaveTextContent(COMMON_TEXT_ADMIN.QUESTION.SAVE_CHANGES);
+        expect(onConfirm).not.toHaveBeenCalled();
+    });
+
+    it('executes section save confirm callback on confirm and does not execute it on cancel', () => {
+        render(<ProgramModal {...addModeProps} />);
+
+        const onConfirm = jest.fn();
+
+        act(() => {
+            capturedFormProps.onRequestSaveSection({ onConfirm });
+        });
+
+        fireEvent.click(screen.getByTestId('question-cancel'));
+        expect(onConfirm).not.toHaveBeenCalled();
+        expect(screen.queryByTestId('question-modal')).not.toBeInTheDocument();
+
+        act(() => {
+            capturedFormProps.onRequestSaveSection({ onConfirm });
+        });
+
+        fireEvent.click(screen.getByTestId('question-confirm'));
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+        expect(screen.queryByTestId('question-modal')).not.toBeInTheDocument();
+    });
 });

--- a/src/pages/admin/programs/components/programs-page-modals/program-modal/ProgramModal.test.tsx
+++ b/src/pages/admin/programs/components/programs-page-modals/program-modal/ProgramModal.test.tsx
@@ -789,4 +789,19 @@ describe('ProgramModal', () => {
         expect(onConfirm).toHaveBeenCalledTimes(1);
         expect(screen.queryByTestId('question-modal')).not.toBeInTheDocument();
     });
+
+    it('hides section-save confirmation when parent ProgramModal closes', () => {
+        const { rerender } = render(<ProgramModal {...addModeProps} isOpen={true} />);
+
+        act(() => {
+            capturedFormProps.onRequestSaveSection({ onConfirm: jest.fn() });
+        });
+
+        expect(screen.getByTestId('question-modal')).toBeInTheDocument();
+        expect(screen.getByTestId('question-title')).toHaveTextContent(COMMON_TEXT_ADMIN.QUESTION.SAVE_CHANGES);
+
+        rerender(<ProgramModal {...addModeProps} isOpen={false} />);
+
+        expect(screen.queryByTestId('question-modal')).not.toBeInTheDocument();
+    });
 });

--- a/src/pages/admin/programs/components/programs-page-modals/program-modal/ProgramModal.tsx
+++ b/src/pages/admin/programs/components/programs-page-modals/program-modal/ProgramModal.tsx
@@ -53,6 +53,8 @@ export const ProgramModal = (props: ProgramModalProps) => {
     const [isSectionRevertModalOpen, setIsSectionRevertModalOpen] = useState(false);
     const [pendingCancelActionType, setPendingCancelActionType] = useState<SectionCancelActionType | null>(null);
     const sectionDiscardActionRef = useRef<(() => void) | null>(null);
+    const [isSectionSaveModalOpen, setIsSectionSaveModalOpen] = useState(false);
+    const sectionSaveActionRef = useRef<(() => void) | null>(null);
 
     const initialData = useMemo<ProgramFormValues | null>(() => {
         if (!isEditMode || !program) return null;
@@ -241,6 +243,21 @@ export const ProgramModal = (props: ProgramModalProps) => {
         [openModalActions],
     );
 
+    const handleRequestSaveSection = useCallback((request: { onConfirm: () => void }) => {
+        sectionSaveActionRef.current = request.onConfirm;
+        setIsSectionSaveModalOpen(true);
+    }, []);
+
+    const handleCloseSectionSaveModal = useCallback(() => {
+        setIsSectionSaveModalOpen(false);
+        sectionSaveActionRef.current = null;
+    }, []);
+
+    const handleConfirmSaveSection = useCallback(() => {
+        sectionSaveActionRef.current?.();
+        handleCloseSectionSaveModal();
+    }, [handleCloseSectionSaveModal]);
+
     return (
         <div className="program-modal">
             <GenericModalWrapper
@@ -278,6 +295,7 @@ export const ProgramModal = (props: ProgramModalProps) => {
                         onAddSection={openModalActions.openAddSectionModal}
                         onReplaceSection={handleReplaceSection}
                         onRequestCancelSection={handleRequestCancelSection}
+                        onRequestSaveSection={handleRequestSaveSection}
                     />
                 )}
             />
@@ -316,6 +334,14 @@ export const ProgramModal = (props: ProgramModalProps) => {
                 }
                 onConfirm={handleConfirmRevertSection}
                 onCancel={handleCloseSectionRevertModal}
+            />
+
+            <ConfirmationModal
+                isOpen={isSectionSaveModalOpen}
+                onClose={handleCloseSectionSaveModal}
+                title={COMMON_TEXT_ADMIN.QUESTION.SAVE_CHANGES}
+                onConfirm={handleConfirmSaveSection}
+                onCancel={handleCloseSectionSaveModal}
             />
         </div>
     );

--- a/src/pages/admin/programs/components/programs-page-modals/program-modal/ProgramModal.tsx
+++ b/src/pages/admin/programs/components/programs-page-modals/program-modal/ProgramModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState, useEffect } from 'react';
 import { ProgramForm, ProgramFormRef, ProgramFormValues } from '../../program-form/ProgramForm';
 import {
     HippotherapyProgram,
@@ -55,6 +55,13 @@ export const ProgramModal = (props: ProgramModalProps) => {
     const sectionDiscardActionRef = useRef<(() => void) | null>(null);
     const [isSectionSaveModalOpen, setIsSectionSaveModalOpen] = useState(false);
     const sectionSaveActionRef = useRef<(() => void) | null>(null);
+
+    useEffect(() => {
+        if (!isOpen) {
+            setIsSectionSaveModalOpen(false);
+            sectionSaveActionRef.current = null;
+        }
+    }, [isOpen]);
 
     const initialData = useMemo<ProgramFormValues | null>(() => {
         if (!isEditMode || !program) return null;
@@ -337,7 +344,7 @@ export const ProgramModal = (props: ProgramModalProps) => {
             />
 
             <ConfirmationModal
-                isOpen={isSectionSaveModalOpen}
+                isOpen={isOpen && isSectionSaveModalOpen}
                 onClose={handleCloseSectionSaveModal}
                 title={COMMON_TEXT_ADMIN.QUESTION.SAVE_CHANGES}
                 onConfirm={handleConfirmSaveSection}


### PR DESCRIPTION
## Github ticker

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2124

## Description

This PR fixes missing save confirmation for Program Section editing in Admin Single Program flow.
Previously, when an Admin edited section content (templates T1–T7) and clicked "Зберегти", changes were applied immediately without confirmation modal.
Now, section save uses explicit confirmation with message "Зберегти зміни?" and action buttons "ТАК" / "НІ", as required by the bug report.

## How it looks

https://github.com/user-attachments/assets/2ce0e31a-1aa7-405a-9a84-d9e88a185296

## Summary of change

- Added confirmation flow for section Save in Program editing.
- When Admin clicks "Зберегти" in a section with unsaved changes, system now shows modal:
   - "Зберегти зміни?"
   - buttons: "ТАК" / "НІ"
- Save is applied only after "ТАК".
- Click on "НІ" closes modal and keeps section in edit mode.
- Updated tests for:
    - section save confirmation behavior,
    - modal confirmation handling,
    - prop wiring between ProgramModal → ProgramForm → ProgramSectionForm.

## How to recreate changes

1. Log in as Admin.
2. Open Program profile edit modal/page.
3. Open any section (T1–T7) in edit mode.
4. Change at least one field.
5. Click "Зберегти".
6. Verify confirmation modal appears with "Зберегти зміни?" and "ТАК" / "НІ".
7. Click "НІ":
   - modal closes
   - section remains unsaved (edit mode).
8. Click "Зберегти" again, then "ТАК":
   - section is saved
   - section returns to view mode.

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [x]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a section-level save confirmation flow: when saving a dirty section, a confirmation modal appears and changes are applied only after the user confirms.
  * Parent program modal now surfaces section save requests and shows the confirmation dialog.

* **Tests**
  * Added tests covering the request-confirm-save interaction, modal confirm/cancel behavior, and UI state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->