### PR TITLE
Fix/issue-2275 Resolved character counter in program form

### DIFF
--- a/src/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup.tsx
+++ b/src/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup.tsx
@@ -16,6 +16,7 @@ export interface InputWithCharacterLimitGroupProps extends InputWithCharacterLim
     className?: string;
     maxLimitWarning?: string;
     showCounterBelow?: boolean;
+    isWhiteLabel?: boolean;
 }
 
 export const InputWithCharacterLimitGroup = ({
@@ -38,6 +39,7 @@ export const InputWithCharacterLimitGroup = ({
     className,
     maxLimitWarning,
     showCounterBelow = false,
+    isWhiteLabel,
 }: InputWithCharacterLimitGroupProps) => {
     const [localWarning, setLocalWarning] = useState<string | null>(null);
     const displayedError = localWarning || error;
@@ -72,6 +74,7 @@ export const InputWithCharacterLimitGroup = ({
                     counterId={counterId}
                     htmlFor={id}
                     value={value}
+                    isWhiteLabel={isWhiteLabel}
                 />
             ) : (
                 <InputError error={displayedError} />

--- a/src/pages/admin/programs/components/program-form/ProgramForm.tsx
+++ b/src/pages/admin/programs/components/program-form/ProgramForm.tsx
@@ -632,6 +632,8 @@ export const ProgramForm = forwardRef<ProgramFormRef, ProgramFormProps>(
                                 maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
                                     PROGRAM_VALIDATION.location.max,
                                 )}
+                                showCounterBelow={true}
+                                isWhiteLabel={hasBackgroundImage}
                             />
 
                             <InputWithCharacterLimitGroup
@@ -646,6 +648,8 @@ export const ProgramForm = forwardRef<ProgramFormRef, ProgramFormProps>(
                                 maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
                                     PROGRAM_VALIDATION.participantsCount.max,
                                 )}
+                                showCounterBelow={true}
+                                isWhiteLabel={hasBackgroundImage}
                             />
 
                             <InputWithCharacterLimitGroup
@@ -660,6 +664,8 @@ export const ProgramForm = forwardRef<ProgramFormRef, ProgramFormProps>(
                                 maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
                                     PROGRAM_VALIDATION.meetingCount.max,
                                 )}
+                                showCounterBelow={true}
+                                isWhiteLabel={hasBackgroundImage}
                             />
                         </div>
 

--- a/src/pages/admin/programs/components/translate-program-form/TranslateProgramForm.tsx
+++ b/src/pages/admin/programs/components/translate-program-form/TranslateProgramForm.tsx
@@ -516,6 +516,8 @@ export const TranslateProgramForm = forwardRef<TranslateProgramFormRef, Translat
                                 disabled={isSubmitting || isFormDisabled}
                                 error={errors.location}
                                 placeholder={PROGRAMS_TEXT.PLACEHOLDER.INSERT_PROGRAM_LOCATION}
+                                showCounterBelow={true}
+                                isWhiteLabel={hasBackgroundImage}
                             />
 
                             <InputWithCharacterLimitGroup
@@ -529,6 +531,8 @@ export const TranslateProgramForm = forwardRef<TranslateProgramFormRef, Translat
                                 disabled={isSubmitting || isFormDisabled}
                                 error={errors.participantsCount}
                                 placeholder={PROGRAMS_TEXT.PLACEHOLDER.INSERT_PROGRAM_PARTICIPANTS_COUNT}
+                                showCounterBelow={true}
+                                isWhiteLabel={hasBackgroundImage}
                             />
 
                             <InputWithCharacterLimitGroup
@@ -542,6 +546,8 @@ export const TranslateProgramForm = forwardRef<TranslateProgramFormRef, Translat
                                 disabled={isSubmitting || isFormDisabled}
                                 error={errors.meetingCount}
                                 placeholder={PROGRAMS_TEXT.PLACEHOLDER.INSERT_PROGRAM_MEETINGS_COUNT}
+                                showCounterBelow={true}
+                                isWhiteLabel={hasBackgroundImage}
                             />
                         </div>
 


### PR DESCRIPTION
## Github ticker

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2275)

## Description

Character counter in program form input fields was displayed inside the field
instead of below it.

## How it looks

<img width="1222" height="624" alt="image" src="https://github.com/user-attachments/assets/fd7b675d-750c-4938-825a-1f0c01637092" />
## Summary of change

- Added `isWhiteLabel` prop to `InputWithCharacterLimitGroup`.
- Added `showCounterBelow={true}` and `isWhiteLabel={hasBackgroundImage}` to
  Location, Participants Count, and Meeting Count in `ProgramForm` and
  `TranslateProgramForm`.

## How to recreate changes


1. Open admin panel → Programs → "Add new Program".
2. Check that counters for Location, Participants Count, Meeting Count appear
   below the fields.
3. Upload a background image — verify counters switch to white text.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Character counters for program form input fields now support display below the inputs
  * Input styling adapts to white-label presentation when background images are present in program forms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->