### PR TITLE
Feature/issue-1825: Filter program expenses by selected programs

### DIFF
--- a/src/components/admin/input-groups/multi-select-input-group/MultiSelectInputGroup.test.tsx
+++ b/src/components/admin/input-groups/multi-select-input-group/MultiSelectInputGroup.test.tsx
@@ -1,13 +1,20 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MultiSelectInputGroup } from './MultiSelectInputGroup';
+import { MultiSelectInputProps } from '@/components/admin/multi-select-input/MultiSelectInput';
 
 jest.mock('@/components/admin/input-label/InputLabel', () => ({
     InputLabel: ({ text }: { text: string }) => <div data-testid="mock-label">{text}</div>,
 }));
 
+const mockMultiSelectInput = jest.fn();
+
 jest.mock('@/components/admin/multi-select-input/MultiSelectInput', () => ({
-    MultiSelectInput: () => <input title="mock-input" data-testid="mock-input" />,
+    MultiSelectInput: (props: MultiSelectInputProps<string>) => {
+        mockMultiSelectInput(props);
+
+        return <input title="mock-input" data-testid="mock-input" />;
+    },
 }));
 
 jest.mock('@/components/admin/input-error/InputError', () => ({
@@ -15,6 +22,10 @@ jest.mock('@/components/admin/input-error/InputError', () => ({
 }));
 
 describe('MultiSelectInputGroup', () => {
+    beforeEach(() => {
+        mockMultiSelectInput.mockClear();
+    });
+
     it('renders label, input and error', () => {
         render(
             <MultiSelectInputGroup<string>
@@ -30,5 +41,30 @@ describe('MultiSelectInputGroup', () => {
         expect(screen.getByTestId('mock-label')).toBeInTheDocument();
         expect(screen.getByTestId('mock-input')).toBeInTheDocument();
         expect(screen.getByTestId('mock-error')).toBeInTheDocument();
+    });
+
+    it('passes display and selection callbacks to input', () => {
+        const getDisplayValue = jest.fn((selectedValues: string[]) => selectedValues.join(', '));
+        const isOptionSelected = jest.fn((option: string, selectedValues: string[]) => selectedValues.includes(option));
+
+        render(
+            <MultiSelectInputGroup<string>
+                id={'test'}
+                label="Test Label"
+                options={['One', 'Two']}
+                value={['One']}
+                getOptionId={(option) => option}
+                getOptionName={(option) => option}
+                getDisplayValue={getDisplayValue}
+                isOptionSelected={isOptionSelected}
+            />,
+        );
+
+        expect(mockMultiSelectInput).toHaveBeenCalledWith(
+            expect.objectContaining({
+                getDisplayValue,
+                isOptionSelected,
+            }),
+        );
     });
 });

--- a/src/components/admin/input-groups/multi-select-input-group/MultiSelectInputGroup.tsx
+++ b/src/components/admin/input-groups/multi-select-input-group/MultiSelectInputGroup.tsx
@@ -21,6 +21,8 @@ export const MultiSelectInputGroup = <T,>({
     onBlur,
     getOptionId,
     getOptionName,
+    getDisplayValue,
+    isOptionSelected,
     placeholder,
     disabled,
     error,
@@ -37,6 +39,8 @@ export const MultiSelectInputGroup = <T,>({
                 onBlur={onBlur}
                 getOptionId={getOptionId}
                 getOptionName={getOptionName}
+                getDisplayValue={getDisplayValue}
+                isOptionSelected={isOptionSelected}
                 placeholder={placeholder}
                 disabled={disabled}
             />

--- a/src/components/admin/multi-select-input/MultiSelectInput.test.tsx
+++ b/src/components/admin/multi-select-input/MultiSelectInput.test.tsx
@@ -258,6 +258,19 @@ describe('Multiselect Component', () => {
             expectPlaceholderTextToBe('Option 1, Option 2');
         });
 
+        it('uses custom display value when provided', () => {
+            const selectedValues = [mockOptions[0], mockOptions[1]];
+            const getDisplayValue = jest.fn((values: TestOption[]) => `Selected: ${values.length}`);
+
+            renderMultiSelectInput({
+                ...createPropsWithSelectedValues(selectedValues),
+                getDisplayValue,
+            });
+
+            expectPlaceholderTextToBe('Selected: 2');
+            expect(getDisplayValue).toHaveBeenCalledWith(selectedValues);
+        });
+
         it('applies has-value className when items are selected', () => {
             const selectedValues = [mockOptions[0]];
             renderMultiSelectInput(createPropsWithSelectedValues(selectedValues));
@@ -282,6 +295,20 @@ describe('Multiselect Component', () => {
             expectOnChangeToBeCalledWith([mockOptions[1]]);
         });
 
+        it('does not call onChange when option id is missing', () => {
+            renderMultiSelectInput(
+                createPropsWithCallbacks({
+                    getOptionId: (option) =>
+                        option.id === mockOptions[0].id ? (null as unknown as number) : option.id,
+                }),
+            );
+
+            openDropdown();
+            clickOptionByName('Option 1');
+
+            expectOnChangeNotToBeCalled();
+        });
+
         it('applies selected className to selected options', () => {
             const selectedValues = [mockOptions[0]];
             renderMultiSelectInput(createPropsWithSelectedValues(selectedValues));
@@ -294,6 +321,19 @@ describe('Multiselect Component', () => {
             renderMultiSelectInput(createPropsWithSelectedValues(selectedValues));
             openDropdown();
 
+            expectSelectedIconsCount(1);
+            expectUnselectedIconsCount(3);
+        });
+
+        it('uses custom selected state when provided', () => {
+            renderMultiSelectInput({
+                isOptionSelected: (option) => option.id === mockOptions[1].id,
+            });
+
+            openDropdown();
+
+            expect(getOptionByName('Option 1')).toHaveAttribute('aria-selected', 'false');
+            expect(getOptionByName('Option 2')).toHaveAttribute('aria-selected', 'true');
             expectSelectedIconsCount(1);
             expectUnselectedIconsCount(3);
         });

--- a/src/components/admin/multi-select-input/MultiSelectInput.tsx
+++ b/src/components/admin/multi-select-input/MultiSelectInput.tsx
@@ -13,6 +13,8 @@ export interface MultiSelectInputProps<T> {
     value?: T[];
     getOptionId: (value: T) => string | number;
     getOptionName: (value: T) => string;
+    getDisplayValue?: (selectedValues: T[]) => string;
+    isOptionSelected?: (option: T, selectedValues: T[]) => boolean;
     onChange?: (selectedValues: T[]) => void;
     onBlur?: () => void;
     placeholder?: string;
@@ -27,6 +29,8 @@ export const MultiSelectInput = <T,>({
     onBlur,
     getOptionId,
     getOptionName,
+    getDisplayValue,
+    isOptionSelected,
     placeholder = 'Select options...',
     disabled,
 }: MultiSelectInputProps<T>) => {
@@ -36,21 +40,23 @@ export const MultiSelectInput = <T,>({
     const selectedIds = useMemo(() => new Set(value.map(getOptionId)), [value, getOptionId]);
 
     const displayLabel = useMemo(() => {
+        if (getDisplayValue) return getDisplayValue(value);
         if (value.length === 0) return placeholder;
         return value.map(getOptionName).join(', ');
-    }, [value, getOptionName, placeholder]);
+    }, [value, getOptionName, getDisplayValue, placeholder]);
 
     const isSelected = useCallback(
         (option: T): boolean => {
+            if (isOptionSelected) return isOptionSelected(option, value);
+
             const optionId = getOptionId(option);
             return optionId != null && selectedIds.has(optionId);
         },
-        [selectedIds, getOptionId],
+        [selectedIds, getOptionId, isOptionSelected, value],
     );
 
     const toggleOption = useCallback(
         (optionValue: T) => {
-            if (disabled) return;
             const optionId = getOptionId(optionValue);
             if (optionId == null) return;
 
@@ -60,13 +66,12 @@ export const MultiSelectInput = <T,>({
                 : [...value, optionValue];
             onChange?.(newSelectedValues);
         },
-        [value, selectedIds, getOptionId, onChange, disabled],
+        [value, selectedIds, getOptionId, onChange],
     );
 
     const toggleDropdown = useCallback(() => {
-        if (disabled) return;
         setIsOpen((prev) => !prev);
-    }, [disabled]);
+    }, []);
 
     const handleOptionKeyDown = useCallback(
         (e: React.KeyboardEvent<HTMLDivElement>, option: T) => {

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -231,6 +231,11 @@ export const PROGRAM_EXPENSES_TEXT = {
     BUTTON: {
         ADD_PROGRAM_EXPENSE: 'Витрата по програмі',
     },
+    FILTER: {
+        PROGRAMS_PLACEHOLDER: 'Програми',
+        ALL_OPTION: 'Всі',
+        getProgramsCounterLabel: (count: number) => `Програми (${count})`,
+    },
     EMPTY_STATE: {
         ADD_RECORD: 'додайте перший запис Програмної витрати',
     },

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
@@ -1,4 +1,3 @@
-import { ChangeEvent, ReactNode } from 'react';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ProgramExpensesSection } from './ProgramExpensesSection';
@@ -11,6 +10,7 @@ const MOCK_PROGRAM_EXPENSES_DATA: ProgramExpensesReadOnlyData = {
     programs: [
         { id: 1, name: 'Program A' },
         { id: 2, name: 'Program B' },
+        { id: 3, name: 'Program C' },
     ],
     summary: {
         totalAmountUah: 125000,
@@ -57,10 +57,6 @@ const EMPTY_PROGRAM_EXPENSES_DATA: ProgramExpensesReadOnlyData = {
     records: [],
 };
 
-jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
-    useAdminClient: () => ({}),
-}));
-
 const mockGetReadOnlyData = jest.fn();
 jest.mock('@/services/api/admin/reports/program-expenses-api', () => ({
     ProgramExpensesApi: {
@@ -90,53 +86,57 @@ jest.mock('@/assets/icons/plus.svg', () => ({
     ReactComponent: () => <svg data-testid="plus-icon" />,
 }));
 
-jest.mock('@/components/common/select/Select', () => {
-    const React = require('react');
-
-    interface MockSelectProps<TValue> {
-        value: TValue;
-        onValueChange: (value: TValue) => void;
-        children: ReactNode;
+jest.mock('@/components/admin/multi-select-input/MultiSelectInput', () => ({
+    MultiSelectInput: ({
+        options,
+        onChange,
+        placeholder,
+    }: {
+        options: { id: number; name: string }[];
+        onChange: (value: { id: number; name: string }[]) => void;
         placeholder?: string;
-    }
-
-    interface MockSelectOptionProps<TValue> {
-        value: TValue;
-        name: string;
-    }
-
-    const Option = <TValue,>(_props: MockSelectOptionProps<TValue>) => null;
-
-    const Select = <TValue,>({ value, onValueChange, children, placeholder }: MockSelectProps<TValue>) => {
-        const options = React.Children.toArray(children) as React.ReactElement<MockSelectOptionProps<TValue>>[];
-        const normalizedValue = value === undefined ? '' : String(value);
+    }) => {
+        const filteredOptions = options.filter((option) => option.id !== 0);
 
         return (
-            <select
-                data-testid="program-select"
-                aria-label={placeholder}
-                value={normalizedValue}
-                onChange={(event: ChangeEvent<HTMLSelectElement>) => {
-                    const nextValue = event.target.value === '' ? undefined : Number(event.target.value);
-                    onValueChange(nextValue as TValue);
-                }}
-            >
-                {options.map((option) => (
-                    <option
-                        key={String(option.props.value)}
-                        value={option.props.value === undefined ? '' : String(option.props.value)}
-                    >
-                        {option.props.name}
-                    </option>
-                ))}
-            </select>
+            <div>
+                <select
+                    data-testid="program-select"
+                    aria-label={placeholder}
+                    defaultValue=""
+                    onChange={(event) => {
+                        const selectedOption = options.find((option) => option.id === Number(event.target.value));
+                        onChange(selectedOption ? [selectedOption] : []);
+                    }}
+                >
+                    <option value="">{placeholder}</option>
+                    {filteredOptions.map((option) => (
+                        <option key={option.id} value={option.id}>
+                            {option.name}
+                        </option>
+                    ))}
+                </select>
+                <button
+                    type="button"
+                    data-testid="program-select-first-two"
+                    onClick={() => onChange(options.filter((option) => option.id === 1 || option.id === 2))}
+                >
+                    First two programs
+                </button>
+                <button
+                    type="button"
+                    data-testid="program-select-no-records"
+                    onClick={() => onChange([options.find((option) => option.id === 3)!])}
+                >
+                    Program without records
+                </button>
+                <button type="button" data-testid="program-select-clear" onClick={() => onChange([])}>
+                    Clear programs
+                </button>
+            </div>
         );
-    };
-
-    Select.Option = Option;
-
-    return { Select };
-});
+    },
+}));
 
 describe('ProgramExpensesSection', () => {
     beforeEach(() => {
@@ -197,6 +197,45 @@ describe('ProgramExpensesSection', () => {
         expect(within(table).queryByText('2024')).not.toBeInTheDocument();
     });
 
+    it('should filter table records by multiple selected programs', () => {
+        render(<ProgramExpensesSection />);
+
+        fireEvent.click(screen.getByTestId('program-select-first-two'));
+
+        const table = screen.getByRole('table');
+        const rows = within(table).getAllByRole('row');
+
+        expect(rows).toHaveLength(4);
+        expect(within(table).getAllByText('Program A')).toHaveLength(2);
+        expect(within(table).getByText('Program B')).toBeInTheDocument();
+        expect(within(table).queryByText('Program C')).not.toBeInTheDocument();
+    });
+
+    it('should restore all table records when selected programs are cleared', () => {
+        render(<ProgramExpensesSection />);
+
+        fireEvent.change(screen.getByTestId('program-select'), {
+            target: { value: '2' },
+        });
+        fireEvent.click(screen.getByTestId('program-select-clear'));
+
+        const table = screen.getByRole('table');
+        const rows = within(table).getAllByRole('row');
+
+        expect(rows).toHaveLength(4);
+        expect(within(table).getAllByText('Program A')).toHaveLength(2);
+        expect(within(table).getByText('Program B')).toBeInTheDocument();
+    });
+
+    it('should render filtered empty state when selected program has no matching records', () => {
+        render(<ProgramExpensesSection />);
+
+        fireEvent.click(screen.getByTestId('program-select-no-records'));
+
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.MESSAGE)).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE })).toBeNull();
+    });
+
     it('should render program expenses empty state when records are missing', () => {
         mockUseDataFetchResult = {
             data: EMPTY_PROGRAM_EXPENSES_DATA,
@@ -222,8 +261,8 @@ describe('ProgramExpensesSection', () => {
         await useDataFetchProps.fetchHandler();
         await useDataFetchProps.fetchHandler({ test: true });
 
-        expect(mockGetReadOnlyData).toHaveBeenCalledWith({}, {});
+        expect(mockGetReadOnlyData).toHaveBeenCalledWith({});
         expect(ProgramExpensesApi.getReadOnlyData).toBeDefined();
-        expect(mockGetReadOnlyData).toHaveBeenCalledWith({}, { test: true });
+        expect(mockGetReadOnlyData).toHaveBeenCalledWith({ test: true });
     });
 });

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { InlineLoader } from '@/components/common/inline-loader/InlineLoader';
 import { useDataFetch } from '@/hooks/common/use-data-fetch/useDataFetch';
-import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
 import { ProgramExpensesApi } from '@/services/api/admin/reports/program-expenses-api';
 import { ProgramExpensesReadOnlyData } from '@/types/admin/reports';
 import { ProgramExpensesToolbar } from './components/program-expenses-toolbar/ProgramExpensesToolbar';
@@ -20,13 +19,9 @@ const INITIAL_PROGRAM_EXPENSES_DATA: ProgramExpensesReadOnlyData = {
 };
 
 export const ProgramExpensesSection = () => {
-    const adminClient = useAdminClient();
-    const [selectedProgramId, setSelectedProgramId] = useState<number | undefined>(undefined);
+    const [selectedProgramIds, setSelectedProgramIds] = useState<number[]>([]);
 
-    const fetchReadOnlyData = useCallback(
-        (options = {}) => ProgramExpensesApi.getReadOnlyData(adminClient, options),
-        [adminClient],
-    );
+    const fetchReadOnlyData = useCallback((options = {}) => ProgramExpensesApi.getReadOnlyData(options), []);
 
     const { data, isLoading } = useDataFetch<ProgramExpensesReadOnlyData>({
         initialData: INITIAL_PROGRAM_EXPENSES_DATA,
@@ -34,12 +29,12 @@ export const ProgramExpensesSection = () => {
     });
 
     const filteredRecords = useMemo(() => {
-        if (!selectedProgramId) {
+        if (selectedProgramIds.length === 0) {
             return data.records;
         }
 
-        return data.records.filter((record) => record.programId === selectedProgramId);
-    }, [data.records, selectedProgramId]);
+        return data.records.filter((record) => selectedProgramIds.includes(record.programId));
+    }, [data.records, selectedProgramIds]);
 
     const programExpenseRecordsCount = data.records.length;
     const hasAnyProgramExpenseRecords = programExpenseRecordsCount > 0;
@@ -62,9 +57,9 @@ export const ProgramExpensesSection = () => {
             <div className={styles.filters}>
                 <ProgramExpensesToolbar
                     programs={data.programs}
-                    selectedProgramId={selectedProgramId}
+                    selectedProgramIds={selectedProgramIds}
                     exchangeRate={data.exchangeRate}
-                    onProgramChange={setSelectedProgramId}
+                    onProgramChange={setSelectedProgramIds}
                 />
                 <ProgramExpensesTable
                     records={filteredRecords}

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.module.scss
@@ -1,6 +1,5 @@
 @use '@/assets/sass/variables/colors' as c;
 @use '@/assets/sass/mixins/typography.mixins' as type;
-@use '@/assets/sass/variables/typography' as t;
 
 .toolbar-row {
     display: flex;
@@ -14,7 +13,33 @@
 .program-select {
     width: 200px;
 
-    :global(.select-options) {
+    :global(.multiselect__placeholder-container) {
+        box-sizing: border-box;
+        width: 200px;
+        height: 60px;
+        padding: 8px 10px;
+        border: 1px solid c.$blue-900;
+        border-radius: 12px;
+        background: c.$white;
+        box-shadow: none;
+
+        &:hover {
+            background: c.$white;
+        }
+    }
+
+    :global(.multiselect__placeholder-content) {
+        @include type.subtitle-2-semibold;
+
+        color: c.$blue-900;
+        letter-spacing: 0;
+    }
+
+    :global(.multiselect__chevron svg path) {
+        stroke: c.$grey-800;
+    }
+
+    :global(.multiselect__options-container) {
         top: calc(100% + 4px);
         width: 200px;
         max-height: 244px;
@@ -25,6 +50,7 @@
             0 1px 2px rgba(c.$black, 0.3),
             0 2px 6px 2px rgba(c.$black, 0.15);
         overflow-y: auto;
+        overflow-x: hidden;
         scrollbar-width: thin;
         scrollbar-color: c.$grey-800 transparent;
 
@@ -43,58 +69,32 @@
             background-clip: content-box;
         }
     }
-}
 
-.program-select-head {
-    box-sizing: border-box;
-    width: 200px;
-    height: 60px;
-    padding: 8px 10px;
-    border: 1px solid c.$blue-900;
-    border-radius: 12px;
-    background: c.$white;
-    font-family: t.$font-family-base;
-    font-weight: t.$fw-semibold;
-    font-size: t.$sub2-size;
-    color: c.$blue-900;
-    line-height: 30px;
-    letter-spacing: t.$sub2-spacing;
+    :global(.multiselect__option) {
+        min-height: 56px;
+        padding: 8px 12px;
 
-    &:hover {
-        background: c.$white;
+        &:hover {
+            background: c.$dropdown-hover;
+        }
     }
 
-    span {
-        display: inline-flex;
-        align-items: center;
-        text-align: center;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+    :global(.multiselect__option-content) {
+        @include type.body-2-regular;
+
+        min-width: 0;
+        color: c.$dropdown-text;
+        letter-spacing: 0;
+        white-space: normal;
+        overflow-wrap: break-word;
     }
 
-    svg {
-        width: 26px;
-        height: 26px;
+    :global(.multiselect__option-checkbox) {
         flex-shrink: 0;
     }
-}
 
-.program-option {
-    @include type.body-2-regular;
-
-    min-height: 56px;
-    padding: 8px 12px;
-    color: c.$dropdown-text;
-    letter-spacing: 0.5px;
-
-    &:global(.select-options-selected) {
-        background-color: c.$dropdown-hover;
-
-        span {
-            color: c.$dropdown-text;
-            border-bottom: none;
-        }
+    :global(.multiselect__option--selected) {
+        background: c.$dropdown-hover;
     }
 }
 

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.test.tsx
@@ -2,34 +2,69 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ProgramExpensesToolbar } from './ProgramExpensesToolbar';
 import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+import { ProgramExpensesProgram } from '@/types/admin/reports';
 
-jest.mock('@/components/common/select/Select', () => {
-    const SelectOption = (_props: { value: unknown; name: string }) => null;
-
-    const MockSelect = ({
-        onValueChange,
+jest.mock('@/components/admin/multi-select-input/MultiSelectInput', () => ({
+    MultiSelectInput: ({
+        options,
+        value,
+        getOptionId,
+        getOptionName,
+        getDisplayValue,
+        isOptionSelected,
+        onChange,
         placeholder,
     }: {
-        onValueChange: (value: unknown) => void;
+        options: ProgramExpensesProgram[];
+        value: ProgramExpensesProgram[];
+        getOptionId: (value: ProgramExpensesProgram) => number;
+        getOptionName: (value: ProgramExpensesProgram) => string;
+        getDisplayValue: (value: ProgramExpensesProgram[]) => string;
+        isOptionSelected: (option: ProgramExpensesProgram, value: ProgramExpensesProgram[]) => boolean;
+        onChange: (value: ProgramExpensesProgram[]) => void;
         placeholder?: string;
     }) => {
         return (
             <div data-testid="program-expenses-select">
                 <span>{placeholder}</span>
-                <button type="button" data-testid="program-filter-all" onClick={() => onValueChange(undefined)}>
+                <span data-testid="program-filter-display">{getDisplayValue(value)}</span>
+                {options.map((option) => (
+                    <span
+                        key={getOptionId(option)}
+                        data-testid={`program-filter-option-${getOptionId(option)}`}
+                        data-selected={String(isOptionSelected(option, value))}
+                    >
+                        {getOptionName(option)}
+                    </span>
+                ))}
+                <button
+                    type="button"
+                    data-testid="program-filter-all"
+                    onClick={() => onChange([options.find((option) => option.id === 0)!])}
+                >
                     All
                 </button>
-                <button type="button" data-testid="program-filter-1" onClick={() => onValueChange(1)}>
+                <button
+                    type="button"
+                    data-testid="program-filter-1"
+                    onClick={() => onChange([options.find((option) => option.id === 1)!])}
+                >
                     Program 1
+                </button>
+                <button
+                    type="button"
+                    data-testid="program-filter-1-and-2"
+                    onClick={() => onChange(options.filter((option) => option.id === 1 || option.id === 2))}
+                >
+                    Program 1 and 2
+                </button>
+                <button type="button" data-testid="program-filter-clear" onClick={() => onChange([])}>
+                    Clear
                 </button>
             </div>
         );
-    };
-
-    MockSelect.Option = SelectOption;
-
-    return { Select: MockSelect };
-});
+    },
+}));
 
 describe('ProgramExpensesToolbar', () => {
     const defaultProps = {
@@ -37,7 +72,7 @@ describe('ProgramExpensesToolbar', () => {
             { id: 1, name: 'Program 1' },
             { id: 2, name: 'Program 2' },
         ],
-        selectedProgramId: undefined,
+        selectedProgramIds: [],
         exchangeRate: '42.15',
         onProgramChange: jest.fn(),
     };
@@ -49,7 +84,36 @@ describe('ProgramExpensesToolbar', () => {
     it('should render program filter placeholder', () => {
         render(<ProgramExpensesToolbar {...defaultProps} />);
 
-        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.PROGRAM)).toBeInTheDocument();
+        expect(screen.getAllByText(PROGRAM_EXPENSES_TEXT.FILTER.PROGRAMS_PLACEHOLDER)).not.toHaveLength(0);
+        expect(screen.getByTestId('program-filter-display')).toHaveTextContent(
+            PROGRAM_EXPENSES_TEXT.FILTER.PROGRAMS_PLACEHOLDER,
+        );
+    });
+
+    it('should render all option as selected when no programs are selected', () => {
+        render(<ProgramExpensesToolbar {...defaultProps} />);
+
+        expect(screen.getByTestId('program-filter-option-0')).toHaveTextContent(
+            PROGRAM_EXPENSES_TEXT.FILTER.ALL_OPTION,
+        );
+        expect(screen.getByTestId('program-filter-option-0')).toHaveAttribute('data-selected', 'true');
+        expect(screen.getByTestId('program-filter-option-1')).toHaveAttribute('data-selected', 'false');
+    });
+
+    it('should render selected program name as display value', () => {
+        render(<ProgramExpensesToolbar {...defaultProps} selectedProgramIds={[1]} />);
+
+        expect(screen.getByTestId('program-filter-display')).toHaveTextContent('Program 1');
+        expect(screen.getByTestId('program-filter-option-0')).toHaveAttribute('data-selected', 'false');
+        expect(screen.getByTestId('program-filter-option-1')).toHaveAttribute('data-selected', 'true');
+    });
+
+    it('should render selected programs counter as display value', () => {
+        render(<ProgramExpensesToolbar {...defaultProps} selectedProgramIds={[1, 2]} />);
+
+        expect(screen.getByTestId('program-filter-display')).toHaveTextContent(
+            PROGRAM_EXPENSES_TEXT.FILTER.getProgramsCounterLabel(2),
+        );
     });
 
     it('should render exchange rate label and value', () => {
@@ -70,14 +134,30 @@ describe('ProgramExpensesToolbar', () => {
 
         fireEvent.click(screen.getByTestId('program-filter-1'));
 
-        expect(defaultProps.onProgramChange).toHaveBeenCalledWith(1);
+        expect(defaultProps.onProgramChange).toHaveBeenCalledWith([1]);
     });
 
-    it('should call onProgramChange with undefined for all option', () => {
+    it('should call onProgramChange with multiple program ids when multiple programs are selected', () => {
+        render(<ProgramExpensesToolbar {...defaultProps} />);
+
+        fireEvent.click(screen.getByTestId('program-filter-1-and-2'));
+
+        expect(defaultProps.onProgramChange).toHaveBeenCalledWith([1, 2]);
+    });
+
+    it('should call onProgramChange with empty array for all option', () => {
         render(<ProgramExpensesToolbar {...defaultProps} />);
 
         fireEvent.click(screen.getByTestId('program-filter-all'));
 
-        expect(defaultProps.onProgramChange).toHaveBeenCalledWith(undefined);
+        expect(defaultProps.onProgramChange).toHaveBeenCalledWith([]);
+    });
+
+    it('should call onProgramChange with empty array when selection is cleared', () => {
+        render(<ProgramExpensesToolbar {...defaultProps} />);
+
+        fireEvent.click(screen.getByTestId('program-filter-clear'));
+
+        expect(defaultProps.onProgramChange).toHaveBeenCalledWith([]);
     });
 });

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.tsx
@@ -1,36 +1,70 @@
-import { Select } from '@/components/common/select/Select';
+import { MultiSelectInput } from '@/components/admin/multi-select-input/MultiSelectInput';
 import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
 import { ProgramExpensesProgram } from '@/types/admin/reports';
 import styles from './ProgramExpensesToolbar.module.scss';
 
 interface ProgramExpensesToolbarProps {
     programs: ProgramExpensesProgram[];
-    selectedProgramId: number | undefined;
+    selectedProgramIds: number[];
     exchangeRate: string | null;
-    onProgramChange: (value: number | undefined) => void;
+    onProgramChange: (value: number[]) => void;
 }
+
+const ALL_PROGRAMS_FILTER_OPTION_ID = 0;
+
+const ALL_PROGRAMS_FILTER_OPTION: ProgramExpensesProgram = {
+    id: ALL_PROGRAMS_FILTER_OPTION_ID,
+    name: PROGRAM_EXPENSES_TEXT.FILTER.ALL_OPTION,
+};
+
+const isAllProgramsFilterOption = (program: ProgramExpensesProgram) => program.id === ALL_PROGRAMS_FILTER_OPTION_ID;
+
+const getProgramsFilterDisplayValue = (selectedPrograms: ProgramExpensesProgram[]) => {
+    if (selectedPrograms.length === 1) return selectedPrograms[0].name;
+    if (selectedPrograms.length > 1) {
+        return PROGRAM_EXPENSES_TEXT.FILTER.getProgramsCounterLabel(selectedPrograms.length);
+    }
+
+    return PROGRAM_EXPENSES_TEXT.FILTER.PROGRAMS_PLACEHOLDER;
+};
 
 export const ProgramExpensesToolbar = ({
     programs,
-    selectedProgramId,
+    selectedProgramIds,
     exchangeRate,
     onProgramChange,
 }: ProgramExpensesToolbarProps) => {
+    const selectedPrograms = programs.filter((program) => selectedProgramIds.includes(program.id));
+    const programOptions = [ALL_PROGRAMS_FILTER_OPTION, ...programs];
+
+    const handleProgramChange = (selectedOptions: ProgramExpensesProgram[]) => {
+        if (selectedOptions.some(isAllProgramsFilterOption)) {
+            onProgramChange([]);
+            return;
+        }
+
+        onProgramChange(selectedOptions.map((program) => program.id));
+    };
+
     return (
         <div className={styles['toolbar-row']}>
-            <Select<number | undefined>
-                value={selectedProgramId}
-                onValueChange={onProgramChange}
-                className={styles['program-select']}
-                headClassName={styles['program-select-head']}
-                optionClassName={styles['program-option']}
-                placeholder={PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.PROGRAM}
-            >
-                <Select.Option value={undefined} name={FUNDS_EXPENDITURES_TEXT.FILTER.ALL_OPTION} />
-                {programs.map((program) => (
-                    <Select.Option key={program.id} value={program.id} name={program.name} />
-                ))}
-            </Select>
+            <div className={styles['program-select']}>
+                <MultiSelectInput<ProgramExpensesProgram>
+                    id="program-expenses-program-filter"
+                    options={programOptions}
+                    value={selectedPrograms}
+                    getOptionId={(program) => program.id}
+                    getOptionName={(program) => program.name}
+                    getDisplayValue={getProgramsFilterDisplayValue}
+                    isOptionSelected={(program, selectedValues) =>
+                        isAllProgramsFilterOption(program)
+                            ? selectedValues.length === 0
+                            : selectedValues.some((selectedProgram) => selectedProgram.id === program.id)
+                    }
+                    onChange={handleProgramChange}
+                    placeholder={PROGRAM_EXPENSES_TEXT.FILTER.PROGRAMS_PLACEHOLDER}
+                />
+            </div>
 
             <div className={styles['exchange-rate']}>
                 <span className={styles['exchange-rate-label']}>{FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL}</span>

--- a/src/services/api/admin/reports/program-expenses-api.test.ts
+++ b/src/services/api/admin/reports/program-expenses-api.test.ts
@@ -112,7 +112,6 @@ describe('ProgramExpensesApi', () => {
         expect(result.programs).toEqual([
             { id: 1, name: 'Program A from categories' },
             { id: 2, name: 'Program B' },
-            { id: 3, name: 'Program C' },
             { id: 4, name: 'Program D' },
         ]);
         expect(result.summary).toEqual({
@@ -121,7 +120,7 @@ describe('ProgramExpensesApi', () => {
         });
     });
 
-    it('should return empty collections and zero summary when no records are published', async () => {
+    it('should return configured programs and zero summary when no records are published', async () => {
         const api = loadProgramExpensesApi(
             [
                 {
@@ -135,7 +134,7 @@ describe('ProgramExpensesApi', () => {
                     isPublished: false,
                 },
             ],
-            [],
+            [{ id: 6, name: 'Configured Program' }],
             '39.00',
         );
 
@@ -143,7 +142,7 @@ describe('ProgramExpensesApi', () => {
 
         expect(result).toEqual({
             exchangeRate: '39.00',
-            programs: [{ id: 5, name: 'Hidden Program' }],
+            programs: [{ id: 6, name: 'Configured Program' }],
             summary: {
                 totalAmountUah: 0,
                 totalAmountUsd: 0,

--- a/src/services/api/admin/reports/program-expenses-api.test.ts
+++ b/src/services/api/admin/reports/program-expenses-api.test.ts
@@ -1,13 +1,14 @@
-import { AxiosInstance } from 'axios';
-import { ProgramExpensesRecord } from '@/types/admin/reports';
+import { ProgramExpensesProgram, ProgramExpensesRecord } from '@/types/admin/reports';
 
 const loadProgramExpensesApi = (
     records: Array<ProgramExpensesRecord & { isPublished: boolean }>,
+    programs: ProgramExpensesProgram[] = [],
     exchangeRate = '42.15',
 ) => {
     jest.resetModules();
     jest.doMock('@/utils/mock-data/admin/reports/program-expenses', () => ({
         MOCK_PROGRAM_EXPENSES_EXCHANGE_RATE: exchangeRate,
+        MOCK_PROGRAM_EXPENSES_PROGRAMS: programs,
         MOCK_PROGRAM_EXPENSES_RECORDS: records,
     }));
 
@@ -26,51 +27,57 @@ describe('ProgramExpensesApi', () => {
         jest.dontMock('@/utils/mock-data/admin/reports/program-expenses');
     });
 
-    it('should return only published records with computed programs and summary', async () => {
-        const api = loadProgramExpensesApi([
-            {
-                id: 1,
-                programId: 2,
-                programName: 'Program B',
-                type: 'expense',
-                reportingYear: '2025',
-                amountUah: '1 500',
-                amountUsd: '1000',
-                isPublished: true,
-            },
-            {
-                id: 2,
-                programId: 1,
-                programName: 'Program A',
-                type: 'expense',
-                reportingYear: '2025',
-                amountUah: '250',
-                amountUsd: '100.5',
-                isPublished: true,
-            },
-            {
-                id: 3,
-                programId: 1,
-                programName: 'Program A',
-                type: 'expense',
-                reportingYear: '2024',
-                amountUah: '2000',
-                amountUsd: '800',
-                isPublished: true,
-            },
-            {
-                id: 4,
-                programId: 3,
-                programName: 'Program C',
-                type: 'expense',
-                reportingYear: '2025',
-                amountUah: '999',
-                amountUsd: '999',
-                isPublished: false,
-            },
-        ]);
+    it('should return published records with computed programs and summary', async () => {
+        const api = loadProgramExpensesApi(
+            [
+                {
+                    id: 1,
+                    programId: 2,
+                    programName: 'Program B',
+                    type: 'expense',
+                    reportingYear: '2025',
+                    amountUah: '1 500',
+                    amountUsd: '1000',
+                    isPublished: true,
+                },
+                {
+                    id: 2,
+                    programId: 1,
+                    programName: 'Program A',
+                    type: 'expense',
+                    reportingYear: '2025',
+                    amountUah: '250',
+                    amountUsd: '100.5',
+                    isPublished: true,
+                },
+                {
+                    id: 3,
+                    programId: 1,
+                    programName: 'Program A',
+                    type: 'expense',
+                    reportingYear: '2024',
+                    amountUah: '2000',
+                    amountUsd: '800',
+                    isPublished: true,
+                },
+                {
+                    id: 4,
+                    programId: 3,
+                    programName: 'Program C',
+                    type: 'expense',
+                    reportingYear: '2025',
+                    amountUah: '999',
+                    amountUsd: '999',
+                    isPublished: false,
+                },
+            ],
+            [
+                { id: 1, name: 'Program A from categories' },
+                { id: 4, name: 'Program D' },
+            ],
+        );
 
-        const result = await api.getReadOnlyData({} as AxiosInstance);
+        const result = await api.getReadOnlyData();
 
         expect(result.exchangeRate).toBe('42.15');
         expect(result.records).toEqual([
@@ -103,8 +110,10 @@ describe('ProgramExpensesApi', () => {
             },
         ]);
         expect(result.programs).toEqual([
-            { id: 1, name: 'Program A' },
+            { id: 1, name: 'Program A from categories' },
             { id: 2, name: 'Program B' },
+            { id: 3, name: 'Program C' },
+            { id: 4, name: 'Program D' },
         ]);
         expect(result.summary).toEqual({
             totalAmountUah: 3750,
@@ -126,14 +135,15 @@ describe('ProgramExpensesApi', () => {
                     isPublished: false,
                 },
             ],
+            [],
             '39.00',
         );
 
-        const result = await api.getReadOnlyData({} as AxiosInstance);
+        const result = await api.getReadOnlyData();
 
         expect(result).toEqual({
             exchangeRate: '39.00',
-            programs: [],
+            programs: [{ id: 5, name: 'Hidden Program' }],
             summary: {
                 totalAmountUah: 0,
                 totalAmountUsd: 0,

--- a/src/services/api/admin/reports/program-expenses-api.ts
+++ b/src/services/api/admin/reports/program-expenses-api.ts
@@ -22,7 +22,7 @@ const getPublishedProgramExpensesRecords = () =>
 const getRecordPrograms = (): ProgramExpensesProgram[] => {
     const uniqueProgramsMap = new Map<number, ProgramExpensesProgram>();
 
-    MOCK_PROGRAM_EXPENSES_RECORDS.forEach((record) => {
+    getPublishedProgramExpensesRecords().forEach((record) => {
         uniqueProgramsMap.set(record.programId, {
             id: record.programId,
             name: record.programName,

--- a/src/services/api/admin/reports/program-expenses-api.ts
+++ b/src/services/api/admin/reports/program-expenses-api.ts
@@ -2,9 +2,9 @@ import { RequestOptions } from '@/types/common/api';
 import { ProgramExpensesProgram, ProgramExpensesReadOnlyData, ProgramExpensesSummary } from '@/types/admin/reports';
 import {
     MOCK_PROGRAM_EXPENSES_EXCHANGE_RATE,
+    MOCK_PROGRAM_EXPENSES_PROGRAMS,
     MOCK_PROGRAM_EXPENSES_RECORDS,
 } from '@/utils/mock-data/admin/reports/program-expenses';
-import { AxiosInstance } from 'axios';
 import { parseAmount } from '@/utils/functions/parse-amount/parse-amount';
 
 const getPublishedProgramExpensesRecords = () =>
@@ -19,20 +19,33 @@ const getPublishedProgramExpensesRecords = () =>
         return firstRecord.programName.localeCompare(secondRecord.programName, 'uk');
     });
 
-const getPrograms = (): ProgramExpensesProgram[] => {
+const getRecordPrograms = (): ProgramExpensesProgram[] => {
     const uniqueProgramsMap = new Map<number, ProgramExpensesProgram>();
 
-    getPublishedProgramExpensesRecords().forEach((record) => {
+    MOCK_PROGRAM_EXPENSES_RECORDS.forEach((record) => {
         uniqueProgramsMap.set(record.programId, {
             id: record.programId,
             name: record.programName,
         });
     });
 
+    return Array.from(uniqueProgramsMap.values());
+};
+
+const mergePrograms = (programs: ProgramExpensesProgram[]): ProgramExpensesProgram[] => {
+    const uniqueProgramsMap = new Map<number, ProgramExpensesProgram>();
+
+    programs.forEach((program) => {
+        uniqueProgramsMap.set(program.id, program);
+    });
+
     return Array.from(uniqueProgramsMap.values()).sort((firstProgram, secondProgram) =>
         firstProgram.name.localeCompare(secondProgram.name, 'uk'),
     );
 };
+
+const getPrograms = (): ProgramExpensesProgram[] =>
+    mergePrograms([...getRecordPrograms(), ...MOCK_PROGRAM_EXPENSES_PROGRAMS]);
 
 const getSummary = (): ProgramExpensesSummary => {
     return getPublishedProgramExpensesRecords().reduce<ProgramExpensesSummary>(
@@ -51,18 +64,13 @@ const PUBLISHED_PROGRAM_EXPENSES_RECORDS = getPublishedProgramExpensesRecords().
     ({ isPublished: _isPublished, ...record }) => record,
 );
 
-const PROGRAM_EXPENSES_PROGRAMS = getPrograms();
-
 const PROGRAM_EXPENSES_SUMMARY = getSummary();
 
 export const ProgramExpensesApi = {
-    getReadOnlyData: async (
-        _client: AxiosInstance,
-        _options: RequestOptions = {},
-    ): Promise<ProgramExpensesReadOnlyData> => {
+    getReadOnlyData: async (_options: RequestOptions = {}): Promise<ProgramExpensesReadOnlyData> => {
         return {
             exchangeRate: MOCK_PROGRAM_EXPENSES_EXCHANGE_RATE,
-            programs: PROGRAM_EXPENSES_PROGRAMS,
+            programs: getPrograms(),
             summary: PROGRAM_EXPENSES_SUMMARY,
             records: PUBLISHED_PROGRAM_EXPENSES_RECORDS,
         };

--- a/src/utils/mock-data/admin/reports/program-expenses.ts
+++ b/src/utils/mock-data/admin/reports/program-expenses.ts
@@ -1,4 +1,4 @@
-import { ProgramExpensesRecord } from '@/types/admin/reports';
+import { ProgramExpensesProgram, ProgramExpensesRecord } from '@/types/admin/reports';
 
 interface MockProgramExpensesRecord extends ProgramExpensesRecord {
     isPublished: boolean;
@@ -6,11 +6,30 @@ interface MockProgramExpensesRecord extends ProgramExpensesRecord {
 
 export const MOCK_PROGRAM_EXPENSES_EXCHANGE_RATE = '42.15';
 
+export const MOCK_PROGRAM_EXPENSES_PROGRAMS: ProgramExpensesProgram[] = [
+    {
+        id: 101,
+        name: 'Дитяча реабілітація',
+    },
+    {
+        id: 102,
+        name: 'Ветеранська реабілітація',
+    },
+    {
+        id: 105,
+        name: 'Іпотерапія для дорослих',
+    },
+    {
+        id: 106,
+        name: 'Раннє втручання',
+    },
+];
+
 export const MOCK_PROGRAM_EXPENSES_RECORDS: MockProgramExpensesRecord[] = [
     {
         id: 1,
         programId: 101,
-        programName: 'Лікування дітей',
+        programName: 'Дитяча реабілітація',
         type: 'expense',
         reportingYear: '2025',
         amountUah: '1500',
@@ -20,7 +39,7 @@ export const MOCK_PROGRAM_EXPENSES_RECORDS: MockProgramExpensesRecord[] = [
     {
         id: 2,
         programId: 101,
-        programName: 'Лікування дітей',
+        programName: 'Дитяча реабілітація',
         type: 'expense',
         reportingYear: '2025',
         amountUah: '1765',
@@ -29,20 +48,20 @@ export const MOCK_PROGRAM_EXPENSES_RECORDS: MockProgramExpensesRecord[] = [
     },
     {
         id: 3,
-        programId: 101,
-        programName: 'Лікування дітей',
+        programId: 103,
+        programName: 'Адаптивний спорт',
         type: 'expense',
-        reportingYear: '2025',
+        reportingYear: '2024',
         amountUah: '2000',
         amountUsd: '1000',
         isPublished: true,
     },
     {
         id: 4,
-        programId: 101,
-        programName: 'Лікування дітей',
+        programId: 104,
+        programName: 'Психологічна підтримка',
         type: 'expense',
-        reportingYear: '2025',
+        reportingYear: '2024',
         amountUah: '2000',
         amountUsd: '1000',
         isPublished: true,
@@ -50,7 +69,7 @@ export const MOCK_PROGRAM_EXPENSES_RECORDS: MockProgramExpensesRecord[] = [
     {
         id: 5,
         programId: 102,
-        programName: 'Реабілітація ветеранів',
+        programName: 'Ветеранська реабілітація',
         type: 'expense',
         reportingYear: '2025',
         amountUah: '900',


### PR DESCRIPTION
## GitHub Ticket
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1825

## Description

Adds a multi-select “Програми” filter to the Program Expenses tab, including all/reset option, selected-count label, multi-program filtering, and empty-state handling when no records match.

## How it looks
<img width="271" height="394" alt="image" src="https://github.com/user-attachments/assets/6a03e21b-406a-4643-954f-9792d170e089" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Program filter now supports selecting multiple programs, with an "All" option and a Clear action to restore all records.

* **Refactor**
  * Program filter and report filtering updated to operate on multiple selected programs and return all records when none selected.

* **Style**
  * Multi-select styling and option rendering improved for clearer selection visuals and wrapped content.

* **Tests**
  * Expanded test coverage for multi-select behavior, display labels, selection predicates, and empty-state filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->