### PR TITLE
Feature/issue-1943: [Reporst] [Admin Panel] Validate data in the "Додати надходження" modal

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -210,9 +210,9 @@ export const FUNDS_EXPENDITURES_TEXT = {
         },
     },
     VALIDATION: {
-        CATEGORY_UNIQUE: 'Категорія має бути унікальна',
-        AMOUNT_ONLY_NUMBER_GT_ZERO: 'Лише число > 0',
-        AMOUNT_MAX_DIGITS: "Не більше 11 цифр, 2 після ','",
+        CATEGORY_UNIQUE: 'Категорія вже додана до надходжень',
+        AMOUNT_ONLY_NUMBER_GT_ZERO: 'Дозволено лише цифри',
+        AMOUNT_MAX_DIGITS: 'Не більше 9 цифр до коми',
         AMOUNT_NOT_NEGATIVE: "Сума не може бути від'ємною",
         EXCHANGE_RATE_ONLY_NUMERIC: 'Дозволено тільки числові значення десяткові та цілі',
         EXCHANGE_RATE_GT_ZERO: 'Значення має бути більше 0',

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -211,9 +211,10 @@ export const FUNDS_EXPENDITURES_TEXT = {
     },
     VALIDATION: {
         CATEGORY_UNIQUE: 'Категорія вже додана до надходжень',
-        AMOUNT_ONLY_NUMBER_GT_ZERO: 'Дозволено лише цифри',
+        AMOUNT_ONLY_NUMBER: 'Дозволено лише цифри',
         AMOUNT_MAX_DIGITS: 'Не більше 9 цифр до коми',
         AMOUNT_NOT_NEGATIVE: "Сума не може бути від'ємною",
+        AMOUNT_NOT_ZERO: 'Сума не може дорівнювати 0',
         EXCHANGE_RATE_ONLY_NUMERIC: 'Дозволено тільки числові значення десяткові та цілі',
         EXCHANGE_RATE_GT_ZERO: 'Значення має бути більше 0',
         EXCHANGE_RATE_MAX_DIGITS: "Не більше 9 цифр, 6 після ','",

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.test.tsx
@@ -537,15 +537,12 @@ describe('AddIncomeModal', () => {
             const user = userEvent.setup({ delay: null });
             renderAddIncomeModal();
 
-            const yearSelect = screen.getByTestId('select-Оберіть звітній рік') as HTMLSelectElement;
-            const categorySelect = screen.getByTestId('select-Оберіть категорію надходження') as HTMLSelectElement;
-            const uahInput = screen.getByTestId('input-add-income-amount-uah') as HTMLInputElement;
-            const usdInput = screen.getByTestId('input-add-income-amount-usd') as HTMLInputElement;
-
-            fireEvent.change(yearSelect, { target: { value: currentYear } });
-            fireEvent.change(categorySelect, { target: { value: '1' } });
-            await user.type(uahInput, '100');
-            await user.type(usdInput, '10');
+            await fillRequiredFormFields(user, {
+                year: currentYear,
+                category: '1',
+                amountUah: '100',
+                amountUsd: '10',
+            });
 
             expect(screen.getByTestId('modal-submit')).toBeDisabled();
         });
@@ -656,15 +653,12 @@ describe('AddIncomeModal', () => {
             const user = userEvent.setup({ delay: null });
             renderAddIncomeModal();
 
-            const yearSelect = screen.getByTestId('select-Оберіть звітній рік') as HTMLSelectElement;
-            const categorySelect = screen.getByTestId('select-Оберіть категорію надходження') as HTMLSelectElement;
-            const uahInput = screen.getByTestId('input-add-income-amount-uah') as HTMLInputElement;
-            const usdInput = screen.getByTestId('input-add-income-amount-usd') as HTMLInputElement;
-
-            fireEvent.change(yearSelect, { target: { value: currentYear } });
-            fireEvent.change(categorySelect, { target: { value: '1' } });
-            await user.type(uahInput, '0');
-            await user.type(usdInput, '1');
+            await fillRequiredFormFields(user, {
+                year: currentYear,
+                category: '1',
+                amountUah: '0',
+                amountUsd: '1',
+            });
             fireEvent.click(screen.getByTestId('modal-force-submit'));
 
             expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_ZERO)).toBeInTheDocument();

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.test.tsx
@@ -600,7 +600,7 @@ describe('AddIncomeModal', () => {
             await user.clear(usdInput);
             await user.type(usdInput, 'abc');
 
-            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER_GT_ZERO)).toBeInTheDocument();
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER)).toBeInTheDocument();
             expect(screen.getByTestId('modal-submit')).toBeDisabled();
         });
     });
@@ -650,6 +650,25 @@ describe('AddIncomeModal', () => {
             uahInput.blur();
 
             expect(uahInput.value).toBe('100');
+        });
+
+        it('should show zero validation on save for amount UAH', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderAddIncomeModal();
+
+            const yearSelect = screen.getByTestId('select-Оберіть звітній рік') as HTMLSelectElement;
+            const categorySelect = screen.getByTestId('select-Оберіть категорію надходження') as HTMLSelectElement;
+            const uahInput = screen.getByTestId('input-add-income-amount-uah') as HTMLInputElement;
+            const usdInput = screen.getByTestId('input-add-income-amount-usd') as HTMLInputElement;
+
+            fireEvent.change(yearSelect, { target: { value: currentYear } });
+            fireEvent.change(categorySelect, { target: { value: '1' } });
+            await user.type(uahInput, '0');
+            await user.type(usdInput, '1');
+            fireEvent.click(screen.getByTestId('modal-force-submit'));
+
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_ZERO)).toBeInTheDocument();
+            expect(screen.getByTestId('modal-submit')).toBeDisabled();
         });
 
         it('should keep UAH unchanged when USD is manually edited and blurred', async () => {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.test.tsx
@@ -104,7 +104,7 @@ jest.mock('@/components/admin/input-with-character-limit/InputWithCharacterLimit
 jest.mock('@/components/common/select/Select', () => {
     const React = require('react');
     return {
-        Select: ({ value, onValueChange, children, placeholder }: any) => {
+        Select: ({ value, onValueChange, onBlur, children, placeholder }: any) => {
             const options = React.Children.toArray(children)
                 .filter((child: any) => child?.type?.name === 'Option' || child?.props?.name !== undefined)
                 .map((child: any) => ({
@@ -131,6 +131,7 @@ jest.mock('@/components/common/select/Select', () => {
                         'data-testid': `select-${placeholder}`,
                         value: value || '',
                         onChange: handleChange,
+                        onBlur,
                         'aria-label': placeholder,
                     },
                     React.createElement('option', { value: '' }, placeholder),
@@ -188,7 +189,7 @@ describe('AddIncomeModal', () => {
         user: ReturnType<typeof userEvent.setup>,
         {
             year = currentYear,
-            category = '1',
+            category = '3',
             amountUah = '400',
             amountUsd = '10',
             selectionMode = 'change',
@@ -530,6 +531,23 @@ describe('AddIncomeModal', () => {
             await user.selectOptions(categorySelect, '2');
 
             expect((categorySelect as HTMLSelectElement).value).toBe('2');
+        });
+
+        it('should disable submit button for duplicate income category', async () => {
+            const user = userEvent.setup({ delay: null });
+            renderAddIncomeModal();
+
+            const yearSelect = screen.getByTestId('select-Оберіть звітній рік') as HTMLSelectElement;
+            const categorySelect = screen.getByTestId('select-Оберіть категорію надходження') as HTMLSelectElement;
+            const uahInput = screen.getByTestId('input-add-income-amount-uah') as HTMLInputElement;
+            const usdInput = screen.getByTestId('input-add-income-amount-usd') as HTMLInputElement;
+
+            fireEvent.change(yearSelect, { target: { value: currentYear } });
+            fireEvent.change(categorySelect, { target: { value: '1' } });
+            await user.type(uahInput, '100');
+            await user.type(usdInput, '10');
+
+            expect(screen.getByTestId('modal-submit')).toBeDisabled();
         });
     });
 

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-income-modal/AddIncomeModal.tsx
@@ -213,7 +213,7 @@ export const AddIncomeModal = ({
                 amountUah: normalizedAmountUah,
                 amountUsd: normalizedAmountUsd,
                 type: 'income',
-            });
+            }).catch(() => false);
 
             if (isCreated) {
                 resetForm();
@@ -229,16 +229,17 @@ export const AddIncomeModal = ({
         formState.amountUah.trim() !== '' ||
         formState.amountUsd.trim() !== '';
 
+    const amountUahValidationError = validateFundsExpendituresAmount(formState.amountUah, 'save');
+    const amountUsdValidationError = validateFundsExpendituresAmount(formState.amountUsd, 'save');
+    const categoryValidationError = getCategoryError(formState.categoryId, 'blur');
+
     const isSubmitDisabled =
         isSubmitting ||
         !formState.reportingYear ||
         !formState.categoryId ||
-        !formState.amountUah.trim() ||
-        !formState.amountUsd.trim() ||
-        Boolean(formState.errors.reportingYear) ||
-        Boolean(formState.errors.categoryId) ||
-        Boolean(formState.errors.amountUah) ||
-        Boolean(formState.errors.amountUsd);
+        Boolean(amountUahValidationError) ||
+        Boolean(amountUsdValidationError) ||
+        Boolean(categoryValidationError);
 
     const handleOpenAddConfirmation = useCallback(() => {
         setIsAddConfirmationOpen(true);

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
@@ -687,7 +687,7 @@ describe('FundsExpendituresTable', () => {
             fireEvent.click(screen.getByLabelText('Edit record 1'));
             fireEvent.change(screen.getByLabelText('Amount USD record 1'), { target: { value: 'abc' } });
 
-            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER_GT_ZERO)).toBeInTheDocument();
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER)).toBeInTheDocument();
             expect(screen.getByLabelText('Accept record 1')).toBeDisabled();
         });
 
@@ -708,6 +708,17 @@ describe('FundsExpendituresTable', () => {
             fireEvent.change(screen.getByLabelText('Amount USD record 1'), { target: { value: '-500' } });
 
             expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_NEGATIVE)).toBeInTheDocument();
+            expect(screen.getByLabelText('Accept record 1')).toBeDisabled();
+        });
+
+        it('should show zero validation for zero amount on blur', () => {
+            renderTable({ isEditing: true });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            fireEvent.change(screen.getByLabelText('Amount UAH record 1'), { target: { value: '0' } });
+            fireEvent.blur(screen.getByLabelText('Amount UAH record 1'));
+
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_ZERO)).toBeInTheDocument();
             expect(screen.getByLabelText('Accept record 1')).toBeDisabled();
         });
 

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
@@ -31,13 +31,19 @@ describe('FUNDS_EXPENDITURES_RECORD_VALIDATION_FUNCTIONS', () => {
         });
 
         it('should return max digits error when integer part is too long', () => {
-            expect(validateFundsExpendituresAmount('123456789012', 'change')).toBe(
+            expect(validateFundsExpendituresAmount('1234567890', 'change')).toBe(
                 FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DIGITS,
             );
         });
 
         it('should return negative error for negative values', () => {
             expect(validateFundsExpendituresAmount('-1', 'change')).toBe(
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_NEGATIVE,
+            );
+        });
+
+        it('should return negative error for zero value', () => {
+            expect(validateFundsExpendituresAmount('0', 'change')).toBe(
                 FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_NEGATIVE,
             );
         });

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
@@ -26,7 +26,7 @@ describe('FUNDS_EXPENDITURES_RECORD_VALIDATION_FUNCTIONS', () => {
 
         it('should return numeric error for non-digit input', () => {
             expect(validateFundsExpendituresAmount('abc', 'change')).toBe(
-                FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER_GT_ZERO,
+            FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER,
             );
         });
 
@@ -42,9 +42,19 @@ describe('FUNDS_EXPENDITURES_RECORD_VALIDATION_FUNCTIONS', () => {
             );
         });
 
-        it('should return negative error for zero value', () => {
-            expect(validateFundsExpendituresAmount('0', 'change')).toBe(
-                FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_NEGATIVE,
+        it('should not return zero error on change', () => {
+            expect(validateFundsExpendituresAmount('0', 'change')).toBeUndefined();
+        });
+
+        it('should return zero error on blur', () => {
+            expect(validateFundsExpendituresAmount('0', 'blur')).toBe(
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_ZERO,
+            );
+        });
+
+        it('should return zero error on save', () => {
+            expect(validateFundsExpendituresAmount('0', 'save')).toBe(
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_ZERO,
             );
         });
 

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
@@ -26,7 +26,7 @@ describe('FUNDS_EXPENDITURES_RECORD_VALIDATION_FUNCTIONS', () => {
 
         it('should return numeric error for non-digit input', () => {
             expect(validateFundsExpendituresAmount('abc', 'change')).toBe(
-            FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER,
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER,
             );
         });
 

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
@@ -35,7 +35,7 @@ export const validateFundsExpendituresAmount = (
     }
 
     if (!/^\d+(?:[.,]\d+)?$/.test(compact)) {
-        return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER_GT_ZERO;
+        return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER;
     }
 
     const [integerPart] = compact.split(/[.,]/);
@@ -44,8 +44,16 @@ export const validateFundsExpendituresAmount = (
     }
 
     const parsed = Number.parseFloat(compact.replace(',', '.'));
-    if (!Number.isFinite(parsed) || parsed <= 0) {
+    if (!Number.isFinite(parsed)) {
+        return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER;
+    }
+
+    if (parsed < 0) {
         return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_NEGATIVE;
+    }
+
+    if (parsed === 0) {
+        return trigger === 'change' ? undefined : FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_ZERO;
     }
 
     return undefined;

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
@@ -38,14 +38,14 @@ export const validateFundsExpendituresAmount = (
         return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER_GT_ZERO;
     }
 
-    const [integerPart, decimalPart = ''] = compact.split(/[.,]/);
-    if (integerPart.length > 11 || decimalPart.length > 2) {
+    const [integerPart] = compact.split(/[.,]/);
+    if (integerPart.length > 9) {
         return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DIGITS;
     }
 
     const parsed = Number.parseFloat(compact.replace(',', '.'));
     if (!Number.isFinite(parsed) || parsed <= 0) {
-        return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER_GT_ZERO;
+        return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_NEGATIVE;
     }
 
     return undefined;


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1493

## Description

This PR implements validaion rules for "Додати надходжнення" modal.

## How it looks


https://github.com/user-attachments/assets/c95b992f-3e3d-4d59-afe2-ebb1d69c3840


## Summary of change

Updated amount validation rules (only numeric input, positive value, max 9 digits before separator).
Updated validation messages to match the new rules.

## How to recreate changes

1. Open Admin panel → Reports → Funds Expenditures.
2. Click Add Income.
3. Check required validation:
  - leave fields empty and try to submit.
4. Check category validation:
 - select an income category that already exists in income records.
5. Check amount validation:
 -enter letters/symbols,
 -enter negative value,
 -enter more than 9 digits before decimal separator.
6. Enter valid data and confirm submit works.

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified Ukrainian validation messages (duplicate category and numeric-input messages).
  * Added zero-value validation so amounts equal to 0 cannot be saved.
  * Tightened numeric amount rules (max 9 digits before the decimal).
  * Improved form submit handling to avoid errors blocking the flow.

* **Tests**
  * Added/updated tests for duplicate-category, zero-amount, and revised numeric validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->