### PR TITLE
Fix/issue 2260 [Single Program] Character counter of "Опис" field is overlaped when it expands according to the entered text (Templste T-6) bug fix

### DIFF
--- a/src/components/admin/input-error-with-character-counter/InputErrorWithCharacterCounter.module.scss
+++ b/src/components/admin/input-error-with-character-counter/InputErrorWithCharacterCounter.module.scss
@@ -4,9 +4,10 @@
 .container {
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
-    gap: 1rem;
+    gap: 0.25rem 1rem;
     margin-top: 0.25rem;
 }
 
@@ -23,6 +24,7 @@
     color: c.$grey-900;
     white-space: nowrap;
     flex-shrink: 0;
+    margin-left: auto;
 
     &.white-label {
         color: c.$white;

--- a/src/components/common/section-templates/shared/images-bottom-section/ImagesBottomSection.module.scss
+++ b/src/components/common/section-templates/shared/images-bottom-section/ImagesBottomSection.module.scss
@@ -51,6 +51,7 @@
 
 .container.form-container {
     gap: 30px;
+    overflow: visible;
 
     .top-section {
         height: auto;

--- a/src/components/common/section-templates/shared/images-bottom-section/ImagesBottomSection.module.scss
+++ b/src/components/common/section-templates/shared/images-bottom-section/ImagesBottomSection.module.scss
@@ -50,6 +50,7 @@
 }
 
 .container.form-container {
+    max-height: none;
     gap: 30px;
     overflow: visible;
 

--- a/src/components/common/section-templates/shared/title-description-section/TitleDescriptionSection.module.scss
+++ b/src/components/common/section-templates/shared/title-description-section/TitleDescriptionSection.module.scss
@@ -46,10 +46,12 @@
 
         .title-section {
             flex: 0 0 30%;
+            min-width: 0;
         }
 
         .description-section {
             flex: 0 0 30%;
+            min-width: 0;
         }
     }
 

--- a/src/components/common/section-templates/shared/title-description-section/TitleDescriptionSection.module.scss
+++ b/src/components/common/section-templates/shared/title-description-section/TitleDescriptionSection.module.scss
@@ -45,12 +45,12 @@
         justify-content: center;
 
         .title-section {
-            flex: 0 0 30%;
+            flex: 1 1 auto;
             min-width: 0;
         }
 
         .description-section {
-            flex: 0 0 30%;
+            flex: 1 1 auto;
             min-width: 0;
         }
     }

--- a/src/components/common/section-templates/single-image-bottom/SingleImageBottom.module.scss
+++ b/src/components/common/section-templates/single-image-bottom/SingleImageBottom.module.scss
@@ -46,6 +46,7 @@ $img-height: 680px;
 .container.form-container {
     max-height: 1400px;
     gap: 30px;
+    overflow: visible;
 
     .bottom-section {
         flex: auto;

--- a/src/components/common/section-templates/single-image-bottom/SingleImageBottom.module.scss
+++ b/src/components/common/section-templates/single-image-bottom/SingleImageBottom.module.scss
@@ -44,9 +44,14 @@ $img-height: 680px;
 }
 
 .container.form-container {
-    max-height: 1400px;
+    max-height: none;
     gap: 30px;
     overflow: visible;
+
+    .top-section {
+        flex: auto;
+        height: auto;
+    }
 
     .bottom-section {
         flex: auto;

--- a/src/components/common/section-templates/single-image-right/SingleImageRight.module.scss
+++ b/src/components/common/section-templates/single-image-right/SingleImageRight.module.scss
@@ -106,8 +106,11 @@
     justify-content: space-between;
 
     .left-section {
-        justify-content: space-around;
+        justify-content: flex-start;
         flex: 0 0 41%;
+        padding-top: 30px;
+        padding-bottom: 30px;
+        gap: 5%;
     }
 
     .title-section {

--- a/src/components/common/section-templates/single-image-top/SingleImageTop.module.scss
+++ b/src/components/common/section-templates/single-image-top/SingleImageTop.module.scss
@@ -47,7 +47,7 @@ $img-height: 680px;
 }
 
 .container.form-container {
-    max-height: 1300px;
+    max-height: none;
     gap: 30px;
     overflow: visible;
 
@@ -56,6 +56,11 @@ $img-height: 680px;
         height: auto;
         justify-content: center;
         padding: 1vw 10vw;
+    }
+
+    .bottom-section {
+        flex: auto;
+        height: auto;
     }
 
     .image-wrapper {

--- a/src/components/common/section-templates/single-image-top/SingleImageTop.module.scss
+++ b/src/components/common/section-templates/single-image-top/SingleImageTop.module.scss
@@ -49,6 +49,7 @@ $img-height: 680px;
 .container.form-container {
     max-height: 1300px;
     gap: 30px;
+    overflow: visible;
 
     .top-section {
         flex: auto;

--- a/src/components/common/section-templates/text-only/TextOnly.module.scss
+++ b/src/components/common/section-templates/text-only/TextOnly.module.scss
@@ -15,6 +15,7 @@
 
 .form-container {
     justify-content: center;
+    overflow: visible;
 }
 
 .title-template {


### PR DESCRIPTION
## Github issue

* [Githus issue](https://github.com/ita-social-projects/VictoryCenter-Client/issues/360)

## Description

Character counter of "Опис" field is overlaped when it expands according to the entered text, so my code adjusts some css files to fix that bug.

## How it looks

https://github.com/user-attachments/assets/5dd434f5-3de8-49ea-9612-272ae1e0db8c

## Summary of change

Section template containers inherit overflow:hidden and max-height:100% from %section-container, clipping the character counter as the description textarea grows. Fixed by overriding these constraints in edit mode across affected templates and allowing text sections to size naturally to their content.

## How to recreate changes

1. Click on "Додати секцію" button
2. Select template T-6 and click on "Обрати шаблон" button.
3. Focus on "Опис" field and enter test data №1
4. Observe behavior of "Опис" field character counter


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [x]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Removed fixed height limits and enabled overflow visibility so form sections can expand without clipping.
  * Updated flex behavior for title, description and section columns to allow flexible growth/shrink and avoid minimum-content sizing issues.
  * Adjusted alignment, spacing, wrapping and gap handling for form containers and input controls to improve responsiveness and visual balance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->