### PR TITLE
Feature/issue-2128: [Reports] Edit text content in ENG in the 'Налаштування медіа' tab

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -40,7 +40,7 @@ export const REPORTS_TEXT = {
 
 export const REPORTS_MEDIA_SETTINGS_COLLECTED_FUNDS_VALIDATION = {
     title: {
-        min: 10,
+        min: 2,
         max: 50,
         getRequiredError: () => `Заголовок обов'язковий`,
     },
@@ -55,7 +55,7 @@ export const REPORTS_MEDIA_SETTINGS_COLLECTED_FUNDS_VALIDATION = {
 
 export const REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION = {
     title: {
-        min: 10,
+        min: 2,
         max: 50,
         getRequiredError: () => `Заголовок обов'язковий`,
     },

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -3,7 +3,7 @@ import { COMMON_TEXT_ADMIN } from './common';
 export const REPORTS_TEXT = {
     FORM: {
         LABEL: {
-            TITLE: 'Заголовок',
+            TITLE: 'Заголовок/EN',
             COLLECTED_FUNDS_WINDOW: 'Вікно 1: Зібрано коштів',
             CHANGED_LIVES_WINDOW: 'Вікно 2: Змінено життів',
             COLLECTED_FUNDS: 'Зібрані кошти',

--- a/src/pages/admin/reports/components/block-component/ReportsMediaBlock.test.tsx
+++ b/src/pages/admin/reports/components/block-component/ReportsMediaBlock.test.tsx
@@ -24,6 +24,7 @@ jest.mock(
             disabled,
             error,
             isRequired,
+            maxLimitWarning,
         }: {
             label: string;
             id: string;
@@ -35,6 +36,7 @@ jest.mock(
             disabled: boolean;
             error?: string;
             isRequired?: boolean;
+            maxLimitWarning?: string;
         }) => (
             <div>
                 <label htmlFor={id}>
@@ -43,6 +45,7 @@ jest.mock(
                 </label>
                 <textarea
                     data-testid={`mock-textarea-${id}`}
+                    data-max-limit-warning={maxLimitWarning}
                     maxLength={maxLength}
                     id={id}
                     name={name}
@@ -167,6 +170,16 @@ describe('ReportsMediaBlock', () => {
 
             const titleInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-title');
             expect(titleInput).toHaveValue('Test Title');
+        });
+
+        it('should pass the title max length warning to the title textarea', () => {
+            renderComponent();
+
+            const titleInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-title');
+            expect(titleInput).toHaveAttribute(
+                'data-max-limit-warning',
+                COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(50),
+            );
         });
 
         it('should render total amount input with correct value', () => {

--- a/src/pages/admin/reports/components/block-component/ReportsMediaBlock.tsx
+++ b/src/pages/admin/reports/components/block-component/ReportsMediaBlock.tsx
@@ -58,7 +58,7 @@ export const ReportsMediaBlock = ({
 }: ReportsMediaBlockProps) => {
     const handleTitleChange = useCallback(
         (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-            const value = getNormalizedInputText(e.target.value);
+            const value = e.target.value;
             const error = validationFunctions.validateTitle(value);
             onValuesChange({ ...values, title: value }, { ...errors, title: error });
         },

--- a/src/pages/admin/reports/components/block-component/ReportsMediaBlock.tsx
+++ b/src/pages/admin/reports/components/block-component/ReportsMediaBlock.tsx
@@ -6,6 +6,7 @@ import { REPORTS_TEXT } from '@/const/admin/reports';
 import { ImageInput } from '@/components/admin/image-input/ImageInput';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { TextAreaWithCharacterLimitGroup } from '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup';
+import { getNormalizedInputText } from '@/utils/functions/formatters/text-formatters';
 import './ReportsMediaBlock.scss';
 
 export interface ReportsMediaBlockValues {
@@ -57,7 +58,7 @@ export const ReportsMediaBlock = ({
 }: ReportsMediaBlockProps) => {
     const handleTitleChange = useCallback(
         (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-            const value = e.target.value;
+            const value = getNormalizedInputText(e.target.value);
             const error = validationFunctions.validateTitle(value);
             onValuesChange({ ...values, title: value }, { ...errors, title: error });
         },
@@ -66,8 +67,9 @@ export const ReportsMediaBlock = ({
 
     const handleTitleBlur = useCallback(
         (_e: React.FocusEvent<HTMLTextAreaElement>) => {
-            const error = validationFunctions.validateTitle(values.title);
-            onValuesChange({ ...values }, { ...errors, title: error });
+            const normalizedTitle = getNormalizedInputText(values.title);
+            const error = validationFunctions.validateTitle(normalizedTitle);
+            onValuesChange({ ...values, title: normalizedTitle }, { ...errors, title: error });
         },
         [onValuesChange, values, errors, validationFunctions],
     );

--- a/src/pages/admin/reports/components/block-component/ReportsMediaBlock.tsx
+++ b/src/pages/admin/reports/components/block-component/ReportsMediaBlock.tsx
@@ -123,6 +123,9 @@ export const ReportsMediaBlock = ({
                             onChange={handleTitleChange}
                             onBlur={handleTitleBlur}
                             maxLength={REPORTS_TEXT.FORM.MAX_LENGTH.TITLE}
+                            maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
+                                REPORTS_TEXT.FORM.MAX_LENGTH.TITLE,
+                            )}
                             error={errors.title}
                             rows={1}
                             isRequired={true}

--- a/src/pages/admin/reports/components/media-settings/MediaSettings.test.tsx
+++ b/src/pages/admin/reports/components/media-settings/MediaSettings.test.tsx
@@ -17,8 +17,8 @@ jest.mock('@/components/common/inline-loader/InlineLoader', () => ({
 }));
 
 jest.mock('@/components/admin/button/Button', () => ({
-    Button: ({ children, onClick, className }: any) => (
-        <button onClick={onClick} className={className}>
+    Button: ({ children, onClick, className, disabled }: any) => (
+        <button onClick={onClick} className={className} disabled={disabled}>
             {children}
         </button>
     ),
@@ -299,6 +299,19 @@ describe('MediaSettings', () => {
             });
 
             expect(mockOnDirtyChange).toHaveBeenCalledWith(true);
+        });
+
+        it('should disable publish button while there are validation errors', () => {
+            renderComponent({ isPublishDisabled: false });
+
+            act(() => {
+                changedLivesBlockProps!.onValuesChange(
+                    { ...changedLivesBlockProps!.values, title: '' },
+                    { title: COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED },
+                );
+            });
+
+            expect(screen.getByText(REPORTS_TEXT.BUTTON.PUBLISH)).toBeDisabled();
         });
 
         it('should update collected funds block values after change', () => {

--- a/src/pages/admin/reports/components/media-settings/MediaSettings.tsx
+++ b/src/pages/admin/reports/components/media-settings/MediaSettings.tsx
@@ -111,6 +111,9 @@ export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
             setChangedLivesErrors(INITIAL_BLOCK_ERRORS);
         }, [mediaSettingsData, resetCounter]);
 
+        const hasBlockErrors = (errors: ReportsMediaBlockErrors) =>
+            Boolean(Object.values(errors).find((error) => Boolean(error)));
+
         const handleCollectedFundsChange = useCallback(
             (values: ReportsMediaBlockValues, errors: ReportsMediaBlockErrors) => {
                 setCollectedFundsValues(values);
@@ -129,7 +132,40 @@ export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
             [onDirtyChange],
         );
 
+        const validateCurrentValues = useCallback((): boolean => {
+            const collectedFundsTitleError = REPORTS_COLLECTED_FUNDS_VALIDATION_FUNCTIONS.validateTitle(
+                collectedFundsValues.title,
+            );
+            const changedLivesTitleError = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTitle(
+                changedLivesValues.title,
+            );
+            const changedLivesValueError = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateChangedLives(
+                changedLivesValues.totalAmount,
+            );
+
+            const hasValidationErrors = Boolean(
+                collectedFundsTitleError || changedLivesTitleError || changedLivesValueError,
+            );
+
+            if (!hasValidationErrors) {
+                return true;
+            }
+
+            setCollectedFundsErrors((prev) => ({ ...prev, title: collectedFundsTitleError }));
+            setChangedLivesErrors((prev) => ({
+                ...prev,
+                title: changedLivesTitleError,
+                totalAmount: changedLivesValueError,
+            }));
+
+            return false;
+        }, [changedLivesValues.title, changedLivesValues.totalAmount, collectedFundsValues.title]);
+
         const handlePublish = useCallback(async (): Promise<boolean> => {
+            if (!validateCurrentValues()) {
+                return false;
+            }
+
             try {
                 let collectedFundsImage = collectedFundsValues.image;
                 let collectedFundsImageId = collectedFundsValues.imageId;
@@ -250,7 +286,11 @@ export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
                                 buttonStyle="primary"
                                 className={styles.button}
                                 onClick={onPublish}
-                                disabled={isPublishDisabled}
+                                disabled={
+                                    isPublishDisabled ||
+                                    hasBlockErrors(collectedFundsErrors) ||
+                                    hasBlockErrors(changedLivesErrors)
+                                }
                             >
                                 {REPORTS_TEXT.BUTTON.PUBLISH}
                             </Button>

--- a/src/pages/admin/reports/components/media-settings/MediaSettings.tsx
+++ b/src/pages/admin/reports/components/media-settings/MediaSettings.tsx
@@ -132,7 +132,7 @@ export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
             [onDirtyChange],
         );
 
-        const validateCurrentValues = (): boolean => {
+        const validateCurrentValues = useCallback((): boolean => {
             const collectedFundsTitleError = REPORTS_COLLECTED_FUNDS_VALIDATION_FUNCTIONS.validateTitle(
                 collectedFundsValues.title,
             );
@@ -159,7 +159,7 @@ export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
             }));
 
             return false;
-        };
+        }, [collectedFundsValues, changedLivesValues]);
 
         const handlePublish = useCallback(async (): Promise<boolean> => {
             if (!validateCurrentValues()) {
@@ -220,7 +220,7 @@ export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
                 addToast(REPORTS_TEXT.MESSAGE.FAIL_TO_UPDATE_REPORT, ToastType.Error);
                 return false;
             }
-        }, [addToast, client, collectedFundsValues, changedLivesValues, refetch]);
+        }, [addToast, client, collectedFundsValues, changedLivesValues, refetch, validateCurrentValues]);
 
         useImperativeHandle(ref, () => ({ submit: handlePublish }));
 

--- a/src/pages/admin/reports/components/media-settings/MediaSettings.tsx
+++ b/src/pages/admin/reports/components/media-settings/MediaSettings.tsx
@@ -132,7 +132,7 @@ export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
             [onDirtyChange],
         );
 
-        const validateCurrentValues = useCallback((): boolean => {
+        const validateCurrentValues = (): boolean => {
             const collectedFundsTitleError = REPORTS_COLLECTED_FUNDS_VALIDATION_FUNCTIONS.validateTitle(
                 collectedFundsValues.title,
             );
@@ -159,7 +159,7 @@ export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
             }));
 
             return false;
-        }, [changedLivesValues.title, changedLivesValues.totalAmount, collectedFundsValues.title]);
+        };
 
         const handlePublish = useCallback(async (): Promise<boolean> => {
             if (!validateCurrentValues()) {

--- a/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.test.ts
+++ b/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.test.ts
@@ -53,6 +53,16 @@ describe('reports-media-settings-schema', () => {
                 const result = REPORTS_COLLECTED_FUNDS_VALIDATION_FUNCTIONS.validateTitle(maxTitle);
                 expect(result).toBeUndefined();
             });
+
+            it('should return required error for a whitespace-only title', () => {
+                const result = REPORTS_COLLECTED_FUNDS_VALIDATION_FUNCTIONS.validateTitle('     ');
+                expect(result).toBe(REPORTS_MEDIA_SETTINGS_COLLECTED_FUNDS_VALIDATION.title.getRequiredError());
+            });
+
+            it('should normalize consecutive spaces and validate successfully', () => {
+                const result = REPORTS_COLLECTED_FUNDS_VALIDATION_FUNCTIONS.validateTitle('Valid   title   text');
+                expect(result).toBeUndefined();
+            });
         });
     });
 
@@ -97,6 +107,16 @@ describe('reports-media-settings-schema', () => {
             it('should return undefined for title at max length', () => {
                 const maxTitle = 'a'.repeat(REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.title.max);
                 const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTitle(maxTitle);
+                expect(result).toBeUndefined();
+            });
+
+            it('should return required error for a whitespace-only title', () => {
+                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTitle('     ');
+                expect(result).toBe(REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.title.getRequiredError());
+            });
+
+            it('should normalize consecutive spaces and validate successfully', () => {
+                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTitle('Valid   title   text');
                 expect(result).toBeUndefined();
             });
         });

--- a/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.ts
+++ b/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.ts
@@ -6,8 +6,11 @@ import {
     REPORTS_TEXT,
 } from '@/const/admin/reports';
 
+const normalizeTextInput = (value: string): string => value.trim().replace(/\s+/g, ' ');
+
 const collectedFundsSchema = Yup.object({
     title: Yup.string()
+        .transform((value) => (typeof value === 'string' ? normalizeTextInput(value) : value))
         .required(REPORTS_MEDIA_SETTINGS_COLLECTED_FUNDS_VALIDATION.title.getRequiredError())
         .min(
             REPORTS_MEDIA_SETTINGS_COLLECTED_FUNDS_VALIDATION.title.min,
@@ -36,6 +39,7 @@ export const REPORTS_COLLECTED_FUNDS_VALIDATION_FUNCTIONS = {
 
 const changedLivesSchema = Yup.object({
     title: Yup.string()
+        .transform((value) => (typeof value === 'string' ? normalizeTextInput(value) : value))
         .required(REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.title.getRequiredError())
         .min(
             REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.title.min,


### PR DESCRIPTION
…ests

## JIRA or Github ticker

[* [JIRA or Github ticket](https://jira.softserve.academy/secure/RapidBoard.jspa?rapidView=id)](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2128)

## Description

This PR improves validation and input handling for ENG text fields in the Reports (Звітність) tab in Admin panel.

It ensures correct behavior for whitespace handling, validation, and user input consistency according to acceptance criteria.
Part of the validation logic already existed and has been reused and extended.

## How it looks


https://github.com/user-attachments/assets/73116b61-da22-46c0-8687-b3c5206d7aad



## Summary of change

-Added normalization of text input (trim + replace multiple spaces with a single space)
-Integrated getNormalizedInputText in input handlers (onChange, onBlur)
-Updated validation schemas using Yup.transform for normalized input
-Fixed handling of whitespace-only values (treated as empty)
-Updated blur behavior to normalize value before validation
-Added unit tests for:
whitespace-only input
normalized input with multiple spaces
Minor label update for ENG field (Заголовок/EN)

## How to recreate changes

1. Login as Admin
2. Navigate to Reports (Звітність) tab
3. Open edit mode (Налаштування медіа)
4. Enter values in title fields:
-only spaces (" ")
-text with multiple spaces ("Valid title text")
5. Observe:
-spaces are trimmed and normalized
-whitespace-only input is treated as empty
-validation works correctly on input and blur


## CHECK LIST
- [x]  Input normalization works (trim + space collapsing)
- [x]  Whitespace-only values handled as empty
- [x]  Validation schema updated with transform
- [x]  onChange and onBlur logic consistent
- [x]  Unit tests added and passing
- [x]  No regressions in existing validation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-publish validation prevents publishing when report fields have errors.
  * Publish button is disabled when validation errors exist.
  * Title fields now show a max-length warning.

* **Improvements**
  * Reduced minimum title length from 10 to 2 characters.
  * Title text is automatically normalized (trimmed and internal spaces collapsed).
  * Title label updated to include "/EN".

* **Tests**
  * Added tests for normalization, whitespace/required handling, max-length warning, and UI disablement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->