### PR TITLE
Feature/issue 1323/24: Implement Delete and View PDF files

### DIFF
--- a/src/components/admin/confirmation-modal/ConfirmationModal.tsx
+++ b/src/components/admin/confirmation-modal/ConfirmationModal.tsx
@@ -13,6 +13,7 @@ export interface ConfirmationModalProps {
     onConfirm: () => void;
     onCancel: () => void;
     isButtonsDisabled?: boolean;
+    className?: string;
 }
 
 export const ConfirmationModal = ({
@@ -25,9 +26,10 @@ export const ConfirmationModal = ({
     onCancel,
     content = null,
     isButtonsDisabled = false,
+    className,
 }: ConfirmationModalProps) => {
     return (
-        <Modal isOpen={isOpen} onClose={onClose}>
+        <Modal isOpen={isOpen} onClose={onClose} className={className}>
             <Modal.Title>{title}</Modal.Title>
             <Modal.Content>{content && <p>{content}</p>}</Modal.Content>
             <Modal.Actions>

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -120,6 +120,11 @@ export const PDF_FILES_SECTION_TEXT = {
             DELETE: 'Видалити файл',
         },
     },
+    DELETE_CONFIRMATION: {
+        TITLE: 'Файл буде видалено. Бажаєте продовжити?',
+    },
+    DELETE_SUCCESS: 'Файл успішно видалено',
+    DELETE_ERROR: 'Не вдалося видалити файл. Спробуйте ще раз.',
 };
 
 export const FUNDS_EXPENDITURES_VALIDATION = {

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -125,6 +125,7 @@ export const PDF_FILES_SECTION_TEXT = {
     },
     DELETE_SUCCESS: 'Файл успішно видалено',
     DELETE_ERROR: 'Не вдалося видалити файл. Спробуйте ще раз.',
+    VIEW_ERROR: 'Не вдалося завантажити файл для перегляду. Спробуйте ще раз.',
 };
 
 export const FUNDS_EXPENDITURES_VALIDATION = {

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
@@ -48,15 +48,11 @@ jest.mock('@/components/common/inline-loader/InlineLoader', () => ({
 const mockCreateObjectURL = jest.fn();
 const mockWindowOpen = jest.fn();
 
-// Setup mocks before tests run
 beforeAll(() => {
-    // Mock URL.createObjectURL
     global.URL.createObjectURL = mockCreateObjectURL as any;
-    // Mock window.open
     global.window.open = mockWindowOpen as any;
 });
 
-// Restore original functions after tests
 afterAll(() => {
     jest.restoreAllMocks();
 });

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
@@ -53,17 +53,23 @@ describe('PdfFilesSection', () => {
     const mockRefetch = jest.fn();
     const mockCreateObjectURL = jest.fn(() => 'blob:http://localhost/mock-blob-url');
     const mockWindowOpen = jest.fn();
+    let originalCreateObjectURL: any;
+    let originalWindowOpen: any;
 
     beforeEach(() => {
         jest.clearAllMocks();
-        jest.spyOn(URL, 'createObjectURL').mockImplementation(mockCreateObjectURL);
-        jest.spyOn(window, 'open').mockImplementation(mockWindowOpen);
+        originalCreateObjectURL = global.URL.createObjectURL;
+        originalWindowOpen = global.window.open;
+        global.URL.createObjectURL = mockCreateObjectURL as any;
+        global.window.open = mockWindowOpen as any;
         (useAdminClient as jest.Mock).mockReturnValue(mockClient);
         (useToast as jest.Mock).mockReturnValue({ addToast: mockAddToast });
         mockCreateObjectURL.mockReturnValue('blob:http://localhost/mock-blob-url');
     });
 
     afterEach(() => {
+        global.URL.createObjectURL = originalCreateObjectURL;
+        global.window.open = originalWindowOpen;
         jest.restoreAllMocks();
     });
 

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
@@ -1,27 +1,41 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { PdfFilesSection } from './PdfFilesSection';
 import { PdfSectionApi } from '@/services/api/admin/reports/pdf-section/pdf-section-api';
 import { PdfReportsApi } from '@/services/api/admin/reports/pdf-reports/pdf-reports-api';
 import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
 import { useDataFetch } from '@/hooks/common/use-data-fetch/useDataFetch';
+import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextProvider';
+import { ToastType } from '@/types/admin/toast';
+import { PDF_FILES_SECTION_TEXT } from '@/const/admin/reports';
 
 jest.mock('@/hooks/admin/use-admin-client/useAdminClient');
 jest.mock('@/services/api/admin/reports/pdf-section/pdf-section-api');
 jest.mock('@/services/api/admin/reports/pdf-reports/pdf-reports-api');
 jest.mock('@/hooks/common/use-data-fetch/useDataFetch');
+jest.mock('@/contexts/admin/toast-context-provider/ToastContextProvider');
 
 jest.mock('./components/pdf-section-content-block/PdfSectionContentBlock', () => ({
     PdfSectionContentBlock: () => <div data-testid="content-block">ContentBlock</div>,
 }));
 
 jest.mock('./components/pdf-files-table/PdfFilesTable', () => ({
-    PdfFilesTable: ({ files }: { files: any[] }) => (
-        <div data-testid="files-table">Files Count: {files?.length ?? 0}</div>
+    PdfFilesTable: ({ files, onDeleteFile, isDeleting }: any) => (
+        <div data-testid="files-table">
+            Files Count: {files?.length ?? 0}
+            {isDeleting && <span data-testid="is-deleting">Deleting...</span>}
+            <button onClick={() => onDeleteFile && onDeleteFile(1)} data-testid="delete-btn">
+                Delete
+            </button>
+        </div>
     ),
 }));
 
 jest.mock('./components/language-switcher-buttons/LanguageSwitcherButtons', () => ({
     LanguageSwitcherButtons: () => <div data-testid="lang-switcher">LanguageSwitcher</div>,
+}));
+
+jest.mock('./components/pdf-dropzone/PdfDropzone', () => ({
+    PdfDropzone: () => <div data-testid="dropzone">Dropzone</div>,
 }));
 
 jest.mock('@/components/common/inline-loader/InlineLoader', () => ({
@@ -30,18 +44,22 @@ jest.mock('@/components/common/inline-loader/InlineLoader', () => ({
 
 describe('PdfFilesSection', () => {
     const mockClient = { get: jest.fn() };
+    const mockAddToast = jest.fn();
     const mockSectionData = { title: 'Test Title', description: 'Test Desc' };
     const mockFilesResponse = { items: [{ id: 1 }, { id: 2 }], totalItemsCount: 2 };
+    const mockRefetch = jest.fn();
 
     beforeEach(() => {
         jest.clearAllMocks();
         (useAdminClient as jest.Mock).mockReturnValue(mockClient);
+        (useToast as jest.Mock).mockReturnValue({ addToast: mockAddToast });
     });
 
     it('should show loader when section or files are loading', () => {
         (useDataFetch as jest.Mock).mockReturnValue({
             data: null,
             isLoading: true,
+            refetch: mockRefetch,
         });
 
         render(<PdfFilesSection />);
@@ -50,13 +68,15 @@ describe('PdfFilesSection', () => {
 
     it('should render all components when data is loaded', () => {
         (useDataFetch as jest.Mock)
-            .mockReturnValueOnce({ data: mockSectionData, isLoading: false })
-            .mockReturnValueOnce({ data: mockFilesResponse.items, isLoading: false });
+            .mockReturnValueOnce({ data: mockSectionData, isLoading: false, refetch: mockRefetch })
+            .mockReturnValueOnce({ data: mockFilesResponse.items, isLoading: false, refetch: mockRefetch });
 
         render(<PdfFilesSection />);
 
         expect(screen.getByTestId('content-block')).toBeInTheDocument();
         expect(screen.getByTestId('files-table')).toHaveTextContent('Files Count: 2');
+        expect(screen.getByTestId('lang-switcher')).toBeInTheDocument();
+        expect(screen.getByTestId('dropzone')).toBeInTheDocument();
     });
 
     it('should use correct API calls in fetch handlers', async () => {
@@ -66,7 +86,7 @@ describe('PdfFilesSection', () => {
         (useDataFetch as jest.Mock).mockImplementation(({ fetchHandler }) => {
             if (!capturedFetchSection) capturedFetchSection = fetchHandler;
             else capturedFetchFiles = fetchHandler;
-            return { data: [], isLoading: false };
+            return { data: [], isLoading: false, refetch: mockRefetch };
         });
 
         render(<PdfFilesSection />);
@@ -83,12 +103,62 @@ describe('PdfFilesSection', () => {
 
     it('should provide default empty content if sectionData is null', () => {
         (useDataFetch as jest.Mock)
-            .mockReturnValueOnce({ data: null, isLoading: false })
-            .mockReturnValueOnce({ data: [], isLoading: false });
+            .mockReturnValueOnce({ data: null, isLoading: false, refetch: mockRefetch })
+            .mockReturnValueOnce({ data: [], isLoading: false, refetch: mockRefetch });
 
         render(<PdfFilesSection />);
 
         expect(screen.getByTestId('content-block')).toBeInTheDocument();
         expect(screen.getByTestId('files-table')).toHaveTextContent('Files Count: 0');
+    });
+
+    it('should call delete API and refetch files on file deletion', async () => {
+        let callCount = 0;
+        (useDataFetch as jest.Mock).mockImplementation(() => {
+            callCount++;
+            if (callCount === 1) {
+                return { data: mockSectionData, isLoading: false, refetch: mockRefetch };
+            }
+            return { data: mockFilesResponse.items, isLoading: false, refetch: mockRefetch };
+        });
+
+        (PdfReportsApi.delete as jest.Mock).mockResolvedValueOnce(undefined);
+
+        render(<PdfFilesSection />);
+
+        const deleteBtn = screen.getByTestId('delete-btn');
+        await waitFor(() => {
+            deleteBtn.click();
+        });
+
+        await waitFor(() => {
+            expect(PdfReportsApi.delete).toHaveBeenCalledWith(mockClient, 1);
+            expect(mockAddToast).toHaveBeenCalledWith(PDF_FILES_SECTION_TEXT.DELETE_SUCCESS, ToastType.Success);
+            expect(mockRefetch).toHaveBeenCalled();
+        });
+    });
+
+    it('should show error toast when deletion fails', async () => {
+        let callCount = 0;
+        (useDataFetch as jest.Mock).mockImplementation(() => {
+            callCount++;
+            if (callCount === 1) {
+                return { data: mockSectionData, isLoading: false, refetch: mockRefetch };
+            }
+            return { data: mockFilesResponse.items, isLoading: false, refetch: mockRefetch };
+        });
+
+        (PdfReportsApi.delete as jest.Mock).mockRejectedValueOnce(new Error('Delete failed'));
+
+        render(<PdfFilesSection />);
+
+        const deleteBtn = screen.getByTestId('delete-btn');
+        await waitFor(() => {
+            deleteBtn.click();
+        });
+
+        await waitFor(() => {
+            expect(mockAddToast).toHaveBeenCalledWith(PDF_FILES_SECTION_TEXT.DELETE_ERROR, ToastType.Error);
+        });
     });
 });

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
@@ -45,30 +45,26 @@ jest.mock('@/components/common/inline-loader/InlineLoader', () => ({
     InlineLoader: () => <div data-testid="loader">Loading...</div>,
 }));
 
-const mockCreateObjectURL = jest.fn(() => 'blob:http://localhost/mock-blob-url');
-const mockWindowOpen = jest.fn();
-
-beforeAll(() => {
-    global.URL.createObjectURL = mockCreateObjectURL as any;
-    global.window.open = mockWindowOpen as any;
-});
-
-afterAll(() => {
-    jest.restoreAllMocks();
-});
-
 describe('PdfFilesSection', () => {
     const mockClient = { get: jest.fn() };
     const mockAddToast = jest.fn();
     const mockSectionData = { title: 'Test Title', description: 'Test Desc' };
     const mockFilesResponse = { items: [{ id: 1 }, { id: 2 }], totalItemsCount: 2 };
     const mockRefetch = jest.fn();
+    const mockCreateObjectURL = jest.fn(() => 'blob:http://localhost/mock-blob-url');
+    const mockWindowOpen = jest.fn();
 
     beforeEach(() => {
         jest.clearAllMocks();
+        jest.spyOn(URL, 'createObjectURL').mockImplementation(mockCreateObjectURL);
+        jest.spyOn(window, 'open').mockImplementation(mockWindowOpen);
         (useAdminClient as jest.Mock).mockReturnValue(mockClient);
         (useToast as jest.Mock).mockReturnValue({ addToast: mockAddToast });
         mockCreateObjectURL.mockReturnValue('blob:http://localhost/mock-blob-url');
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
     });
 
     it('should show loader when section or files are loading', () => {

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { PdfFilesSection } from './PdfFilesSection';
 import { PdfSectionApi } from '@/services/api/admin/reports/pdf-section/pdf-section-api';
 import { PdfReportsApi } from '@/services/api/admin/reports/pdf-reports/pdf-reports-api';
@@ -45,7 +45,7 @@ jest.mock('@/components/common/inline-loader/InlineLoader', () => ({
     InlineLoader: () => <div data-testid="loader">Loading...</div>,
 }));
 
-const mockCreateObjectURL = jest.fn();
+const mockCreateObjectURL = jest.fn(() => 'blob:http://localhost/mock-blob-url');
 const mockWindowOpen = jest.fn();
 
 beforeAll(() => {
@@ -68,7 +68,6 @@ describe('PdfFilesSection', () => {
         jest.clearAllMocks();
         (useAdminClient as jest.Mock).mockReturnValue(mockClient);
         (useToast as jest.Mock).mockReturnValue({ addToast: mockAddToast });
-        // Setup mock to return blob URL when called
         mockCreateObjectURL.mockReturnValue('blob:http://localhost/mock-blob-url');
     });
 
@@ -144,9 +143,7 @@ describe('PdfFilesSection', () => {
         render(<PdfFilesSection />);
 
         const deleteBtn = screen.getByTestId('delete-btn');
-        await waitFor(() => {
-            deleteBtn.click();
-        });
+        fireEvent.click(deleteBtn);
 
         await waitFor(() => {
             expect(PdfReportsApi.delete).toHaveBeenCalledWith(mockClient, 1);
@@ -170,9 +167,7 @@ describe('PdfFilesSection', () => {
         render(<PdfFilesSection />);
 
         const deleteBtn = screen.getByTestId('delete-btn');
-        await waitFor(() => {
-            deleteBtn.click();
-        });
+        fireEvent.click(deleteBtn);
 
         await waitFor(() => {
             expect(mockAddToast).toHaveBeenCalledWith(PDF_FILES_SECTION_TEXT.DELETE_ERROR, ToastType.Error);
@@ -196,9 +191,7 @@ describe('PdfFilesSection', () => {
         render(<PdfFilesSection />);
 
         const viewBtn = screen.getByTestId('view-btn');
-        await waitFor(() => {
-            viewBtn.click();
-        });
+        fireEvent.click(viewBtn);
 
         await waitFor(() => {
             expect(PdfReportsApi.fetchById).toHaveBeenCalledWith(mockClient, mockFilesResponse.items[0].id);
@@ -222,9 +215,7 @@ describe('PdfFilesSection', () => {
         render(<PdfFilesSection />);
 
         const viewBtn = screen.getByTestId('view-btn');
-        await waitFor(() => {
-            viewBtn.click();
-        });
+        fireEvent.click(viewBtn);
 
         await waitFor(() => {
             expect(mockAddToast).toHaveBeenCalledWith(PDF_FILES_SECTION_TEXT.VIEW_ERROR, ToastType.Error);

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
@@ -191,7 +191,7 @@ describe('PdfFilesSection', () => {
             return { data: mockFilesResponse.items, isLoading: false, refetch: mockRefetch };
         });
 
-        (PdfReportsApi.getById as jest.Mock).mockResolvedValueOnce(mockPdfBlob);
+        (PdfReportsApi.fetchById as jest.Mock).mockResolvedValueOnce(mockPdfBlob);
 
         render(<PdfFilesSection />);
 
@@ -201,7 +201,7 @@ describe('PdfFilesSection', () => {
         });
 
         await waitFor(() => {
-            expect(PdfReportsApi.getById).toHaveBeenCalledWith(mockClient, mockFilesResponse.items[0].id);
+            expect(PdfReportsApi.fetchById).toHaveBeenCalledWith(mockClient, mockFilesResponse.items[0].id);
             expect(mockCreateObjectURL).toHaveBeenCalledWith(mockPdfBlob);
             expect(mockWindowOpen).toHaveBeenCalledWith('blob:http://localhost/mock-blob-url', '_blank');
         });
@@ -217,7 +217,7 @@ describe('PdfFilesSection', () => {
             return { data: mockFilesResponse.items, isLoading: false, refetch: mockRefetch };
         });
 
-        (PdfReportsApi.getById as jest.Mock).mockRejectedValueOnce(new Error('Download failed'));
+        (PdfReportsApi.fetchById as jest.Mock).mockRejectedValueOnce(new Error('Download failed'));
 
         render(<PdfFilesSection />);
 

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
@@ -19,12 +19,15 @@ jest.mock('./components/pdf-section-content-block/PdfSectionContentBlock', () =>
 }));
 
 jest.mock('./components/pdf-files-table/PdfFilesTable', () => ({
-    PdfFilesTable: ({ files, onDeleteFile, isDeleting }: any) => (
+    PdfFilesTable: ({ files, onDeleteFile, onViewFile, isDeleting }: any) => (
         <div data-testid="files-table">
             Files Count: {files?.length ?? 0}
             {isDeleting && <span data-testid="is-deleting">Deleting...</span>}
             <button onClick={() => onDeleteFile && onDeleteFile(1)} data-testid="delete-btn">
                 Delete
+            </button>
+            <button onClick={() => onViewFile && onViewFile(files?.[0])} data-testid="view-btn">
+                View
             </button>
         </div>
     ),
@@ -42,6 +45,22 @@ jest.mock('@/components/common/inline-loader/InlineLoader', () => ({
     InlineLoader: () => <div data-testid="loader">Loading...</div>,
 }));
 
+const mockCreateObjectURL = jest.fn();
+const mockWindowOpen = jest.fn();
+
+// Setup mocks before tests run
+beforeAll(() => {
+    // Mock URL.createObjectURL
+    global.URL.createObjectURL = mockCreateObjectURL as any;
+    // Mock window.open
+    global.window.open = mockWindowOpen as any;
+});
+
+// Restore original functions after tests
+afterAll(() => {
+    jest.restoreAllMocks();
+});
+
 describe('PdfFilesSection', () => {
     const mockClient = { get: jest.fn() };
     const mockAddToast = jest.fn();
@@ -53,6 +72,8 @@ describe('PdfFilesSection', () => {
         jest.clearAllMocks();
         (useAdminClient as jest.Mock).mockReturnValue(mockClient);
         (useToast as jest.Mock).mockReturnValue({ addToast: mockAddToast });
+        // Setup mock to return blob URL when called
+        mockCreateObjectURL.mockReturnValue('blob:http://localhost/mock-blob-url');
     });
 
     it('should show loader when section or files are loading', () => {
@@ -159,6 +180,58 @@ describe('PdfFilesSection', () => {
 
         await waitFor(() => {
             expect(mockAddToast).toHaveBeenCalledWith(PDF_FILES_SECTION_TEXT.DELETE_ERROR, ToastType.Error);
+        });
+    });
+
+    it('should fetch and open PDF file when view button is clicked', async () => {
+        const mockPdfBlob = new Blob(['PDF content'], { type: 'application/pdf' });
+
+        let callCount = 0;
+        (useDataFetch as jest.Mock).mockImplementation(() => {
+            callCount++;
+            if (callCount === 1) {
+                return { data: mockSectionData, isLoading: false, refetch: mockRefetch };
+            }
+            return { data: mockFilesResponse.items, isLoading: false, refetch: mockRefetch };
+        });
+
+        (PdfReportsApi.getById as jest.Mock).mockResolvedValueOnce(mockPdfBlob);
+
+        render(<PdfFilesSection />);
+
+        const viewBtn = screen.getByTestId('view-btn');
+        await waitFor(() => {
+            viewBtn.click();
+        });
+
+        await waitFor(() => {
+            expect(PdfReportsApi.getById).toHaveBeenCalledWith(mockClient, mockFilesResponse.items[0].id);
+            expect(mockCreateObjectURL).toHaveBeenCalledWith(mockPdfBlob);
+            expect(mockWindowOpen).toHaveBeenCalledWith('blob:http://localhost/mock-blob-url', '_blank');
+        });
+    });
+
+    it('should show error toast when PDF download fails', async () => {
+        let callCount = 0;
+        (useDataFetch as jest.Mock).mockImplementation(() => {
+            callCount++;
+            if (callCount === 1) {
+                return { data: mockSectionData, isLoading: false, refetch: mockRefetch };
+            }
+            return { data: mockFilesResponse.items, isLoading: false, refetch: mockRefetch };
+        });
+
+        (PdfReportsApi.getById as jest.Mock).mockRejectedValueOnce(new Error('Download failed'));
+
+        render(<PdfFilesSection />);
+
+        const viewBtn = screen.getByTestId('view-btn');
+        await waitFor(() => {
+            viewBtn.click();
+        });
+
+        await waitFor(() => {
+            expect(mockAddToast).toHaveBeenCalledWith(PDF_FILES_SECTION_TEXT.VIEW_ERROR, ToastType.Error);
         });
     });
 });

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
@@ -65,14 +65,17 @@ export const PdfFilesSection = () => {
             setIsDeleting(true);
             try {
                 await PdfReportsApi.delete(client, fileId);
-                addToast(PDF_FILES_SECTION_TEXT.DELETE_SUCCESS, ToastType.Success);
-                await refetchFiles();
                 setUploadedFiles((prev) => prev.filter((f) => f.id !== fileId));
+                addToast(PDF_FILES_SECTION_TEXT.DELETE_SUCCESS, ToastType.Success);
             } catch {
                 addToast(PDF_FILES_SECTION_TEXT.DELETE_ERROR, ToastType.Error);
             } finally {
                 setIsDeleting(false);
             }
+
+            try {
+                await refetchFiles();
+            } catch {}
         },
         [client, addToast, refetchFiles],
     );
@@ -103,6 +106,10 @@ export const PdfFilesSection = () => {
         );
     }
 
+    const mergedDedupedFiles = Array.from(
+        new Map([...fetchedFiles, ...uploadedFiles].map((file) => [file.id, file])).values(),
+    );
+
     return (
         <div className={styles.root}>
             <div className={styles['top-section']}>
@@ -113,7 +120,7 @@ export const PdfFilesSection = () => {
             </div>
             <PdfDropzone onUploaded={handleUploaded} />
             <PdfFilesTable
-                files={[...fetchedFiles, ...uploadedFiles]}
+                files={mergedDedupedFiles}
                 onViewFile={handleViewFile}
                 onDeleteFile={handleDeleteFile}
                 isDeleting={isDeleting}

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
@@ -77,6 +77,19 @@ export const PdfFilesSection = () => {
         [client, addToast, refetchFiles],
     );
 
+    const handleViewFile = useCallback(
+        async (file: PdfReportDto) => {
+            try {
+                const pdfBlob = await PdfReportsApi.getById(client, file.id);
+                const blobUrl = URL.createObjectURL(pdfBlob);
+                window.open(blobUrl, '_blank');
+            } catch {
+                addToast(PDF_FILES_SECTION_TEXT.VIEW_ERROR, ToastType.Error);
+            }
+        },
+        [client, addToast],
+    );
+
     if (isSectionLoading || isFilesLoading) {
         return (
             <div className={styles.loader}>
@@ -96,7 +109,7 @@ export const PdfFilesSection = () => {
             <PdfDropzone onUploaded={handleUploaded} />
             <PdfFilesTable
                 files={[...fetchedFiles, ...uploadedFiles]}
-                onViewFile={() => {}}
+                onViewFile={handleViewFile}
                 onDeleteFile={handleDeleteFile}
                 isDeleting={isDeleting}
             />

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
@@ -10,13 +10,18 @@ import { PdfReportsApi } from '@/services/api/admin/reports/pdf-reports/pdf-repo
 import { useDataFetch } from '@/hooks/common/use-data-fetch/useDataFetch';
 import { InlineLoader } from '@/components/common/inline-loader/InlineLoader';
 import { PdfDropzone } from './components/pdf-dropzone/PdfDropzone';
+import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextProvider';
+import { ToastType } from '@/types/admin/toast';
+import { PDF_FILES_SECTION_TEXT } from '@/const/admin/reports';
 
 const EMPTY_SECTION = { title: '', description: '' };
 
 export const PdfFilesSection = () => {
     const client = useAdminClient();
+    const { addToast } = useToast();
     const [uploadedFiles, setUploadedFiles] = useState<PdfReportDto[]>([]);
     const [currentLanguage, setCurrentLanguage] = useState<'uk' | 'en'>('uk');
+    const [isDeleting, setIsDeleting] = useState(false);
 
     const fetchSection = useCallback(async () => {
         return PdfSectionApi.getPdfSection(client);
@@ -37,7 +42,11 @@ export const PdfFilesSection = () => {
         autoFetchDependencies: [fetchSection],
     });
 
-    const { data: fetchedFiles, isLoading: isFilesLoading } = useDataFetch<PdfReportDto[]>({
+    const {
+        data: fetchedFiles,
+        isLoading: isFilesLoading,
+        refetch: refetchFiles,
+    } = useDataFetch<PdfReportDto[]>({
         initialData: [],
         fetchHandler: fetchFiles,
         autoFetchDependencies: [fetchFiles],
@@ -50,6 +59,23 @@ export const PdfFilesSection = () => {
     const handleSaveSection = useCallback(async () => {
         await refetchSection();
     }, [refetchSection]);
+
+    const handleDeleteFile = useCallback(
+        async (fileId: number) => {
+            setIsDeleting(true);
+            try {
+                await PdfReportsApi.delete(client, fileId);
+                addToast(PDF_FILES_SECTION_TEXT.DELETE_SUCCESS, ToastType.Success);
+                await refetchFiles();
+                setUploadedFiles((prev) => prev.filter((f) => f.id !== fileId));
+            } catch {
+                addToast(PDF_FILES_SECTION_TEXT.DELETE_ERROR, ToastType.Error);
+            } finally {
+                setIsDeleting(false);
+            }
+        },
+        [client, addToast, refetchFiles],
+    );
 
     if (isSectionLoading || isFilesLoading) {
         return (
@@ -68,7 +94,12 @@ export const PdfFilesSection = () => {
                 <LanguageSwitcherButtons currentLanguage={currentLanguage} onLanguageChange={setCurrentLanguage} />
             </div>
             <PdfDropzone onUploaded={handleUploaded} />
-            <PdfFilesTable files={[...fetchedFiles, ...uploadedFiles]} onViewFile={() => {}} />
+            <PdfFilesTable
+                files={[...fetchedFiles, ...uploadedFiles]}
+                onViewFile={() => {}}
+                onDeleteFile={handleDeleteFile}
+                isDeleting={isDeleting}
+            />
         </div>
     );
 };

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
@@ -80,7 +80,7 @@ export const PdfFilesSection = () => {
     const handleViewFile = useCallback(
         async (file: PdfReportDto) => {
             try {
-                const pdfBlob = await PdfReportsApi.getById(client, file.id);
+                const pdfBlob = await PdfReportsApi.fetchById(client, file.id);
                 const blobUrl = URL.createObjectURL(pdfBlob);
                 window.open(blobUrl, '_blank');
             } catch {

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
@@ -82,7 +82,12 @@ export const PdfFilesSection = () => {
             try {
                 const pdfBlob = await PdfReportsApi.fetchById(client, file.id);
                 const blobUrl = URL.createObjectURL(pdfBlob);
-                window.open(blobUrl, '_blank');
+                const openedWindow = window.open(blobUrl, '_blank');
+                if (openedWindow) {
+                    setTimeout(() => {
+                        URL.revokeObjectURL(blobUrl);
+                    }, 1500);
+                }
             } catch {
                 addToast(PDF_FILES_SECTION_TEXT.VIEW_ERROR, ToastType.Error);
             }

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.scss
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.scss
@@ -1,6 +1,6 @@
 /* LEGACY CSS */
 
-.delete-file-confirmation-modal{
+.delete-file-confirmation-modal {
     width: 440px;
 
     .modal-header-text {

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.scss
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.scss
@@ -1,0 +1,13 @@
+/* LEGACY CSS */
+
+.delete-file-confirmation-modal{
+    width: 440px;
+
+    .modal-header-text {
+        line-height: 36px;
+    }
+
+    .modal-footer {
+        margin-top: 30px;
+    }
+}

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.test.tsx
@@ -5,20 +5,23 @@ import { PDF_FILES_SECTION_TEXT } from '@/const/admin/reports';
 import { PdfReportDto } from '@/types/admin/pdf-section';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 
-jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
-    ConfirmationModal: ({ isOpen, onConfirm, onCancel, title, isButtonsDisabled }: any) =>
-        isOpen ? (
-            <div data-testid="delete-confirmation-modal" role="dialog">
-                <h2>{title}</h2>
-                <button onClick={onCancel} disabled={isButtonsDisabled}>
-                    {COMMON_TEXT_ADMIN.BUTTON.NO}
-                </button>
-                <button onClick={onConfirm} disabled={isButtonsDisabled}>
-                    {COMMON_TEXT_ADMIN.BUTTON.YES}
-                </button>
-            </div>
-        ) : null,
-}));
+jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => {
+    const { COMMON_TEXT_ADMIN } = jest.requireActual('@/const/admin/common');
+    return {
+        ConfirmationModal: ({ isOpen, onConfirm, onCancel, title, isButtonsDisabled, className }: any) =>
+            isOpen ? (
+                <div data-testid="delete-confirmation-modal" role="dialog" className={className}>
+                    <h2>{title}</h2>
+                    <button onClick={onCancel} disabled={isButtonsDisabled}>
+                        {COMMON_TEXT_ADMIN.BUTTON.NO}
+                    </button>
+                    <button onClick={onConfirm} disabled={isButtonsDisabled}>
+                        {COMMON_TEXT_ADMIN.BUTTON.YES}
+                    </button>
+                </div>
+            ) : null,
+    };
+});
 
 jest.mock('@/assets/icons/eye-opened.svg', () => ({
     ReactComponent: () => <svg data-testid="eye-icon" />,
@@ -66,6 +69,13 @@ describe('PdfFilesTable', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+    });
+
+    it('should render view button for each file', () => {
+        render(<PdfFilesTable {...defaultProps} />);
+
+        const viewButtons = screen.getAllByLabelText(PDF_FILES_SECTION_TEXT.ACTIONS.FILE.VIEW);
+        expect(viewButtons).toHaveLength(mockFiles.length);
     });
 
     it('should render table headers correctly', () => {
@@ -156,15 +166,76 @@ describe('PdfFilesTable', () => {
 
     it('should disable modal buttons when isDeleting is true', async () => {
         const user = userEvent.setup();
-        render(<PdfFilesTable {...defaultProps} isDeleting={true} />);
+        // First render with isDeleting={false} to open the modal
+        const { rerender } = render(<PdfFilesTable {...defaultProps} isDeleting={false} />);
 
         const deleteButtons = screen.getAllByLabelText(PDF_FILES_SECTION_TEXT.ACTIONS.FILE.DELETE);
         await user.click(deleteButtons[0]);
 
-        const confirmButton = await screen.findByText(COMMON_TEXT_ADMIN.BUTTON.YES);
-        const cancelButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.NO);
+        // Wait for modal to appear
+        await waitFor(() => {
+            expect(screen.getByTestId('delete-confirmation-modal')).toBeInTheDocument();
+        });
 
+        // Modal is now open, verify buttons are not disabled
+        let confirmButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.YES);
+        let cancelButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.NO);
+        expect(confirmButton).not.toBeDisabled();
+        expect(cancelButton).not.toBeDisabled();
+
+        // Now re-render with isDeleting={true}
+        rerender(<PdfFilesTable {...defaultProps} isDeleting={true} />);
+
+        // Buttons should now be disabled
+        confirmButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.YES);
+        cancelButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.NO);
         expect(confirmButton).toBeDisabled();
         expect(cancelButton).toBeDisabled();
+    });
+
+    it('should call onViewFile when view button is clicked', async () => {
+        const user = userEvent.setup();
+        const mockOnViewFile = jest.fn();
+        render(<PdfFilesTable {...defaultProps} onViewFile={mockOnViewFile} />);
+
+        const viewButtons = screen.getAllByLabelText(PDF_FILES_SECTION_TEXT.ACTIONS.FILE.VIEW);
+        await user.click(viewButtons[0]);
+
+        await waitFor(() => {
+            expect(mockOnViewFile).toHaveBeenCalledWith(mockFiles[0]);
+        });
+    });
+
+    it('should call onViewFile with correct file when multiple view buttons are present', async () => {
+        const user = userEvent.setup();
+        const mockOnViewFile = jest.fn();
+        render(<PdfFilesTable {...defaultProps} onViewFile={mockOnViewFile} />);
+
+        const viewButtons = screen.getAllByLabelText(PDF_FILES_SECTION_TEXT.ACTIONS.FILE.VIEW);
+        await user.click(viewButtons[1]);
+
+        await waitFor(() => {
+            expect(mockOnViewFile).toHaveBeenCalledWith(mockFiles[1]);
+        });
+    });
+
+    it('should allow multiple view button clicks for different files', async () => {
+        const user = userEvent.setup();
+        const mockOnViewFile = jest.fn();
+        render(<PdfFilesTable {...defaultProps} onViewFile={mockOnViewFile} />);
+
+        const viewButtons = screen.getAllByLabelText(PDF_FILES_SECTION_TEXT.ACTIONS.FILE.VIEW);
+
+        await user.click(viewButtons[0]);
+        await waitFor(() => {
+            expect(mockOnViewFile).toHaveBeenNthCalledWith(1, mockFiles[0]);
+        });
+
+        await user.click(viewButtons[1]);
+        await waitFor(() => {
+            expect(mockOnViewFile).toHaveBeenNthCalledWith(2, mockFiles[1]);
+        });
+
+        expect(mockOnViewFile).toHaveBeenCalledTimes(2);
     });
 });

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.test.tsx
@@ -1,7 +1,24 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { PdfFilesTable } from './PdfFilesTable';
 import { PDF_FILES_SECTION_TEXT } from '@/const/admin/reports';
 import { PdfReportDto } from '@/types/admin/pdf-section';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+
+jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
+    ConfirmationModal: ({ isOpen, onConfirm, onCancel, title, isButtonsDisabled }: any) =>
+        isOpen ? (
+            <div data-testid="delete-confirmation-modal" role="dialog">
+                <h2>{title}</h2>
+                <button onClick={onCancel} disabled={isButtonsDisabled}>
+                    {COMMON_TEXT_ADMIN.BUTTON.NO}
+                </button>
+                <button onClick={onConfirm} disabled={isButtonsDisabled}>
+                    {COMMON_TEXT_ADMIN.BUTTON.YES}
+                </button>
+            </div>
+        ) : null,
+}));
 
 jest.mock('@/assets/icons/eye-opened.svg', () => ({
     ReactComponent: () => <svg data-testid="eye-icon" />,
@@ -12,6 +29,11 @@ jest.mock('@/assets/icons/file.svg', () => ({
 jest.mock('@/assets/icons/not-found.svg', () => ({
     ReactComponent: () => <svg data-testid="not-found-icon" />,
 }));
+jest.mock('@/components/admin/icon-button/IconButton', () => ({
+    IconButton: ({ onClick, disabled, 'aria-label': ariaLabel }: any) => (
+        <button onClick={onClick} disabled={disabled} aria-label={ariaLabel} />
+    ),
+}));
 
 describe('PdfFilesTable', () => {
     const mockFiles: PdfReportDto[] = [
@@ -20,21 +42,26 @@ describe('PdfFilesTable', () => {
             name: 'Report_2024.pdf',
             createdAt: '2024-01-15T12:00:00Z',
             fileSizeBytes: 102400, // 100 KB
-            fileUrl: 'http://test.com/1.pdf',
+            blobName: 'blob-1',
+            priority: 0,
         },
         {
             id: 2,
             name: 'Audit_Final.pdf',
             createdAt: '2024-02-20T15:30:00Z',
             fileSizeBytes: 204800, // 200 KB
-            fileUrl: 'http://test.com/2.pdf',
+            blobName: 'blob-2',
+            priority: 1,
         },
-    ] as any;
+    ];
+
+    const mockOnDeleteFile = jest.fn();
 
     const defaultProps = {
         files: mockFiles,
-        isEditing: false,
         onViewFile: jest.fn(),
+        onDeleteFile: mockOnDeleteFile,
+        isDeleting: false,
     };
 
     beforeEach(() => {
@@ -56,8 +83,6 @@ describe('PdfFilesTable', () => {
         expect(screen.getByText('Report_2024.pdf')).toBeInTheDocument();
         expect(screen.getByText('Audit_Final.pdf')).toBeInTheDocument();
 
-        expect(screen.getByText('15.01.2024')).toBeInTheDocument();
-
         expect(screen.getByText('100 KB')).toBeInTheDocument();
         expect(screen.getByText('200 KB')).toBeInTheDocument();
     });
@@ -69,19 +94,77 @@ describe('PdfFilesTable', () => {
         expect(screen.getByTestId('not-found-icon')).toBeInTheDocument();
     });
 
-    it('should render icons for each file row', () => {
+    it('should render delete button for each file', () => {
         render(<PdfFilesTable {...defaultProps} />);
 
-        const fileIcons = screen.getAllByTestId('file-icon');
-        const eyeIcons = screen.getAllByTestId('eye-icon');
-
-        expect(fileIcons).toHaveLength(mockFiles.length);
-        expect(eyeIcons).toHaveLength(mockFiles.length);
+        const deleteButtons = screen.getAllByLabelText(PDF_FILES_SECTION_TEXT.ACTIONS.FILE.DELETE);
+        expect(deleteButtons).toHaveLength(mockFiles.length);
     });
 
-    it('should render file-name span with correct text', () => {
+    it('should show delete confirmation modal when delete button is clicked', async () => {
+        const user = userEvent.setup();
         render(<PdfFilesTable {...defaultProps} />);
-        const fileName = screen.getByText('Report_2024.pdf');
-        expect(fileName).toHaveClass('file-name');
+
+        const deleteButtons = screen.getAllByLabelText(PDF_FILES_SECTION_TEXT.ACTIONS.FILE.DELETE);
+        await user.click(deleteButtons[0]);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('delete-confirmation-modal')).toBeInTheDocument();
+            expect(screen.getByText(PDF_FILES_SECTION_TEXT.DELETE_CONFIRMATION.TITLE)).toBeInTheDocument();
+        });
+    });
+
+    it('should call onDeleteFile when delete confirmation is confirmed', async () => {
+        const user = userEvent.setup();
+        render(<PdfFilesTable {...defaultProps} />);
+
+        const deleteButtons = screen.getAllByLabelText(PDF_FILES_SECTION_TEXT.ACTIONS.FILE.DELETE);
+        await user.click(deleteButtons[0]);
+
+        const confirmButton = await screen.findByText(COMMON_TEXT_ADMIN.BUTTON.YES);
+        await user.click(confirmButton);
+
+        await waitFor(() => {
+            expect(mockOnDeleteFile).toHaveBeenCalledWith(mockFiles[0].id);
+        });
+    });
+
+    it('should close modal without calling onDeleteFile when delete is cancelled', async () => {
+        const user = userEvent.setup();
+        render(<PdfFilesTable {...defaultProps} />);
+
+        const deleteButtons = screen.getAllByLabelText(PDF_FILES_SECTION_TEXT.ACTIONS.FILE.DELETE);
+        await user.click(deleteButtons[0]);
+
+        const cancelButton = await screen.findByText(COMMON_TEXT_ADMIN.BUTTON.NO);
+        await user.click(cancelButton);
+
+        await waitFor(() => {
+            expect(mockOnDeleteFile).not.toHaveBeenCalled();
+            expect(screen.queryByTestId('delete-confirmation-modal')).not.toBeInTheDocument();
+        });
+    });
+
+    it('should disable delete button when isDeleting is true', () => {
+        render(<PdfFilesTable {...defaultProps} isDeleting={true} />);
+
+        const deleteButtons = screen.getAllByLabelText(PDF_FILES_SECTION_TEXT.ACTIONS.FILE.DELETE);
+        deleteButtons.forEach((button) => {
+            expect(button).toBeDisabled();
+        });
+    });
+
+    it('should disable modal buttons when isDeleting is true', async () => {
+        const user = userEvent.setup();
+        render(<PdfFilesTable {...defaultProps} isDeleting={true} />);
+
+        const deleteButtons = screen.getAllByLabelText(PDF_FILES_SECTION_TEXT.ACTIONS.FILE.DELETE);
+        await user.click(deleteButtons[0]);
+
+        const confirmButton = await screen.findByText(COMMON_TEXT_ADMIN.BUTTON.YES);
+        const cancelButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.NO);
+
+        expect(confirmButton).toBeDisabled();
+        expect(cancelButton).toBeDisabled();
     });
 });

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.test.tsx
@@ -166,27 +166,22 @@ describe('PdfFilesTable', () => {
 
     it('should disable modal buttons when isDeleting is true', async () => {
         const user = userEvent.setup();
-        // First render with isDeleting={false} to open the modal
         const { rerender } = render(<PdfFilesTable {...defaultProps} isDeleting={false} />);
 
         const deleteButtons = screen.getAllByLabelText(PDF_FILES_SECTION_TEXT.ACTIONS.FILE.DELETE);
         await user.click(deleteButtons[0]);
 
-        // Wait for modal to appear
         await waitFor(() => {
             expect(screen.getByTestId('delete-confirmation-modal')).toBeInTheDocument();
         });
 
-        // Modal is now open, verify buttons are not disabled
         let confirmButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.YES);
         let cancelButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.NO);
         expect(confirmButton).not.toBeDisabled();
         expect(cancelButton).not.toBeDisabled();
 
-        // Now re-render with isDeleting={true}
         rerender(<PdfFilesTable {...defaultProps} isDeleting={true} />);
 
-        // Buttons should now be disabled
         confirmButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.YES);
         cancelButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.NO);
         expect(confirmButton).toBeDisabled();

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.tsx
@@ -17,7 +17,12 @@ interface PdfFilesTableProps {
     isDeleting?: boolean;
 }
 
-export const PdfFilesTable: React.FC<PdfFilesTableProps> = ({ files, onDeleteFile, isDeleting = false }) => {
+export const PdfFilesTable: React.FC<PdfFilesTableProps> = ({
+    files,
+    onDeleteFile,
+    onViewFile,
+    isDeleting = false,
+}) => {
     const [deleteConfirmation, setDeleteConfirmation] = useState<{ isOpen: boolean; fileId: number | null }>({
         isOpen: false,
         fileId: null,
@@ -93,7 +98,7 @@ export const PdfFilesTable: React.FC<PdfFilesTableProps> = ({ files, onDeleteFil
                                             <IconButton
                                                 aria-label={PDF_FILES_SECTION_TEXT.ACTIONS.FILE.VIEW}
                                                 type="button"
-                                                onClick={() => {}}
+                                                onClick={() => onViewFile(file)}
                                                 className={styles['view-button']}
                                                 DefaultIcon={ACTION_ICONS.view.default}
                                             />

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.tsx
@@ -5,88 +5,124 @@ import { ReactComponent as NotFoundIcon } from '@/assets/icons/not-found.svg';
 import { PDF_FILES_SECTION_TEXT } from '@/const/admin/reports';
 import cn from 'classnames';
 import styles from './PdfFilesTable.module.scss';
+import './PdfFilesTable.scss';
 import { PdfReportDto } from '@/types/admin/pdf-section';
+import { useState, useCallback } from 'react';
+import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
 
 interface PdfFilesTableProps {
     files: PdfReportDto[];
     onViewFile: (file: PdfReportDto) => void;
+    onDeleteFile: (id: number) => Promise<void>;
+    isDeleting?: boolean;
 }
 
-export const PdfFilesTable: React.FC<PdfFilesTableProps> = ({ files }) => {
+export const PdfFilesTable: React.FC<PdfFilesTableProps> = ({ files, onDeleteFile, isDeleting = false }) => {
+    const [deleteConfirmation, setDeleteConfirmation] = useState<{ isOpen: boolean; fileId: number | null }>({
+        isOpen: false,
+        fileId: null,
+    });
+
+    const handleDeleteClick = useCallback((fileId: number) => {
+        setDeleteConfirmation({ isOpen: true, fileId });
+    }, []);
+
+    const handleDeleteConfirm = useCallback(async () => {
+        if (deleteConfirmation.fileId !== null) {
+            await onDeleteFile(deleteConfirmation.fileId);
+        }
+        setDeleteConfirmation({ isOpen: false, fileId: null });
+    }, [deleteConfirmation.fileId, onDeleteFile]);
+
+    const handleDeleteCancel = useCallback(() => {
+        setDeleteConfirmation({ isOpen: false, fileId: null });
+    }, []);
     return (
-        <div className={styles['table-container']}>
-            <table className={styles.table}>
-                <thead>
-                    <tr className={styles['header-row']}>
-                        <th className={cn(styles.cell, styles['name-cell'])}>
-                            {PDF_FILES_SECTION_TEXT.TABLE.HEADER.NAME}
-                        </th>
-                        <th className={cn(styles.cell, styles['date-cell'])}>
-                            {PDF_FILES_SECTION_TEXT.TABLE.HEADER.DATE_TIME}
-                        </th>
-                        <th className={cn(styles.cell, styles['size-cell'])}>
-                            {PDF_FILES_SECTION_TEXT.TABLE.HEADER.SIZE}
-                        </th>
-                        <th className={cn(styles.cell, styles['actions-cell'])}>
-                            {PDF_FILES_SECTION_TEXT.TABLE.HEADER.ACTIONS}
-                        </th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {files.length === 0 ? (
-                        <tr className={styles['empty-row']}>
-                            <td colSpan={4} className={styles['empty-cell']}>
-                                <div className={styles['empty-container']}>
-                                    <NotFoundIcon className={styles['not-found-icon']} />
-                                    <p className={styles['empty-text']}>{PDF_FILES_SECTION_TEXT.TABLE.NO_FILES}</p>
-                                </div>
-                            </td>
+        <>
+            <div className={styles['table-container']}>
+                <table className={styles.table}>
+                    <thead>
+                        <tr className={styles['header-row']}>
+                            <th className={cn(styles.cell, styles['name-cell'])}>
+                                {PDF_FILES_SECTION_TEXT.TABLE.HEADER.NAME}
+                            </th>
+                            <th className={cn(styles.cell, styles['date-cell'])}>
+                                {PDF_FILES_SECTION_TEXT.TABLE.HEADER.DATE_TIME}
+                            </th>
+                            <th className={cn(styles.cell, styles['size-cell'])}>
+                                {PDF_FILES_SECTION_TEXT.TABLE.HEADER.SIZE}
+                            </th>
+                            <th className={cn(styles.cell, styles['actions-cell'])}>
+                                {PDF_FILES_SECTION_TEXT.TABLE.HEADER.ACTIONS}
+                            </th>
                         </tr>
-                    ) : (
-                        files.map((file) => (
-                            <tr key={file.id} className={styles.row}>
-                                <td className={cn(styles.cell, styles['name-cell'])}>
-                                    <FileIcon className={styles['file-icon']} />
-                                    <span className={styles['file-name']}>{file.name}</span>
-                                </td>
-                                <td className={cn(styles.cell, styles['date-cell'])}>
-                                    {new Date(file.createdAt).toLocaleDateString('uk-UA')}
-                                </td>
-                                <td className={cn(styles.cell, styles['size-cell'])}>
-                                    {Math.round(file.fileSizeBytes / 1024)} KB
-                                </td>
-                                <td className={cn(styles.cell, styles['actions-cell'])}>
-                                    <div className={styles['action-buttons']}>
-                                        <IconButton
-                                            aria-label={PDF_FILES_SECTION_TEXT.ACTIONS.FILE.EDIT}
-                                            type="button"
-                                            onClick={() => {}}
-                                            className={styles['edit-button']}
-                                            DefaultIcon={ACTION_ICONS.edit.default}
-                                            FilledIcon={ACTION_ICONS.edit.hover}
-                                        />
-                                        <IconButton
-                                            aria-label={PDF_FILES_SECTION_TEXT.ACTIONS.FILE.VIEW}
-                                            type="button"
-                                            onClick={() => {}}
-                                            className={styles['view-button']}
-                                            DefaultIcon={ACTION_ICONS.view.default}
-                                        />
-                                        <IconButton
-                                            aria-label={PDF_FILES_SECTION_TEXT.ACTIONS.FILE.DELETE}
-                                            type="button"
-                                            onClick={() => {}}
-                                            className={styles['delete-button']}
-                                            DefaultIcon={ACTION_ICONS.delete.default}
-                                            FilledIcon={ACTION_ICONS.delete.hover}
-                                        />
+                    </thead>
+                    <tbody>
+                        {files.length === 0 ? (
+                            <tr className={styles['empty-row']}>
+                                <td colSpan={4} className={styles['empty-cell']}>
+                                    <div className={styles['empty-container']}>
+                                        <NotFoundIcon className={styles['not-found-icon']} />
+                                        <p className={styles['empty-text']}>{PDF_FILES_SECTION_TEXT.TABLE.NO_FILES}</p>
                                     </div>
                                 </td>
                             </tr>
-                        ))
-                    )}
-                </tbody>
-            </table>
-        </div>
+                        ) : (
+                            files.map((file) => (
+                                <tr key={file.id} className={styles.row}>
+                                    <td className={cn(styles.cell, styles['name-cell'])}>
+                                        <FileIcon className={styles['file-icon']} />
+                                        <span className={styles['file-name']}>{file.name}</span>
+                                    </td>
+                                    <td className={cn(styles.cell, styles['date-cell'])}>
+                                        {new Date(file.createdAt).toLocaleDateString('uk-UA')}
+                                    </td>
+                                    <td className={cn(styles.cell, styles['size-cell'])}>
+                                        {Math.round(file.fileSizeBytes / 1024)} KB
+                                    </td>
+                                    <td className={cn(styles.cell, styles['actions-cell'])}>
+                                        <div className={styles['action-buttons']}>
+                                            <IconButton
+                                                aria-label={PDF_FILES_SECTION_TEXT.ACTIONS.FILE.EDIT}
+                                                type="button"
+                                                onClick={() => {}}
+                                                className={styles['edit-button']}
+                                                DefaultIcon={ACTION_ICONS.edit.default}
+                                                FilledIcon={ACTION_ICONS.edit.hover}
+                                            />
+                                            <IconButton
+                                                aria-label={PDF_FILES_SECTION_TEXT.ACTIONS.FILE.VIEW}
+                                                type="button"
+                                                onClick={() => {}}
+                                                className={styles['view-button']}
+                                                DefaultIcon={ACTION_ICONS.view.default}
+                                            />
+                                            <IconButton
+                                                aria-label={PDF_FILES_SECTION_TEXT.ACTIONS.FILE.DELETE}
+                                                type="button"
+                                                onClick={() => handleDeleteClick(file.id)}
+                                                className={styles['delete-button']}
+                                                DefaultIcon={ACTION_ICONS.delete.default}
+                                                FilledIcon={ACTION_ICONS.delete.hover}
+                                                disabled={isDeleting}
+                                            />
+                                        </div>
+                                    </td>
+                                </tr>
+                            ))
+                        )}
+                    </tbody>
+                </table>
+            </div>
+            <ConfirmationModal
+                isOpen={deleteConfirmation.isOpen}
+                onClose={handleDeleteCancel}
+                title={PDF_FILES_SECTION_TEXT.DELETE_CONFIRMATION.TITLE}
+                onConfirm={handleDeleteConfirm}
+                onCancel={handleDeleteCancel}
+                isButtonsDisabled={isDeleting}
+                className="delete-file-confirmation-modal"
+            />
+        </>
     );
 };

--- a/src/services/api/admin/reports/pdf-reports/pdf-reports-api.test.ts
+++ b/src/services/api/admin/reports/pdf-reports/pdf-reports-api.test.ts
@@ -31,6 +31,8 @@ describe('PdfReportsApi', () => {
         jest.clearAllMocks();
         mockClient = {
             get: jest.fn(),
+            post: jest.fn(),
+            delete: jest.fn(),
         } as any;
     });
 
@@ -78,6 +80,42 @@ describe('PdfReportsApi', () => {
                     params: { offset: 50, limit: 25 },
                 }),
             );
+        });
+    });
+
+    describe('getById', () => {
+        it('should fetch pdf blob by id with correct responseType', async () => {
+            const mockBlob = new Blob() as any;
+            mockClient.get.mockResolvedValueOnce({ data: mockBlob });
+
+            const result = PdfReportsApi.getById(mockClient, 1);
+
+            expect(mockClient.get).toHaveBeenCalledWith(`${API_ROUTES.PDF_REPORTS.BASE}/1`, {
+                responseType: 'blob',
+            });
+            expect(result).toEqual(mockBlob);
+        });
+
+        it('should use correct endpoint with file id', async () => {
+            const mockBlob = new Blob() as any;
+            mockClient.get.mockResolvedValueOnce({ data: mockBlob });
+
+            PdfReportsApi.getById(mockClient, 42);
+
+            expect(mockClient.get).toHaveBeenCalledWith(`${API_ROUTES.PDF_REPORTS.BASE}/42`, expect.any(Object));
+        });
+
+        it('should throw error when api request fails', async () => {
+            mockClient.get.mockRejectedValueOnce(new Error('Download failed'));
+
+            await expect(PdfReportsApi.getById(mockClient, 1)).rejects.toThrow('Download failed');
+        });
+
+        it('should handle 404 error when file not found', async () => {
+            const notFoundError = new Error('Not Found');
+            mockClient.get.mockRejectedValueOnce(notFoundError);
+
+            await expect(PdfReportsApi.getById(mockClient, 99)).rejects.toThrow('Not Found');
         });
     });
 });

--- a/src/services/api/admin/reports/pdf-reports/pdf-reports-api.test.ts
+++ b/src/services/api/admin/reports/pdf-reports/pdf-reports-api.test.ts
@@ -83,12 +83,12 @@ describe('PdfReportsApi', () => {
         });
     });
 
-    describe('getById', () => {
+    describe('fetchById', () => {
         it('should fetch pdf blob by id with correct responseType', async () => {
             const mockBlob = new Blob() as any;
             mockClient.get.mockResolvedValueOnce({ data: mockBlob });
 
-            const result = PdfReportsApi.getById(mockClient, 1);
+            const result = await PdfReportsApi.fetchById(mockClient, 1);
 
             expect(mockClient.get).toHaveBeenCalledWith(`${API_ROUTES.PDF_REPORTS.BASE}/1`, {
                 responseType: 'blob',
@@ -100,7 +100,7 @@ describe('PdfReportsApi', () => {
             const mockBlob = new Blob() as any;
             mockClient.get.mockResolvedValueOnce({ data: mockBlob });
 
-            PdfReportsApi.getById(mockClient, 42);
+            await PdfReportsApi.fetchById(mockClient, 42);
 
             expect(mockClient.get).toHaveBeenCalledWith(`${API_ROUTES.PDF_REPORTS.BASE}/42`, expect.any(Object));
         });
@@ -108,14 +108,14 @@ describe('PdfReportsApi', () => {
         it('should throw error when api request fails', async () => {
             mockClient.get.mockRejectedValueOnce(new Error('Download failed'));
 
-            await expect(PdfReportsApi.getById(mockClient, 1)).rejects.toThrow('Download failed');
+            await expect(PdfReportsApi.fetchById(mockClient, 1)).rejects.toThrow('Download failed');
         });
 
         it('should handle 404 error when file not found', async () => {
             const notFoundError = new Error('Not Found');
             mockClient.get.mockRejectedValueOnce(notFoundError);
 
-            await expect(PdfReportsApi.getById(mockClient, 99)).rejects.toThrow('Not Found');
+            await expect(PdfReportsApi.fetchById(mockClient, 99)).rejects.toThrow('Not Found');
         });
     });
 });

--- a/src/services/api/admin/reports/pdf-reports/pdf-reports-api.ts
+++ b/src/services/api/admin/reports/pdf-reports/pdf-reports-api.ts
@@ -14,6 +14,10 @@ export const PdfReportsApi = {
         return response.data;
     },
 
+    delete: async (client: AxiosInstance, id: number): Promise<void> => {
+        await client.delete(`${API_ROUTES.PDF_REPORTS.BASE}/${id}`);
+    },
+
     getAll: async (
         client: AxiosInstance,
         filter: { offset: number; limit: number },

--- a/src/services/api/admin/reports/pdf-reports/pdf-reports-api.ts
+++ b/src/services/api/admin/reports/pdf-reports/pdf-reports-api.ts
@@ -27,4 +27,11 @@ export const PdfReportsApi = {
         });
         return response.data;
     },
+
+    getById: async (client: AxiosInstance, id: number): Promise<Blob> => {
+        const response = await client.get<Blob>(`${API_ROUTES.PDF_REPORTS.BASE}/${id}`, {
+            responseType: 'blob',
+        });
+        return response.data;
+    },
 };

--- a/src/services/api/admin/reports/pdf-reports/pdf-reports-api.ts
+++ b/src/services/api/admin/reports/pdf-reports/pdf-reports-api.ts
@@ -28,7 +28,7 @@ export const PdfReportsApi = {
         return response.data;
     },
 
-    getById: async (client: AxiosInstance, id: number): Promise<Blob> => {
+    fetchById: async (client: AxiosInstance, id: number): Promise<Blob> => {
         const response = await client.get<Blob>(`${API_ROUTES.PDF_REPORTS.BASE}/${id}`, {
             responseType: 'blob',
         });


### PR DESCRIPTION
## Github ticket

* [Github ticket 1323](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1323)
* [Github ticket 1324](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1324)

## Description

This PR implements the view (download) and delete functionality for PDF reports in the admin panel. Previously, the action buttons in the PDF files table had no behavior attached. Now users can open a PDF file directly in a new browser tab and delete a file through a confirmation modal.

## How it looks

Deleting file
<img width="2303" height="470" alt="image" src="https://github.com/user-attachments/assets/114e37be-1e0f-48ed-8ae1-4f58a64548b7" />
<img width="756" height="385" alt="image" src="https://github.com/user-attachments/assets/c766b586-6574-47a4-9a6a-6ae167815960" />
<img width="505" height="132" alt="image" src="https://github.com/user-attachments/assets/d8925a50-93d5-4425-a254-40a001c3f291" />
<img width="2323" height="387" alt="image" src="https://github.com/user-attachments/assets/b3288af1-8717-43fb-b37d-10afac27d660" />

Viewing file
<img width="2305" height="138" alt="image" src="https://github.com/user-attachments/assets/0ca9976f-b8a6-44a3-97dc-7f4923c26d04" />
<img width="2879" height="1410" alt="image" src="https://github.com/user-attachments/assets/2499b4f8-79b5-40ed-b883-d5b05cfe9247" />

## Summary of change

- Added getById method that fetches a PDF file by ID as a Blob using responseType: 'blob'
- Added delete method that sends a DELETE request for a given report ID
- Wired up onViewFile and onDeleteFile props to the corresponding action buttons
- Added local state for delete confirmation modal (deleteConfirmation)
- Integrated ConfirmationModal component to require user confirmation before deletion
- Added isDeleting prop to disable the delete button during an in-flight request
- Implemented handleDeleteFile: calls the delete API, shows a success/error toast, and refetches the file list
- Implemented handleViewFile: fetches the PDF blob, creates an object URL, and opens it in a new tab
- Passed onViewFile, onDeleteFile, and isDeleting down to PdfFilesTable
- Added className prop support to allow custom styling per call site
- Added DELETE_CONFIRMATION, DELETE_SUCCESS, DELETE_ERROR, and VIEW_ERROR text constants
- Added .delete-file-confirmation-modal legacy CSS styles for the modal dimensions

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View PDF files in a new tab.
  * Delete PDF files with confirmation and disabled controls while deleting.
  * Merged/deduplicated file list for more accurate file display.

* **Bug Fixes / UX**
  * Success and error toasts for view and delete flows.

* **Tests**
  * Expanded tests covering view/delete interactions, toasts, file fetch behavior, and deletion states.

* **Style**
  * Added styling for delete confirmation modal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->