### PR TITLE
Feature/issue-2047: [Main] Create a page blocks view list

### DIFF
--- a/src/components/admin/admin-navigation/AdminNavigation.tsx
+++ b/src/components/admin/admin-navigation/AdminNavigation.tsx
@@ -20,6 +20,18 @@ export const AdminNavigation = () => {
                 <div className="admin-pages">
                     <nav>
                         <NavLink
+                            to={ADMIN_ROUTES.MAIN.FULL}
+                            end
+                            className={({ isActive }) =>
+                                classNames('admin-page-link', {
+                                    'admin-pages-selected': isActive,
+                                })
+                            }
+                        >
+                            {COMMON_TEXT_ADMIN.TAB.MAIN}
+                        </NavLink>
+
+                        <NavLink
                             to={ADMIN_ROUTES.PROFILE_COMPANY.FULL}
                             end
                             className={({ isActive }) =>

--- a/src/const/admin/common.ts
+++ b/src/const/admin/common.ts
@@ -1,5 +1,6 @@
 export const COMMON_TEXT_ADMIN = {
     TAB: {
+        MAIN: 'Головна',
         PROFILE_COMPANY: 'Профіль',
         REPORTS: 'Звітність',
         TEAM_MEMBERS: 'Команда',

--- a/src/const/admin/main-page.ts
+++ b/src/const/admin/main-page.ts
@@ -1,0 +1,43 @@
+import { COMMON_TEXT_ADMIN } from './common';
+
+export const MAIN_PAGE_TEXT = {
+    TABS: {
+        TITLE: 'Титульна',
+        ABOUT_US: 'Про нас',
+        STATISTICS: 'Статистика',
+        DONATIONS: COMMON_TEXT_ADMIN.TAB.DONATE,
+        PARTNERS: COMMON_TEXT_ADMIN.TAB.PARTNERS,
+    },
+
+    BLOCKS: {
+        TITLE: {
+            IMAGE_LABEL: 'Зображення',
+            TITLE_LABEL: COMMON_TEXT_ADMIN.TYPE.TITLE,
+            DESCRIPTION_LABEL: COMMON_TEXT_ADMIN.TYPE.DESCRIPTION,
+        },
+        ABOUT_US: {
+            TITLE_LABEL: COMMON_TEXT_ADMIN.TYPE.TITLE,
+            DESCRIPTION_LABEL: COMMON_TEXT_ADMIN.TYPE.DESCRIPTION,
+        },
+    },
+
+    BUTTONS: {
+        PUBLISH: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED,
+    },
+} as const;
+
+export const MAIN_PAGE_VALIDATION = {
+    common: {
+        REQUIRED: COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED,
+    },
+
+    title: {
+        max: 50,
+        getMaxError: () => COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(50),
+    },
+
+    description: {
+        max: 1000,
+        getMaxError: () => COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(1000),
+    },
+} as const;

--- a/src/const/admin/main-page.ts
+++ b/src/const/admin/main-page.ts
@@ -11,7 +11,6 @@ export const MAIN_PAGE_TEXT = {
 
     BLOCKS: {
         TITLE: {
-            IMAGE_LABEL: 'Зображення',
             TITLE_LABEL: COMMON_TEXT_ADMIN.TYPE.TITLE,
             DESCRIPTION_LABEL: COMMON_TEXT_ADMIN.TYPE.DESCRIPTION,
         },

--- a/src/const/admin/routes.ts
+++ b/src/const/admin/routes.ts
@@ -4,6 +4,10 @@ export const ADMIN_ROUTES = {
         PATH: 'login',
         FULL: '/login',
     },
+    MAIN: {
+        PATH: 'main',
+        FULL: '/admin-panel/main',
+    },
     TEAM: {
         PATH: 'team',
         FULL: '/admin-panel/team',

--- a/src/pages/admin/main/components/about-us-block/AboutUsBlockForm.module.scss
+++ b/src/pages/admin/main/components/about-us-block/AboutUsBlockForm.module.scss
@@ -1,0 +1,38 @@
+@use '@/assets/sass/variables/colors' as c;
+
+.form {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+}
+
+.content {
+    display: flex;
+    flex-direction: row;
+    gap: 40px;
+    margin-bottom: 40px;
+    width: 100%;
+}
+
+.column {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.textarea-custom textarea {
+    min-height: 349px;
+    resize: none;
+}
+
+.actions {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+}
+
+.publish-button {
+    width: 608px;
+    max-width: 100%;
+}

--- a/src/pages/admin/main/components/about-us-block/AboutUsBlockForm.test.tsx
+++ b/src/pages/admin/main/components/about-us-block/AboutUsBlockForm.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { AboutUsBlockForm } from './AboutUsBlockForm';
+import { MainPage } from '@/types/admin/main-page';
+
+jest.mock('@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup', () => ({
+    __esModule: true,
+    InputWithCharacterLimitGroup: ({ id, value, onChange, onBlur }: any) => (
+        <input data-testid={id} value={value ?? ''} onChange={(e) => onChange(e.target.value)} onBlur={onBlur} />
+    ),
+}));
+
+jest.mock(
+    '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup',
+    () => ({
+        __esModule: true,
+        TextAreaWithCharacterLimitGroup: ({ id, value, onChange, onBlur }: any) => (
+            <textarea data-testid={id} value={value ?? ''} onChange={(e) => onChange(e.target.value)} onBlur={onBlur} />
+        ),
+    }),
+);
+
+jest.mock('@/components/admin/button/Button', () => ({
+    __esModule: true,
+    Button: ({ children, disabled, type }: any) => (
+        <button data-testid="submit-btn" type={type} disabled={disabled}>
+            {children}
+        </button>
+    ),
+}));
+
+const mockInitialData: MainPage = {
+    id: 1,
+    title: 'Титульний заголовок',
+    description: 'Титульний опис',
+    image: null,
+    mainAboutUs: {
+        id: 1,
+        title: 'Про нас заголовок',
+        description: 'Про нас опис',
+    },
+    mainPartners: null,
+};
+
+describe('AboutUsBlockForm', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders with empty default values when initialData is null', () => {
+        render(<AboutUsBlockForm initialData={null} />);
+
+        const titleInput = screen.getByTestId('about-us-block-title') as HTMLInputElement;
+        const descriptionInput = screen.getByTestId('about-us-block-description') as HTMLTextAreaElement;
+
+        expect(titleInput.value).toBe('');
+        expect(descriptionInput.value).toBe('');
+
+        expect(screen.getByTestId('submit-btn')).toBeDisabled();
+    });
+
+    it('renders with empty default values when initialData.mainAboutUs is null', () => {
+        render(<AboutUsBlockForm initialData={{ ...mockInitialData, mainAboutUs: null }} />);
+
+        const titleInput = screen.getByTestId('about-us-block-title') as HTMLInputElement;
+
+        expect(titleInput.value).toBe('');
+        expect(screen.getByTestId('submit-btn')).toBeDisabled();
+    });
+
+    it('populates fields correctly from initialData.mainAboutUs', async () => {
+        render(<AboutUsBlockForm initialData={mockInitialData} />);
+
+        const titleInput = screen.getByTestId('about-us-block-title') as HTMLInputElement;
+        const descriptionInput = screen.getByTestId('about-us-block-description') as HTMLTextAreaElement;
+
+        await waitFor(() => {
+            expect(titleInput.value).toBe('Про нас заголовок');
+            expect(descriptionInput.value).toBe('Про нас опис');
+        });
+
+        expect(screen.getByTestId('submit-btn')).toBeDisabled();
+    });
+
+    it('enables submit button when form becomes dirty and is valid', async () => {
+        render(<AboutUsBlockForm initialData={mockInitialData} />);
+
+        const titleInput = screen.getByTestId('about-us-block-title');
+
+        fireEvent.change(titleInput, { target: { value: 'Новий заголовок Про Нас' } });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('submit-btn')).not.toBeDisabled();
+        });
+    });
+
+    it('disables submit button when a required field is cleared', async () => {
+        render(<AboutUsBlockForm initialData={mockInitialData} />);
+
+        const descriptionInput = screen.getByTestId('about-us-block-description');
+
+        fireEvent.change(descriptionInput, { target: { value: '   ' } });
+        fireEvent.blur(descriptionInput);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('submit-btn')).toBeDisabled();
+        });
+    });
+
+    it('allows submitting the form without throwing errors', async () => {
+        render(<AboutUsBlockForm initialData={mockInitialData} />);
+
+        const descriptionInput = screen.getByTestId('about-us-block-description');
+        fireEvent.change(descriptionInput, { target: { value: 'Оновлений текст про нашу місію' } });
+
+        const submitBtn = screen.getByTestId('submit-btn');
+        await waitFor(() => {
+            expect(submitBtn).not.toBeDisabled();
+        });
+
+        expect(() => fireEvent.click(submitBtn)).not.toThrow();
+    });
+});

--- a/src/pages/admin/main/components/about-us-block/AboutUsBlockForm.test.tsx
+++ b/src/pages/admin/main/components/about-us-block/AboutUsBlockForm.test.tsx
@@ -6,28 +6,21 @@ import { MainPage } from '@/types/admin/main-page';
 
 jest.mock('@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup', () => ({
     __esModule: true,
-    InputWithCharacterLimitGroup: ({ id, value, onChange, onBlur }: any) => (
-        <input data-testid={id} value={value ?? ''} onChange={(e) => onChange(e.target.value)} onBlur={onBlur} />
-    ),
+    InputWithCharacterLimitGroup: require('@/utils/test-mocks/main-page-mocks').MockInputWithCharacterLimitGroup,
 }));
 
 jest.mock(
     '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup',
     () => ({
         __esModule: true,
-        TextAreaWithCharacterLimitGroup: ({ id, value, onChange, onBlur }: any) => (
-            <textarea data-testid={id} value={value ?? ''} onChange={(e) => onChange(e.target.value)} onBlur={onBlur} />
-        ),
+        TextAreaWithCharacterLimitGroup: require('@/utils/test-mocks/main-page-mocks')
+            .MockTextAreaWithCharacterLimitGroup,
     }),
 );
 
 jest.mock('@/components/admin/button/Button', () => ({
     __esModule: true,
-    Button: ({ children, disabled, type }: any) => (
-        <button data-testid="submit-btn" type={type} disabled={disabled}>
-            {children}
-        </button>
-    ),
+    Button: require('@/utils/test-mocks/main-page-mocks').MockSubmitButton,
 }));
 
 const mockInitialData: MainPage = {
@@ -56,7 +49,6 @@ describe('AboutUsBlockForm', () => {
 
         expect(titleInput.value).toBe('');
         expect(descriptionInput.value).toBe('');
-
         expect(screen.getByTestId('submit-btn')).toBeDisabled();
     });
 
@@ -87,7 +79,6 @@ describe('AboutUsBlockForm', () => {
         render(<AboutUsBlockForm initialData={mockInitialData} />);
 
         const titleInput = screen.getByTestId('about-us-block-title');
-
         fireEvent.change(titleInput, { target: { value: 'Новий заголовок Про Нас' } });
 
         await waitFor(() => {
@@ -99,7 +90,6 @@ describe('AboutUsBlockForm', () => {
         render(<AboutUsBlockForm initialData={mockInitialData} />);
 
         const descriptionInput = screen.getByTestId('about-us-block-description');
-
         fireEvent.change(descriptionInput, { target: { value: '   ' } });
         fireEvent.blur(descriptionInput);
 
@@ -115,9 +105,7 @@ describe('AboutUsBlockForm', () => {
         fireEvent.change(descriptionInput, { target: { value: 'Оновлений текст про нашу місію' } });
 
         const submitBtn = screen.getByTestId('submit-btn');
-        await waitFor(() => {
-            expect(submitBtn).not.toBeDisabled();
-        });
+        await waitFor(() => expect(submitBtn).not.toBeDisabled());
 
         expect(() => fireEvent.click(submitBtn)).not.toThrow();
     });

--- a/src/pages/admin/main/components/about-us-block/AboutUsBlockForm.tsx
+++ b/src/pages/admin/main/components/about-us-block/AboutUsBlockForm.tsx
@@ -27,16 +27,14 @@ export const AboutUsBlockForm = ({ initialData }: AboutUsBlockFormProps) => {
     });
 
     useEffect(() => {
-        if (initialData?.mainAboutUs) {
-            reset({
-                title: initialData.mainAboutUs.title || '',
-                description: initialData.mainAboutUs.description || '',
-            });
-        }
+        reset({
+            title: initialData?.mainAboutUs?.title || '',
+            description: initialData?.mainAboutUs?.description || '',
+        });
     }, [initialData, reset]);
 
-    const onSubmit = (data: AboutUsBlockFormValues) => {
-        // TODO: Implement API call
+    const onSubmit = () => {
+        // API integration is intentionally deferred for the display-only phase.
     };
 
     return (

--- a/src/pages/admin/main/components/about-us-block/AboutUsBlockForm.tsx
+++ b/src/pages/admin/main/components/about-us-block/AboutUsBlockForm.tsx
@@ -1,0 +1,100 @@
+import { useEffect } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { Button } from '@/components/admin/button/Button';
+import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
+import { TextAreaWithCharacterLimitGroup } from '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup';
+import { AboutUsBlockValidationSchema } from '@/validation/admin/main-page-schema/main-page-schema';
+import { MainPage, AboutUsBlockFormValues, ABOUT_US_BLOCK_FORM_DEFAULTS } from '@/types/admin/main-page';
+import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
+
+import styles from './AboutUsBlockForm.module.scss';
+
+interface AboutUsBlockFormProps {
+    initialData: MainPage | null;
+}
+
+export const AboutUsBlockForm = ({ initialData }: AboutUsBlockFormProps) => {
+    const {
+        control,
+        handleSubmit,
+        reset,
+        formState: { isDirty, isValid, errors },
+    } = useForm<AboutUsBlockFormValues>({
+        mode: 'onChange',
+        resolver: yupResolver(AboutUsBlockValidationSchema),
+        defaultValues: ABOUT_US_BLOCK_FORM_DEFAULTS,
+    });
+
+    useEffect(() => {
+        if (initialData?.mainAboutUs) {
+            reset({
+                title: initialData.mainAboutUs.title || '',
+                description: initialData.mainAboutUs.description || '',
+            });
+        }
+    }, [initialData, reset]);
+
+    const onSubmit = (data: AboutUsBlockFormValues) => {
+        // TODO: Implement API call
+    };
+
+    return (
+        <form className={styles.form} onSubmit={handleSubmit(onSubmit)}>
+            <div className={styles.content}>
+                <div className={styles.column}>
+                    <Controller
+                        name="title"
+                        control={control}
+                        render={({ field: { onChange, value, onBlur, name } }) => (
+                            <InputWithCharacterLimitGroup
+                                id="about-us-block-title"
+                                name={name}
+                                label={MAIN_PAGE_TEXT.BLOCKS.ABOUT_US.TITLE_LABEL}
+                                value={value}
+                                onChange={onChange}
+                                onBlur={onBlur}
+                                error={errors.title?.message}
+                                maxLength={MAIN_PAGE_VALIDATION.title.max}
+                                isRequired={true}
+                            />
+                        )}
+                    />
+                </div>
+
+                <div className={styles.column}>
+                    <Controller
+                        name="description"
+                        control={control}
+                        render={({ field: { onChange, value, onBlur, name } }) => (
+                            <TextAreaWithCharacterLimitGroup
+                                id="about-us-block-description"
+                                name={name}
+                                label={MAIN_PAGE_TEXT.BLOCKS.ABOUT_US.DESCRIPTION_LABEL}
+                                value={value}
+                                onChange={onChange}
+                                onBlur={onBlur}
+                                error={errors.description?.message}
+                                maxLength={MAIN_PAGE_VALIDATION.description.max}
+                                isRequired={true}
+                                rows={14}
+                                className={styles['textarea-custom']}
+                            />
+                        )}
+                    />
+                </div>
+            </div>
+
+            <div className={styles.actions}>
+                <Button
+                    type="submit"
+                    buttonStyle="primary"
+                    disabled={!isDirty || !isValid}
+                    className={styles['publish-button']}
+                >
+                    {MAIN_PAGE_TEXT.BUTTONS.PUBLISH}
+                </Button>
+            </div>
+        </form>
+    );
+};

--- a/src/pages/admin/main/components/main-page-content/MainPageContent.module.scss
+++ b/src/pages/admin/main/components/main-page-content/MainPageContent.module.scss
@@ -1,0 +1,46 @@
+@use '@/assets/sass/variables/colors' as c;
+
+.wrapper {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    padding: 120px 40px 54px 40px;
+    gap: 54px;
+    overflow: hidden;
+    background-color: c.$white;
+}
+
+.toolbar {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+}
+
+.toolbar-bottom {
+    display: flex;
+    justify-content: flex-start;
+    align-items: flex-end;
+    width: 100%;
+    border-bottom: 1px solid c.$grey-600;
+}
+
+.tabs-wrapper {
+    margin-bottom: -1px;
+    display: flex;
+    align-items: flex-end;
+}
+
+.main-content {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+}
+
+.form-actions {
+    display: flex;
+    justify-content: center;
+    margin-top: 40px;
+    padding-bottom: 40px;
+}

--- a/src/pages/admin/main/components/main-page-content/MainPageContent.module.scss
+++ b/src/pages/admin/main/components/main-page-content/MainPageContent.module.scss
@@ -6,6 +6,7 @@
     flex-direction: column;
     height: 100vh;
     padding: 120px 40px 54px 40px;
+    box-sizing: border-box;
     gap: 54px;
     overflow: hidden;
     background-color: c.$white;
@@ -36,11 +37,4 @@
     display: flex;
     flex-direction: column;
     overflow-y: auto;
-}
-
-.form-actions {
-    display: flex;
-    justify-content: center;
-    margin-top: 40px;
-    padding-bottom: 40px;
 }

--- a/src/pages/admin/main/components/main-page-content/MainPageContent.test.tsx
+++ b/src/pages/admin/main/components/main-page-content/MainPageContent.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { act } from 'react';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MainPageContent } from './MainPageContent';
@@ -16,20 +17,7 @@ jest.mock('../about-us-block/AboutUsBlockForm', () => ({
 
 jest.mock('@/components/admin/category-bar/CategoryBar', () => ({
     __esModule: true,
-    CategoryBar: ({ categories, onCategorySelect, selectedCategory }: any) => (
-        <div data-testid="category-bar">
-            {categories.map((c: any) => (
-                <button
-                    key={c.id}
-                    data-testid={`tab-btn-${c.id}`}
-                    disabled={selectedCategory?.id === c.id}
-                    onClick={() => onCategorySelect(c)}
-                >
-                    {c.label}
-                </button>
-            ))}
-        </div>
-    ),
+    CategoryBar: require('@/utils/test-mocks/main-page-mocks').MockMainPageCategoryBar,
 }));
 
 jest.mock('@/components/common/page-loader/PageLoader', () => ({
@@ -37,13 +25,23 @@ jest.mock('@/components/common/page-loader/PageLoader', () => ({
     PageLoader: () => <div data-testid="page-loader">Loading...</div>,
 }));
 
+const advanceTimers = () =>
+    act(() => {
+        jest.advanceTimersByTime(500);
+    });
+
+const getByExactText = (text: string) =>
+    screen.getByText((_, el) => el?.children.length === 0 && el?.textContent === text);
+
 describe('MainPageContent', () => {
     beforeEach(() => {
         jest.useFakeTimers();
     });
 
     afterEach(() => {
-        jest.runOnlyPendingTimers();
+        act(() => {
+            jest.runOnlyPendingTimers();
+        });
         jest.useRealTimers();
         jest.clearAllMocks();
     });
@@ -55,8 +53,7 @@ describe('MainPageContent', () => {
 
     it('renders TitleBlockForm as the default tab after loading', async () => {
         render(<MainPageContent />);
-
-        jest.advanceTimersByTime(500);
+        await advanceTimers();
 
         await waitFor(() => {
             expect(screen.queryByTestId('page-loader')).not.toBeInTheDocument();
@@ -68,7 +65,7 @@ describe('MainPageContent', () => {
 
     it('switches tabs correctly', async () => {
         render(<MainPageContent />);
-        jest.advanceTimersByTime(500);
+        await advanceTimers();
 
         await waitFor(() => {
             expect(screen.getByTestId('category-bar')).toBeInTheDocument();
@@ -78,12 +75,41 @@ describe('MainPageContent', () => {
         expect(screen.queryByTestId('about-us-block-form')).not.toBeInTheDocument();
 
         fireEvent.click(screen.getByTestId('tab-btn-about'));
-
         expect(screen.getByTestId('about-us-block-form')).toBeInTheDocument();
         expect(screen.queryByTestId('title-block-form')).not.toBeInTheDocument();
 
         fireEvent.click(screen.getByTestId('tab-btn-statistics'));
+        expect(getByExactText(`Блок "${MAIN_PAGE_TEXT.TABS.STATISTICS}" в розробці`)).toBeInTheDocument();
+    });
 
-        expect(screen.getByText(`Блок "${MAIN_PAGE_TEXT.TABS.STATISTICS}" в розробці`)).toBeInTheDocument();
+    it('does not update state after unmount (cleanup isMounted)', async () => {
+        const { unmount } = render(<MainPageContent />);
+        unmount();
+        await advanceTimers();
+        expect(true).toBe(true);
+    });
+
+    it('renders donations tab content', async () => {
+        render(<MainPageContent />);
+        await advanceTimers();
+
+        await waitFor(() => {
+            expect(screen.getByTestId('category-bar')).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByTestId('tab-btn-donations'));
+        expect(getByExactText(`Блок "${MAIN_PAGE_TEXT.TABS.DONATIONS}" в розробці`)).toBeInTheDocument();
+    });
+
+    it('renders partners tab content', async () => {
+        render(<MainPageContent />);
+        await advanceTimers();
+
+        await waitFor(() => {
+            expect(screen.getByTestId('category-bar')).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByTestId('tab-btn-partners'));
+        expect(getByExactText(`Блок "${MAIN_PAGE_TEXT.TABS.PARTNERS}" в розробці`)).toBeInTheDocument();
     });
 });

--- a/src/pages/admin/main/components/main-page-content/MainPageContent.test.tsx
+++ b/src/pages/admin/main/components/main-page-content/MainPageContent.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MainPageContent } from './MainPageContent';
+import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
+
+jest.mock('../title-block/TitleBlockForm', () => ({
+    __esModule: true,
+    TitleBlockForm: () => <div data-testid="title-block-form">Title Form</div>,
+}));
+
+jest.mock('../about-us-block/AboutUsBlockForm', () => ({
+    __esModule: true,
+    AboutUsBlockForm: () => <div data-testid="about-us-block-form">About Us Form</div>,
+}));
+
+jest.mock('@/components/admin/category-bar/CategoryBar', () => ({
+    __esModule: true,
+    CategoryBar: ({ categories, onCategorySelect, selectedCategory }: any) => (
+        <div data-testid="category-bar">
+            {categories.map((c: any) => (
+                <button
+                    key={c.id}
+                    data-testid={`tab-btn-${c.id}`}
+                    disabled={selectedCategory?.id === c.id}
+                    onClick={() => onCategorySelect(c)}
+                >
+                    {c.label}
+                </button>
+            ))}
+        </div>
+    ),
+}));
+
+jest.mock('@/components/common/page-loader/PageLoader', () => ({
+    __esModule: true,
+    PageLoader: () => <div data-testid="page-loader">Loading...</div>,
+}));
+
+describe('MainPageContent', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+        jest.clearAllMocks();
+    });
+
+    it('renders loader initially while data is "fetching"', () => {
+        render(<MainPageContent />);
+        expect(screen.getByTestId('page-loader')).toBeInTheDocument();
+    });
+
+    it('renders TitleBlockForm as the default tab after loading', async () => {
+        render(<MainPageContent />);
+
+        jest.advanceTimersByTime(500);
+
+        await waitFor(() => {
+            expect(screen.queryByTestId('page-loader')).not.toBeInTheDocument();
+        });
+
+        expect(screen.getByTestId('category-bar')).toBeInTheDocument();
+        expect(screen.getByTestId('title-block-form')).toBeInTheDocument();
+    });
+
+    it('switches tabs correctly', async () => {
+        render(<MainPageContent />);
+        jest.advanceTimersByTime(500);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('category-bar')).toBeInTheDocument();
+        });
+
+        expect(screen.getByTestId('title-block-form')).toBeInTheDocument();
+        expect(screen.queryByTestId('about-us-block-form')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('tab-btn-about'));
+
+        expect(screen.getByTestId('about-us-block-form')).toBeInTheDocument();
+        expect(screen.queryByTestId('title-block-form')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('tab-btn-statistics'));
+
+        expect(screen.getByText(`Блок "${MAIN_PAGE_TEXT.TABS.STATISTICS}" в розробці`)).toBeInTheDocument();
+    });
+});

--- a/src/pages/admin/main/components/main-page-content/MainPageContent.tsx
+++ b/src/pages/admin/main/components/main-page-content/MainPageContent.tsx
@@ -1,0 +1,88 @@
+import { useState, useEffect } from 'react';
+import { CategoryBar } from '@/components/admin/category-bar/CategoryBar';
+import { PageLoader } from '@/components/common/page-loader/PageLoader';
+import { TitleBlockForm } from '../title-block/TitleBlockForm';
+import { AboutUsBlockForm } from '../about-us-block/AboutUsBlockForm';
+import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
+import { MainPage } from '@/types/admin/main-page';
+import { MOCK_MAIN_PAGE_DATA } from '@/utils/mock-data/admin/main-page/main-page';
+import styles from './MainPageContent.module.scss';
+
+type TabType = 'title' | 'about' | 'statistics' | 'donations' | 'partners';
+
+type TabItem = {
+    id: TabType;
+    label: string;
+};
+
+const TABS: TabItem[] = [
+    { id: 'title', label: MAIN_PAGE_TEXT.TABS.TITLE },
+    { id: 'about', label: MAIN_PAGE_TEXT.TABS.ABOUT_US },
+    { id: 'statistics', label: MAIN_PAGE_TEXT.TABS.STATISTICS },
+    { id: 'donations', label: MAIN_PAGE_TEXT.TABS.DONATIONS },
+    { id: 'partners', label: MAIN_PAGE_TEXT.TABS.PARTNERS },
+];
+
+export const MainPageContent = () => {
+    const [activeTab, setActiveTab] = useState<TabType>('title');
+    const [data, setData] = useState<MainPage | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+
+    const handleTabSelect = (tab: TabItem) => {
+        setActiveTab(tab.id);
+    };
+
+    useEffect(() => {
+        let isMounted = true;
+
+        const fetchMockData = () => {
+            setIsLoading(true);
+            setTimeout(() => {
+                if (isMounted) {
+                    setData(MOCK_MAIN_PAGE_DATA);
+                    setIsLoading(false);
+                }
+            }, 500);
+        };
+
+        fetchMockData();
+
+        return () => {
+            isMounted = false;
+        };
+    }, []);
+
+    const selectedTab = TABS.find((tab) => tab.id === activeTab) || TABS[0];
+
+    if (isLoading || !data) {
+        return <PageLoader />;
+    }
+
+    return (
+        <div className={styles.wrapper}>
+            <div className={styles.toolbar}>
+                <div className={styles['toolbar-bottom']}>
+                    <div className={styles['tabs-wrapper']}>
+                        <CategoryBar<TabItem>
+                            categories={TABS}
+                            selectedCategory={selectedTab}
+                            getCategoryDisplayName={(tab) => tab.label}
+                            getCategoryKey={(tab) => tab.id}
+                            onCategorySelect={handleTabSelect}
+                        />
+                    </div>
+                </div>
+            </div>
+
+            <div className={styles['main-content']}>
+                {activeTab === 'title' && <TitleBlockForm initialData={data} />}
+                {activeTab === 'about' && <AboutUsBlockForm initialData={data} />}
+                {activeTab === 'statistics' && <div>Блок "{MAIN_PAGE_TEXT.TABS.STATISTICS}" в розробці</div>}
+                {activeTab === 'donations' && <div>Блок "{MAIN_PAGE_TEXT.TABS.DONATIONS}" в розробці</div>}
+                {activeTab === 'partners' && <div>Блок "{MAIN_PAGE_TEXT.TABS.PARTNERS}" в розробці</div>}
+            </div>
+        </div>
+    );
+};
+
+export default MainPageContent;

--- a/src/pages/admin/main/components/title-block/TitleBlockForm.module.scss
+++ b/src/pages/admin/main/components/title-block/TitleBlockForm.module.scss
@@ -29,7 +29,6 @@
 
 .error {
     color: c.$error;
-    font-size: 0.875rem;
     margin: 0;
 }
 
@@ -40,7 +39,7 @@
     gap: 24px;
 }
 
-.textarea-custom :global(.textarea) {
+.textarea-custom textarea {
     height: 200px;
     resize: none;
 }

--- a/src/pages/admin/main/components/title-block/TitleBlockForm.module.scss
+++ b/src/pages/admin/main/components/title-block/TitleBlockForm.module.scss
@@ -1,0 +1,56 @@
+@use '@/assets/sass/variables/colors' as c;
+
+.form {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+}
+
+.content {
+    display: flex;
+    flex-direction: row;
+    gap: 40px;
+    margin-bottom: 40px;
+    align-items: center; 
+}
+
+.image-section {
+    flex: 6;
+    max-width: 60%;
+}
+
+.image-wrapper {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.error {
+    color: c.$error;
+    font-size: 0.875rem;
+    margin: 0;
+}
+
+.text-section {
+    flex: 4;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.textarea-custom :global(.textarea) {
+    height: 200px;
+    resize: none;
+}
+
+.actions {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+}
+
+.publish-button {
+    width: 608px;
+}

--- a/src/pages/admin/main/components/title-block/TitleBlockForm.test.tsx
+++ b/src/pages/admin/main/components/title-block/TitleBlockForm.test.tsx
@@ -6,20 +6,22 @@ import { MainPage } from '@/types/admin/main-page';
 
 jest.mock('@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup', () => ({
     __esModule: true,
-    InputWithCharacterLimitGroup: ({ id, value, onChange, onBlur }: any) => (
-        <input data-testid={id} value={value ?? ''} onChange={(e) => onChange(e.target.value)} onBlur={onBlur} />
-    ),
+    InputWithCharacterLimitGroup: require('@/utils/test-mocks/main-page-mocks').MockInputWithCharacterLimitGroup,
 }));
 
 jest.mock(
     '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup',
     () => ({
         __esModule: true,
-        TextAreaWithCharacterLimitGroup: ({ id, value, onChange, onBlur }: any) => (
-            <textarea data-testid={id} value={value ?? ''} onChange={(e) => onChange(e.target.value)} onBlur={onBlur} />
-        ),
+        TextAreaWithCharacterLimitGroup: require('@/utils/test-mocks/main-page-mocks')
+            .MockTextAreaWithCharacterLimitGroup,
     }),
 );
+
+jest.mock('@/components/admin/button/Button', () => ({
+    __esModule: true,
+    Button: require('@/utils/test-mocks/main-page-mocks').MockSubmitButton,
+}));
 
 jest.mock('@/components/admin/image-input/ImageInput', () => ({
     __esModule: true,
@@ -35,15 +37,6 @@ jest.mock('@/components/admin/image-input/ImageInput', () => ({
                 Clear Error
             </button>
         </div>
-    ),
-}));
-
-jest.mock('@/components/admin/button/Button', () => ({
-    __esModule: true,
-    Button: ({ children, disabled, type }: any) => (
-        <button data-testid="submit-btn" type={type} disabled={disabled}>
-            {children}
-        </button>
     ),
 }));
 
@@ -90,7 +83,6 @@ describe('TitleBlockForm', () => {
         render(<TitleBlockForm initialData={mockInitialData} />);
 
         const titleInput = screen.getByTestId('title-block-title');
-
         fireEvent.change(titleInput, { target: { value: 'Новий змінений заголовок' } });
 
         await waitFor(() => {
@@ -102,7 +94,6 @@ describe('TitleBlockForm', () => {
         render(<TitleBlockForm initialData={mockInitialData} />);
 
         const titleInput = screen.getByTestId('title-block-title');
-
         fireEvent.change(titleInput, { target: { value: '   ' } });
         fireEvent.blur(titleInput);
 
@@ -115,23 +106,14 @@ describe('TitleBlockForm', () => {
         render(<TitleBlockForm initialData={mockInitialData} />);
 
         const titleInput = screen.getByTestId('title-block-title');
-
         fireEvent.change(titleInput, { target: { value: 'Новий змінений заголовок' } });
-        await waitFor(() => {
-            expect(screen.getByTestId('submit-btn')).not.toBeDisabled();
-        });
+        await waitFor(() => expect(screen.getByTestId('submit-btn')).not.toBeDisabled());
 
         fireEvent.click(screen.getByTestId('trigger-image-error'));
-
-        await waitFor(() => {
-            expect(screen.getByTestId('submit-btn')).toBeDisabled();
-        });
+        await waitFor(() => expect(screen.getByTestId('submit-btn')).toBeDisabled());
 
         fireEvent.click(screen.getByTestId('clear-image-error'));
-
-        await waitFor(() => {
-            expect(screen.getByTestId('submit-btn')).not.toBeDisabled();
-        });
+        await waitFor(() => expect(screen.getByTestId('submit-btn')).not.toBeDisabled());
     });
 
     it('allows submitting the form without throwing errors', async () => {
@@ -141,9 +123,7 @@ describe('TitleBlockForm', () => {
         fireEvent.change(titleInput, { target: { value: 'Фінальний заголовок' } });
 
         const submitBtn = screen.getByTestId('submit-btn');
-        await waitFor(() => {
-            expect(submitBtn).not.toBeDisabled();
-        });
+        await waitFor(() => expect(submitBtn).not.toBeDisabled());
 
         expect(() => fireEvent.click(submitBtn)).not.toThrow();
     });

--- a/src/pages/admin/main/components/title-block/TitleBlockForm.test.tsx
+++ b/src/pages/admin/main/components/title-block/TitleBlockForm.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { TitleBlockForm } from './TitleBlockForm';
+import { MainPage } from '@/types/admin/main-page';
+
+jest.mock('@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup', () => ({
+    __esModule: true,
+    InputWithCharacterLimitGroup: ({ id, value, onChange, onBlur }: any) => (
+        <input data-testid={id} value={value ?? ''} onChange={(e) => onChange(e.target.value)} onBlur={onBlur} />
+    ),
+}));
+
+jest.mock(
+    '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup',
+    () => ({
+        __esModule: true,
+        TextAreaWithCharacterLimitGroup: ({ id, value, onChange, onBlur }: any) => (
+            <textarea data-testid={id} value={value ?? ''} onChange={(e) => onChange(e.target.value)} onBlur={onBlur} />
+        ),
+    }),
+);
+
+jest.mock('@/components/admin/image-input/ImageInput', () => ({
+    __esModule: true,
+    ImageInput: ({ setError, onChange }: any) => (
+        <div data-testid="image-input-mock">
+            <button data-testid="trigger-image-change" type="button" onClick={() => onChange({ file: 'fake.jpg' })}>
+                Change Image
+            </button>
+            <button data-testid="trigger-image-error" type="button" onClick={() => setError('Image size error')}>
+                Set Error
+            </button>
+            <button data-testid="clear-image-error" type="button" onClick={() => setError(null)}>
+                Clear Error
+            </button>
+        </div>
+    ),
+}));
+
+jest.mock('@/components/admin/button/Button', () => ({
+    __esModule: true,
+    Button: ({ children, disabled, type }: any) => (
+        <button data-testid="submit-btn" type={type} disabled={disabled}>
+            {children}
+        </button>
+    ),
+}));
+
+const mockInitialData: MainPage = {
+    id: 1,
+    title: 'Початковий заголовок',
+    description: 'Початковий опис',
+    image: null,
+    mainAboutUs: null,
+    mainPartners: null,
+};
+
+describe('TitleBlockForm', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders with empty default values when initialData is null', () => {
+        render(<TitleBlockForm initialData={null} />);
+
+        const titleInput = screen.getByTestId('title-block-title') as HTMLInputElement;
+        const descriptionInput = screen.getByTestId('title-block-description') as HTMLTextAreaElement;
+
+        expect(titleInput.value).toBe('');
+        expect(descriptionInput.value).toBe('');
+        expect(screen.getByTestId('submit-btn')).toBeDisabled();
+    });
+
+    it('populates fields with initialData', async () => {
+        render(<TitleBlockForm initialData={mockInitialData} />);
+
+        const titleInput = screen.getByTestId('title-block-title') as HTMLInputElement;
+        const descriptionInput = screen.getByTestId('title-block-description') as HTMLTextAreaElement;
+
+        await waitFor(() => {
+            expect(titleInput.value).toBe('Початковий заголовок');
+            expect(descriptionInput.value).toBe('Початковий опис');
+        });
+
+        expect(screen.getByTestId('submit-btn')).toBeDisabled();
+    });
+
+    it('enables submit button when form is dirty and valid', async () => {
+        render(<TitleBlockForm initialData={mockInitialData} />);
+
+        const titleInput = screen.getByTestId('title-block-title');
+
+        fireEvent.change(titleInput, { target: { value: 'Новий змінений заголовок' } });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('submit-btn')).not.toBeDisabled();
+        });
+    });
+
+    it('disables submit button when required fields are cleared', async () => {
+        render(<TitleBlockForm initialData={mockInitialData} />);
+
+        const titleInput = screen.getByTestId('title-block-title');
+
+        fireEvent.change(titleInput, { target: { value: '   ' } });
+        fireEvent.blur(titleInput);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('submit-btn')).toBeDisabled();
+        });
+    });
+
+    it('disables submit button when ImageInput sets an error', async () => {
+        render(<TitleBlockForm initialData={mockInitialData} />);
+
+        const titleInput = screen.getByTestId('title-block-title');
+
+        fireEvent.change(titleInput, { target: { value: 'Новий змінений заголовок' } });
+        await waitFor(() => {
+            expect(screen.getByTestId('submit-btn')).not.toBeDisabled();
+        });
+
+        fireEvent.click(screen.getByTestId('trigger-image-error'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('submit-btn')).toBeDisabled();
+        });
+
+        fireEvent.click(screen.getByTestId('clear-image-error'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('submit-btn')).not.toBeDisabled();
+        });
+    });
+
+    it('allows submitting the form without throwing errors', async () => {
+        render(<TitleBlockForm initialData={mockInitialData} />);
+
+        const titleInput = screen.getByTestId('title-block-title');
+        fireEvent.change(titleInput, { target: { value: 'Фінальний заголовок' } });
+
+        const submitBtn = screen.getByTestId('submit-btn');
+        await waitFor(() => {
+            expect(submitBtn).not.toBeDisabled();
+        });
+
+        expect(() => fireEvent.click(submitBtn)).not.toThrow();
+    });
+});

--- a/src/pages/admin/main/components/title-block/TitleBlockForm.tsx
+++ b/src/pages/admin/main/components/title-block/TitleBlockForm.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { Button } from '@/components/admin/button/Button';
+import { ImageInput } from '@/components/admin/image-input/ImageInput';
+import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
+import { TextAreaWithCharacterLimitGroup } from '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup';
+import { TitleBlockValidationSchema } from '@/validation/admin/main-page-schema/main-page-schema';
+import { MainPage, TitleBlockFormValues, TITLE_BLOCK_FORM_DEFAULTS } from '@/types/admin/main-page';
+import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import DefaultPlaceholder from '@/assets/images/man-facing-horse-forehead.webp';
+
+import styles from './TitleBlockForm.module.scss';
+
+interface TitleBlockFormProps {
+    initialData: MainPage | null;
+}
+
+const IMAGE_CONFIG = {
+    cropWidth: 1440,
+    cropHeight: 860,
+    minWidth: 1440,
+    minHeight: 860,
+    label: 'Додайте файл сюди',
+    subText: 'Розмір: 1440x860',
+    style: {
+        width: '100%',
+        aspectRatio: '1440 / 860',
+        backgroundImage: `linear-gradient(rgba(245, 245, 245, 0.85), rgba(245, 245, 245, 0.85)), url(${DefaultPlaceholder})`,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+    },
+};
+
+export const TitleBlockForm = ({ initialData }: TitleBlockFormProps) => {
+    const [imageError, setImageError] = useState<string | null>(null);
+
+    const {
+        control,
+        handleSubmit,
+        reset,
+        formState: { isDirty, isValid, errors },
+    } = useForm<TitleBlockFormValues>({
+        mode: 'onChange',
+        resolver: yupResolver(TitleBlockValidationSchema),
+        defaultValues: TITLE_BLOCK_FORM_DEFAULTS,
+    });
+
+    useEffect(() => {
+        if (initialData) {
+            reset({
+                title: initialData.title || '',
+                description: initialData.description || '',
+                image: initialData.image || null,
+            });
+        }
+    }, [initialData, reset]);
+
+    const onSubmit = (data: TitleBlockFormValues) => {
+        // TODO: implement api call
+    };
+
+    return (
+        <form className={styles.form} onSubmit={handleSubmit(onSubmit)}>
+            <div className={styles.content}>
+                <div className={styles['image-section']}>
+                    <Controller
+                        name="image"
+                        control={control}
+                        render={({ field: { onChange, value } }) => (
+                            <div className={styles['image-wrapper']}>
+                                <ImageInput
+                                    value={value}
+                                    onChange={onChange}
+                                    setError={setImageError}
+                                    variant="whoWeAre"
+                                    {...IMAGE_CONFIG}
+                                />
+                                {(imageError || errors.image?.message) && (
+                                    <p className={styles.error}> {imageError || errors.image?.message}</p>
+                                )}
+                            </div>
+                        )}
+                    />
+                </div>
+
+                <div className={styles['text-section']}>
+                    <Controller
+                        name="title"
+                        control={control}
+                        render={({ field: { onChange, value, onBlur } }) => (
+                            <InputWithCharacterLimitGroup
+                                id="title-block-title"
+                                name={COMMON_TEXT_ADMIN.TYPE.TITLE}
+                                label={MAIN_PAGE_TEXT.BLOCKS.TITLE.TITLE_LABEL}
+                                value={value}
+                                onChange={onChange}
+                                onBlur={onBlur}
+                                error={errors.title?.message}
+                                maxLength={MAIN_PAGE_VALIDATION.title.max}
+                                isRequired={true}
+                            />
+                        )}
+                    />
+
+                    <Controller
+                        name="description"
+                        control={control}
+                        render={({ field: { onChange, value, onBlur } }) => (
+                            <TextAreaWithCharacterLimitGroup
+                                id="title-block-description"
+                                name={COMMON_TEXT_ADMIN.TYPE.DESCRIPTION}
+                                label={MAIN_PAGE_TEXT.BLOCKS.TITLE.DESCRIPTION_LABEL}
+                                value={value}
+                                onChange={onChange}
+                                onBlur={onBlur}
+                                error={errors.description?.message}
+                                maxLength={MAIN_PAGE_VALIDATION.description.max}
+                                isRequired={true}
+                                className={styles['textarea-custom']}
+                            />
+                        )}
+                    />
+                </div>
+            </div>
+
+            <div className={styles.actions}>
+                <Button
+                    type="submit"
+                    buttonStyle="primary"
+                    disabled={!isDirty || !isValid || !!imageError}
+                    className={styles['publish-button']}
+                >
+                    {MAIN_PAGE_TEXT.BUTTONS.PUBLISH}
+                </Button>
+            </div>
+        </form>
+    );
+};

--- a/src/pages/admin/main/components/title-block/TitleBlockForm.tsx
+++ b/src/pages/admin/main/components/title-block/TitleBlockForm.tsx
@@ -48,17 +48,20 @@ export const TitleBlockForm = ({ initialData }: TitleBlockFormProps) => {
     });
 
     useEffect(() => {
-        if (initialData) {
-            reset({
-                title: initialData.title || '',
-                description: initialData.description || '',
-                image: initialData.image || null,
-            });
-        }
+        setImageError(null);
+        reset(
+            initialData
+                ? {
+                      title: initialData.title || '',
+                      description: initialData.description || '',
+                      image: initialData.image || null,
+                  }
+                : TITLE_BLOCK_FORM_DEFAULTS,
+        );
     }, [initialData, reset]);
 
-    const onSubmit = (data: TitleBlockFormValues) => {
-        // TODO: implement api call
+    const onSubmit = () => {
+        // API integration is intentionally deferred for the display-only phase.
     };
 
     return (

--- a/src/routes/app-router/AppRouter.jsx
+++ b/src/routes/app-router/AppRouter.jsx
@@ -27,6 +27,7 @@ import { CompanyProfileContent } from '@/pages/admin/company-profile/components/
 import { LanguageSyncWrapper } from '@/components/public/language-sync-wrapper/LanguageSyncWrapper';
 import { ReportsPanelContent } from '@/pages/admin/reports/components/reports-panel-content/ReportsPanelContent';
 import { HistoryPageContent } from '@/pages/admin/history/components/history-page-content/HistoryPageContent';
+import { MainPageContent } from '@/pages/admin/main/components/main-page-content/MainPageContent';
 
 export const AppRouter = () => {
     const PublicContent = () => (
@@ -78,6 +79,7 @@ export const AppRouter = () => {
                             <Route path={ADMIN_ROUTES.PROFILE_COMPANY.PATH} element={<CompanyProfileContent />} />
                             <Route path={ADMIN_ROUTES.REPORTS.PATH} element={<ReportsPanelContent />} />
                             <Route path={ADMIN_ROUTES.HISTORY.PATH} element={<HistoryPageContent />} />
+                            <Route path={ADMIN_ROUTES.MAIN.PATH} element={<MainPageContent />} />
                         </Route>
                     </Route>
                 </Route>

--- a/src/types/admin/main-page.ts
+++ b/src/types/admin/main-page.ts
@@ -1,0 +1,44 @@
+import { Image, ImageValues } from '../common/image';
+
+export interface MainAboutUs {
+    id: number;
+    title: string;
+    description: string;
+}
+
+export interface MainPartners {
+    id: number;
+    title: string;
+    description: string;
+}
+
+export interface MainPage {
+    id: number;
+    title: string;
+    description: string;
+    image: Image | ImageValues | null;
+    mainAboutUs: MainAboutUs | null;
+    mainPartners: MainPartners | null;
+}
+
+export interface TitleBlockFormValues {
+    title: string;
+    description: string;
+    image: Image | ImageValues | null;
+}
+
+export const TITLE_BLOCK_FORM_DEFAULTS: TitleBlockFormValues = {
+    title: '',
+    description: '',
+    image: null,
+};
+
+export interface AboutUsBlockFormValues {
+    title: string;
+    description: string;
+}
+
+export const ABOUT_US_BLOCK_FORM_DEFAULTS: AboutUsBlockFormValues = {
+    title: '',
+    description: '',
+};

--- a/src/utils/mock-data/admin/main-page/main-page.ts
+++ b/src/utils/mock-data/admin/main-page/main-page.ts
@@ -1,0 +1,18 @@
+import { MainPage } from '@/types/admin/main-page';
+
+export const MOCK_MAIN_PAGE_DATA: MainPage = {
+    id: 1,
+    title: 'Коні з досвідом зцілення',
+    description: 'Коли тіло та душа відновлюються — народжується справжня сила',
+    image: null,
+    mainAboutUs: {
+        id: 1,
+        title: 'Про нас',
+        description: 'Коли тіло та душа відновлюються — народжується справжня сила',
+    },
+    mainPartners: {
+        id: 1,
+        title: 'Наші партнери',
+        description: 'Коли тіло та душа відновлюються — народжується справжня сила.',
+    },
+};

--- a/src/utils/test-mocks/main-page-mocks.tsx
+++ b/src/utils/test-mocks/main-page-mocks.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export const MockInputWithCharacterLimitGroup = ({ id, value, onChange, onBlur }: any) => (
+    <input data-testid={id} value={value ?? ''} onChange={(e) => onChange(e.target.value)} onBlur={onBlur} />
+);
+
+export const MockTextAreaWithCharacterLimitGroup = ({ id, value, onChange, onBlur }: any) => (
+    <textarea data-testid={id} value={value ?? ''} onChange={(e) => onChange(e.target.value)} onBlur={onBlur} />
+);
+
+export const MockSubmitButton = ({ children, disabled, type }: any) => (
+    <button data-testid="submit-btn" type={type} disabled={disabled}>
+        {children}
+    </button>
+);
+
+export const MockMainPageCategoryBar = ({ categories, onCategorySelect, selectedCategory }: any) => (
+    <div data-testid="category-bar">
+        {categories.map((c: any) => (
+            <button
+                key={c.id}
+                data-testid={`tab-btn-${c.id}`}
+                disabled={selectedCategory?.id === c.id}
+                onClick={() => onCategorySelect(c)}
+            >
+                {c.label}
+            </button>
+        ))}
+    </div>
+);

--- a/src/validation/admin/main-page-schema/main-page-schema.test.ts
+++ b/src/validation/admin/main-page-schema/main-page-schema.test.ts
@@ -1,0 +1,70 @@
+import { MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
+import { MAIN_PAGE_VALIDATION_FUNCTIONS } from './main-page-schema';
+
+describe('MAIN_PAGE_VALIDATION_FUNCTIONS', () => {
+    describe('validateTitle', () => {
+        it('returns undefined for a valid title', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateTitle('Коні з досвідом зцілення')).toBeUndefined();
+        });
+
+        it('returns required error for an empty title', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateTitle('')).toBe(MAIN_PAGE_VALIDATION.common.REQUIRED);
+        });
+
+        it('treats spaces as empty and returns required error', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateTitle('   ')).toBe(MAIN_PAGE_VALIDATION.common.REQUIRED);
+        });
+
+        it('returns max error for title longer than 50 chars', () => {
+            const longTitle = 'a'.repeat(MAIN_PAGE_VALIDATION.title.max + 1);
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateTitle(longTitle)).toBe(
+                MAIN_PAGE_VALIDATION.title.getMaxError(),
+            );
+        });
+    });
+
+    describe('validateDescription', () => {
+        it('returns undefined for a valid description', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateDescription('Це коректний опис для блоку.')).toBeUndefined();
+        });
+
+        it('returns required error for an empty description', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateDescription('')).toBe(MAIN_PAGE_VALIDATION.common.REQUIRED);
+        });
+
+        it('treats spaces as empty and returns required error', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateDescription('      ')).toBe(
+                MAIN_PAGE_VALIDATION.common.REQUIRED,
+            );
+        });
+
+        it('returns max error for description longer than 1000 chars', () => {
+            const longDescription = 'a'.repeat(MAIN_PAGE_VALIDATION.description.max + 1);
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateDescription(longDescription)).toBe(
+                MAIN_PAGE_VALIDATION.description.getMaxError(),
+            );
+        });
+    });
+
+    describe('validateImage', () => {
+        it('returns undefined for null (optional field)', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateImage(null)).toBeUndefined();
+        });
+
+        it('returns undefined for ImageValues object', () => {
+            const mockImageValues = {
+                file: new File([''], 'test.png', { type: 'image/png' }),
+                preview: 'blob:http://localhost/test',
+            };
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateImage(mockImageValues as any)).toBeUndefined();
+        });
+
+        it('returns undefined for existing Image object', () => {
+            const mockImage = {
+                id: 123,
+                url: 'http://example.com/image.jpg',
+            };
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateImage(mockImage as any)).toBeUndefined();
+        });
+    });
+});

--- a/src/validation/admin/main-page-schema/main-page-schema.ts
+++ b/src/validation/admin/main-page-schema/main-page-schema.ts
@@ -1,0 +1,65 @@
+import * as Yup from 'yup';
+import { MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
+import { AboutUsBlockFormValues, TitleBlockFormValues } from '@/types/admin/main-page';
+import { Image, ImageValues } from '@/types/common/image';
+
+const requiredTrimmedTitle = () => {
+    return Yup.string()
+        .trim()
+        .required(MAIN_PAGE_VALIDATION.common.REQUIRED)
+        .max(MAIN_PAGE_VALIDATION.title.max, MAIN_PAGE_VALIDATION.title.getMaxError());
+};
+
+const requiredTrimmedDescription = () => {
+    return Yup.string()
+        .trim()
+        .required(MAIN_PAGE_VALIDATION.common.REQUIRED)
+        .max(MAIN_PAGE_VALIDATION.description.max, MAIN_PAGE_VALIDATION.description.getMaxError());
+};
+
+export const TitleBlockValidationSchema: Yup.ObjectSchema<TitleBlockFormValues> = Yup.object({
+    title: requiredTrimmedTitle(),
+    description: requiredTrimmedDescription(),
+    image: Yup.mixed<Image | ImageValues>()
+        .transform((value) => {
+            if (value === null || typeof value === 'string') return undefined;
+            return value;
+        })
+        .nullable()
+        .notRequired()
+        .default(null),
+});
+
+export const AboutUsBlockValidationSchema: Yup.ObjectSchema<AboutUsBlockFormValues> = Yup.object({
+    title: requiredTrimmedTitle(),
+    description: requiredTrimmedDescription(),
+});
+
+export const MAIN_PAGE_VALIDATION_FUNCTIONS = {
+    validateTitle: (value: string): string | undefined => {
+        try {
+            TitleBlockValidationSchema.validateSyncAt('title', { title: value });
+            return undefined;
+        } catch (error: any) {
+            return error.message;
+        }
+    },
+
+    validateDescription: (value: string): string | undefined => {
+        try {
+            TitleBlockValidationSchema.validateSyncAt('description', { description: value });
+            return undefined;
+        } catch (error: any) {
+            return error.message;
+        }
+    },
+
+    validateImage: (value: Image | ImageValues | null): string | undefined => {
+        try {
+            TitleBlockValidationSchema.validateSyncAt('image', { image: value });
+            return undefined;
+        } catch (error: any) {
+            return error.message;
+        }
+    },
+};


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2047
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2048
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2054

## Description

The main goal of this PR is to implement the initial UI structure for the "Main Page" management in the Admin Panel. It includes navigation between different content blocks and the visual representation of the "Title" and "About Us" forms with character counters and field validation.

### Note

This is a Display Only (Dummy UI) implementation. Data is provided via mocks. API integration for saving/publishing changes is planned for future tasks.

## How it looks

https://github.com/user-attachments/assets/4e392137-ca9d-449d-bc47-f6b93c89138c

## Summary of change

- Created the `MainPageContent` component with tab-based navigation using `CategoryBar`.
- Implemented `TitleBlockForm` for managing the hero section (image, title, description).
- Implemented `AboutUsBlockForm` with a two-column layout according to Figma mock-ups.
- Integrated react-hook-form with `yupResolver` for form state management and validation.
- Added `TitleBlockValidationSchema` and `AboutUsBlockValidationSchema` using Yup.
- Created `MAIN_PAGE_VALIDATION_FUNCTIONS` for individual field validation (onBlur/onChange).
- Updated `MAIN_PAGE_TEXT` constants using shared values from `COMMON_TEXT_ADMIN`.
- Added unit tests for `MainPageContent` (tab switching and loading states).
- Added unit tests for `TitleBlockForm` and `AboutUsBlockForm` (initialization, dirty states, validation triggers).
- Added tests for validation schemas and helper functions.

### Out of Scope

- Statistics block (https://github.com/ita-social-projects/VictoryCenter-Back/issues/2057): Currently represented as a placeholder due to pending requirements/design updates.
- Donate block (https://github.com/ita-social-projects/VictoryCenter-Back/issues/2060): Currently in backlog and not described.
- Partners block (https://github.com/ita-social-projects/VictoryCenter-Back/issues/2063): Currently in backlog and not described.
- API Integration: Actual GET/POST/PUT requests are not included in this PR.
- Localization for this page is planned, but not yet implemented or described.

## How to recreate changes

1. Login to the Admin Panel.
2. Navigate to the "Головна" menu item in the sidebar.
3. Verify that the "Титульна" tab is opened by default and shows mock data.
4. Switch to the "Про нас" tab and verify the layout.
5. Try to clear mandatory fields to see validation errors and the "Опублікувати" button becoming disabled.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Admin "Main" section accessible from the admin navigation with its own route and tabbed interface.
  * New editable Title and About sections (image support), publish action, character limits and inline validation.

* **Style**
  * Added styles for main page layout, title and about forms, and responsive publish controls.

* **Tests**
  * Added unit tests covering form validation, tab switching, and form interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->