### PR TITLE
Feature/issue-1826: Implement edit mode for Program Expenses tab

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -245,8 +245,10 @@ export const PROGRAM_EXPENSES_TEXT = {
         TITLE: 'Всього програмні витрати',
     },
     TABLE: {
+        TYPE_LABEL: 'Програмні',
         COLUMNS: {
             PROGRAM: 'Програма',
+            ACTIONS: 'Дії',
         },
     },
 };

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
@@ -554,6 +554,13 @@ describe('FundsExpenditureSection', () => {
             );
         });
 
+        it('should initialize exchange rate from draft value when mounted in edit mode', () => {
+            render(<FundsExpenditureSection initialIsEditing draftExchangeRate="44.20" />);
+
+            expect(screen.getByTestId('funds-toolbar')).toHaveAttribute('data-editing', 'true');
+            expect(screen.getByTestId('exchange-rate')).toHaveTextContent('44.20');
+        });
+
         it('should hide edit button while editing', () => {
             render(<FundsExpenditureSection />);
             fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
@@ -542,6 +542,18 @@ describe('FundsExpenditureSection', () => {
             expect(textarea).toHaveValue(MOCK_FUNDS_EXPENDITURES_SETTINGS.disclaimerTitle);
         });
 
+        it('should initialize edit values from settings when mounted in edit mode', () => {
+            render(<FundsExpenditureSection initialIsEditing />);
+
+            expect(screen.getByTestId('funds-toolbar')).toHaveAttribute('data-editing', 'true');
+            expect(screen.getByTestId('textarea-funds-disclaimer')).toHaveValue(
+                MOCK_FUNDS_EXPENDITURES_SETTINGS.disclaimerTitle,
+            );
+            expect(screen.getByTestId('exchange-rate')).toHaveTextContent(
+                MOCK_FUNDS_EXPENDITURES_SETTINGS.exchangeRate!,
+            );
+        });
+
         it('should hide edit button while editing', () => {
             render(<FundsExpenditureSection />);
             fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useEffect } from 'react';
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION, REPORTS_TEXT } from '@/const/admin/reports';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS } from '@/validation/admin/reports-schema/funds-expenditures-disclaimer-schema/funds-expenditures-disclaimer-schema';
@@ -73,6 +73,7 @@ export const FundsExpenditureSection = ({
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
     const [recordToDelete, setRecordToDelete] = useState<ReportFundsExpendituresRecord | null>(null);
     const [isDeletingRecord, setIsDeletingRecord] = useState(false);
+    const hasSeededEditingValuesRef = useRef(false);
 
     const handleCancel = useCallback(() => {
         setIsEditing(false);
@@ -208,10 +209,18 @@ export const FundsExpenditureSection = ({
 
     useEffect(() => {
         if (!isEditing) {
+            hasSeededEditingValuesRef.current = false;
             setDisclaimerValue(settings?.disclaimerTitle ?? '');
             setExchangeRateValue(settings?.exchangeRate ?? '');
             setDisclaimerError(undefined);
             setExchangeRateError(undefined);
+            return;
+        }
+
+        if (settings && !hasSeededEditingValuesRef.current) {
+            setDisclaimerValue((currentValue) => currentValue || (settings.disclaimerTitle ?? ''));
+            setExchangeRateValue((currentValue) => currentValue || (settings.exchangeRate ?? ''));
+            hasSeededEditingValuesRef.current = true;
         }
     }, [settings, isEditing]);
 

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -44,11 +44,21 @@ const enrichRecords = (
     }));
 };
 
-export const FundsExpenditureSection = () => {
+interface FundsExpenditureSectionProps {
+    initialIsEditing?: boolean;
+    onEditModeChange?: (isEditing: boolean) => void;
+    onExchangeRateValueChange?: (exchangeRate: string | null) => void;
+}
+
+export const FundsExpenditureSection = ({
+    initialIsEditing = false,
+    onEditModeChange,
+    onExchangeRateValueChange,
+}: FundsExpenditureSectionProps = {}) => {
     const adminClient = useAdminClient();
     const { addToast } = useToast();
 
-    const [isEditing, setIsEditing] = useState(false);
+    const [isEditing, setIsEditing] = useState(initialIsEditing);
     const [disclaimerValue, setDisclaimerValue] = useState('');
     const [disclaimerError, setDisclaimerError] = useState<string | undefined>(undefined);
     const [exchangeRateValue, setExchangeRateValue] = useState('');
@@ -64,12 +74,12 @@ export const FundsExpenditureSection = () => {
     const [recordToDelete, setRecordToDelete] = useState<ReportFundsExpendituresRecord | null>(null);
     const [isDeletingRecord, setIsDeletingRecord] = useState(false);
 
-    const handleEdit = useCallback(() => setIsEditing(true), []);
     const handleCancel = useCallback(() => {
         setIsEditing(false);
+        onEditModeChange?.(false);
         setDisclaimerError(undefined);
         setExchangeRateError(undefined);
-    }, []);
+    }, [onEditModeChange]);
 
     const handleDisclaimerChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
         const normalized = e.target.value.replaceAll(/ {2,}/g, ' ');
@@ -82,17 +92,22 @@ export const FundsExpenditureSection = () => {
         setDisclaimerError(FUNDS_EXPENDITURES_DISCLAIMER_VALIDATION_FUNCTIONS.validateDisclaimer(trimmed));
     }, [disclaimerValue]);
 
-    const handleExchangeRateChange = useCallback((value: string) => {
-        const normalized = normalizeFundsExpendituresExchangeRateInput(value);
-        setExchangeRateValue(normalized);
-        setExchangeRateError(validateFundsExpendituresExchangeRate(normalized, 'change'));
-    }, []);
+    const handleExchangeRateChange = useCallback(
+        (value: string) => {
+            const normalized = normalizeFundsExpendituresExchangeRateInput(value);
+            setExchangeRateValue(normalized);
+            onExchangeRateValueChange?.(normalized);
+            setExchangeRateError(validateFundsExpendituresExchangeRate(normalized, 'change'));
+        },
+        [onExchangeRateValueChange],
+    );
 
     const handleExchangeRateBlur = useCallback(() => {
         const normalized = normalizeFundsExpendituresExchangeRateInput(exchangeRateValue, true);
         setExchangeRateValue(normalized);
+        onExchangeRateValueChange?.(normalized || null);
         setExchangeRateError(validateFundsExpendituresExchangeRate(normalized, 'blur'));
-    }, [exchangeRateValue]);
+    }, [exchangeRateValue, onExchangeRateValueChange]);
 
     const handleTypeChange = useCallback((type: TypeFilterValue) => {
         setSelectedType(type);
@@ -136,6 +151,12 @@ export const FundsExpenditureSection = () => {
         initialData: null,
         fetchHandler: fetchSettings,
     });
+
+    const handleEdit = useCallback(() => {
+        setIsEditing(true);
+        onEditModeChange?.(true);
+        onExchangeRateValueChange?.(settings?.exchangeRate ?? null);
+    }, [onEditModeChange, onExchangeRateValueChange, settings?.exchangeRate]);
 
     const { data: categories, isLoading: isCategoriesLoading } = useDataFetch<ReportFundsExpendituresCategory[]>({
         initialData: [],
@@ -308,7 +329,9 @@ export const FundsExpenditureSection = () => {
 
             setDisclaimerValue(updatedSettings.disclaimerTitle ?? '');
             setExchangeRateValue(updatedSettings.exchangeRate ?? '');
+            onExchangeRateValueChange?.(updatedSettings.exchangeRate ?? null);
             setIsEditing(false);
+            onEditModeChange?.(false);
 
             refetchSettings();
 
@@ -316,7 +339,15 @@ export const FundsExpenditureSection = () => {
         } catch {
             addToast(REPORTS_TEXT.MESSAGE.FAIL_TO_UPDATE_REPORT, ToastType.Error);
         }
-    }, [addToast, adminClient, disclaimerValue, exchangeRateValue, refetchSettings]);
+    }, [
+        addToast,
+        adminClient,
+        disclaimerValue,
+        exchangeRateValue,
+        onEditModeChange,
+        onExchangeRateValueChange,
+        refetchSettings,
+    ]);
 
     if (isInitialLoading) {
         return (

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -46,12 +46,14 @@ const enrichRecords = (
 
 interface FundsExpenditureSectionProps {
     initialIsEditing?: boolean;
+    draftExchangeRate?: string | null;
     onEditModeChange?: (isEditing: boolean) => void;
     onExchangeRateValueChange?: (exchangeRate: string | null) => void;
 }
 
 export const FundsExpenditureSection = ({
     initialIsEditing = false,
+    draftExchangeRate,
     onEditModeChange,
     onExchangeRateValueChange,
 }: FundsExpenditureSectionProps = {}) => {
@@ -218,11 +220,14 @@ export const FundsExpenditureSection = ({
         }
 
         if (settings && !hasSeededEditingValuesRef.current) {
+            const initialExchangeRateValue =
+                draftExchangeRate !== undefined ? (draftExchangeRate ?? '') : (settings.exchangeRate ?? '');
+
             setDisclaimerValue((currentValue) => currentValue || (settings.disclaimerTitle ?? ''));
-            setExchangeRateValue((currentValue) => currentValue || (settings.exchangeRate ?? ''));
+            setExchangeRateValue((currentValue) => currentValue || initialExchangeRateValue);
             hasSeededEditingValuesRef.current = true;
         }
-    }, [settings, isEditing]);
+    }, [draftExchangeRate, settings, isEditing]);
 
     const enrichedRecords = useMemo(() => enrichRecords(recordsState, categories), [recordsState, categories]);
 

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ProgramExpensesSection } from './ProgramExpensesSection';
 import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
@@ -225,6 +225,32 @@ describe('ProgramExpensesSection', () => {
         expect(rows).toHaveLength(4);
         expect(within(table).getAllByText('Program A')).toHaveLength(2);
         expect(within(table).getByText('Program B')).toBeInTheDocument();
+    });
+
+    it('should drop selected program ids that are no longer present in programs data', async () => {
+        const { rerender } = render(<ProgramExpensesSection />);
+
+        fireEvent.change(screen.getByTestId('program-select'), {
+            target: { value: '2' },
+        });
+
+        expect(within(screen.getByRole('table')).getByText('Program B')).toBeInTheDocument();
+
+        mockUseDataFetchResult = {
+            data: {
+                ...MOCK_PROGRAM_EXPENSES_DATA,
+                programs: MOCK_PROGRAM_EXPENSES_DATA.programs.filter((program) => program.id !== 2),
+                records: MOCK_PROGRAM_EXPENSES_DATA.records.filter((record) => record.programId !== 2),
+            },
+            isLoading: false,
+        };
+
+        rerender(<ProgramExpensesSection />);
+
+        await waitFor(() => {
+            expect(within(screen.getByRole('table')).getAllByText('Program A')).toHaveLength(2);
+        });
+        expect(screen.queryByText(FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.MESSAGE)).not.toBeInTheDocument();
     });
 
     it('should render filtered empty state when selected program has no matching records', () => {

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
@@ -281,6 +281,13 @@ describe('ProgramExpensesSection', () => {
         expect(screen.queryByText('41.25')).not.toBeInTheDocument();
     });
 
+    it('should display empty synced exchange rate in edit mode when the funds value is cleared', () => {
+        render(<ProgramExpensesSection isEditing syncedExchangeRate={null} />);
+
+        expect(screen.getByText('-')).toBeInTheDocument();
+        expect(screen.queryByText('41.25')).not.toBeInTheDocument();
+    });
+
     it('should disable add program expense button when four records exist', () => {
         mockUseDataFetchResult = {
             data: {

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
@@ -265,4 +265,44 @@ describe('ProgramExpensesSection', () => {
         expect(ProgramExpensesApi.getReadOnlyData).toBeDefined();
         expect(mockGetReadOnlyData).toHaveBeenCalledWith({ test: true });
     });
+
+    it('should render edit mode controls when edit mode is active', () => {
+        render(<ProgramExpensesSection isEditing />);
+
+        expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE })).toBeEnabled();
+        expect(screen.getByRole('checkbox', { name: 'Select all program expense records' })).toBeEnabled();
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.ACTIONS)).toBeInTheDocument();
+    });
+
+    it('should display synced exchange rate in edit mode', () => {
+        render(<ProgramExpensesSection isEditing syncedExchangeRate="44.20" />);
+
+        expect(screen.getByText('44.20')).toBeInTheDocument();
+        expect(screen.queryByText('41.25')).not.toBeInTheDocument();
+    });
+
+    it('should disable add program expense button when four records exist', () => {
+        mockUseDataFetchResult = {
+            data: {
+                ...MOCK_PROGRAM_EXPENSES_DATA,
+                records: [
+                    ...MOCK_PROGRAM_EXPENSES_DATA.records,
+                    {
+                        id: 4,
+                        programId: 3,
+                        programName: 'Program C',
+                        type: 'expense',
+                        reportingYear: '2025',
+                        amountUah: '100',
+                        amountUsd: '10',
+                    },
+                ],
+            },
+            isLoading: false,
+        };
+
+        render(<ProgramExpensesSection isEditing />);
+
+        expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE })).toBeDisabled();
+    });
 });

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
@@ -18,7 +18,14 @@ const INITIAL_PROGRAM_EXPENSES_DATA: ProgramExpensesReadOnlyData = {
     records: [],
 };
 
-export const ProgramExpensesSection = () => {
+const MAX_PROGRAM_EXPENSE_RECORDS = 4;
+
+interface ProgramExpensesSectionProps {
+    isEditing?: boolean;
+    syncedExchangeRate?: string | null;
+}
+
+export const ProgramExpensesSection = ({ isEditing = false, syncedExchangeRate }: ProgramExpensesSectionProps) => {
     const [selectedProgramIds, setSelectedProgramIds] = useState<number[]>([]);
 
     const fetchReadOnlyData = useCallback((options = {}) => ProgramExpensesApi.getReadOnlyData(options), []);
@@ -39,6 +46,8 @@ export const ProgramExpensesSection = () => {
     const programExpenseRecordsCount = data.records.length;
     const hasAnyProgramExpenseRecords = programExpenseRecordsCount > 0;
     const isInitialLoading = isLoading && programExpenseRecordsCount === 0 && data.programs.length === 0;
+    const exchangeRate = syncedExchangeRate ?? data.exchangeRate;
+    const isAddProgramExpenseDisabled = programExpenseRecordsCount >= MAX_PROGRAM_EXPENSE_RECORDS;
 
     if (isInitialLoading) {
         return (
@@ -58,12 +67,15 @@ export const ProgramExpensesSection = () => {
                 <ProgramExpensesToolbar
                     programs={data.programs}
                     selectedProgramIds={selectedProgramIds}
-                    exchangeRate={data.exchangeRate}
+                    exchangeRate={exchangeRate}
+                    isEditing={isEditing}
+                    isAddProgramExpenseDisabled={isAddProgramExpenseDisabled}
                     onProgramChange={setSelectedProgramIds}
                 />
                 <ProgramExpensesTable
                     records={filteredRecords}
                     hasAnyProgramExpenseRecords={hasAnyProgramExpenseRecords}
+                    isEditing={isEditing}
                 />
             </div>
         </div>

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
@@ -46,7 +46,7 @@ export const ProgramExpensesSection = ({ isEditing = false, syncedExchangeRate }
     const programExpenseRecordsCount = data.records.length;
     const hasAnyProgramExpenseRecords = programExpenseRecordsCount > 0;
     const isInitialLoading = isLoading && programExpenseRecordsCount === 0 && data.programs.length === 0;
-    const exchangeRate = syncedExchangeRate ?? data.exchangeRate;
+    const exchangeRate = isEditing ? (syncedExchangeRate ?? null) : data.exchangeRate;
     const isAddProgramExpenseDisabled = programExpenseRecordsCount >= MAX_PROGRAM_EXPENSE_RECORDS;
 
     if (isInitialLoading) {

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { InlineLoader } from '@/components/common/inline-loader/InlineLoader';
 import { useDataFetch } from '@/hooks/common/use-data-fetch/useDataFetch';
 import { ProgramExpensesApi } from '@/services/api/admin/reports/program-expenses-api';
@@ -34,6 +34,17 @@ export const ProgramExpensesSection = ({ isEditing = false, syncedExchangeRate }
         initialData: INITIAL_PROGRAM_EXPENSES_DATA,
         fetchHandler: fetchReadOnlyData,
     });
+
+    useEffect(() => {
+        setSelectedProgramIds((previousSelectedProgramIds) => {
+            const availableProgramIds = new Set(data.programs.map((program) => program.id));
+            const validSelectedProgramIds = previousSelectedProgramIds.filter((id) => availableProgramIds.has(id));
+
+            return validSelectedProgramIds.length === previousSelectedProgramIds.length
+                ? previousSelectedProgramIds
+                : validSelectedProgramIds;
+        });
+    }, [data.programs]);
 
     const filteredRecords = useMemo(() => {
         if (selectedProgramIds.length === 0) {

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.module.scss
@@ -136,7 +136,7 @@
     height: 24px;
     padding: 0;
     border: none;
-    color: c.$blue-500;
+    color: var(--icon-btn-color, c.$blue-500);
 
     svg {
         width: 20px;

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.module.scss
@@ -23,20 +23,28 @@
     }
 }
 
+.column-checkbox {
+    width: 52px;
+}
+
 .column-year {
-    width: 19%;
+    width: 16%;
 }
 
 .column-type {
-    width: 18%;
+    width: 16%;
 }
 
 .column-program {
-    width: 24%;
+    width: 26%;
 }
 
 .column-amount {
-    width: 19.5%;
+    width: 18.5%;
+}
+
+.column-actions {
+    width: 88px;
 }
 
 .th {
@@ -48,10 +56,28 @@
     white-space: nowrap;
 }
 
+.checkbox-th,
+.checkbox-td {
+    width: 52px;
+    padding-right: 0;
+    text-align: center;
+}
+
+.actions-th,
+.actions-td {
+    padding-left: 16px;
+    padding-right: 16px;
+    text-align: center;
+}
+
 .tr {
     height: 65px;
     background: c.$white;
     border-top: 1px solid c.$grey-500;
+
+    &:hover {
+        background: c.$light-blue-50;
+    }
 }
 
 .td {
@@ -84,6 +110,48 @@
     line-height: 15px;
     letter-spacing: t.$small-spacing;
     text-align: center;
+}
+
+.row-checkbox {
+    width: 20px;
+    height: 20px;
+    margin: 0;
+    cursor: pointer;
+    accent-color: c.$blue-500;
+
+    &:disabled {
+        cursor: not-allowed;
+    }
+}
+
+.row-actions {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+}
+
+.icon-button {
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: none;
+    color: c.$blue-500;
+
+    svg {
+        width: 20px;
+        height: 20px;
+    }
+}
+
+.edit-icon-button {
+    --icon-btn-color: #{c.$blue-500};
+    --icon-btn-hover-color: #{c.$blue-900};
+}
+
+.delete-icon-button {
+    --icon-btn-color: #{c.$blue-500};
+    --icon-btn-hover-color: #{c.$error};
 }
 
 @media (max-width: 1200px) {

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.test.tsx
@@ -1,6 +1,5 @@
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { ProgramExpensesTable } from './ProgramExpensesTable';
 import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
 
@@ -21,15 +20,23 @@ jest.mock(
     }),
 );
 
+jest.mock('@/components/admin/icon-button/IconButton', () => ({
+    IconButton: ({ 'aria-label': ariaLabel, onClick }: { 'aria-label': string; onClick?: () => void }) => (
+        <button type="button" aria-label={ariaLabel} onClick={onClick}>
+            {ariaLabel}
+        </button>
+    ),
+}));
+
 const getEmptyState = () => screen.getByTestId('program-expenses-empty-state');
 const getEmptyStateCell = () => screen.getByTestId('program-expenses-empty-state-cell');
 
-const expectEmptyState = (variant: 'filtered' | 'program-expenses') => {
+const expectEmptyState = (variant: 'filtered' | 'program-expenses', colSpan = '5') => {
     const emptyState = getEmptyState();
 
     expect(emptyState).toBeInTheDocument();
     expect(emptyState).toHaveAttribute('data-variant', variant);
-    expect(getEmptyStateCell()).toHaveAttribute('colspan', '5');
+    expect(getEmptyStateCell()).toHaveAttribute('colspan', colSpan);
 };
 
 describe('ProgramExpensesTable', () => {
@@ -72,7 +79,7 @@ describe('ProgramExpensesTable', () => {
 
         expect(within(table).getByText('2025')).toBeInTheDocument();
         expect(within(table).getByText('Program A')).toBeInTheDocument();
-        expect(within(table).getAllByText(COMMON_TEXT_ADMIN.TAB.PROGRAMS)).toHaveLength(2);
+        expect(within(table).getAllByText(PROGRAM_EXPENSES_TEXT.TABLE.TYPE_LABEL)).toHaveLength(2);
 
         const normalizedText = normalizeText(container.textContent ?? '');
         expect(normalizedText).toContain('7 265');
@@ -91,5 +98,59 @@ describe('ProgramExpensesTable', () => {
         expect(screen.getByRole('table')).toBeInTheDocument();
         expect(screen.getByText(PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.PROGRAM)).toBeInTheDocument();
         expectEmptyState('program-expenses');
+    });
+
+    it('should render checkboxes and action column in edit mode', () => {
+        render(<ProgramExpensesTable records={records} hasAnyProgramExpenseRecords isEditing />);
+
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.ACTIONS)).toBeInTheDocument();
+        expect(screen.getAllByRole('checkbox')).toHaveLength(3);
+        expect(screen.getByRole('button', { name: 'Edit record 1' })).toBeEnabled();
+        expect(screen.getByRole('button', { name: 'Delete record 1' })).toBeEnabled();
+    });
+
+    it('should select all visible records from the header checkbox', () => {
+        render(<ProgramExpensesTable records={records} hasAnyProgramExpenseRecords isEditing />);
+
+        fireEvent.click(screen.getByRole('checkbox', { name: 'Select all program expense records' }));
+
+        expect(screen.getByRole('checkbox', { name: 'Select record 1' })).toBeChecked();
+        expect(screen.getByRole('checkbox', { name: 'Select record 2' })).toBeChecked();
+    });
+
+    it('should toggle a single record checkbox in edit mode', () => {
+        render(<ProgramExpensesTable records={records} hasAnyProgramExpenseRecords isEditing />);
+
+        fireEvent.click(screen.getByRole('checkbox', { name: 'Select record 1' }));
+
+        expect(screen.getByRole('checkbox', { name: 'Select record 1' })).toBeChecked();
+        expect(screen.getByRole('checkbox', { name: 'Select record 2' })).not.toBeChecked();
+    });
+
+    it('should call edit and delete callbacks from row action icons', () => {
+        const onEditRecord = jest.fn();
+        const onDeleteRecord = jest.fn();
+
+        render(
+            <ProgramExpensesTable
+                records={records}
+                hasAnyProgramExpenseRecords
+                isEditing
+                onEditRecord={onEditRecord}
+                onDeleteRecord={onDeleteRecord}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Edit record 1' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Delete record 1' }));
+
+        expect(onEditRecord).toHaveBeenCalledWith(records[0]);
+        expect(onDeleteRecord).toHaveBeenCalledWith(records[0]);
+    });
+
+    it('should use edit-mode colSpan for empty state', () => {
+        render(<ProgramExpensesTable records={[]} hasAnyProgramExpenseRecords={false} isEditing />);
+
+        expectEmptyState('program-expenses', '7');
     });
 });

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.tsx
@@ -1,56 +1,163 @@
+import { useEffect, useRef, useState } from 'react';
 import { ProgramExpensesEmptyState } from '@/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState';
-import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
 import { ProgramExpensesRecord } from '@/types/admin/reports';
 import { formatSummaryAmount } from '@/utils/functions/format-summary-amount/format-summary-amount';
 import { parseAmount } from '@/utils/functions/parse-amount/parse-amount';
+import { IconButton } from '@/components/admin/icon-button/IconButton';
+import { ACTION_ICONS } from '@/const/common/action-icons';
+import cn from 'classnames';
 import styles from './ProgramExpensesTable.module.scss';
 
 interface ProgramExpensesTableProps {
     records: ProgramExpensesRecord[];
     hasAnyProgramExpenseRecords: boolean;
+    isEditing?: boolean;
+    onEditRecord?: (record: ProgramExpensesRecord) => void;
+    onDeleteRecord?: (record: ProgramExpensesRecord) => void;
 }
 
-const TABLE_COLUMNS_COUNT = 5;
+const READ_ONLY_TABLE_COLUMNS_COUNT = 5;
+const EDITING_TABLE_COLUMNS_COUNT = 7;
 
-export const ProgramExpensesTable = ({ records, hasAnyProgramExpenseRecords }: ProgramExpensesTableProps) => {
+export const ProgramExpensesTable = ({
+    records,
+    hasAnyProgramExpenseRecords,
+    isEditing = false,
+    onEditRecord,
+    onDeleteRecord,
+}: ProgramExpensesTableProps) => {
+    const [selectedRecordIds, setSelectedRecordIds] = useState<number[]>([]);
+    const headerCheckboxRef = useRef<HTMLInputElement>(null);
     const hasNoRecords = records.length === 0;
+    const visibleRecordIds = records.map((record) => record.id);
+    const selectedVisibleRecordIds = visibleRecordIds.filter((id) => selectedRecordIds.includes(id));
+    const areAllVisibleRecordsSelected = records.length > 0 && selectedVisibleRecordIds.length === records.length;
+    const hasSelectedVisibleRecords = selectedVisibleRecordIds.length > 0;
+    const tableColumnsCount = isEditing ? EDITING_TABLE_COLUMNS_COUNT : READ_ONLY_TABLE_COLUMNS_COUNT;
+
+    useEffect(() => {
+        if (headerCheckboxRef.current) {
+            headerCheckboxRef.current.indeterminate = hasSelectedVisibleRecords && !areAllVisibleRecordsSelected;
+        }
+    }, [areAllVisibleRecordsSelected, hasSelectedVisibleRecords]);
+
+    useEffect(() => {
+        if (!isEditing) {
+            setSelectedRecordIds([]);
+        }
+    }, [isEditing]);
+
+    const handleSelectAllVisibleRecords = (isChecked: boolean) => {
+        const visibleRecordIdsSet = new Set(visibleRecordIds);
+
+        if (isChecked) {
+            setSelectedRecordIds(Array.from(new Set([...selectedRecordIds, ...visibleRecordIds])));
+            return;
+        }
+
+        setSelectedRecordIds(selectedRecordIds.filter((id) => !visibleRecordIdsSet.has(id)));
+    };
+
+    const handleSelectRecord = (recordId: number, isChecked: boolean) => {
+        if (isChecked) {
+            setSelectedRecordIds(Array.from(new Set([...selectedRecordIds, recordId])));
+            return;
+        }
+
+        setSelectedRecordIds(selectedRecordIds.filter((id) => id !== recordId));
+    };
 
     return (
         <div className={styles['table-wrapper']}>
             <table className={styles.table}>
                 <colgroup>
+                    {isEditing && <col className={styles['column-checkbox']} />}
                     <col className={styles['column-year']} />
                     <col className={styles['column-type']} />
                     <col className={styles['column-program']} />
                     <col className={styles['column-amount']} />
                     <col className={styles['column-amount']} />
+                    {isEditing && <col className={styles['column-actions']} />}
                 </colgroup>
                 <thead>
                     <tr>
+                        {isEditing && (
+                            <th className={cn(styles.th, styles['checkbox-th'])}>
+                                <input
+                                    ref={headerCheckboxRef}
+                                    type="checkbox"
+                                    className={styles['row-checkbox']}
+                                    aria-label="Select all program expense records"
+                                    checked={areAllVisibleRecordsSelected}
+                                    disabled={records.length === 0}
+                                    onChange={(event) => handleSelectAllVisibleRecords(event.target.checked)}
+                                />
+                            </th>
+                        )}
                         <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.REPORTING_YEAR}</th>
                         <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.TYPE}</th>
                         <th className={styles.th}>{PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.PROGRAM}</th>
                         <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_UAH}</th>
                         <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_USD}</th>
+                        {isEditing && (
+                            <th className={cn(styles.th, styles['actions-th'])}>
+                                {PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.ACTIONS}
+                            </th>
+                        )}
                     </tr>
                 </thead>
                 <tbody>
                     {hasNoRecords ? (
                         <ProgramExpensesEmptyState
-                            colSpan={TABLE_COLUMNS_COUNT}
+                            colSpan={tableColumnsCount}
                             variant={hasAnyProgramExpenseRecords ? 'filtered' : 'program-expenses'}
                         />
                     ) : (
                         records.map((record) => (
                             <tr key={record.id} className={styles.tr}>
+                                {isEditing && (
+                                    <td className={cn(styles.td, styles['checkbox-td'])}>
+                                        <input
+                                            type="checkbox"
+                                            className={styles['row-checkbox']}
+                                            aria-label={`Select record ${record.id}`}
+                                            checked={selectedRecordIds.includes(record.id)}
+                                            onChange={(event) => handleSelectRecord(record.id, event.target.checked)}
+                                        />
+                                    </td>
+                                )}
                                 <td className={styles.td}>{record.reportingYear}</td>
                                 <td className={styles.td}>
-                                    <span className={styles['type-chip']}>{COMMON_TEXT_ADMIN.TAB.PROGRAMS}</span>
+                                    <span className={styles['type-chip']}>
+                                        {PROGRAM_EXPENSES_TEXT.TABLE.TYPE_LABEL}
+                                    </span>
                                 </td>
                                 <td className={styles.td}>{record.programName}</td>
                                 <td className={styles.td}>{formatSummaryAmount(parseAmount(record.amountUah))}</td>
                                 <td className={styles.td}>{formatSummaryAmount(parseAmount(record.amountUsd))}</td>
+                                {isEditing && (
+                                    <td className={cn(styles.td, styles['actions-td'])}>
+                                        <div className={styles['row-actions']}>
+                                            <IconButton
+                                                type="button"
+                                                className={cn(styles['icon-button'], styles['edit-icon-button'])}
+                                                aria-label={`Edit record ${record.id}`}
+                                                onClick={() => onEditRecord?.(record)}
+                                                DefaultIcon={ACTION_ICONS.edit.default}
+                                                FilledIcon={ACTION_ICONS.edit.hover}
+                                            />
+                                            <IconButton
+                                                type="button"
+                                                className={cn(styles['icon-button'], styles['delete-icon-button'])}
+                                                aria-label={`Delete record ${record.id}`}
+                                                onClick={() => onDeleteRecord?.(record)}
+                                                DefaultIcon={ACTION_ICONS.delete.default}
+                                                FilledIcon={ACTION_ICONS.delete.hover}
+                                            />
+                                        </div>
+                                    </td>
+                                )}
                             </tr>
                         ))
                     )}

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.module.scss
@@ -4,7 +4,7 @@
 .toolbar-row {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-end;
     gap: 24px;
     width: 100%;
     min-height: 60px;
@@ -98,12 +98,18 @@
     }
 }
 
+.toolbar-actions {
+    display: flex;
+    align-items: flex-end;
+    gap: 10px;
+    margin-left: auto;
+}
+
 .exchange-rate {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
     gap: 8px;
-    margin-left: auto;
 }
 
 .exchange-rate-label {
@@ -132,14 +138,77 @@
     color: c.$blue-900;
 }
 
+.add-program-expense-button {
+    @include type.body-2-semibold;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    width: 206px;
+    height: 60px;
+    padding: 8px;
+    border-radius: 12px;
+    background-color: c.$error;
+    white-space: nowrap;
+    transition:
+        background-color 0.2s ease,
+        box-shadow 0.2s ease,
+        transform 0.15s ease;
+
+    &:not(:disabled):hover {
+        background-color: c.$yellow-500;
+        color: c.$blue-900;
+        box-shadow: 0 4px 14px rgba(c.$yellow-500, 0.5);
+        transform: translateY(-1px);
+
+        svg path {
+            fill: c.$blue-900;
+            stroke: c.$blue-900;
+        }
+    }
+
+    &:not(:disabled):active {
+        background-color: c.$yellow-600;
+        color: c.$blue-900;
+        box-shadow: 0 2px 6px rgba(c.$yellow-500, 0.35);
+        transform: translateY(0);
+    }
+
+    &:disabled {
+        opacity: 1;
+        cursor: not-allowed;
+        background: c.$grey-700;
+        color: c.$white;
+        box-shadow: none;
+
+        svg,
+        svg path {
+            fill: c.$white;
+            stroke: c.$white;
+        }
+    }
+}
+
+.plus-icon {
+    width: 24px;
+    height: 24px;
+    flex-shrink: 0;
+}
+
 @media (max-width: 1200px) {
     .toolbar-row {
         align-items: flex-start;
         flex-direction: column;
     }
 
+    .toolbar-actions {
+        align-items: flex-start;
+        flex-direction: column;
+        margin-left: 0;
+    }
+
     .exchange-rate {
         align-items: flex-start;
-        margin-left: 0;
     }
 }

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.test.tsx
@@ -75,6 +75,7 @@ describe('ProgramExpensesToolbar', () => {
         selectedProgramIds: [],
         exchangeRate: '42.15',
         onProgramChange: jest.fn(),
+        onAddProgramExpense: jest.fn(),
     };
 
     beforeEach(() => {
@@ -159,5 +160,26 @@ describe('ProgramExpensesToolbar', () => {
         fireEvent.click(screen.getByTestId('program-filter-clear'));
 
         expect(defaultProps.onProgramChange).toHaveBeenCalledWith([]);
+    });
+
+    it('should render singular program placeholder and add button in edit mode', () => {
+        render(<ProgramExpensesToolbar {...defaultProps} isEditing />);
+
+        expect(screen.getAllByText(PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.PROGRAM)).not.toHaveLength(0);
+        expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE })).toBeEnabled();
+    });
+
+    it('should call onAddProgramExpense when edit mode add button is clicked', () => {
+        render(<ProgramExpensesToolbar {...defaultProps} isEditing />);
+
+        fireEvent.click(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE }));
+
+        expect(defaultProps.onAddProgramExpense).toHaveBeenCalledTimes(1);
+    });
+
+    it('should disable edit mode add button when the limit is reached', () => {
+        render(<ProgramExpensesToolbar {...defaultProps} isEditing isAddProgramExpenseDisabled />);
+
+        expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE })).toBeDisabled();
     });
 });

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.tsx
@@ -1,4 +1,6 @@
 import { MultiSelectInput } from '@/components/admin/multi-select-input/MultiSelectInput';
+import { Button } from '@/components/admin/button/Button';
+import { ReactComponent as PlusIcon } from '@/assets/icons/plus.svg';
 import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
 import { ProgramExpensesProgram } from '@/types/admin/reports';
 import styles from './ProgramExpensesToolbar.module.scss';
@@ -7,7 +9,10 @@ interface ProgramExpensesToolbarProps {
     programs: ProgramExpensesProgram[];
     selectedProgramIds: number[];
     exchangeRate: string | null;
+    isEditing?: boolean;
+    isAddProgramExpenseDisabled?: boolean;
     onProgramChange: (value: number[]) => void;
+    onAddProgramExpense?: () => void;
 }
 
 const ALL_PROGRAMS_FILTER_OPTION_ID = 0;
@@ -19,23 +24,29 @@ const ALL_PROGRAMS_FILTER_OPTION: ProgramExpensesProgram = {
 
 const isAllProgramsFilterOption = (program: ProgramExpensesProgram) => program.id === ALL_PROGRAMS_FILTER_OPTION_ID;
 
-const getProgramsFilterDisplayValue = (selectedPrograms: ProgramExpensesProgram[]) => {
+const getProgramsFilterDisplayValue = (selectedPrograms: ProgramExpensesProgram[], placeholder: string) => {
     if (selectedPrograms.length === 1) return selectedPrograms[0].name;
     if (selectedPrograms.length > 1) {
         return PROGRAM_EXPENSES_TEXT.FILTER.getProgramsCounterLabel(selectedPrograms.length);
     }
 
-    return PROGRAM_EXPENSES_TEXT.FILTER.PROGRAMS_PLACEHOLDER;
+    return placeholder;
 };
 
 export const ProgramExpensesToolbar = ({
     programs,
     selectedProgramIds,
     exchangeRate,
+    isEditing = false,
+    isAddProgramExpenseDisabled = false,
     onProgramChange,
+    onAddProgramExpense,
 }: ProgramExpensesToolbarProps) => {
     const selectedPrograms = programs.filter((program) => selectedProgramIds.includes(program.id));
     const programOptions = [ALL_PROGRAMS_FILTER_OPTION, ...programs];
+    const placeholder = isEditing
+        ? PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.PROGRAM
+        : PROGRAM_EXPENSES_TEXT.FILTER.PROGRAMS_PLACEHOLDER;
 
     const handleProgramChange = (selectedOptions: ProgramExpensesProgram[]) => {
         if (selectedOptions.some(isAllProgramsFilterOption)) {
@@ -55,20 +66,33 @@ export const ProgramExpensesToolbar = ({
                     value={selectedPrograms}
                     getOptionId={(program) => program.id}
                     getOptionName={(program) => program.name}
-                    getDisplayValue={getProgramsFilterDisplayValue}
+                    getDisplayValue={(selectedValues) => getProgramsFilterDisplayValue(selectedValues, placeholder)}
                     isOptionSelected={(program, selectedValues) =>
                         isAllProgramsFilterOption(program)
                             ? selectedValues.length === 0
                             : selectedValues.some((selectedProgram) => selectedProgram.id === program.id)
                     }
                     onChange={handleProgramChange}
-                    placeholder={PROGRAM_EXPENSES_TEXT.FILTER.PROGRAMS_PLACEHOLDER}
+                    placeholder={placeholder}
                 />
             </div>
 
-            <div className={styles['exchange-rate']}>
-                <span className={styles['exchange-rate-label']}>{FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL}</span>
-                <span className={styles['exchange-rate-value']}>{exchangeRate ?? '-'}</span>
+            <div className={styles['toolbar-actions']}>
+                <div className={styles['exchange-rate']}>
+                    <span className={styles['exchange-rate-label']}>{FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL}</span>
+                    <span className={styles['exchange-rate-value']}>{exchangeRate ?? '-'}</span>
+                </div>
+                {isEditing && (
+                    <Button
+                        buttonStyle="primary"
+                        className={styles['add-program-expense-button']}
+                        disabled={isAddProgramExpenseDisabled}
+                        onClick={onAddProgramExpense}
+                    >
+                        <PlusIcon className={styles['plus-icon']} />
+                        {PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE}
+                    </Button>
+                )}
             </div>
         </div>
     );

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
@@ -9,14 +9,20 @@ jest.mock('../pdf-files-section/PdfFilesSection', () => ({
 jest.mock('../funds-expenditures-section/FundsExpendituresSection', () => ({
     FundsExpenditureSection: ({
         initialIsEditing,
+        draftExchangeRate,
         onEditModeChange,
         onExchangeRateValueChange,
     }: {
         initialIsEditing?: boolean;
+        draftExchangeRate?: string | null;
         onEditModeChange?: (isEditing: boolean) => void;
         onExchangeRateValueChange?: (exchangeRate: string | null) => void;
     }) => (
-        <div data-testid="funds-expenditure-section" data-initial-editing={String(initialIsEditing)}>
+        <div
+            data-testid="funds-expenditure-section"
+            data-initial-editing={String(initialIsEditing)}
+            data-draft-exchange-rate={draftExchangeRate ?? ''}
+        >
             FundsExpenditureSection
             <button
                 type="button"
@@ -28,6 +34,13 @@ jest.mock('../funds-expenditures-section/FundsExpendituresSection', () => ({
             >
                 Activate edit
             </button>
+            <button
+                type="button"
+                data-testid="change-funds-exchange-rate"
+                onClick={() => onExchangeRateValueChange?.('44.20')}
+            >
+                Change rate
+            </button>
             <button type="button" data-testid="deactivate-funds-edit" onClick={() => onEditModeChange?.(false)}>
                 Deactivate edit
             </button>
@@ -37,7 +50,7 @@ jest.mock('../funds-expenditures-section/FundsExpendituresSection', () => ({
 
 jest.mock('../program-expenses-section/ProgramExpensesSection', () => ({
     ProgramExpensesSection: ({
-        isEditing,
+        isEditing = false,
         syncedExchangeRate,
     }: {
         isEditing?: boolean;
@@ -89,21 +102,10 @@ describe('ReportAnalytics', () => {
         expect(screen.queryByTestId('pdf-files-section')).not.toBeInTheDocument();
     });
 
-    it('should keep program expenses in edit mode after funds edit is activated', () => {
+    it('should render program expenses mock independently from funds edit mode', () => {
         render(<ReportAnalytics />);
 
         fireEvent.click(screen.getByTestId('activate-funds-edit'));
-        fireEvent.click(screen.getByText(REPORTS_TEXT.REPORT_AND_ANALYTICS.TAB.PROGRAM_EXPENSES));
-
-        expect(screen.getByTestId('program-expenses-section')).toHaveAttribute('data-editing', 'true');
-        expect(screen.getByTestId('program-expenses-section')).toHaveAttribute('data-exchange-rate', '42.15');
-    });
-
-    it('should not pass synced exchange rate when funds edit mode is inactive', () => {
-        render(<ReportAnalytics />);
-
-        fireEvent.click(screen.getByTestId('activate-funds-edit'));
-        fireEvent.click(screen.getByTestId('deactivate-funds-edit'));
         fireEvent.click(screen.getByText(REPORTS_TEXT.REPORT_AND_ANALYTICS.TAB.PROGRAM_EXPENSES));
 
         expect(screen.getByTestId('program-expenses-section')).toHaveAttribute('data-editing', 'false');
@@ -118,5 +120,16 @@ describe('ReportAnalytics', () => {
         fireEvent.click(screen.getByText(REPORTS_TEXT.REPORT_AND_ANALYTICS.TAB.INCOME_EXPENSES));
 
         expect(screen.getByTestId('funds-expenditure-section')).toHaveAttribute('data-initial-editing', 'true');
+    });
+
+    it('should restore funds exchange rate draft after returning from another tab', () => {
+        render(<ReportAnalytics />);
+
+        fireEvent.click(screen.getByTestId('activate-funds-edit'));
+        fireEvent.click(screen.getByTestId('change-funds-exchange-rate'));
+        fireEvent.click(screen.getByText(REPORTS_TEXT.REPORT_AND_ANALYTICS.TAB.PROGRAM_EXPENSES));
+        fireEvent.click(screen.getByText(REPORTS_TEXT.REPORT_AND_ANALYTICS.TAB.INCOME_EXPENSES));
+
+        expect(screen.getByTestId('funds-expenditure-section')).toHaveAttribute('data-draft-exchange-rate', '44.20');
     });
 });

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
@@ -7,7 +7,50 @@ jest.mock('../pdf-files-section/PdfFilesSection', () => ({
 }));
 
 jest.mock('../funds-expenditures-section/FundsExpendituresSection', () => ({
-    FundsExpenditureSection: () => <div data-testid="funds-expenditure-section">FundsExpenditureSection</div>,
+    FundsExpenditureSection: ({
+        initialIsEditing,
+        onEditModeChange,
+        onExchangeRateValueChange,
+    }: {
+        initialIsEditing?: boolean;
+        onEditModeChange?: (isEditing: boolean) => void;
+        onExchangeRateValueChange?: (exchangeRate: string | null) => void;
+    }) => (
+        <div data-testid="funds-expenditure-section" data-initial-editing={String(initialIsEditing)}>
+            FundsExpenditureSection
+            <button
+                type="button"
+                data-testid="activate-funds-edit"
+                onClick={() => {
+                    onExchangeRateValueChange?.('42.15');
+                    onEditModeChange?.(true);
+                }}
+            >
+                Activate edit
+            </button>
+            <button type="button" data-testid="deactivate-funds-edit" onClick={() => onEditModeChange?.(false)}>
+                Deactivate edit
+            </button>
+        </div>
+    ),
+}));
+
+jest.mock('../program-expenses-section/ProgramExpensesSection', () => ({
+    ProgramExpensesSection: ({
+        isEditing,
+        syncedExchangeRate,
+    }: {
+        isEditing?: boolean;
+        syncedExchangeRate?: string | null;
+    }) => (
+        <div
+            data-testid="program-expenses-section"
+            data-editing={String(isEditing)}
+            data-exchange-rate={syncedExchangeRate ?? ''}
+        >
+            ProgramExpensesSection
+        </div>
+    ),
 }));
 
 describe('ReportAnalytics', () => {
@@ -44,5 +87,36 @@ describe('ReportAnalytics', () => {
         const incomeTab = screen.getByText('Доходи та витрати');
         fireEvent.click(incomeTab);
         expect(screen.queryByTestId('pdf-files-section')).not.toBeInTheDocument();
+    });
+
+    it('should keep program expenses in edit mode after funds edit is activated', () => {
+        render(<ReportAnalytics />);
+
+        fireEvent.click(screen.getByTestId('activate-funds-edit'));
+        fireEvent.click(screen.getByText(REPORTS_TEXT.REPORT_AND_ANALYTICS.TAB.PROGRAM_EXPENSES));
+
+        expect(screen.getByTestId('program-expenses-section')).toHaveAttribute('data-editing', 'true');
+        expect(screen.getByTestId('program-expenses-section')).toHaveAttribute('data-exchange-rate', '42.15');
+    });
+
+    it('should not pass synced exchange rate when funds edit mode is inactive', () => {
+        render(<ReportAnalytics />);
+
+        fireEvent.click(screen.getByTestId('activate-funds-edit'));
+        fireEvent.click(screen.getByTestId('deactivate-funds-edit'));
+        fireEvent.click(screen.getByText(REPORTS_TEXT.REPORT_AND_ANALYTICS.TAB.PROGRAM_EXPENSES));
+
+        expect(screen.getByTestId('program-expenses-section')).toHaveAttribute('data-editing', 'false');
+        expect(screen.getByTestId('program-expenses-section')).toHaveAttribute('data-exchange-rate', '');
+    });
+
+    it('should restore funds edit mode after returning from another tab', () => {
+        render(<ReportAnalytics />);
+
+        fireEvent.click(screen.getByTestId('activate-funds-edit'));
+        fireEvent.click(screen.getByText(REPORTS_TEXT.REPORT_AND_ANALYTICS.TAB.PROGRAM_EXPENSES));
+        fireEvent.click(screen.getByText(REPORTS_TEXT.REPORT_AND_ANALYTICS.TAB.INCOME_EXPENSES));
+
+        expect(screen.getByTestId('funds-expenditure-section')).toHaveAttribute('data-initial-editing', 'true');
     });
 });

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
@@ -21,7 +21,7 @@ const ANALYTICS_TABS: ReportAnalyticsTab[] = [
 export const ReportAnalytics = () => {
     const [activeTab, setActiveTab] = useState<ReportAnalyticsTab>(ANALYTICS_TABS[0]);
     const [isFundsEditing, setIsFundsEditing] = useState(false);
-    const [programExpensesExchangeRate, setProgramExpensesExchangeRate] = useState<string | null>(null);
+    const [fundsExchangeRateDraft, setFundsExchangeRateDraft] = useState<string | null>();
 
     return (
         <div className={styles['report-analytics']}>
@@ -39,16 +39,12 @@ export const ReportAnalytics = () => {
                 {activeTab.id === 'income-expenses' && (
                     <FundsExpenditureSection
                         initialIsEditing={isFundsEditing}
+                        draftExchangeRate={fundsExchangeRateDraft}
                         onEditModeChange={setIsFundsEditing}
-                        onExchangeRateValueChange={setProgramExpensesExchangeRate}
+                        onExchangeRateValueChange={setFundsExchangeRateDraft}
                     />
                 )}
-                {activeTab.id === 'program-expenses' && (
-                    <ProgramExpensesSection
-                        isEditing={isFundsEditing}
-                        syncedExchangeRate={isFundsEditing ? programExpensesExchangeRate : null}
-                    />
-                )}
+                {activeTab.id === 'program-expenses' && <ProgramExpensesSection />}
             </div>
         </div>
     );

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
@@ -20,6 +20,8 @@ const ANALYTICS_TABS: ReportAnalyticsTab[] = [
 
 export const ReportAnalytics = () => {
     const [activeTab, setActiveTab] = useState<ReportAnalyticsTab>(ANALYTICS_TABS[0]);
+    const [isFundsEditing, setIsFundsEditing] = useState(false);
+    const [programExpensesExchangeRate, setProgramExpensesExchangeRate] = useState<string | null>(null);
 
     return (
         <div className={styles['report-analytics']}>
@@ -34,8 +36,19 @@ export const ReportAnalytics = () => {
             />
             <div className={styles['tab-content']}>
                 {activeTab.id === 'pdf-files' && <PdfFilesSection />}
-                {activeTab.id === 'income-expenses' && <FundsExpenditureSection />}
-                {activeTab.id === 'program-expenses' && <ProgramExpensesSection />}
+                {activeTab.id === 'income-expenses' && (
+                    <FundsExpenditureSection
+                        initialIsEditing={isFundsEditing}
+                        onEditModeChange={setIsFundsEditing}
+                        onExchangeRateValueChange={setProgramExpensesExchangeRate}
+                    />
+                )}
+                {activeTab.id === 'program-expenses' && (
+                    <ProgramExpensesSection
+                        isEditing={isFundsEditing}
+                        syncedExchangeRate={isFundsEditing ? programExpensesExchangeRate : null}
+                    />
+                )}
             </div>
         </div>
     );


### PR DESCRIPTION

## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1826

## Description

Implemented edit mode UI for the “Програмні витрати” tab. When edit mode is enabled from “Доходи та витрати”, the “Програмні витрати” tab now shows the edit layout with selectable rows, action column, edit/delete icons, synced USD/UAH exchange rate, and the “+ Витрата по програмі” button with disabled state when the record limit is reached.

## How it looks
<img width="1410" height="430" alt="image" src="https://github.com/user-attachments/assets/c1f00286-d809-4c9f-bf5e-fcd51bedc8d6" />

## How to recreate changes

1. Open Admin Panel → “Звітність” → “Звіт та аналітика”.
2. Go to “Доходи та витрати”.
3. Click “Редагувати доходи та витрати”.
4. Switch to the “Програмні витрати” tab.
5. Verify that the tab is displayed in edit mode according to the mockup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editing mode for program expenses with row checkboxes, bulk select, and per-row edit/delete actions
  * "Add program expense" button (disabled when 4 records reached)
  * Exchange-rate draft/edit sync between funds and program expenses; draft restored when navigating
  * New UI labels: program-type label and actions column header localized ("Програмні", "Дії")
  * Selection now auto-prunes removed programs to avoid empty-state

* **Style**
  * Updated table and toolbar layout, responsive behavior, and row hover/controls styling

* **Tests**
  * Expanded test coverage for edit-mode, selection edge cases, and exchange-rate behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->