### PR TITLE
Fix/issue-2231: add image URL versioning in getImageSrc using updateDate

### DIFF
--- a/src/components/public/program-card/ProgramCard.tsx
+++ b/src/components/public/program-card/ProgramCard.tsx
@@ -2,6 +2,7 @@ import { PublishedProgramDto } from '@/types/public/programs-page';
 import { ReactComponent as ArrowIcon } from '@/assets/icons/arrow-up-right.svg';
 import styleswhoWeAre from './ProgramCardAboutUsPage.module.scss';
 import stylesPrograms from './ProgramCardProgramsPage.module.scss';
+import { getImageSrc } from '@/utils/functions/image-helper/image-helper';
 import { useNavigate } from 'react-router-dom';
 import { PUBLIC_ROUTES } from '@/const/public/routes';
 import cn from 'classnames';
@@ -50,7 +51,7 @@ export const ProgramCard = ({ program, variant }: ProgramCardProps) => {
             style={{ cursor: program.slug ? 'pointer' : 'default' }}
         >
             <div className={styles['image-wrapper']}>
-                <img src={program.previewImage?.url} alt={program.name} className={styles.image} />
+                <img src={getImageSrc(program.previewImage)} alt={program.name} className={styles.image} />
             </div>
             <div className={styles.content}>
                 <div className={styles[`subtitle-content`]}>

--- a/src/pages/public/about-us-page/intro-section/IntroSection.tsx
+++ b/src/pages/public/about-us-page/intro-section/IntroSection.tsx
@@ -4,6 +4,7 @@ import { ContentType } from '@/types/common/about-us';
 import { AboutUsContent } from '@/types/public/about-us-page';
 import { SafeHtml } from '@/components/common/safe-html';
 import { useGetLocalization } from '@/hooks/common/use-get-localization/useGetLocalization';
+import { getImageSrc } from '@/utils/functions/image-helper/image-helper';
 
 export interface AboutUsIntroProps {
     content?: AboutUsContent[] | null;
@@ -20,7 +21,7 @@ export const AboutUsIntro = ({ content }: AboutUsIntroProps) => {
         description: descriptionContent?.description,
     });
 
-    const imageUrl = content?.find((x) => x.contentType === ContentType.Image)?.image?.url ?? background;
+    const imageUrl = getImageSrc(content?.find((x) => x.contentType === ContentType.Image)?.image) || background;
 
     return (
         <section className={styles.root}>

--- a/src/pages/public/about-us-page/main-value/MainValue.tsx
+++ b/src/pages/public/about-us-page/main-value/MainValue.tsx
@@ -4,6 +4,7 @@ import styles from './MainValue.module.scss';
 import { WaveSwiper } from '@/components/public/swiper/wave-swiper/WaveSwiper';
 import { AboutUsContent } from '@/types/public/about-us-page';
 import { SwipedCard } from '@/components/public/swiper/swiped-card/SwipedCard';
+import { getImageSrc } from '@/utils/functions/image-helper/image-helper';
 
 export interface MainValuesProps {
     content: AboutUsContent[] | null;
@@ -28,7 +29,7 @@ export const MainValues = ({ content }: MainValuesProps) => {
                 <WaveSwiper
                     items={content}
                     renderItemCallback={(person, index) => {
-                        const imageUrl = person.image?.url ?? ABOUT_US_DATA.PEOPLE_DATA[index].IMG;
+                        const imageUrl = getImageSrc(person.image) || ABOUT_US_DATA.PEOPLE_DATA[index].IMG;
                         const altText = peopleData[index].ALT;
                         return (
                             <SwipedCard

--- a/src/pages/public/about-us-page/our-team-section/OurTeam.tsx
+++ b/src/pages/public/about-us-page/our-team-section/OurTeam.tsx
@@ -7,6 +7,7 @@ import defaultOurTeamImage from '@/assets/images/our-team.webp';
 import { Button } from '@/components/public/ui/button';
 import { SafeHtml } from '@/components/common/safe-html';
 import { useGetLocalization } from '@/hooks/common/use-get-localization/useGetLocalization';
+import { getImageSrc } from '@/utils/functions/image-helper/image-helper';
 
 export interface OurTeamProps {
     content?: AboutUsContent[] | null;
@@ -15,7 +16,8 @@ export interface OurTeamProps {
 export const OurTeam = ({ content }: OurTeamProps) => {
     const { t } = useTranslation('aboutUsPage');
 
-    const imageUrl = content?.find((x) => x.contentType === ContentType.Image)?.image?.url ?? defaultOurTeamImage;
+    const imageUrl =
+        getImageSrc(content?.find((x) => x.contentType === ContentType.Image)?.image) || defaultOurTeamImage;
 
     const descriptionContent = content?.find((x) => x.contentType === ContentType.Description);
     const { description } = useGetLocalization(descriptionContent?.localizations, {

--- a/src/pages/public/about-us-page/support-section/components/support-card/SupportCard.tsx
+++ b/src/pages/public/about-us-page/support-section/components/support-card/SupportCard.tsx
@@ -5,6 +5,7 @@ import styles from './SupportCard.module.scss';
 import cn from 'classnames';
 import { SafeHtml } from '@/components/common/safe-html';
 import { useGetLocalization } from '@/hooks/common/use-get-localization/useGetLocalization';
+import { getImageSrc } from '@/utils/functions/image-helper/image-helper';
 
 interface SupportCardProps {
     card: AboutUsContent;
@@ -15,7 +16,7 @@ export function SupportCard({ card, index }: SupportCardProps) {
     const { t } = useTranslation('aboutUsPage');
     const supportData = t('SUPPORT_DATA', { returnObjects: true });
 
-    const imageUrl = card.image?.url ?? ABOUT_US_DATA.SUPPORT_DATA[index].IMG;
+    const imageUrl = getImageSrc(card.image) || ABOUT_US_DATA.SUPPORT_DATA[index].IMG;
     const altText = supportData[index].ALT;
 
     const { description } = useGetLocalization(card?.localizations, {

--- a/src/pages/public/detailed-program-page/components/detailed-program-page-content/DetailedProgramPageContent.tsx
+++ b/src/pages/public/detailed-program-page/components/detailed-program-page-content/DetailedProgramPageContent.tsx
@@ -8,6 +8,7 @@ import { ReactComponent as MapPin } from '@/assets/icons/map-pin.svg';
 import { ReactComponent as UsersRound } from '@/assets/icons/users-round.svg';
 import { ReactComponent as CalendarDays } from '@/assets/icons/calendar-days.svg';
 import { useProgramBySlug } from '@/hooks/common/use-get-program-by-slug/useGetProgramBySlug';
+import { getImageSrc } from '@/utils/functions/image-helper/image-helper';
 import { InfoItem } from '../info-item/InfoItem';
 import { DetailedProgramSection } from '@/components/public/detailed-program-section/DetailedProgramSection';
 import { CtaSection } from '@/components/public/cta';
@@ -56,7 +57,7 @@ export const DetailedProgramPageContent: React.FC = () => {
                 {program.backgroundImage && (
                     <div className={styles['background-media-wrapper']}>
                         <BackgroundMedia
-                            mediaUrl={program.backgroundImage.url}
+                            mediaUrl={getImageSrc(program.backgroundImage)}
                             className={styles['background-gradient']}
                         />
                         <div className={styles['content-container']}>

--- a/src/pages/public/partners-page/partners-sections/intro-section/IntroSection.tsx
+++ b/src/pages/public/partners-page/partners-sections/intro-section/IntroSection.tsx
@@ -3,6 +3,7 @@ import background from '@/assets/images/horses.webp';
 import { PartnersBanner } from '@/types/public/partners-page';
 import DOMPurify from 'dompurify';
 import { SafeHtml } from '@/components/common/safe-html';
+import { getImageSrc } from '@/utils/functions/image-helper/image-helper';
 
 export interface IntroSectionProps {
     banner: PartnersBanner | null;
@@ -14,7 +15,7 @@ export const IntroSection = ({ banner }: IntroSectionProps) => {
     }
 
     const { title, description, image } = banner;
-    const imageUrl = image?.url ?? background;
+    const imageUrl = getImageSrc(image) || background;
 
     const sanitizedTitle = DOMPurify.sanitize(title, {
         ALLOWED_TAGS: ['strong', 'em', 'b', 'i', 'br'],

--- a/src/pages/public/partners-page/partners-sections/partners-section/PartnersSection.tsx
+++ b/src/pages/public/partners-page/partners-sections/partners-section/PartnersSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { PartnerSection } from '@/types/public/partners-page';
 import styles from './PartnersSection.module.scss';
+import { getImageSrc } from '@/utils/functions/image-helper/image-helper';
 
 interface PartnersSectionProps {
     section: PartnerSection | null;
@@ -22,7 +23,7 @@ export const PartnersSection = ({ section }: PartnersSectionProps) => {
                     {section.partners.map((partner) => (
                         <div key={partner.id} className={styles['partner-item']}>
                             <img
-                                src={partner.image.url}
+                                src={getImageSrc(partner.image)}
                                 alt={`${partner.id} logo`}
                                 className={styles['partner-logo']}
                             />

--- a/src/services/api/public/team/team-api.ts
+++ b/src/services/api/public/team/team-api.ts
@@ -8,6 +8,7 @@ import {
 } from '@/types/public/team-page';
 import { axiosInstance } from '@/services/api/axios';
 import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/localization/localization-mappers';
+import { getImageSrc } from '@/utils/functions/image-helper/image-helper';
 
 const isValidCategory = (category: PublicCategoryWithTeamMembersDto): boolean => {
     return Boolean(
@@ -23,7 +24,7 @@ const mapTeamMemberDtoToTeamMember = (dto: PublicTeamMemberDto): MemberCard => (
     id: dto.id,
     name: dto.fullName,
     role: dto.description || '',
-    photo: dto.image?.url ?? null,
+    photo: getImageSrc(dto.image) || null,
     localizations: dto.localizations?.map((loc) => mapLocalizationDtoToModel(loc)) ?? [],
 });
 

--- a/src/types/common/image.ts
+++ b/src/types/common/image.ts
@@ -2,6 +2,7 @@ export interface Image {
     id: number | null;
     url: string;
     mimeType: string;
+    updatedAt?: string;
 }
 
 export interface ImageValues {

--- a/src/utils/functions/image-helper/image-helper.ts
+++ b/src/utils/functions/image-helper/image-helper.ts
@@ -10,7 +10,8 @@ export const getImageSrc = (image: Image | ImageValues | string | null | undefin
     }
 
     if ('url' in image && image.url) {
-        return image.url;
+        const v = image.updatedAt ? `?v=${new Date(image.updatedAt).getTime()}` : '';
+        return `${image.url}${v}`;
     }
 
     if ('base64' in image && image.base64) {


### PR DESCRIPTION
## Github ticker

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2231)

* [Related  backend PR](https://github.com/ita-social-projects/VictoryCenter-Back/pull/2280)

## Description

Updated image URL generation to support cache busting.

## Summary of change

	•	Updated the getImageSrc function.
	•	The function now appends a version parameter derived from updateDate to the image URL.

## How to recreate changes

	1.	Open the admin panel.
	2.	Navigate to any section that contains an image.
	3.	Replace the image.
	4.	Click “Publish”.
	5.	Open the corresponding public page.
	6.	Reload the page and verify that the image has been updated.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions
