### PR TITLE
feature: add en disclaimer and USD converting for reports page

### DIFF
--- a/src/locales/en/reports.json
+++ b/src/locales/en/reports.json
@@ -1,10 +1,10 @@
 {
     "summary": {
-        "collected": "Collected",
+        "collected": "Total raised",
         "expenses": "Main Expenses",
-        "income": "Where Funds Came From",
-        "programs": "Funds Distribution by Program",
-        "lives": "Lives Changed"
+        "income": "Sources of funds",
+        "programs": "Allocation of funds by program",
+        "lives": "Lives impacted"
     },
     "reports": {
         "title": "Results in Reports",

--- a/src/pages/public/reports-page/components/summary-section/SummarySection.module.scss
+++ b/src/pages/public/reports-page/components/summary-section/SummarySection.module.scss
@@ -1,5 +1,6 @@
 @use '@/assets/sass/variables/colors' as c;
 @use '@/assets/sass/mixins/effects.mixins' as effects;
+@use '@/assets/sass/mixins/typography.mixins' as type;
 
 .root {
     display: grid;
@@ -71,4 +72,14 @@
 .programs {
     grid-area: programs;
     background-color: c.$yellow-300;
+}
+
+.disclaimer {
+    grid-column: 1 / -1;
+    padding: 16px;
+    text-align: center;
+    text-wrap: balance;
+    background-color: c.$light-blue-100;
+    color: c.$blue-900;
+    @include type.body-2-bold;
 }

--- a/src/pages/public/reports-page/components/summary-section/SummarySection.test.tsx
+++ b/src/pages/public/reports-page/components/summary-section/SummarySection.test.tsx
@@ -1,89 +1,131 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { useTranslation } from 'react-i18next';
 import { SummarySection } from './SummarySection';
+import { useLocale } from '@/hooks/common/use-locale/useLocale';
+
+jest.mock('@/hooks/common/use-locale/useLocale', () => ({
+    useLocale: jest.fn(),
+}));
 
 jest.mock('@/utils/mock-data/public/reports-page', () => ({
     SUMMARY_DATA: {
-        collected: { uah: 100000, usd: 2500 },
+        collected: { uah: 100000, usd: 2352.94 },
         livesChanged: 42,
+        disclaimer: 'Test currency disclaimer text',
     },
-    EXPENSES_DATA: { items: [{ label: 'Expense 1', amount: 10 }] },
-    FUNDING_DATA: { items: [{ label: 'Funding 1', amount: 20 }] },
-    PROGRAMS_ALLOCATION_DATA: { items: [{ label: 'Program 1', amount: 30 }] },
+    EXPENSES_DATA: { items: [{ label: 'Expense 1', amount: { uah: 10, usd: 0.24 }, percent: 10 }] },
+    FUNDING_DATA: { items: [{ label: 'Funding 1', amount: { uah: 20, usd: 0.47 } }] },
+    PROGRAMS_ALLOCATION_DATA: { items: [{ label: 'Program 1', amount: { uah: 30, usd: 0.71 } }] },
 }));
 
 jest.mock('./stat-card', () => ({
-    StatCard: ({ label, value, currency }: any) => (
+    StatCard: ({ label, value, currency, formattedValue }: any) => (
         <div data-testid="stat-card">
-            {label}: {value} {currency}
+            {label}: {formattedValue !== undefined ? formattedValue : `${value} ${currency ?? ''}`}
         </div>
     ),
 }));
 
 jest.mock('./expenses-breakdown-chart', () => ({
-    ExpensesBreakdownChart: ({ items }: any) => <div data-testid="expenses-chart">{JSON.stringify(items)}</div>,
+    ExpensesBreakdownChart: ({ items, formatAmount }: any) => (
+        <div data-testid="expenses-chart">
+            {JSON.stringify(items)}
+            {items[0] ? formatAmount(items[0].amount) : ''}
+        </div>
+    ),
 }));
 
 jest.mock('./funding-sources-chart', () => ({
-    FundingSourcesChart: ({ items }: any) => <div data-testid="funding-chart">{JSON.stringify(items)}</div>,
+    FundingSourcesChart: ({ items, formatAmount }: any) => (
+        <div data-testid="funding-chart">
+            {JSON.stringify(items)}
+            {items[0] ? formatAmount(items[0].amount) : ''}
+        </div>
+    ),
 }));
 
 jest.mock('./programs-allocation-chart', () => ({
-    ProgramsAllocationChart: ({ items }: any) => <div data-testid="programs-chart">{JSON.stringify(items)}</div>,
+    ProgramsAllocationChart: ({ items, formatAmount }: any) => (
+        <div data-testid="programs-chart">
+            {JSON.stringify(items)}
+            {items[0] ? formatAmount(items[0].amount) : ''}
+        </div>
+    ),
 }));
 
-jest.mock('react-i18next', () => ({
-    useTranslation: jest.fn(),
-}));
+const mockUseLocale = useLocale as jest.Mock;
 
 describe('SummarySection', () => {
-    const useTranslationMock = useTranslation as jest.Mock;
-
     beforeEach(() => {
+        mockUseLocale.mockReturnValue({ isEn: false });
+    });
+
+    afterEach(() => {
         jest.clearAllMocks();
-
-        useTranslationMock.mockReturnValue({
-            t: (key: string) => key,
-            i18n: { language: 'uk' },
-        });
     });
 
-    it('renders correct collected amount and currency for Ukrainian (Default)', () => {
+    it('renders collected stat card with UAH currency by default', () => {
         render(<SummarySection />);
 
         const cards = screen.getAllByTestId('stat-card');
-        expect(cards[0]).toHaveTextContent('summary.collected: 100000 UAH');
+        expect(cards[0]).toHaveTextContent('Зібрано: 100 000 грн');
     });
 
-    it('renders correct collected amount and currency for English', () => {
-        useTranslationMock.mockReturnValue({
-            t: (key: string) => key,
-            i18n: { language: 'en' },
-        });
+    it('renders collected stat card with pre-formatted USD value when English is active', () => {
+        mockUseLocale.mockReturnValue({ isEn: true });
 
         render(<SummarySection />);
 
         const cards = screen.getAllByTestId('stat-card');
-        expect(cards[0]).toHaveTextContent('summary.collected: 2500 USD');
+        expect(cards[0]).toHaveTextContent('Зібрано: 2 352 USD');
     });
 
     it('renders lives changed card with static data', () => {
         render(<SummarySection />);
 
         const cards = screen.getAllByTestId('stat-card');
-        expect(cards[1]).toHaveTextContent('summary.lives: 42');
+        expect(cards[1]).toHaveTextContent('Змінених життів: 42');
     });
 
-    it('passes correct data props to Expenses chart', () => {
+    it('does not render disclaimer when UAH is active', () => {
+        render(<SummarySection />);
+
+        expect(screen.queryByText('Test currency disclaimer text')).not.toBeInTheDocument();
+    });
+
+    it('renders disclaimer for the report summary', () => {
+        mockUseLocale.mockReturnValue({ isEn: true });
+
+        render(<SummarySection />);
+
+        expect(screen.getByText('Test currency disclaimer text')).toBeInTheDocument();
+    });
+
+    it('does not render disclaimer when English is active but disclaimer text is missing', () => {
+        mockUseLocale.mockReturnValue({ isEn: true });
+
+        const reportsPageMock = jest.requireMock('@/utils/mock-data/public/reports-page') as {
+            SUMMARY_DATA: { disclaimer?: string };
+        };
+        const originalDisclaimer = reportsPageMock.SUMMARY_DATA.disclaimer;
+        reportsPageMock.SUMMARY_DATA.disclaimer = undefined;
+
+        render(<SummarySection />);
+
+        expect(screen.queryByText('Test currency disclaimer text')).not.toBeInTheDocument();
+
+        reportsPageMock.SUMMARY_DATA.disclaimer = originalDisclaimer;
+    });
+
+    it('passes correct data to Expenses chart', () => {
         render(<SummarySection />);
 
         const chart = screen.getByTestId('expenses-chart');
-        const expectedData = [{ label: 'Expense 1', amount: 10 }];
+        const expectedData = [{ label: 'Expense 1', amount: 10, percent: 10 }];
         expect(chart).toHaveTextContent(JSON.stringify(expectedData));
     });
 
-    it('passes correct data props to Funding chart', () => {
+    it('passes correct data to Funding chart', () => {
         render(<SummarySection />);
 
         const chart = screen.getByTestId('funding-chart');
@@ -91,7 +133,7 @@ describe('SummarySection', () => {
         expect(chart).toHaveTextContent(JSON.stringify(expectedData));
     });
 
-    it('passes correct data props to Programs chart', () => {
+    it('passes correct data to Programs chart', () => {
         render(<SummarySection />);
 
         const chart = screen.getByTestId('programs-chart');

--- a/src/pages/public/reports-page/components/summary-section/SummarySection.tsx
+++ b/src/pages/public/reports-page/components/summary-section/SummarySection.tsx
@@ -1,41 +1,68 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocale } from '@/hooks/common/use-locale/useLocale';
 import {
     EXPENSES_DATA,
     FUNDING_DATA,
     PROGRAMS_ALLOCATION_DATA,
     SUMMARY_DATA,
 } from '@/utils/mock-data/public/reports-page';
+import { formatAllocationAmount, formatCollectedAmount } from '@/utils/functions/formatters/report-amount-formatters';
 import { StatCard } from './stat-card';
 import { ExpensesBreakdownChart } from './expenses-breakdown-chart';
 import { FundingSourcesChart } from './funding-sources-chart';
 import { ProgramsAllocationChart } from './programs-allocation-chart';
 import styles from './SummarySection.module.scss';
 
-export const SummarySection = () => {
-    const { t, i18n } = useTranslation('reportsPage');
+const UAH_LABEL = 'грн';
+const USD_LABEL = 'USD';
 
-    const isUa = i18n.language === 'uk';
-    const collectedValue = isUa ? SUMMARY_DATA.collected.uah : SUMMARY_DATA.collected.usd;
-    const currencyCode = isUa ? 'UAH' : 'USD';
+export const SummarySection = () => {
+    const { t } = useTranslation('reportsPage');
+    const { isEn } = useLocale();
+
+    const currencyKey: 'uah' | 'usd' = isEn ? 'usd' : 'uah';
+    const currencyLabel = isEn ? USD_LABEL : UAH_LABEL;
+
+    const formatItemAmount = (amount: number) => {
+        return `${formatAllocationAmount(amount, isEn)} ${currencyLabel}`;
+    };
+
+    const collectedAmount = SUMMARY_DATA.collected[currencyKey];
+    const formattedCollectedValue = `${formatCollectedAmount(collectedAmount)} ${currencyLabel}`;
+
+    const expensesItems = EXPENSES_DATA.items.map((item) => ({
+        ...item,
+        amount: item.amount[currencyKey],
+    }));
+
+    const fundingItems = FUNDING_DATA.items.map((item) => ({
+        ...item,
+        amount: item.amount[currencyKey],
+    }));
+
+    const programsItems = PROGRAMS_ALLOCATION_DATA.items.map((item) => ({
+        ...item,
+        amount: item.amount[currencyKey],
+    }));
 
     return (
         <section className={styles.root}>
             <StatCard
                 className={styles.collected}
-                value={collectedValue}
-                currency={currencyCode}
+                value={collectedAmount}
+                formattedValue={formattedCollectedValue}
                 label={t('summary.collected')}
                 color="blue"
             />
             <div className={styles.expenses}>
-                <ExpensesBreakdownChart items={EXPENSES_DATA.items} />
+                <ExpensesBreakdownChart items={expensesItems} formatAmount={formatItemAmount} />
             </div>
             <div className={styles.income}>
-                <FundingSourcesChart items={FUNDING_DATA.items} />
+                <FundingSourcesChart items={fundingItems} formatAmount={formatItemAmount} />
             </div>
             <div className={styles.programs}>
-                <ProgramsAllocationChart items={PROGRAMS_ALLOCATION_DATA.items} />
+                <ProgramsAllocationChart items={programsItems} formatAmount={formatItemAmount} />
             </div>
             <StatCard
                 className={styles.lives}
@@ -43,6 +70,7 @@ export const SummarySection = () => {
                 label={t('summary.lives')}
                 color="yellow"
             />
+            {isEn && SUMMARY_DATA.disclaimer && <p className={styles.disclaimer}>{SUMMARY_DATA.disclaimer}</p>}
         </section>
     );
 };

--- a/src/pages/public/reports-page/components/summary-section/expenses-breakdown-chart/ExpensesBreakdownChart.test.tsx
+++ b/src/pages/public/reports-page/components/summary-section/expenses-breakdown-chart/ExpensesBreakdownChart.test.tsx
@@ -15,6 +15,8 @@ jest.mock('./chart-legend', () => ({
     ),
 }));
 
+const mockFormatAmount = jest.fn((amount: number) => `${amount} грн`);
+
 describe('ExpensesBreakdownChart', () => {
     const mockItems: ExpenseItem[] = [
         { label: 'Admin Expenses', amount: 500, percent: 0.25 },
@@ -22,13 +24,13 @@ describe('ExpensesBreakdownChart', () => {
     ];
 
     it('renders the chart title', () => {
-        render(<ExpensesBreakdownChart items={mockItems} />);
+        render(<ExpensesBreakdownChart items={mockItems} formatAmount={mockFormatAmount} />);
 
         expect(screen.getByRole('heading', { level: 3, name: /основні витрати/i })).toBeInTheDocument();
     });
 
     it('passes reversed items to child components', () => {
-        render(<ExpensesBreakdownChart items={mockItems} />);
+        render(<ExpensesBreakdownChart items={mockItems} formatAmount={mockFormatAmount} />);
 
         const expectedOrder = 'Operational Expenses,Admin Expenses';
 
@@ -37,7 +39,7 @@ describe('ExpensesBreakdownChart', () => {
     });
 
     it('renders correctly with empty items', () => {
-        render(<ExpensesBreakdownChart items={[]} />);
+        render(<ExpensesBreakdownChart items={[]} formatAmount={mockFormatAmount} />);
 
         expect(screen.getByRole('heading', { level: 3 })).toBeInTheDocument();
         expect(screen.getByTestId('chart-graphic')).toBeEmptyDOMElement();

--- a/src/pages/public/reports-page/components/summary-section/expenses-breakdown-chart/ExpensesBreakdownChart.tsx
+++ b/src/pages/public/reports-page/components/summary-section/expenses-breakdown-chart/ExpensesBreakdownChart.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ExpenseItem } from '@/types/public/reports/expenses';
 import { ChartGraphic } from './chart-graphic';
 import { ChartLegend } from './chart-legend';
@@ -6,15 +7,17 @@ import styles from './ExpensesBreakdownChart.module.scss';
 
 interface ExpensesBreakdownChartProps {
     items: ExpenseItem[];
+    formatAmount: (uahAmount: number) => string;
 }
 
-export const ExpensesBreakdownChart = ({ items }: ExpensesBreakdownChartProps) => {
+export const ExpensesBreakdownChart = ({ items, formatAmount }: ExpensesBreakdownChartProps) => {
+    const { t } = useTranslation('reportsPage');
     const normalizedItems = useMemo(() => items.toReversed(), [items]);
 
     return (
         <div className={styles.container}>
-            <h3 className={styles.title}>Основні витрати</h3>
-            <ChartGraphic items={normalizedItems} />
+            <h3 className={styles.title}>{t('summary.expenses')}</h3>
+            <ChartGraphic items={normalizedItems} formatAmount={formatAmount} />
             <ChartLegend items={normalizedItems} />
         </div>
     );

--- a/src/pages/public/reports-page/components/summary-section/expenses-breakdown-chart/chart-graphic/ChartGraphic.test.tsx
+++ b/src/pages/public/reports-page/components/summary-section/expenses-breakdown-chart/chart-graphic/ChartGraphic.test.tsx
@@ -36,6 +36,8 @@ jest.mock('./chart.config', () => ({
 const mockedUseMediaQuery = useMediaQuery as jest.Mock;
 const mockedUseChartGeometry = useChartGeometry as jest.Mock;
 
+const defaultFormatAmount = (amount: number) => `${amount.toLocaleString('uk-UA')} грн`;
+
 describe('ChartGraphic', () => {
     const items = [
         { label: 'A', percent: 25, amount: 1000 },
@@ -59,7 +61,7 @@ describe('ChartGraphic', () => {
     it('renders desktop config when media query matches', () => {
         mockedUseMediaQuery.mockReturnValue(true);
 
-        render(<ChartGraphic items={items} />);
+        render(<ChartGraphic items={items} formatAmount={defaultFormatAmount} />);
 
         const svg = document.querySelector('svg');
 
@@ -69,7 +71,7 @@ describe('ChartGraphic', () => {
     it('renders mobile config when media query does not match', () => {
         mockedUseMediaQuery.mockReturnValue(false);
 
-        render(<ChartGraphic items={items} />);
+        render(<ChartGraphic items={items} formatAmount={defaultFormatAmount} />);
 
         const svg = document.querySelector('svg');
 
@@ -79,7 +81,7 @@ describe('ChartGraphic', () => {
     it('renders correct number of paths', () => {
         mockedUseMediaQuery.mockReturnValue(true);
 
-        render(<ChartGraphic items={items} />);
+        render(<ChartGraphic items={items} formatAmount={defaultFormatAmount} />);
 
         const paths = document.querySelectorAll('path');
 
@@ -89,13 +91,15 @@ describe('ChartGraphic', () => {
     it('renders labels with formatted percent and amount', () => {
         mockedUseMediaQuery.mockReturnValue(true);
 
-        render(<ChartGraphic items={items} />);
+        const spyFormatAmount = jest.fn(defaultFormatAmount);
+
+        render(<ChartGraphic items={items} formatAmount={spyFormatAmount} />);
 
         expect(screen.getByText('25.0%')).toBeInTheDocument();
         expect(screen.getByText('75.0%')).toBeInTheDocument();
 
-        expect(screen.getByText('1 000 грн')).toBeInTheDocument();
-        expect(screen.getByText('3 000 грн')).toBeInTheDocument();
+        expect(spyFormatAmount).toHaveBeenCalledWith(1000);
+        expect(spyFormatAmount).toHaveBeenCalledWith(3000);
     });
 
     it('does not render label if position is missing', () => {
@@ -106,7 +110,7 @@ describe('ChartGraphic', () => {
             positions: [undefined, { x: 200, y: 200 }],
         });
 
-        render(<ChartGraphic items={items} />);
+        render(<ChartGraphic items={items} formatAmount={defaultFormatAmount} />);
 
         expect(screen.queryByText('25.0%')).not.toBeInTheDocument();
         expect(screen.getByText('75.0%')).toBeInTheDocument();
@@ -115,7 +119,7 @@ describe('ChartGraphic', () => {
     it('calls useChartGeometry with correct arguments', () => {
         mockedUseMediaQuery.mockReturnValue(true);
 
-        render(<ChartGraphic items={items} />);
+        render(<ChartGraphic items={items} formatAmount={defaultFormatAmount} />);
 
         expect(mockedUseChartGeometry).toHaveBeenCalledWith(items.length, true);
     });

--- a/src/pages/public/reports-page/components/summary-section/expenses-breakdown-chart/chart-graphic/ChartGraphic.tsx
+++ b/src/pages/public/reports-page/components/summary-section/expenses-breakdown-chart/chart-graphic/ChartGraphic.tsx
@@ -7,9 +7,10 @@ import styles from './ChartGraphic.module.scss';
 
 interface ChartGraphicProps {
     items: ExpenseItem[];
+    formatAmount: (uahAmount: number) => string;
 }
 
-export const ChartGraphic = ({ items }: ChartGraphicProps) => {
+export const ChartGraphic = ({ items, formatAmount }: ChartGraphicProps) => {
     const isDesktop = useMediaQuery('(min-width: 1440px)');
     const { pathRefs, positions } = useChartGeometry(items.length, isDesktop);
     const config = isDesktop ? CHART_CONFIG.desktop : CHART_CONFIG.mobile;
@@ -39,7 +40,7 @@ export const ChartGraphic = ({ items }: ChartGraphicProps) => {
                                 <text x={positions[index].x} y={positions[index].y} className={styles.label}>
                                     <tspan className={styles.percent}>{item.percent.toFixed(1)}%</tspan>
                                     <tspan x={positions[index].x} dy="1.2em" className={styles.amount}>
-                                        {item.amount.toLocaleString('uk-UA')} грн
+                                        {formatAmount(item.amount)}
                                     </tspan>
                                 </text>
                             )}

--- a/src/pages/public/reports-page/components/summary-section/funding-sources-chart/FundingSourcesChart.test.tsx
+++ b/src/pages/public/reports-page/components/summary-section/funding-sources-chart/FundingSourcesChart.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { FundingSourcesChart } from './FundingSourcesChart';
 
+const defaultFormatAmount = (amount: number) => `${amount.toLocaleString('uk-UA')} грн`;
+
 describe('FundingSourcesChart', () => {
     const mockItems = [
         { label: 'Source A', amount: 100 },
@@ -10,7 +12,7 @@ describe('FundingSourcesChart', () => {
     ];
 
     it('renders title', () => {
-        render(<FundingSourcesChart items={mockItems} />);
+        render(<FundingSourcesChart items={mockItems} formatAmount={defaultFormatAmount} />);
         expect(screen.getByText('Звідки прийшли кошти')).toBeInTheDocument();
     });
 
@@ -19,7 +21,7 @@ describe('FundingSourcesChart', () => {
             { label: 'Grant', amount: 20000 },
             { label: 'Donation', amount: 5000 },
         ];
-        render(<FundingSourcesChart items={items} />);
+        render(<FundingSourcesChart items={items} formatAmount={defaultFormatAmount} />);
 
         expect(screen.getByText('Grant')).toBeInTheDocument();
         expect(screen.getByText(/20\s+000\s+грн/)).toBeInTheDocument();
@@ -29,7 +31,7 @@ describe('FundingSourcesChart', () => {
     });
 
     it('calculates ratios correctly based on max amount', () => {
-        render(<FundingSourcesChart items={mockItems} />);
+        render(<FundingSourcesChart items={mockItems} formatAmount={defaultFormatAmount} />);
 
         const barA = screen.getByText('Source A').closest('.row')?.querySelector('.bar');
         const barB = screen.getByText('Source B').closest('.row')?.querySelector('.bar');
@@ -48,7 +50,7 @@ describe('FundingSourcesChart', () => {
             { label: '4', amount: 10 },
             { label: '5', amount: 10 },
         ];
-        render(<FundingSourcesChart items={items} />);
+        render(<FundingSourcesChart items={items} formatAmount={defaultFormatAmount} />);
 
         const getBar = (label: string) => screen.getByText(label).closest('.row')?.querySelector('.bar');
 
@@ -61,7 +63,7 @@ describe('FundingSourcesChart', () => {
 
     it('handles zero amounts gracefully', () => {
         const items = [{ label: 'Zero', amount: 0 }];
-        render(<FundingSourcesChart items={items} />);
+        render(<FundingSourcesChart items={items} formatAmount={defaultFormatAmount} />);
 
         expect(screen.getByText('Zero')).toBeInTheDocument();
         expect(screen.getByText(/0\s+грн/)).toBeInTheDocument();

--- a/src/pages/public/reports-page/components/summary-section/funding-sources-chart/FundingSourcesChart.tsx
+++ b/src/pages/public/reports-page/components/summary-section/funding-sources-chart/FundingSourcesChart.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { FundingSourcesRow } from './funding-sources-row';
 import styles from './FundingSourcesChart.module.scss';
 
@@ -9,22 +10,24 @@ export interface FundingSourceItem {
 
 interface FundingSourcesChartProps {
     items: FundingSourceItem[];
+    formatAmount: (uahAmount: number) => string;
 }
 
-export const FundingSourcesChart = ({ items }: FundingSourcesChartProps) => {
+export const FundingSourcesChart = ({ items, formatAmount }: FundingSourcesChartProps) => {
+    const { t } = useTranslation('reportsPage');
     const maxAmount = useMemo(() => {
         return Math.max(...items.map((item) => item.amount));
     }, [items]);
 
     return (
         <div className={styles.root}>
-            <p className={styles.title}>Звідки прийшли кошти</p>
+            <p className={styles.title}>{t('summary.income')}</p>
             <div className={styles.chart}>
                 {items.map((item, index) => (
                     <FundingSourcesRow
                         key={item.label}
                         label={item.label}
-                        formattedAmount={`${item.amount.toLocaleString('uk-UA')} грн`}
+                        formattedAmount={formatAmount(item.amount)}
                         ratio={maxAmount > 0 ? item.amount / maxAmount : 0}
                         variant={styles[`variant${index % 4}`]}
                     />

--- a/src/pages/public/reports-page/components/summary-section/programs-allocation-chart/ProgramsAllocationChart.test.tsx
+++ b/src/pages/public/reports-page/components/summary-section/programs-allocation-chart/ProgramsAllocationChart.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { ProgramsAllocationChart } from './ProgramsAllocationChart';
 
+const defaultFormatAmount = (amount: number) => `${amount.toLocaleString('uk-UA')} грн`;
+
 describe('ProgramsAllocationChart', () => {
     const defaultItems = [
         { label: 'Program A', amount: 1000 },
@@ -9,18 +11,18 @@ describe('ProgramsAllocationChart', () => {
     ];
 
     it('renders title', () => {
-        render(<ProgramsAllocationChart items={defaultItems} />);
+        render(<ProgramsAllocationChart items={defaultItems} formatAmount={defaultFormatAmount} />);
         expect(screen.getByText('Розподіл коштів по програмах')).toBeInTheDocument();
     });
 
     it('renders labels and formatted amounts for 2 items', () => {
-        render(<ProgramsAllocationChart items={defaultItems} />);
+        render(<ProgramsAllocationChart items={defaultItems} formatAmount={defaultFormatAmount} />);
 
         expect(screen.getByText('Program A')).toBeInTheDocument();
         expect(screen.getByText(/1\s+000/)).toBeInTheDocument();
         expect(screen.getByText('Program B')).toBeInTheDocument();
         expect(screen.getByText(/3\s+000/)).toBeInTheDocument();
-        expect(screen.getAllByText('грн')).toHaveLength(2);
+        expect(screen.getAllByText(/ грн$/)).toHaveLength(2);
     });
 
     it('renders correctly for 3 items structure', () => {
@@ -29,7 +31,7 @@ describe('ProgramsAllocationChart', () => {
             { label: 'B', amount: 200 },
             { label: 'C', amount: 300 },
         ];
-        render(<ProgramsAllocationChart items={items} />);
+        render(<ProgramsAllocationChart items={items} formatAmount={defaultFormatAmount} />);
 
         expect(screen.getByText('A')).toBeInTheDocument();
         expect(screen.getByText('B')).toBeInTheDocument();
@@ -41,13 +43,13 @@ describe('ProgramsAllocationChart', () => {
             { label: 'Large', amount: 1234567 },
             { label: 'Small', amount: 1 },
         ];
-        render(<ProgramsAllocationChart items={items} />);
+        render(<ProgramsAllocationChart items={items} formatAmount={defaultFormatAmount} />);
 
         expect(screen.getByText(/1\s+234\s+567/)).toBeInTheDocument();
     });
 
     it('renders correctly for 1 item structure', () => {
-        render(<ProgramsAllocationChart items={[{ label: 'Solo', amount: 100 }]} />);
+        render(<ProgramsAllocationChart items={[{ label: 'Solo', amount: 100 }]} formatAmount={defaultFormatAmount} />);
 
         expect(screen.getByText('Розподіл коштів по програмах')).toBeInTheDocument();
 
@@ -64,7 +66,7 @@ describe('ProgramsAllocationChart', () => {
             { label: 'E', amount: 1 },
         ];
 
-        render(<ProgramsAllocationChart items={items} />);
+        render(<ProgramsAllocationChart items={items} formatAmount={defaultFormatAmount} />);
 
         expect(screen.getByText('Розподіл коштів по програмах')).toBeInTheDocument();
 

--- a/src/pages/public/reports-page/components/summary-section/programs-allocation-chart/ProgramsAllocationChart.tsx
+++ b/src/pages/public/reports-page/components/summary-section/programs-allocation-chart/ProgramsAllocationChart.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import cn from 'classnames';
 import { resolveProgramsLayout } from './resolve-programs-layout';
 import styles from './ProgramsAllocationChart.module.scss';
@@ -10,14 +11,16 @@ export interface ProgramAllocationItem {
 
 interface ProgramsAllocationChartProps {
     items: ProgramAllocationItem[];
+    formatAmount: (uahAmount: number) => string;
 }
 
-export const ProgramsAllocationChart = ({ items }: ProgramsAllocationChartProps) => {
+export const ProgramsAllocationChart = ({ items, formatAmount }: ProgramsAllocationChartProps) => {
+    const { t } = useTranslation('reportsPage');
     const columns = useMemo(() => resolveProgramsLayout(items), [items]);
 
     return (
         <div className={styles.root}>
-            <p className={styles.title}>Розподіл коштів по програмах</p>
+            <p className={styles.title}>{t('summary.programs')}</p>
             <div className={styles.chart}>
                 {columns.map((col, i) => (
                     <div key={i} className={styles.column} style={{ width: `${col.widthPercent}%` }}>
@@ -28,10 +31,7 @@ export const ProgramsAllocationChart = ({ items }: ProgramsAllocationChartProps)
                                 style={{ flexGrow: block.flexGrow }}
                             >
                                 <span className={styles.label}>{block.label}</span>
-                                <span className={styles.amount}>
-                                    <span className={styles.number}>{block.amount.toLocaleString('uk-UA')}</span>{' '}
-                                    <span className={styles.currency}>грн</span>
-                                </span>
+                                <span className={styles.amount}>{formatAmount(block.amount)}</span>
                             </div>
                         ))}
                     </div>

--- a/src/pages/public/reports-page/components/summary-section/stat-card/StatCard.test.tsx
+++ b/src/pages/public/reports-page/components/summary-section/stat-card/StatCard.test.tsx
@@ -35,6 +35,12 @@ describe('StatCard', () => {
         expect(screen.getByText('$20,000')).toBeInTheDocument();
     });
 
+    it('renders formattedValue without Intl formatting when provided', () => {
+        render(<StatCard value={20000} label="Revenue" formattedValue="Custom amount" currency="USD" />);
+
+        expect(screen.getByText('Custom amount')).toBeInTheDocument();
+    });
+
     it('applies default blue color class', () => {
         const { container } = render(<StatCard value={10} label="Test" />);
         const valueElement = container.querySelector('.value-class');

--- a/src/pages/public/reports-page/components/summary-section/stat-card/StatCard.tsx
+++ b/src/pages/public/reports-page/components/summary-section/stat-card/StatCard.tsx
@@ -10,19 +10,21 @@ interface StatCardProps {
     label: string;
     color?: ValueColorVariant;
     currency?: string;
+    formattedValue?: string;
     className?: string;
 }
 
-export const StatCard = ({ value, label, color = 'blue', currency, className }: StatCardProps) => {
+export const StatCard = ({ value, label, color = 'blue', currency, formattedValue, className }: StatCardProps) => {
     const { i18n } = useTranslation();
 
-    const formattedValue = useMemo(() => {
+    const displayValue = useMemo(() => {
+        if (formattedValue !== undefined) return formattedValue;
         return new Intl.NumberFormat(i18n.language, {
             style: currency ? 'currency' : 'decimal',
             currency: currency,
             maximumFractionDigits: 0,
         }).format(value);
-    }, [value, currency, i18n.language]);
+    }, [value, currency, formattedValue, i18n.language]);
 
     const rootClasses = cn(styles.card, className);
     const valueClasses = cn(styles.value, styles[`text-${color}`]);
@@ -30,7 +32,7 @@ export const StatCard = ({ value, label, color = 'blue', currency, className }: 
     return (
         <div className={rootClasses}>
             <div className={styles.wrapper}>
-                <div className={valueClasses}>{formattedValue}</div>
+                <div className={valueClasses}>{displayValue}</div>
                 <div className={styles.label}>{label}</div>
             </div>
         </div>

--- a/src/utils/functions/formatters/report-amount-formatters.test.ts
+++ b/src/utils/functions/formatters/report-amount-formatters.test.ts
@@ -1,0 +1,29 @@
+import { formatAllocationAmount, formatCollectedAmount } from './report-amount-formatters';
+
+const normalizeSpaces = (value: string) => value.replace(/\u00a0/g, ' ');
+
+describe('report-amount-formatters', () => {
+    describe('formatAllocationAmount', () => {
+        it('formats integer amounts with thousands separators', () => {
+            expect(normalizeSpaces(formatAllocationAmount(1234))).toBe('1 234');
+        });
+
+        it('formats decimal amounts with comma for Ukrainian locale', () => {
+            expect(normalizeSpaces(formatAllocationAmount(1234.56))).toBe('1 234,56');
+        });
+
+        it('formats decimal amounts with dot for English locale', () => {
+            expect(normalizeSpaces(formatAllocationAmount(1234.56, true))).toBe('1 234.56');
+        });
+    });
+
+    describe('formatCollectedAmount', () => {
+        it('truncates decimal amounts before formatting', () => {
+            expect(normalizeSpaces(formatCollectedAmount(1249854.09))).toBe('1 249 854');
+        });
+
+        it('formats integer amounts with thousands separators', () => {
+            expect(normalizeSpaces(formatCollectedAmount(1234))).toBe('1 234');
+        });
+    });
+});

--- a/src/utils/functions/formatters/report-amount-formatters.ts
+++ b/src/utils/functions/formatters/report-amount-formatters.ts
@@ -1,0 +1,19 @@
+const GROUP_LOCALE = 'uk-UA';
+
+export function formatAllocationAmount(amount: number, isEn = false): string {
+    const hasCents = Math.round(amount * 100) % 100 !== 0;
+
+    const formatted = new Intl.NumberFormat(GROUP_LOCALE, {
+        minimumFractionDigits: hasCents ? 2 : 0,
+        maximumFractionDigits: hasCents ? 2 : 0,
+    }).format(amount);
+
+    return isEn ? formatted.replace(',', '.') : formatted;
+}
+
+export function formatCollectedAmount(amount: number): string {
+    return new Intl.NumberFormat(GROUP_LOCALE, {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+    }).format(Math.trunc(amount));
+}

--- a/src/utils/mock-data/public/reports-page.ts
+++ b/src/utils/mock-data/public/reports-page.ts
@@ -1,9 +1,11 @@
 export const SUMMARY_DATA = {
     collected: {
         uah: 1249854.09,
-        usd: 32890.9,
+        usd: 29408.33,
     },
     livesChanged: 205,
+    disclaimer:
+        'Amounts shown in USD are approximate and provided for informational purposes only. They are converted from UAH using the official NBU exchange rate applicable for the reporting period. The organization\u2019s official accounting and financial records are maintained in UAH.',
 };
 
 export const REPORTS_DATA = [
@@ -26,20 +28,20 @@ export const CTA_DATA = {
 
 export const EXPENSES_DATA = {
     items: [
-        { label: 'Інші', amount: 2270, percent: 0.2 },
-        { label: 'Комунікація та партнерства', amount: 103485, percent: 9.3 },
-        { label: 'Операційні', amount: 290955, percent: 26.2 },
-        { label: 'Програмні', amount: 443042, percent: 64.3 },
+        { label: 'Інші', amount: { uah: 2270, usd: 53.41 }, percent: 0.2 },
+        { label: 'Комунікація та партнерства', amount: { uah: 103485, usd: 2434.94 }, percent: 9.3 },
+        { label: 'Операційні', amount: { uah: 290955, usd: 6846 }, percent: 26.2 },
+        { label: 'Програмні', amount: { uah: 443042, usd: 10424.52 }, percent: 64.3 },
     ],
 };
 
 export const FUNDING_DATA = {
     items: [
-        { amount: 100000, label: 'Підтримка від бізнесу' },
-        { amount: 371964.52, label: 'Грантові кошти' },
-        { amount: 267889.57, label: 'Благодійні внески' },
+        { amount: { uah: 100000, usd: 2352.94 }, label: 'Підтримка від бізнесу' },
+        { amount: { uah: 371964.52, usd: 8752.11 }, label: 'Грантові кошти' },
+        { amount: { uah: 267889.57, usd: 6303.28 }, label: 'Благодійні внески' },
         {
-            amount: 700000,
+            amount: { uah: 700000, usd: 16470.59 },
             label: 'Дуууже дооовга наааааааааааааааааааааааааааааааааааааааазва',
         },
     ],
@@ -49,19 +51,19 @@ export const PROGRAMS_ALLOCATION_DATA = {
     items: [
         {
             label: 'для ветеранів',
-            amount: 356052,
+            amount: { uah: 356052, usd: 8377.69 },
         },
         {
             label: 'для жінок',
-            amount: 152737,
+            amount: { uah: 152737, usd: 3593.81 },
         },
         {
             label: 'для дітей',
-            amount: 205000,
+            amount: { uah: 205000, usd: 4823.53 },
         },
         {
             label: 'інші',
-            amount: 35000,
+            amount: { uah: 35000, usd: 823.53 },
         },
     ],
 };


### PR DESCRIPTION
## GitHub ticket

* [GitHub ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/952)
<img width="1443" height="1058" alt="image" src="https://github.com/user-attachments/assets/fefe1474-7704-4cfe-8a9b-89e80d4b507f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented localized currency amount formatting for reports with proper thousands separators and locale-specific decimal conventions

* **Tests**
  * Added unit tests for currency formatting functions to ensure accurate localization

* **Chores**
  * Revised UI display labels in the reports summary section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->