### PR TITLE
Refactor/issue-2301: Implement new requirements for Funds and Expenditures Tab

### DIFF
--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.module.scss
@@ -28,6 +28,7 @@
 
 .disclaimer-label {
     @include type.subtitle-1-medium;
+    font-weight: 700;
     line-height: 24px;
     color: c.$grey-900;
 }

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -418,10 +418,6 @@ export const FundsExpenditureSection = () => {
                 allRecordsForTypeInference={recordsState}
                 isEditing={isEditing}
                 isRowActionsDisabled={hasExchangeRateError}
-                isAddIncomeDisabled={isAddIncomeDisabled}
-                isAddExpenseDisabled={isAddExpenseDisabled}
-                onAddIncome={handleOpenAddIncomeModal}
-                onAddExpense={handleOpenAddExpenseModal}
                 onRowEditModeChange={setIsRowEditMode}
                 onRecordSave={handleRecordSave}
                 onDeleteRecord={handleDeleteClick}

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
@@ -13,10 +13,10 @@
     overflow-y: auto;
     max-height: 60vh;
     scroll-behavior: smooth;
-    background: #f8fafc;
-    border: 1px solid #e2e2e2;
+    background-color: c.$light-blue-25;
+    border: 1px solid c.$grey-400;
     border-radius: 16px;
-    box-shadow: 0 24px 48px -12px rgba(17, 17, 19, 0.2);
+    box-shadow: 0 24px 48px -12px rgba(c.$bluish-black, 0.2);
 }
 
 .table {
@@ -29,7 +29,7 @@
     padding: 16px 20px;
     text-align: left;
     line-height: 24px;
-    color: rgba(29, 27, 32, 0.88);
+    color: rgba(c.$graphite-black, 0.88);
     white-space: nowrap;
 
     &.sortable {
@@ -59,7 +59,7 @@
 
 .tr {
     background-color: c.$white;
-    border: 1px solid #e2e2e2;
+    border: 1px solid c.$grey-400;
 
     &:hover {
         background-color: c.$light-blue-50;
@@ -73,7 +73,7 @@
     line-height: 24px;
     color: c.$graphite-black;
     vertical-align: middle;
-    height: 65px;
+    height: 72px;
     box-sizing: border-box;
 }
 
@@ -90,8 +90,8 @@
 }
 
 .type-chip-income {
-    background-color: #4e6183;
-    border: 1px solid #123288;
+    background-color: c.$blue-400;
+    border: 1px solid c.$blue-500;
     color: c.$white;
 }
 
@@ -171,7 +171,7 @@
     width: 28px;
     height: 28px;
     border: none;
-    background: transparent;
+    background-color: transparent;
     border-radius: 6px;
     cursor: pointer;
     padding: 4px;
@@ -251,13 +251,25 @@
     height: auto;
 }
 
-.category-edit-wrapper,
+.category-edit-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    height: 80px;
+    overflow: visible;
+    position: relative;
+}
+
 .amount-edit-wrapper {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 6px;
-    min-height: 80px;
+    justify-content: center;
+    height: 72px;
+    overflow: visible;
+    position: relative;
+    width: 128px;
 }
 
 .category-edit-select {
@@ -286,23 +298,19 @@
     border-radius: 6px;
 }
 
-.category-edit-error,
-.amount-edit-error {
-    margin: 0;
-    color: c.$error;
-}
-
 .amount-edit-info {
     display: flex;
-    align-items: flex-start;
-    gap: 8px;
-    width: 128px;
-    min-width: 0;
+    align-items: center;
+    gap: 6px;
+    position: absolute;
+    top: 64px;
+    left: 0;
 }
 
 .amount-edit-info-icon {
     width: 18px;
     height: 18px;
+    flex-shrink: 0;
 
     path {
         stroke: c.$blue-500;
@@ -310,27 +318,36 @@
 }
 
 .amount-edit-info-text {
-    @include type.small-text-medium;
+    @include type.small-text-regular;
     margin: 0;
     color: c.$blue-500;
-    overflow-wrap: anywhere;
-    word-break: break-word;
-    white-space: normal;
-    min-width: 0;
+    white-space: nowrap;
 }
 
 .category-edit-error {
     @include type.small-text-regular;
+    position: absolute;
+    top: 66px;
+    left: 0;
+    margin: 0;
+    color: c.$error;
+    white-space: nowrap;
 }
 
 .amount-edit-error {
-    @include type.subtitle-2-medium;
+    @include type.small-text-regular;
+    position: absolute;
+    top: 64px;
+    left: 0;
+    margin: 0;
+    color: c.$error;
+    white-space: nowrap;
 }
 
 .amount-edit-input {
     @include type.subtitle-2-medium;
     width: 128px;
-    min-height: 55px;
+    min-height: 48px;
     padding: 10px 17px;
     border: 1px solid c.$grey-700;
     border-radius: 8px;

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
@@ -260,43 +260,23 @@ describe('FundsExpendituresTable', () => {
         expect(onDeleteRecord).toHaveBeenCalledWith(MOCK_RECORDS[0]);
     });
 
-    it('should render empty state row when records is empty', () => {
-        renderTable({ records: [] });
+    it('should render nothing when records is empty in view mode', () => {
+        renderTable({ records: [], isEditing: false });
 
-        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.TITLE)).toBeInTheDocument();
-        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.ADD_RECORD)).toBeInTheDocument();
+        expect(screen.queryByTestId('funds-table-empty-cell')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('not-found')).not.toBeInTheDocument();
+    });
+
+    it('should render empty state row with message when records is empty in edit mode', () => {
+        renderTable({ records: [], isEditing: true });
+
+        expect(screen.getByTestId('funds-table-empty-cell')).toBeInTheDocument();
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.MESSAGE)).toBeInTheDocument();
         expect(screen.getByTestId('not-found')).toBeInTheDocument();
     });
 
-    it('should render add action buttons in empty state for view mode', () => {
-        renderTable({ records: [], isEditing: false });
-
-        expect(screen.getByTestId('empty-state-actions')).toBeInTheDocument();
-        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.ADD_EXPENSE)).toBeEnabled();
-        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.ADD_INCOME)).toBeEnabled();
-    });
-
-    it('should trigger add callbacks from empty state buttons in view mode', () => {
-        const onAddIncome = jest.fn();
-        const onAddExpense = jest.fn();
-
-        renderTable({ records: [], isEditing: false, onAddIncome, onAddExpense });
-
-        fireEvent.click(screen.getByTestId('mock-add-expense'));
-        fireEvent.click(screen.getByTestId('mock-add-income'));
-
-        expect(onAddExpense).toHaveBeenCalledTimes(1);
-        expect(onAddIncome).toHaveBeenCalledTimes(1);
-    });
-
-    it('should use correct empty-state colSpan in view and edit modes', () => {
-        const { rerender } = render(
-            <FundsExpendituresTable records={[]} categories={MOCK_CATEGORIES} isEditing={false} />,
-        );
-
-        expect(screen.getByTestId('funds-table-empty-cell')).toHaveAttribute('colspan', '5');
-
-        rerender(<FundsExpendituresTable records={[]} categories={MOCK_CATEGORIES} isEditing />);
+    it('should use correct empty-state colSpan in edit mode', () => {
+        renderTable({ records: [], isEditing: true });
 
         expect(screen.getByTestId('funds-table-empty-cell')).toHaveAttribute('colspan', '7');
     });

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
@@ -643,6 +643,33 @@ describe('FundsExpendituresTable', () => {
             });
         });
 
+        it('should preserve amount decimal text when saving table row', () => {
+            const onRecordSave = jest.fn();
+            const recordsWithDecimals: EnrichedRecord[] = [
+                {
+                    id: 1,
+                    categoryId: 1,
+                    categoryName: 'Грантові кошти',
+                    type: 'income',
+                    reportingYear: '2025',
+                    amountUah: '7 265,123',
+                    amountUsd: '173,221',
+                },
+            ];
+
+            renderTable({ isEditing: true, onRecordSave, records: recordsWithDecimals });
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            fireEvent.click(screen.getByTestId('select-option-Благодійні внески-2'));
+            fireEvent.click(screen.getByLabelText('Accept record 1'));
+
+            expect(onRecordSave).toHaveBeenCalledWith(1, {
+                categoryId: 2,
+                amountUah: '7 265,123',
+                amountUsd: '173,221',
+            });
+        });
+
         it('should show saving indicator, lock controls and disable inputs while row save is in progress', async () => {
             let resolveSave: (() => void) | undefined;
             const onRecordSave = jest.fn(
@@ -819,10 +846,10 @@ describe('FundsExpendituresTable', () => {
             fireEvent.click(screen.getByLabelText('Edit record 1'));
 
             fireEvent.change(screen.getByLabelText('Amount UAH record 1'), { target: { value: '50 000' } });
-            expect(screen.getByLabelText('Amount USD record 1')).toHaveValue('1190.48');
+            expect(screen.getByLabelText('Amount USD record 1')).toHaveValue('1190,48');
 
             fireEvent.change(screen.getByLabelText('Amount UAH record 1'), { target: { value: '500 000' } });
-            expect(screen.getByLabelText('Amount USD record 1')).toHaveValue('11904.77');
+            expect(screen.getByLabelText('Amount USD record 1')).toHaveValue('11904,77');
         });
     });
 });

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
@@ -23,7 +23,6 @@ import { updateFundsAmounts } from '@/utils/functions/update-funds-amounts/updat
 import { parseAmount } from '@/utils/functions/parse-amount/parse-amount';
 import { isUsdAmountMismatch } from '@/utils/functions/validate-usd-amount-mismatch/validate-usd-amount-mismatch';
 import { InlineLoader } from '@/components/common/inline-loader/InlineLoader';
-import { FundsRecordActions } from '@/pages/admin/reports/components/funds-expenditures-section/components/common/funds-record-actions/FundsRecordActions';
 import cn from 'classnames';
 import styles from './FundsExpendituresTable.module.scss';
 
@@ -46,10 +45,6 @@ interface FundsExpendituresTableProps {
     allRecordsForTypeInference?: ReportFundsExpendituresRecord[];
     isEditing?: boolean;
     isRowActionsDisabled?: boolean;
-    isAddIncomeDisabled?: boolean;
-    isAddExpenseDisabled?: boolean;
-    onAddIncome?: () => void;
-    onAddExpense?: () => void;
     onRowEditModeChange?: (isEditMode: boolean) => void;
     onRecordSave?: (
         recordId: number,
@@ -151,10 +146,6 @@ export const FundsExpendituresTable = ({
     allRecordsForTypeInference,
     isEditing = false,
     isRowActionsDisabled = false,
-    isAddIncomeDisabled = false,
-    isAddExpenseDisabled = false,
-    onAddIncome,
-    onAddExpense,
     onRowEditModeChange,
     onRecordSave,
     onDeleteRecord,
@@ -535,7 +526,7 @@ export const FundsExpendituresTable = ({
                         </tr>
                     </thead>
                     <tbody>
-                        {sortedRecords.length === 0 ? (
+                        {sortedRecords.length === 0 && isEditing ? (
                             <tr>
                                 <td
                                     colSpan={colSpan}
@@ -544,28 +535,9 @@ export const FundsExpendituresTable = ({
                                 >
                                     <div className={styles['empty-state']}>
                                         <NotFoundIcon className={styles['empty-state-image']} />
-                                        {isEditing ? (
-                                            <p className={styles['empty-state-message']}>
-                                                {FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.MESSAGE}
-                                            </p>
-                                        ) : (
-                                            <>
-                                                <p className={styles['empty-state-title']}>
-                                                    {FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.TITLE}
-                                                </p>
-                                                <p className={styles['empty-state-message']}>
-                                                    {FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.ADD_RECORD}
-                                                </p>
-                                                <FundsRecordActions
-                                                    className={styles['empty-state-actions']}
-                                                    testId="empty-state-actions"
-                                                    isAddExpenseDisabled={isAddExpenseDisabled}
-                                                    isAddIncomeDisabled={isAddIncomeDisabled}
-                                                    onAddExpense={onAddExpense}
-                                                    onAddIncome={onAddIncome}
-                                                />
-                                            </>
-                                        )}
+                                        <p className={styles['empty-state-message']}>
+                                            {FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.MESSAGE}
+                                        </p>
                                     </div>
                                 </td>
                             </tr>

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
@@ -377,13 +377,15 @@ export const FundsExpendituresTable = ({
             const finalError = getRowEditValidationError(record, rowEditState.categoryId, 'blur');
             const isCategoryUnchanged = rowEditState.categoryId === rowEditState.originalCategoryId;
             const isCategoryMissing = rowEditState.categoryId === undefined;
-            const normalizedAmountUah = normalizeFundsExpendituresAmountInput(rowEditState.amountUah, true);
-            const normalizedAmountUsd = normalizeFundsExpendituresAmountInput(rowEditState.amountUsd, true);
-            const amountUahError = validateFundsExpendituresAmount(normalizedAmountUah, 'save');
-            const amountUsdError = validateFundsExpendituresAmount(normalizedAmountUsd, 'save');
+            const preparedAmountUah = rowEditState.amountUah.trim();
+            const preparedAmountUsd = rowEditState.amountUsd.trim();
+            const amountUahError = validateFundsExpendituresAmount(preparedAmountUah, 'save');
+            const amountUsdError = validateFundsExpendituresAmount(preparedAmountUsd, 'save');
             const isAmountsUnchanged =
-                normalizeFundsExpendituresAmountInput(rowEditState.originalAmountUah, true) === normalizedAmountUah &&
-                normalizeFundsExpendituresAmountInput(rowEditState.originalAmountUsd, true) === normalizedAmountUsd;
+                normalizeFundsExpendituresAmountInput(rowEditState.originalAmountUah, true) ===
+                    normalizeFundsExpendituresAmountInput(preparedAmountUah, true) &&
+                normalizeFundsExpendituresAmountInput(rowEditState.originalAmountUsd, true) ===
+                    normalizeFundsExpendituresAmountInput(preparedAmountUsd, true);
 
             if (
                 finalError ||
@@ -399,8 +401,8 @@ export const FundsExpendituresTable = ({
 
                     return {
                         ...prev,
-                        amountUah: normalizedAmountUah,
-                        amountUsd: normalizedAmountUsd,
+                        amountUah: preparedAmountUah,
+                        amountUsd: preparedAmountUsd,
                         errors: {
                             ...prev.errors,
                             category: finalError,
@@ -423,8 +425,8 @@ export const FundsExpendituresTable = ({
             try {
                 const isSaved = await onRecordSave?.(record.id, {
                     categoryId: nextCategoryId,
-                    amountUah: normalizedAmountUah,
-                    amountUsd: normalizedAmountUsd,
+                    amountUah: preparedAmountUah,
+                    amountUsd: preparedAmountUsd,
                 });
 
                 if (isSaved === false) {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
@@ -117,7 +117,7 @@
 
 .filter-select {
     :global(.select-head) {
-        border: 1px solid c.$error;
+        border: 1px solid c.$blue-900;
         border-radius: 12px;
         padding: 8px 10px;
         height: 60px;

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
@@ -131,7 +131,7 @@
         color: c.$blue-900;
 
         &:hover {
-            background-color: rgba(c.$error, 0.06);
+            background-color: rgba(c.$dropdown-hover, 0.3);
         }
     }
 

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
@@ -40,10 +40,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    inline-size: 150px;
-    overflow-wrap: break-word;
-    text-align: center;
-    gap: 4px;
+    position: relative;
 }
 
 .exchange-rate-label {
@@ -103,7 +100,14 @@
 
 .exchange-rate-error {
     @include type.small-text-regular;
+    position: absolute;
+    top: calc(100% + 15px);
+    left: 50%;
+    transform: translateX(-50%);
+    white-space: nowrap;
     color: c.$error;
+    margin: 0;
+    text-align: center;
 }
 
 .exchange-rate-input-disabled {
@@ -134,7 +138,7 @@
     :global(.select-options) {
         top: 42px;
         min-width: 204px;
-        border: 1px solid #c6c2de;
+        border: 1px solid c.$dropdown-hover;
         border-radius: 6px;
         box-shadow: 0 5px 8px rgba(c.$black, 0.2);
         padding: 6px 10px;
@@ -162,7 +166,7 @@
     @include type.small-text-regular;
     line-height: 17px;
     letter-spacing: 0.05em;
-    color: #25213b;
+    color: c.$dropdown-text;
     border-radius: 4px;
     padding: 5px 10px;
     height: auto;

--- a/src/services/api/admin/reports/funds-expenditures-api.test.ts
+++ b/src/services/api/admin/reports/funds-expenditures-api.test.ts
@@ -25,7 +25,7 @@ describe('FundsExpendituresApi', () => {
             expect(mockClient.get).toHaveBeenCalledWith(API_ROUTES.REPORTS.FUNDS_EXPENDITURES.SETTINGS, {
                 signal: undefined,
             });
-            expect(result).toEqual({ id: 1, disclaimerTitle: 'Disclaimer', exchangeRate: '42.18' });
+            expect(result).toEqual({ id: 1, disclaimerTitle: 'Disclaimer', exchangeRate: '42,18' });
         });
 
         it('should pass cancellation signal', async () => {
@@ -151,8 +151,8 @@ describe('FundsExpendituresApi', () => {
                     categoryId: 1,
                     type: 'income',
                     reportingYear: '2025',
-                    amountUah: '7265.5',
-                    amountUsd: '4200.25',
+                    amountUah: '7265,5',
+                    amountUsd: '4200,25',
                 },
             ]);
         });
@@ -246,7 +246,7 @@ describe('FundsExpendituresApi', () => {
                 type: 2,
                 reportingYear: 2025,
                 amountUah: 350,
-                amountUsd: 9,
+                amountUsd: 9.5,
             });
             expect(result).toEqual({
                 id: 12,
@@ -254,7 +254,7 @@ describe('FundsExpendituresApi', () => {
                 type: 'expense',
                 reportingYear: '2025',
                 amountUah: '350',
-                amountUsd: '9.5',
+                amountUsd: '9,5',
             });
         });
     });

--- a/src/utils/functions/formatters/format-number.test.ts
+++ b/src/utils/functions/formatters/format-number.test.ts
@@ -1,0 +1,20 @@
+import { formatNumberDecimalComma } from '@/utils/functions/formatters/format-number';
+
+describe('formatNumberDecimalComma', () => {
+    it('returns empty string for null and undefined', () => {
+        expect(formatNumberDecimalComma(null)).toBe('');
+        expect(formatNumberDecimalComma(undefined)).toBe('');
+    });
+
+    it('formats numbers and strings with dot to comma', () => {
+        expect(formatNumberDecimalComma(123)).toBe('123');
+        expect(formatNumberDecimalComma(123.45)).toBe('123,45');
+        expect(formatNumberDecimalComma('1000.5')).toBe('1000,5');
+        // only the first dot is replaced (keeps previous behaviour)
+        expect(formatNumberDecimalComma('1.2.3')).toBe('1,2.3');
+    });
+
+    it('leaves strings without dot unchanged', () => {
+        expect(formatNumberDecimalComma('1000')).toBe('1000');
+    });
+});

--- a/src/utils/functions/formatters/format-number.ts
+++ b/src/utils/functions/formatters/format-number.ts
@@ -1,0 +1,7 @@
+export const formatNumberDecimalComma = (value: number | string | null | undefined): string => {
+    if (value === null || value === undefined) {
+        return '';
+    }
+
+    return String(value).replace('.', ',');
+};

--- a/src/utils/functions/get-converted-amount/get-converted-amount.test.ts
+++ b/src/utils/functions/get-converted-amount/get-converted-amount.test.ts
@@ -2,7 +2,7 @@ import { getConvertedAmount } from '@/utils/functions/get-converted-amount/get-c
 
 describe('getConvertedAmount', () => {
     it('returns USD when converting from UAH', () => {
-        expect(getConvertedAmount('500000', '42')).toBe('11904.77');
+        expect(getConvertedAmount('500000', '42')).toBe('11904,77');
     });
 
     it('returns null when exchange rate is empty', () => {
@@ -14,7 +14,7 @@ describe('getConvertedAmount', () => {
     });
 
     it('returns value rounded up to two decimals for UAH to USD conversion', () => {
-        expect(getConvertedAmount('100', '3')).toBe('33.34');
+        expect(getConvertedAmount('100', '3')).toBe('33,34');
     });
 
     it('should return null for empty or invalid source amount', () => {

--- a/src/utils/functions/get-converted-amount/get-converted-amount.ts
+++ b/src/utils/functions/get-converted-amount/get-converted-amount.ts
@@ -1,4 +1,5 @@
 import { parseAmount } from '@/utils/functions/parse-amount/parse-amount';
+import { formatNumberDecimalComma } from '@/utils/functions/formatters/format-number';
 
 const roundUpToTwoDecimals = (value: number): number => Math.ceil(value * 100) / 100;
 
@@ -18,5 +19,5 @@ export const getConvertedAmount = (value: string, exchangeRate: string | null | 
 
     const roundedConvertedAmount = roundUpToTwoDecimals(convertedAmount);
 
-    return Number.isFinite(roundedConvertedAmount) ? String(roundedConvertedAmount).replace('.', ',') : null;
+    return Number.isFinite(roundedConvertedAmount) ? formatNumberDecimalComma(roundedConvertedAmount) : null;
 };

--- a/src/utils/functions/get-converted-amount/get-converted-amount.ts
+++ b/src/utils/functions/get-converted-amount/get-converted-amount.ts
@@ -18,5 +18,5 @@ export const getConvertedAmount = (value: string, exchangeRate: string | null | 
 
     const roundedConvertedAmount = roundUpToTwoDecimals(convertedAmount);
 
-    return Number.isFinite(roundedConvertedAmount) ? String(roundedConvertedAmount) : null;
+    return Number.isFinite(roundedConvertedAmount) ? String(roundedConvertedAmount).replace('.', ',') : null;
 };

--- a/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.test.ts
+++ b/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.test.ts
@@ -209,7 +209,7 @@ describe('reports-mapper', () => {
             expect(mapReportFundsExpendituresSettingsDtoToSettings(dto)).toEqual({
                 id: 1,
                 disclaimerTitle: 'Disclaimer',
-                exchangeRate: '42.18',
+                exchangeRate: '42,18',
             });
         });
 
@@ -242,8 +242,8 @@ describe('reports-mapper', () => {
                 categoryId: 2,
                 type: 'income',
                 reportingYear: '2026',
-                amountUah: '125.5',
-                amountUsd: '3.75',
+                amountUah: '125,5',
+                amountUsd: '3,75',
             });
         });
 
@@ -267,7 +267,7 @@ describe('reports-mapper', () => {
             });
         });
 
-        it('should truncate decimal amounts when mapping record to create dto', () => {
+        it('should preserve decimal amounts when mapping record to create dto', () => {
             const result = mapReportFundsExpendituresRecordToCreateDto({
                 categoryId: 2,
                 type: 'expense',
@@ -280,12 +280,12 @@ describe('reports-mapper', () => {
                 categoryId: 2,
                 type: 2,
                 reportingYear: 2026,
-                amountUah: 1249854,
-                amountUsd: 1234,
+                amountUah: 1249854.99,
+                amountUsd: 1234.56,
             });
         });
 
-        it('should truncate decimal amounts when mapping record to update dto', () => {
+        it('should preserve decimal amounts when mapping record to update dto', () => {
             const result = mapReportFundsExpendituresRecordToUpdateDto({
                 categoryId: 1,
                 type: 'income',
@@ -298,8 +298,8 @@ describe('reports-mapper', () => {
                 categoryId: 1,
                 type: 1,
                 reportingYear: 2025,
-                amountUah: 350,
-                amountUsd: 9,
+                amountUah: 350.99,
+                amountUsd: 9.5,
             });
         });
     });

--- a/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.ts
+++ b/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.ts
@@ -67,7 +67,7 @@ export const mapReportFundsExpendituresSettingsDtoToSettings = (
 ): ReportFundsExpendituresSettings => ({
     id: dto.id,
     disclaimerTitle: dto.disclaimerTitle,
-    exchangeRate: String(dto.exchangeRate),
+    exchangeRate: String(dto.exchangeRate).replace('.', ','),
 });
 
 export const mapReportFundsExpendituresSettingsToUpdateDto = (
@@ -106,8 +106,8 @@ export const mapReportFundsExpendituresRecordDtoToRecord = (
     categoryId: dto.categoryId,
     type: mapFundsExpendituresTypeDtoToTransactionType(dto.type),
     reportingYear: String(dto.reportingYear),
-    amountUah: String(dto.amountUah),
-    amountUsd: String(dto.amountUsd),
+    amountUah: String(dto.amountUah).replace('.', ','),
+    amountUsd: String(dto.amountUsd).replace('.', ','),
 });
 
 type ReportFundsExpendituresRecordRequestPayload = Pick<
@@ -119,8 +119,8 @@ const mapReportFundsExpendituresRecordToRequestDto = (record: ReportFundsExpendi
     categoryId: record.categoryId,
     type: mapFundsExpendituresTransactionTypeToTypeDto(record.type),
     reportingYear: Number.parseInt(record.reportingYear, 10) || new Date().getFullYear(),
-    amountUah: Math.trunc(Number.parseFloat(record.amountUah.replaceAll(' ', '').replace(',', '.')) || 0),
-    amountUsd: Math.trunc(Number.parseFloat(record.amountUsd.replaceAll(' ', '').replace(',', '.')) || 0),
+    amountUah: Number.parseFloat(record.amountUah.replaceAll(' ', '').replace(',', '.')) || 0,
+    amountUsd: Number.parseFloat(record.amountUsd.replaceAll(' ', '').replace(',', '.')) || 0,
 });
 
 export const mapReportFundsExpendituresRecordToCreateDto = (

--- a/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.ts
+++ b/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.ts
@@ -22,6 +22,8 @@ import {
     UpdateReportFundsExpendituresSettingsDto,
 } from '@/types/admin/reports';
 
+import { formatNumberDecimalComma } from '@/utils/functions/formatters/format-number';
+
 export const mapReportsMediaSettingsDtoToMediaSettings = (dto: ReportsMediaSettingsDto): ReportsMediaSettings => ({
     collectedFunds: mapReportsMediaSettingsCollectedFundsDtoToCollectedFunds(dto.collectedFundsBlock),
     changedLives: mapReportsMediaSettingsChangedLivesDtoToChangedLives(dto.changedLivesBlock),
@@ -67,7 +69,7 @@ export const mapReportFundsExpendituresSettingsDtoToSettings = (
 ): ReportFundsExpendituresSettings => ({
     id: dto.id,
     disclaimerTitle: dto.disclaimerTitle,
-    exchangeRate: String(dto.exchangeRate).replace('.', ','),
+    exchangeRate: formatNumberDecimalComma(dto.exchangeRate),
 });
 
 export const mapReportFundsExpendituresSettingsToUpdateDto = (
@@ -106,8 +108,8 @@ export const mapReportFundsExpendituresRecordDtoToRecord = (
     categoryId: dto.categoryId,
     type: mapFundsExpendituresTypeDtoToTransactionType(dto.type),
     reportingYear: String(dto.reportingYear),
-    amountUah: String(dto.amountUah).replace('.', ','),
-    amountUsd: String(dto.amountUsd).replace('.', ','),
+    amountUah: formatNumberDecimalComma(dto.amountUah),
+    amountUsd: formatNumberDecimalComma(dto.amountUsd),
 });
 
 type ReportFundsExpendituresRecordRequestPayload = Pick<

--- a/src/utils/functions/validate-usd-amount-mismatch/validate-usd-amount-mismatch.ts
+++ b/src/utils/functions/validate-usd-amount-mismatch/validate-usd-amount-mismatch.ts
@@ -17,5 +17,5 @@ export const isUsdAmountMismatch = (
 
     const normalizedUsd = Number.parseFloat(parseAmount(amountUsd).toFixed(2));
 
-    return Math.abs(normalizedUsd - Number.parseFloat(expectedUsd)) > 0.000001;
+    return Math.abs(normalizedUsd - parseAmount(expectedUsd)) > 0.000001;
 };

--- a/src/validation/admin/reports-schema/funds-expenditures-exchange-rate-schema/funds-expenditures-exchange-rate-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-exchange-rate-schema/funds-expenditures-exchange-rate-schema.test.ts
@@ -8,11 +8,23 @@ import {
 describe('funds-expenditures-exchange-rate-schema', () => {
     describe('normalizeFundsExpendituresExchangeRateInput', () => {
         it('removes spaces from input', () => {
-            expect(normalizeFundsExpendituresExchangeRateInput(' 4 2. 1 2 ')).toBe('42.12');
+            expect(normalizeFundsExpendituresExchangeRateInput(' 4 2. 1 2 ')).toBe('42,12');
         });
 
         it('trims value when trimEnd is true', () => {
-            expect(normalizeFundsExpendituresExchangeRateInput(' 42.12 ', true)).toBe('42.12');
+            expect(normalizeFundsExpendituresExchangeRateInput(' 42.12 ', true)).toBe('42,12');
+        });
+
+        it('converts dot decimal separator to comma', () => {
+            expect(normalizeFundsExpendituresExchangeRateInput('42.123456')).toBe('42,123456');
+        });
+
+        it('passes through comma decimal separator unchanged', () => {
+            expect(normalizeFundsExpendituresExchangeRateInput('42,123456')).toBe('42,123456');
+        });
+
+        it('collapses multiple commas keeping only the first', () => {
+            expect(normalizeFundsExpendituresExchangeRateInput('42,12,34')).toBe('42,1234');
         });
     });
 

--- a/src/validation/admin/reports-schema/funds-expenditures-exchange-rate-schema/funds-expenditures-exchange-rate-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-exchange-rate-schema/funds-expenditures-exchange-rate-schema.ts
@@ -5,7 +5,18 @@ export type ExchangeRateValidationTrigger = 'change' | 'blur';
 
 export const normalizeFundsExpendituresExchangeRateInput = (value: string, trimEnd = false): string => {
     const withoutSpaces = value.replaceAll(/\s+/g, '').trimStart();
-    return trimEnd ? withoutSpaces.trim() : withoutSpaces;
+    const withCommaSeparator = withoutSpaces.replaceAll('.', ',');
+    const firstCommaIndex = withCommaSeparator.indexOf(',');
+
+    if (firstCommaIndex === -1) {
+        return trimEnd ? withCommaSeparator.trim() : withCommaSeparator;
+    }
+
+    const integerPart = withCommaSeparator.slice(0, firstCommaIndex);
+    const decimalPart = withCommaSeparator.slice(firstCommaIndex + 1).replaceAll(',', '');
+    const normalized = `${integerPart},${decimalPart}`;
+
+    return trimEnd ? normalized.trim() : normalized;
 };
 
 export const validateFundsExpendituresExchangeRate = (
@@ -18,11 +29,11 @@ export const validateFundsExpendituresExchangeRate = (
         return trigger === 'blur' ? COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED : undefined;
     }
 
-    if (!/^\d+(?:[.,]\d+)?$/.test(normalized)) {
+    if (!/^\d+(?:,\d+)?$/.test(normalized)) {
         return FUNDS_EXPENDITURES_TEXT.VALIDATION.EXCHANGE_RATE_ONLY_NUMERIC;
     }
 
-    const [integerPart, decimalPart = ''] = normalized.split(/[.,]/);
+    const [integerPart, decimalPart = ''] = normalized.split(',');
     if (
         integerPart.length > FUNDS_EXPENDITURES_VALIDATION.exchangeRate.maxIntegerDigits ||
         decimalPart.length > FUNDS_EXPENDITURES_VALIDATION.exchangeRate.maxDecimalDigits

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
@@ -16,6 +16,14 @@ describe('FUNDS_EXPENDITURES_RECORD_VALIDATION_FUNCTIONS', () => {
         it('should trim trailing spaces when trimEnd is true', () => {
             expect(normalizeFundsExpendituresAmountInput('   1 200   ', true)).toBe('1 200');
         });
+
+        it('should convert dot separator to comma', () => {
+            expect(normalizeFundsExpendituresAmountInput('1200.5')).toBe('1200,5');
+        });
+
+        it('should keep only first two digits after comma', () => {
+            expect(normalizeFundsExpendituresAmountInput('1200,5678')).toBe('1200,56');
+        });
     });
 
     describe('validateFundsExpendituresAmount', () => {
@@ -61,6 +69,14 @@ describe('FUNDS_EXPENDITURES_RECORD_VALIDATION_FUNCTIONS', () => {
 
         it('should pass valid value with comma decimals', () => {
             expect(validateFundsExpendituresAmount('1 200,50', 'save')).toBeUndefined();
+        });
+
+        it('should not return an error when user types more than two decimal digits', () => {
+            expect(validateFundsExpendituresAmount('1 200,123', 'change')).toBeUndefined();
+        });
+
+        it('should support dot input by normalizing it to comma', () => {
+            expect(validateFundsExpendituresAmount('1 200.50', 'save')).toBeUndefined();
         });
     });
 

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
@@ -16,7 +16,21 @@ interface ValidateFundsExpendituresCategoryParams {
 
 export const normalizeFundsExpendituresAmountInput = (value: string, trimEnd = false): string => {
     const withNormalizedSpaces = value.replaceAll(/\s+/g, ' ').trimStart();
-    return trimEnd ? withNormalizedSpaces.trim() : withNormalizedSpaces;
+    const withCommaSeparator = withNormalizedSpaces.replaceAll('.', ',');
+    const firstCommaIndex = withCommaSeparator.indexOf(',');
+
+    if (firstCommaIndex === -1) {
+        return trimEnd ? withCommaSeparator.trim() : withCommaSeparator;
+    }
+
+    const integerPart = withCommaSeparator.slice(0, firstCommaIndex);
+    const decimalPart = withCommaSeparator
+        .slice(firstCommaIndex + 1)
+        .replaceAll(',', '')
+        .slice(0, 2);
+    const normalized = `${integerPart},${decimalPart}`;
+
+    return trimEnd ? normalized.trim() : normalized;
 };
 
 export const validateFundsExpendituresAmount = (
@@ -35,11 +49,11 @@ export const validateFundsExpendituresAmount = (
         return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_NEGATIVE;
     }
 
-    if (!/^\d+(?:[.,]\d+)?$/.test(compact)) {
+    if (!/^\d+(?:,\d{1,2})?$/.test(compact)) {
         return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER;
     }
 
-    const [integerPart] = compact.split(/[.,]/);
+    const [integerPart] = compact.split(',');
     if (integerPart.length > 9) {
         return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DIGITS;
     }


### PR DESCRIPTION
## Github ticker

*  https://github.com/ita-social-projects/VictoryCenter-Back/issues/2301

## Description

This PR sync Funds and Expenditures tab with new requirements.
Math rounding logic in total cards is a backend responsibility (will be implmented in a separate PR on the backend).

## How it looks

1. Descirption text is now bolder

<img width="1280" height="700" alt="image" src="https://github.com/user-attachments/assets/650539f8-ec9b-4551-b999-92b84857cd9d" />

2. Filter selects is no longer have red color

<img width="1047" height="451" alt="image" src="https://github.com/user-attachments/assets/75ec61d1-2971-4ee6-874e-8083a567f982" />

<img width="477" height="225" alt="image" src="https://github.com/user-attachments/assets/228c2cd6-4f59-4549-90d0-9b57a7b5f449" />

3. No epmty state when tab in view mode and there is no records

<img width="1017" height="205" alt="image" src="https://github.com/user-attachments/assets/f200de50-9240-42fe-9dbc-306a5ebc3c5b" />

4. Comma as a main separator

<img width="200" height="72" alt="image" src="https://github.com/user-attachments/assets/69a4c7f9-32e1-4a91-a9eb-76ce972c3add" />

5. Max two numbers for decimal part

<img width="426" height="174" alt="image" src="https://github.com/user-attachments/assets/e304c91f-eed9-4d35-9906-cb5e1206531e" />

6. Amounts saves with decimal part

<img width="1004" height="153" alt="image" src="https://github.com/user-attachments/assets/1914dc10-36a4-4062-b7a6-5fe797d63a63" />

<img width="452" height="80" alt="image" src="https://github.com/user-attachments/assets/ed6e802e-2df6-4732-808d-ca2b97274e60" />

7. Changed error showing to fix jumping inputs behavior

<img width="1016" height="211" alt="image" src="https://github.com/user-attachments/assets/55522266-633a-454b-9cbd-2165bee1317c" />

<img width="997" height="175" alt="image" src="https://github.com/user-attachments/assets/410b875d-c225-43d7-ad24-f7e22fb573a1" />

<img width="994" height="158" alt="image" src="https://github.com/user-attachments/assets/55bd24ff-987e-4a2e-a3c6-f4209a74a458" />

8. Amount in USD automatically calculated with rounding up to 2 numbers after comma

<img width="991" height="156" alt="image" src="https://github.com/user-attachments/assets/78d3fe25-80cf-4340-b97c-1cc12577ab8c" />


 
## Summary of change

changed hardoded colors to use scss variables 
deleted empty state 
fixed inputs jumping when error appears
added automate replacing logic when user enter '.' insted of ',' as a separator

## How to recreate changes

1. Open Admin panel
2. Open Funds and Expenditures tab
3. Check for all changes that presents in How it looks part 

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Currency amounts now display with comma decimal separators for improved regional formatting consistency.

* **Changes**
  * Removed add income/add expense actions from the funds expenditure section.
  * Updated empty state behavior in table edit and view modes.

* **Style**
  * Enhanced table styling with improved cell sizing and spacing for better readability.
  * Applied bold emphasis to disclaimer labels.
  * Refined color scheme for dropdown and form elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->