### PR TITLE
Feature/issue-1827: Implement Program Expenses Empty State and related components

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -225,7 +225,6 @@ export const PROGRAM_EXPENSES_TEXT = {
         ADD_PROGRAM_EXPENSE: 'Витрата по програмі',
     },
     EMPTY_STATE: {
-        TITLE: 'Немає записів',
         ADD_RECORD: 'додайте перший запис Програмної витрати',
     },
     SUMMARY_CARD: {

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -221,6 +221,13 @@ export const FUNDS_EXPENDITURES_TEXT = {
 };
 
 export const PROGRAM_EXPENSES_TEXT = {
+    BUTTON: {
+        ADD_PROGRAM_EXPENSE: 'Витрата по програмі',
+    },
+    EMPTY_STATE: {
+        TITLE: 'Немає записів',
+        ADD_RECORD: 'додайте перший запис Програмної витрати',
+    },
     SUMMARY_CARD: {
         TITLE: 'Всього програмні витрати',
     },

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
@@ -47,6 +47,16 @@ const MOCK_PROGRAM_EXPENSES_DATA: ProgramExpensesReadOnlyData = {
     ],
 };
 
+const EMPTY_PROGRAM_EXPENSES_DATA: ProgramExpensesReadOnlyData = {
+    exchangeRate: null,
+    programs: [],
+    summary: {
+        totalAmountUah: 0,
+        totalAmountUsd: 0,
+    },
+    records: [],
+};
+
 jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
     useAdminClient: () => ({}),
 }));
@@ -74,6 +84,10 @@ jest.mock('@/components/common/inline-loader/InlineLoader', () => ({
 
 jest.mock('@/assets/icons/not-found.svg', () => ({
     ReactComponent: () => <svg data-testid="not-found-icon" />,
+}));
+
+jest.mock('@/assets/icons/plus.svg', () => ({
+    ReactComponent: () => <svg data-testid="plus-icon" />,
 }));
 
 jest.mock('@/components/common/select/Select', () => {
@@ -181,6 +195,19 @@ describe('ProgramExpensesSection', () => {
         expect(rows).toHaveLength(2);
         expect(within(table).getByText('Program B')).toBeInTheDocument();
         expect(within(table).queryByText('2024')).not.toBeInTheDocument();
+    });
+
+    it('should render program expenses empty state when records are missing', () => {
+        mockUseDataFetchResult = {
+            data: EMPTY_PROGRAM_EXPENSES_DATA,
+            isLoading: false,
+        };
+
+        render(<ProgramExpensesSection />);
+
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.EMPTY_STATE.TITLE)).toBeInTheDocument();
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.EMPTY_STATE.ADD_RECORD)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE })).toBeEnabled();
     });
 
     it('should pass fetch handler that calls ProgramExpensesApi.getReadOnlyData', async () => {

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
@@ -2,7 +2,7 @@ import { ChangeEvent, ReactNode } from 'react';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ProgramExpensesSection } from './ProgramExpensesSection';
-import { PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
 import { ProgramExpensesReadOnlyData } from '@/types/admin/reports';
 import { ProgramExpensesApi } from '@/services/api/admin/reports/program-expenses-api';
 
@@ -205,7 +205,7 @@ describe('ProgramExpensesSection', () => {
 
         render(<ProgramExpensesSection />);
 
-        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.EMPTY_STATE.TITLE)).toBeInTheDocument();
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.TITLE)).toBeInTheDocument();
         expect(screen.getByText(PROGRAM_EXPENSES_TEXT.EMPTY_STATE.ADD_RECORD)).toBeInTheDocument();
         expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE })).toBeEnabled();
     });

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
@@ -41,7 +41,9 @@ export const ProgramExpensesSection = () => {
         return data.records.filter((record) => record.programId === selectedProgramId);
     }, [data.records, selectedProgramId]);
 
-    const isInitialLoading = isLoading && data.records.length === 0 && data.programs.length === 0;
+    const programExpenseRecordsCount = data.records.length;
+    const hasAnyProgramExpenseRecords = programExpenseRecordsCount > 0;
+    const isInitialLoading = isLoading && programExpenseRecordsCount === 0 && data.programs.length === 0;
 
     if (isInitialLoading) {
         return (
@@ -64,7 +66,10 @@ export const ProgramExpensesSection = () => {
                     exchangeRate={data.exchangeRate}
                     onProgramChange={setSelectedProgramId}
                 />
-                <ProgramExpensesTable records={filteredRecords} />
+                <ProgramExpensesTable
+                    records={filteredRecords}
+                    hasAnyProgramExpenseRecords={hasAnyProgramExpenseRecords}
+                />
             </div>
         </div>
     );

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState.module.scss
@@ -1,6 +1,5 @@
 @use '@/assets/sass/variables/colors' as c;
 @use '@/assets/sass/mixins/typography.mixins' as type;
-@use '@/assets/sass/variables/typography' as t;
 
 .empty-row-program-expenses {
     height: 510px;
@@ -69,6 +68,8 @@
 }
 
 .empty-state-actions .add-program-expense-button {
+    @include type.body-2-semibold;
+
     display: flex;
     justify-content: center;
     align-items: center;
@@ -78,8 +79,6 @@
     padding: 8px;
     border-radius: 12px;
     background-color: c.$error;
-    font-size: 16px;
-    font-weight: t.$fw-semibold;
     white-space: nowrap;
     transition:
         background-color 0.2s ease,

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState.module.scss
@@ -1,0 +1,124 @@
+@use '@/assets/sass/variables/colors' as c;
+@use '@/assets/sass/mixins/typography.mixins' as type;
+@use '@/assets/sass/variables/typography' as t;
+
+.empty-row-program-expenses {
+    height: 510px;
+    border-top: 1px solid c.$grey-700;
+}
+
+.empty-cell {
+    padding: 48px 20px;
+    text-align: center;
+}
+
+.empty-cell-program-expenses {
+    padding-top: 66px;
+    padding-bottom: 88px;
+    vertical-align: top;
+}
+
+.empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+}
+
+.empty-state-program-expenses {
+    gap: 8px;
+}
+
+.empty-state-image {
+    width: 180px;
+    height: auto;
+}
+
+.empty-state-image-program-expenses {
+    margin-bottom: 22px;
+}
+
+.empty-state-title {
+    @include type.h4-semibold;
+    line-height: 24px;
+    color: c.$blue-900;
+    margin: 0;
+}
+
+.empty-state-message {
+    @include type.subtitle-2-medium;
+    margin: 0;
+    line-height: 24px;
+    color: c.$blue-900;
+}
+
+.empty-state-message-filtered {
+    font-weight: 400;
+    color: c.$graphite-black;
+}
+
+.empty-state-actions {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-top: 22px;
+}
+
+.empty-state-actions .add-program-expense-button {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    width: 206px;
+    height: 60px;
+    padding: 8px;
+    border-radius: 12px;
+    background-color: c.$error;
+    font-size: 16px;
+    font-weight: t.$fw-semibold;
+    white-space: nowrap;
+    transition:
+        background-color 0.2s ease,
+        box-shadow 0.2s ease,
+        transform 0.15s ease;
+
+    &:not(:disabled):hover {
+        background-color: c.$yellow-500;
+        color: c.$blue-900;
+        box-shadow: 0 4px 14px rgba(c.$yellow-500, 0.5);
+        transform: translateY(-1px);
+
+        svg path {
+            fill: c.$blue-900;
+        }
+    }
+
+    &:not(:disabled):active {
+        background-color: c.$yellow-600;
+        color: c.$blue-900;
+        box-shadow: 0 2px 6px rgba(c.$yellow-500, 0.35);
+        transform: translateY(0);
+    }
+
+    &:disabled {
+        opacity: 1;
+        cursor: not-allowed;
+        background: c.$grey-700;
+        color: c.$white;
+        box-shadow: none;
+
+        svg,
+        svg path {
+            fill: c.$white;
+            stroke: c.$white;
+        }
+    }
+}
+
+.plus-icon {
+    width: 24px;
+    height: 24px;
+    flex-shrink: 0;
+}

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState.module.scss
@@ -40,6 +40,7 @@
 
 .empty-state-title {
     @include type.h4-semibold;
+
     line-height: 24px;
     color: c.$blue-900;
     margin: 0;
@@ -47,6 +48,7 @@
 
 .empty-state-message {
     @include type.subtitle-2-medium;
+
     margin: 0;
     line-height: 24px;
     color: c.$blue-900;

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState.test.tsx
@@ -45,7 +45,7 @@ describe('ProgramExpensesEmptyState', () => {
         expect(screen.getByRole('table')).toBeInTheDocument();
         expect(screen.getByRole('cell')).toHaveAttribute('colspan', '5');
         expect(screen.getByTestId('not-found-icon')).toBeInTheDocument();
-        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.EMPTY_STATE.TITLE)).toBeInTheDocument();
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.TITLE)).toBeInTheDocument();
         expect(screen.getByText(PROGRAM_EXPENSES_TEXT.EMPTY_STATE.ADD_RECORD)).toBeInTheDocument();
         expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE })).toBeEnabled();
     });

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+import { ProgramExpensesEmptyState } from './ProgramExpensesEmptyState';
+
+jest.mock('@/assets/icons/not-found.svg', () => ({
+    ReactComponent: () => <svg data-testid="not-found-icon" />,
+}));
+
+jest.mock('@/assets/icons/plus.svg', () => ({
+    ReactComponent: () => <svg data-testid="plus-icon" />,
+}));
+
+const renderFilteredEmptyState = () =>
+    render(
+        <table>
+            <tbody>
+                <ProgramExpensesEmptyState colSpan={5} variant="filtered" />
+            </tbody>
+        </table>,
+    );
+
+const renderProgramExpensesEmptyState = () =>
+    render(
+        <table>
+            <tbody>
+                <ProgramExpensesEmptyState colSpan={5} variant="program-expenses" />
+            </tbody>
+        </table>,
+    );
+
+describe('ProgramExpensesEmptyState', () => {
+    it('should render filtered empty message', () => {
+        renderFilteredEmptyState();
+
+        expect(screen.getByRole('cell')).toHaveAttribute('colspan', '5');
+        expect(screen.getByTestId('not-found-icon')).toBeInTheDocument();
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.MESSAGE)).toBeInTheDocument();
+        expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('should render program expenses empty state with active button', () => {
+        renderProgramExpensesEmptyState();
+
+        expect(screen.getByRole('table')).toBeInTheDocument();
+        expect(screen.getByRole('cell')).toHaveAttribute('colspan', '5');
+        expect(screen.getByTestId('not-found-icon')).toBeInTheDocument();
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.EMPTY_STATE.TITLE)).toBeInTheDocument();
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.EMPTY_STATE.ADD_RECORD)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE })).toBeEnabled();
+    });
+});

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState.tsx
@@ -1,0 +1,50 @@
+import cn from 'classnames';
+import { Button } from '@/components/admin/button/Button';
+import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+import { ReactComponent as NotFoundIcon } from '@/assets/icons/not-found.svg';
+import { ReactComponent as PlusIcon } from '@/assets/icons/plus.svg';
+import styles from './ProgramExpensesEmptyState.module.scss';
+
+interface ProgramExpensesEmptyStateProps {
+    colSpan: number;
+    variant: 'filtered' | 'program-expenses';
+}
+
+export const ProgramExpensesEmptyState = ({ colSpan, variant }: ProgramExpensesEmptyStateProps) => {
+    if (variant === 'program-expenses') {
+        return (
+            <tr className={styles['empty-row-program-expenses']}>
+                <td className={styles['empty-cell-program-expenses']} colSpan={colSpan}>
+                    <div className={cn(styles['empty-state'], styles['empty-state-program-expenses'])}>
+                        <NotFoundIcon
+                            aria-hidden="true"
+                            className={cn(styles['empty-state-image'], styles['empty-state-image-program-expenses'])}
+                            focusable="false"
+                        />
+                        <p className={styles['empty-state-title']}>{PROGRAM_EXPENSES_TEXT.EMPTY_STATE.TITLE}</p>
+                        <p className={styles['empty-state-message']}>{PROGRAM_EXPENSES_TEXT.EMPTY_STATE.ADD_RECORD}</p>
+                        <div className={styles['empty-state-actions']}>
+                            <Button buttonStyle="primary" className={styles['add-program-expense-button']}>
+                                <PlusIcon aria-hidden="true" className={styles['plus-icon']} focusable="false" />
+                                {PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE}
+                            </Button>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+        );
+    }
+
+    return (
+        <tr>
+            <td className={styles['empty-cell']} colSpan={colSpan}>
+                <div className={styles['empty-state']}>
+                    <NotFoundIcon aria-hidden="true" className={styles['empty-state-image']} focusable="false" />
+                    <p className={cn(styles['empty-state-message'], styles['empty-state-message-filtered'])}>
+                        {FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.MESSAGE}
+                    </p>
+                </div>
+            </td>
+        </tr>
+    );
+};

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState.tsx
@@ -21,7 +21,7 @@ export const ProgramExpensesEmptyState = ({ colSpan, variant }: ProgramExpensesE
                             className={cn(styles['empty-state-image'], styles['empty-state-image-program-expenses'])}
                             focusable="false"
                         />
-                        <p className={styles['empty-state-title']}>{PROGRAM_EXPENSES_TEXT.EMPTY_STATE.TITLE}</p>
+                        <p className={styles['empty-state-title']}>{FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.TITLE}</p>
                         <p className={styles['empty-state-message']}>{PROGRAM_EXPENSES_TEXT.EMPTY_STATE.ADD_RECORD}</p>
                         <div className={styles['empty-state-actions']}>
                             <Button buttonStyle="primary" className={styles['add-program-expense-button']}>

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.module.scss
@@ -7,10 +7,10 @@
     width: 100%;
     min-height: 347px;
     overflow-x: auto;
-    background: c.$light-blue-25;
-    border: 1px solid c.$grey-500;
+    background: #f8fafc;
+    border: 1px solid #e2e2e2;
     border-radius: 16px;
-    box-shadow: 0 24px 48px -12px rgba(c.$bluish-black, 0.2);
+    box-shadow: 0 24px 48px -12px rgba(17, 17, 19, 0.2);
 }
 
 .table {
@@ -84,31 +84,6 @@
     line-height: 15px;
     letter-spacing: t.$small-spacing;
     text-align: center;
-}
-
-.empty-cell {
-    padding: 48px 20px;
-    text-align: center;
-}
-
-.empty-state {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 16px;
-}
-
-.empty-state-image {
-    width: 180px;
-    height: auto;
-}
-
-.empty-state-message {
-    @include type.subtitle-2-medium;
-    margin: 0;
-    font-weight: 400;
-    line-height: 24px;
-    color: c.$graphite-black;
 }
 
 @media (max-width: 1200px) {

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.module.scss
@@ -7,10 +7,10 @@
     width: 100%;
     min-height: 347px;
     overflow-x: auto;
-    background: #f8fafc;
-    border: 1px solid #e2e2e2;
+    background: c.$light-blue-25;
+    border: 1px solid c.$grey-500;
     border-radius: 16px;
-    box-shadow: 0 24px 48px -12px rgba(17, 17, 19, 0.2);
+    box-shadow: 0 24px 48px -12px rgba(c.$bluish-black, 0.2);
 }
 
 .table {

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.test.tsx
@@ -4,9 +4,33 @@ import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { ProgramExpensesTable } from './ProgramExpensesTable';
 import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
 
-jest.mock('@/assets/icons/not-found.svg', () => ({
-    ReactComponent: () => <svg data-testid="not-found-icon" />,
-}));
+jest.mock(
+    '@/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState',
+    () => ({
+        ProgramExpensesEmptyState: ({
+            colSpan = 5,
+            variant = 'filtered',
+        }: {
+            colSpan?: number;
+            variant?: 'filtered' | 'program-expenses';
+        }) => (
+            <tr data-testid="program-expenses-empty-state" data-variant={variant}>
+                <td colSpan={colSpan} data-testid="program-expenses-empty-state-cell" />
+            </tr>
+        ),
+    }),
+);
+
+const getEmptyState = () => screen.getByTestId('program-expenses-empty-state');
+const getEmptyStateCell = () => screen.getByTestId('program-expenses-empty-state-cell');
+
+const expectEmptyState = (variant: 'filtered' | 'program-expenses') => {
+    const emptyState = getEmptyState();
+
+    expect(emptyState).toBeInTheDocument();
+    expect(emptyState).toHaveAttribute('data-variant', variant);
+    expect(getEmptyStateCell()).toHaveAttribute('colspan', '5');
+};
 
 describe('ProgramExpensesTable', () => {
     const records = [
@@ -33,7 +57,7 @@ describe('ProgramExpensesTable', () => {
     const normalizeText = (value: string) => value.replaceAll('\u00A0', ' ').replaceAll(/\s+/g, ' ').trim();
 
     it('should render table headers', () => {
-        render(<ProgramExpensesTable records={records} />);
+        render(<ProgramExpensesTable records={records} hasAnyProgramExpenseRecords />);
 
         expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.REPORTING_YEAR)).toBeInTheDocument();
         expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.TYPE)).toBeInTheDocument();
@@ -43,7 +67,7 @@ describe('ProgramExpensesTable', () => {
     });
 
     it('should render formatted record values', () => {
-        const { container } = render(<ProgramExpensesTable records={records} />);
+        const { container } = render(<ProgramExpensesTable records={records} hasAnyProgramExpenseRecords />);
         const table = screen.getByRole('table');
 
         expect(within(table).getByText('2025')).toBeInTheDocument();
@@ -56,9 +80,16 @@ describe('ProgramExpensesTable', () => {
     });
 
     it('should render empty state when records are missing', () => {
-        render(<ProgramExpensesTable records={[]} />);
+        render(<ProgramExpensesTable records={[]} hasAnyProgramExpenseRecords />);
 
-        expect(screen.getByTestId('not-found-icon')).toBeInTheDocument();
-        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.MESSAGE)).toBeInTheDocument();
+        expectEmptyState('filtered');
+    });
+
+    it('should render program expenses empty state when there are no records in system', () => {
+        render(<ProgramExpensesTable records={[]} hasAnyProgramExpenseRecords={false} />);
+
+        expect(screen.getByRole('table')).toBeInTheDocument();
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.PROGRAM)).toBeInTheDocument();
+        expectEmptyState('program-expenses');
     });
 });

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.tsx
@@ -1,16 +1,21 @@
+import { ProgramExpensesEmptyState } from '@/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
 import { ProgramExpensesRecord } from '@/types/admin/reports';
-import { ReactComponent as NotFoundIcon } from '@/assets/icons/not-found.svg';
 import { formatSummaryAmount } from '@/utils/functions/format-summary-amount/format-summary-amount';
 import { parseAmount } from '@/utils/functions/parse-amount/parse-amount';
 import styles from './ProgramExpensesTable.module.scss';
 
 interface ProgramExpensesTableProps {
     records: ProgramExpensesRecord[];
+    hasAnyProgramExpenseRecords: boolean;
 }
 
-export const ProgramExpensesTable = ({ records }: ProgramExpensesTableProps) => {
+const TABLE_COLUMNS_COUNT = 5;
+
+export const ProgramExpensesTable = ({ records, hasAnyProgramExpenseRecords }: ProgramExpensesTableProps) => {
+    const hasNoRecords = records.length === 0;
+
     return (
         <div className={styles['table-wrapper']}>
             <table className={styles.table}>
@@ -31,17 +36,11 @@ export const ProgramExpensesTable = ({ records }: ProgramExpensesTableProps) => 
                     </tr>
                 </thead>
                 <tbody>
-                    {records.length === 0 ? (
-                        <tr>
-                            <td className={styles['empty-cell']} colSpan={5}>
-                                <div className={styles['empty-state']}>
-                                    <NotFoundIcon className={styles['empty-state-image']} />
-                                    <p className={styles['empty-state-message']}>
-                                        {FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.MESSAGE}
-                                    </p>
-                                </div>
-                            </td>
-                        </tr>
+                    {hasNoRecords ? (
+                        <ProgramExpensesEmptyState
+                            colSpan={TABLE_COLUMNS_COUNT}
+                            variant={hasAnyProgramExpenseRecords ? 'filtered' : 'program-expenses'}
+                        />
                     ) : (
                         records.map((record) => (
                             <tr key={record.id} className={styles.tr}>


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1827

## Description

Added an empty state for the “Program Expenses” reports section, including a dedicated empty-state component with the not-found illustration, text, and a non-functional “Program Expense” button. Updated the table to render the empty state as a table row while keeping the table structure in one place, and added/updated tests for the section, table, and empty-state behavior.

## How it looks

<img width="1412" height="661" alt="image" src="https://github.com/user-attachments/assets/2165b8bd-10ac-4a5c-a712-e60738ac702b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced empty-state UI for program expenses with localized title, message, add-record prompt and an "Add program expense" action.

* **Refactor**
  * Consolidated empty-state rendering into a shared component; table now distinguishes "no records" vs "filtered" variants and passes variant info.

* **Style**
  * Added comprehensive styles for empty-state layout, imagery and themed add button.

* **Tests**
  * Added/updated tests covering empty-state variants, localized copy, button presence/state and table behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->