### PR TITLE
Fix/issues-2276,2277,2333,2369: [Single Program] Handle decline action in section save confirmation

### DIFF
--- a/src/pages/admin/programs/components/program-form/ProgramForm.tsx
+++ b/src/pages/admin/programs/components/program-form/ProgramForm.tsx
@@ -71,7 +71,7 @@ export interface ProgramFormProps {
     selectedLanguage?: string;
     onLanguageChange?: (language: string) => void;
     onRequestCancelSection?: (request: { type: SectionCancelActionType; onDiscard: () => void }) => void;
-    onRequestSaveSection?: (request: { onConfirm: () => void }) => void;
+    onRequestSaveSection?: (request: { onConfirm: () => void; onDecline?: () => void }) => void;
 }
 
 interface SectionEditingState {

--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.test.tsx
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.test.tsx
@@ -1106,6 +1106,7 @@ describe('ProgramSectionForm', () => {
         expect(onRequestSaveSection).toHaveBeenCalledTimes(1);
         expect(onRequestSaveSection).toHaveBeenCalledWith({
             onConfirm: expect.any(Function),
+            onDecline: expect.any(Function),
         });
 
         expect(onSave).not.toHaveBeenCalled();

--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
@@ -550,53 +550,40 @@ export const ProgramSectionForm = ({
 
     const isCardTemplate = CARD_TEMPLATES.includes(section.template);
 
+    const performCancel = useCallback(
+        (forceCleanState: boolean) => {
+            const shouldRemove = isNewSection;
+            const revertTo = originalSection;
+            const isTemplateReplacement = isReplacingTemplate;
+
+            const onAfterDiscard = () => {
+                if (!shouldRemove) {
+                    localSectionRef.current = revertTo;
+                    setLocalSection(revertTo);
+                    setIsDirty(false);
+                    setSectionMode(SectionMode.View);
+                    setValidationResetKey((prev) => prev + 1);
+                }
+            };
+
+            onCancel({
+                isDirty: forceCleanState ? false : isDirty,
+                shouldRemove,
+                revertTo,
+                onAfterDiscard,
+                isTemplateReplacement,
+            });
+        },
+        [isDirty, isNewSection, onCancel, originalSection, isReplacingTemplate],
+    );
+
     const handleCancelClick = useCallback(() => {
-        const shouldRemove = isNewSection;
-        const revertTo = originalSection;
-        const isTemplateReplacement = isReplacingTemplate;
-
-        const onAfterDiscard = () => {
-            if (!shouldRemove) {
-                localSectionRef.current = revertTo;
-                setLocalSection(revertTo);
-                setIsDirty(false);
-                setSectionMode(SectionMode.View);
-                setValidationResetKey((prev) => prev + 1);
-            }
-        };
-
-        onCancel({
-            isDirty,
-            shouldRemove,
-            revertTo,
-            onAfterDiscard,
-            isTemplateReplacement,
-        });
-    }, [isDirty, isNewSection, onCancel, originalSection, isReplacingTemplate]);
+        performCancel(false);
+    }, [performCancel]);
 
     const handleDeclineSave = useCallback(() => {
-        const shouldRemove = isNewSection;
-        const revertTo = originalSection;
-        const isTemplateReplacement = isReplacingTemplate;
-
-        const onAfterDiscard = () => {
-            if (!shouldRemove) {
-                localSectionRef.current = revertTo;
-                setLocalSection(revertTo);
-                setIsDirty(false);
-                setSectionMode(SectionMode.View);
-                setValidationResetKey((prev) => prev + 1);
-            }
-        };
-
-        onCancel({
-            isDirty: false,
-            shouldRemove,
-            revertTo,
-            onAfterDiscard,
-            isTemplateReplacement,
-        });
-    }, [isNewSection, originalSection, isReplacingTemplate, onCancel]);
+        performCancel(true);
+    }, [performCancel]);
 
     const handleDeleteClick = useCallback(
         (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
@@ -39,7 +39,7 @@ export interface ProgramSectionFormProps {
     isLastSection: boolean;
     onMoveUpSection: () => void;
     onMoveDownSection: () => void;
-    onRequestSaveSection?: (request: { onConfirm: () => void }) => void;
+    onRequestSaveSection?: (request: { onConfirm: () => void; onDecline?: () => void }) => void;
 }
 
 export interface SectionCancelOptions {
@@ -542,25 +542,6 @@ export const ProgramSectionForm = ({
         [localSection],
     );
 
-    const handleSaveClick = useCallback(() => {
-        if (isDisabled || !isSectionSaveValid) return;
-
-        const applySave = () => {
-            onSave();
-            setOriginalSection(localSection);
-            setIsDirty(false);
-            setSectionMode(SectionMode.View);
-            setValidationResetKey((prev) => prev + 1);
-        };
-
-        if (onRequestSaveSection && isDirty) {
-            onRequestSaveSection({ onConfirm: applySave });
-            return;
-        }
-
-        applySave();
-    }, [isDisabled, isSectionSaveValid, onSave, localSection, onRequestSaveSection, isDirty]);
-
     const CARD_TEMPLATES = [
         SectionTemplate.DualTitleDescriptionPairs,
         SectionTemplate.TripleTitleDescriptionPairs,
@@ -593,6 +574,30 @@ export const ProgramSectionForm = ({
         });
     }, [isDirty, isNewSection, onCancel, originalSection, isReplacingTemplate]);
 
+    const handleDeclineSave = useCallback(() => {
+        const shouldRemove = isNewSection;
+        const revertTo = originalSection;
+        const isTemplateReplacement = isReplacingTemplate;
+
+        const onAfterDiscard = () => {
+            if (!shouldRemove) {
+                localSectionRef.current = revertTo;
+                setLocalSection(revertTo);
+                setIsDirty(false);
+                setSectionMode(SectionMode.View);
+                setValidationResetKey((prev) => prev + 1);
+            }
+        };
+
+        onCancel({
+            isDirty: false,
+            shouldRemove,
+            revertTo,
+            onAfterDiscard,
+            isTemplateReplacement,
+        });
+    }, [isNewSection, originalSection, isReplacingTemplate, onCancel]);
+
     const handleDeleteClick = useCallback(
         (e: React.MouseEvent<HTMLButtonElement>) => {
             e.preventDefault();
@@ -610,6 +615,25 @@ export const ProgramSectionForm = ({
         },
         [onRequestReplace],
     );
+
+    const handleSaveClick = useCallback(() => {
+        if (isDisabled || !isSectionSaveValid) return;
+
+        const applySave = () => {
+            onSave();
+            setOriginalSection(localSection);
+            setIsDirty(false);
+            setSectionMode(SectionMode.View);
+            setValidationResetKey((prev) => prev + 1);
+        };
+
+        if (onRequestSaveSection && isDirty) {
+            onRequestSaveSection({ onConfirm: applySave, onDecline: handleDeclineSave });
+            return;
+        }
+
+        applySave();
+    }, [isDisabled, isSectionSaveValid, onSave, localSection, onRequestSaveSection, isDirty, handleDeclineSave]);
 
     const editableSection = renderProgramSection({
         templateId: section.template,

--- a/src/pages/admin/programs/components/programs-page-modals/program-modal/ProgramModal.tsx
+++ b/src/pages/admin/programs/components/programs-page-modals/program-modal/ProgramModal.tsx
@@ -57,11 +57,13 @@ export const ProgramModal = (props: ProgramModalProps) => {
     const sectionDiscardActionRef = useRef<(() => void) | null>(null);
     const [isSectionSaveModalOpen, setIsSectionSaveModalOpen] = useState(false);
     const sectionSaveActionRef = useRef<(() => void) | null>(null);
+    const sectionDeclineActionRef = useRef<(() => void) | null>(null);
 
     useEffect(() => {
         if (!isOpen) {
             setIsSectionSaveModalOpen(false);
             sectionSaveActionRef.current = null;
+            sectionDeclineActionRef.current = null;
         }
     }, [isOpen]);
 
@@ -252,15 +254,25 @@ export const ProgramModal = (props: ProgramModalProps) => {
         [openModalActions],
     );
 
-    const handleRequestSaveSection = useCallback((request: { onConfirm: () => void }) => {
+    const handleRequestSaveSection = useCallback((request: { onConfirm: () => void; onDecline?: () => void }) => {
         sectionSaveActionRef.current = request.onConfirm;
+        sectionDeclineActionRef.current = request.onDecline || null;
         setIsSectionSaveModalOpen(true);
     }, []);
 
     const handleCloseSectionSaveModal = useCallback(() => {
         setIsSectionSaveModalOpen(false);
         sectionSaveActionRef.current = null;
+        sectionDeclineActionRef.current = null;
     }, []);
+
+    const handleDeclineSaveSection = useCallback(() => {
+        const declineAction = sectionDeclineActionRef.current;
+        handleCloseSectionSaveModal();
+        if (declineAction) {
+            declineAction();
+        }
+    }, [handleCloseSectionSaveModal]);
 
     const handleConfirmSaveSection = useCallback(() => {
         sectionSaveActionRef.current?.();
@@ -350,7 +362,7 @@ export const ProgramModal = (props: ProgramModalProps) => {
                 onClose={handleCloseSectionSaveModal}
                 title={COMMON_TEXT_ADMIN.QUESTION.SAVE_CHANGES}
                 onConfirm={handleConfirmSaveSection}
-                onCancel={handleCloseSectionSaveModal}
+                onCancel={handleDeclineSaveSection}
             />
         </div>
     );


### PR DESCRIPTION
## Github tickets

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2276
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2277
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2333
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2370

## Description

This PR fixes a bug where clicking "НІ" (No) in the "Save Changes?" confirmation modal left the program section in Edit Mode instead of reverting it to View Mode and discarding the changes. It addresses an architectural gap by properly propagating the decline action back to the section form.

## How it looks

https://github.com/user-attachments/assets/e7768b04-0166-4331-9b9c-15d7b1e5174f


## Summary of change

* **`ProgramSectionForm.tsx`**: Added `handleDeclineSave` callback to forcefully revert the form to View Mode (`isDirty: false`) without triggering a secondary "Unsaved changes" warning. Passed this callback into `onRequestSaveSection`.
* **`ProgramForm.tsx`**: Updated the `ProgramFormProps` interface to support the optional `onDecline?: () => void` property within `onRequestSaveSection`.
* **`ProgramModal.tsx`**: Implemented `sectionDeclineActionRef` to store the decline callback. Updated `handleDeclineSaveSection` to execute this callback when the user clicks "Cancel/No" in the save confirmation modal.
* **`ProgramSectionForm.test.tsx`**: Updated unit tests to expect `onDecline` in the `onRequestSaveSection` mock calls to match the new component signature.

## How to recreate changes

1. Log in to the Admin panel and navigate to the 'Program profile' page.
2. Open a draft program that contains at least one section (e.g., Template T-1 or FAQ).
3. Click the "Edit" icon on the section to enter Edit Mode.
4. Make valid changes to at least one field.
5. Click the "Зберегти" (Save) button.
6. In the confirmation pop-up ("Зберегти зміни?"), click the "НІ" (No) button.
7. **Expected result:** The pop-up closes, the section reverts to read-only view (Edit Mode is deactivated), and the changes are successfully discarded.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [x]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated save confirmation modal to support decline operations alongside confirmation actions.
  * Extended save request callback interface with optional decline handler support.
  * Enhanced save operation lifecycle to properly restore state when decline is triggered.

* **Tests**
  * Updated test assertions to verify decline handler is provided in save confirmation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->