### PR TITLE
Feature/issue-1439: [Reports] Add modal for creating new categories for Funds and Expenditures

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -146,6 +146,7 @@ export const FUNDS_EXPENDITURES_VALIDATION = {
         maxDecimalDigits: 6,
     },
     maxCategoriesPerType: 4,
+    categoryNameMax: 200,
 };
 
 export const FUNDS_EXPENDITURES_TEXT = {
@@ -188,11 +189,21 @@ export const FUNDS_EXPENDITURES_TEXT = {
             SUBMIT_BUTTON: 'Додати витрату',
             CONFIRM_ADD_TITLE: 'Додати нову витрату?',
         },
+        CATEGORY: {
+            TITLE: 'Додати категорію',
+            SUBTITLE: 'Додавання категорії витрат/надходжень для формування звітності',
+            TYPE_LABEL: 'Витрата/Надходження',
+            TYPE_PLACEHOLDER: 'Витрата/Надходження',
+            NAME_LABEL: 'Назва',
+            NAME_PLACEHOLDER: 'Введіть назву категорії',
+            SUBMIT_BUTTON: 'Зберегти',
+        },
     },
     BUTTON: {
         EDIT: 'Редагувати Доходи та витрати',
         ADD_INCOME: 'Надходження',
         ADD_EXPENSE: 'Витрати',
+        ADD_CATEGORY: 'Додати категорію',
     },
     FILTER: {
         TYPE_PLACEHOLDER: 'Тип',

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -146,6 +146,7 @@ export const FUNDS_EXPENDITURES_VALIDATION = {
         maxDecimalDigits: 6,
     },
     maxCategoriesPerType: 4,
+    categoryNameMin: 5,
     categoryNameMax: 200,
 };
 
@@ -160,6 +161,12 @@ export const FUNDS_EXPENDITURES_TEXT = {
         RECORD_DELETED_SUCCESSFULLY: 'Запис успішно видалено',
         RECORD_DELETE_FAILED_RETRY: 'Не вдалося видалити запис. Спробуйте ще раз',
         AMOUNT_USD_NOT_MATCH: 'Сума в USD не відповідає сумі в UAH',
+        CATEGORY_CREATED_SUCCESSFULLY: 'Категорію додано успішно',
+        CATEGORY_CREATE_FAILED_RETRY: 'Виникла помилка, спробуйте ще раз',
+        CATEGORY_DELETED_SUCCESSFULLY: 'Категорію видалено успішно',
+        CATEGORY_DELETE_FAILED_RETRY: 'Виникла помилка, спробуйте ще раз',
+        CATEGORY_UPDATED_SUCCESSFULLY: 'Категорію оновлено успішно',
+        CATEGORY_UPDATE_FAILED_RETRY: 'Виникла помилка, спробуйте ще раз',
     },
     MODAL: {
         SHARED: {
@@ -189,6 +196,29 @@ export const FUNDS_EXPENDITURES_TEXT = {
             SUBMIT_BUTTON: 'Додати витрату',
             CONFIRM_ADD_TITLE: 'Додати нову витрату?',
         },
+        EDIT_CATEGORY: {
+            TITLE: 'Редагувати категорію',
+            SUBTITLE: 'Редагування категорії витрат/надходжень для формування звітності',
+            CATEGORY_LABEL: 'Категорія',
+            CATEGORY_PLACEHOLDER: 'Оберіть категорію',
+            NAME_LABEL: 'Редагувати назву',
+            NAME_PLACEHOLDER: 'Введіть назву категорії',
+            SUBMIT_BUTTON: 'Зберегти',
+            CONFIRM_SAVE_TITLE: 'Зберегти зміни?',
+        },
+        DELETE_CATEGORY: {
+            TITLE: 'Видалити категорію',
+            CATEGORY_LABEL: 'Категорія',
+            CATEGORY_PLACEHOLDER: 'Оберіть категорію',
+            CONFIRM_TITLE: 'Видалити категорію?',
+            ERROR: {
+                getHasIncomeRecordTitle: (count: number) =>
+                    `Категорія використовується в надходженнях, ${count} ${count === 1 ? 'запис' : count < 5 ? 'записи' : 'записів'}`,
+                getHasExpenseRecordTitle: (count: number) =>
+                    `Категорія використовується у витратах, ${count} ${count === 1 ? 'запис' : count < 5 ? 'записи' : 'записів'}`,
+                HAS_RECORD_TEXT: 'Видаліть або змініть їх',
+            },
+        },
         CATEGORY: {
             TITLE: 'Додати категорію',
             SUBTITLE: 'Додавання категорії витрат/надходжень для формування звітності',
@@ -197,6 +227,9 @@ export const FUNDS_EXPENDITURES_TEXT = {
             NAME_LABEL: 'Назва',
             NAME_PLACEHOLDER: 'Введіть назву категорії',
             SUBMIT_BUTTON: 'Зберегти',
+            ERROR: {
+                NAME_DUPLICATE: 'Категорія з такою назвою вже існує',
+            },
         },
     },
     BUTTON: {
@@ -204,6 +237,8 @@ export const FUNDS_EXPENDITURES_TEXT = {
         ADD_INCOME: 'Надходження',
         ADD_EXPENSE: 'Витрати',
         ADD_CATEGORY: 'Додати категорію',
+        DELETE_CATEGORY: 'Видалити',
+        EDIT_CATEGORY: 'Редагувати',
     },
     FILTER: {
         TYPE_PLACEHOLDER: 'Тип',

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
@@ -254,6 +254,16 @@ jest.mock('./components/funds-expenditures-table/FundsExpendituresTable', () => 
     ),
 }));
 
+jest.mock('./components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal', () => ({
+    AddFundsExpendituresCategoryModal: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) => (
+        <div data-testid="add-category-modal" data-open={String(isOpen)}>
+            <button data-testid="add-category-modal-close" onClick={onClose}>
+                Close
+            </button>
+        </div>
+    ),
+}));
+
 jest.mock('./components/common/add-funds-expenditures-record-modal/AddFundsExpendituresRecordModal', () => ({
     AddFundsExpendituresRecordModal: ({
         isOpen,
@@ -861,6 +871,29 @@ describe('FundsExpenditureSection', () => {
             fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.NO));
 
             expect(screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE.TITLE)).not.toBeInTheDocument();
+        });
+    });
+
+    describe('add category modal', () => {
+        it('should render add category modal as closed by default', () => {
+            render(<FundsExpenditureSection />);
+
+            expect(screen.getByTestId('add-category-modal')).toHaveAttribute('data-open', 'false');
+        });
+
+        it('should render add category modal as open when isAddCategoryModalOpen is true', () => {
+            render(<FundsExpenditureSection isAddCategoryModalOpen onAddCategoryModalClose={jest.fn()} />);
+
+            expect(screen.getByTestId('add-category-modal')).toHaveAttribute('data-open', 'true');
+        });
+
+        it('should call onAddCategoryModalClose when modal close is triggered', () => {
+            const mockClose = jest.fn();
+            render(<FundsExpenditureSection isAddCategoryModalOpen onAddCategoryModalClose={mockClose} />);
+
+            fireEvent.click(screen.getByTestId('add-category-modal-close'));
+
+            expect(mockClose).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -30,6 +30,7 @@ import {
 } from './components/funds-expenditures-toolbar/FundsExpendituresToolbar';
 import { EnrichedRecord, FundsExpendituresTable } from './components/funds-expenditures-table/FundsExpendituresTable';
 import { AddFundsExpendituresRecordModal } from './components/common/add-funds-expenditures-record-modal/AddFundsExpendituresRecordModal';
+import { AddFundsExpendituresCategoryModal } from './components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal';
 import { DeleteRecordModal } from './components/common/delete-record-modal/DeleteRecordModal';
 import styles from './FundsExpendituresSection.module.scss';
 
@@ -49,6 +50,8 @@ interface FundsExpenditureSectionProps {
     draftExchangeRate?: string | null;
     onEditModeChange?: (isEditing: boolean) => void;
     onExchangeRateValueChange?: (exchangeRate: string | null) => void;
+    isAddCategoryModalOpen?: boolean;
+    onAddCategoryModalClose?: () => void;
 }
 
 export const FundsExpenditureSection = ({
@@ -56,6 +59,8 @@ export const FundsExpenditureSection = ({
     draftExchangeRate,
     onEditModeChange,
     onExchangeRateValueChange,
+    isAddCategoryModalOpen = false,
+    onAddCategoryModalClose,
 }: FundsExpenditureSectionProps = {}) => {
     const adminClient = useAdminClient();
     const { addToast } = useToast();
@@ -492,6 +497,11 @@ export const FundsExpenditureSection = ({
                 records={recordsState}
                 exchangeRate={currentExchangeRate}
                 onSubmit={handleCreateRecord}
+            />
+
+            <AddFundsExpendituresCategoryModal
+                isOpen={isAddCategoryModalOpen}
+                onClose={onAddCategoryModalClose ?? (() => {})}
             />
 
             <DeleteRecordModal

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -32,6 +32,8 @@ import { EnrichedRecord, FundsExpendituresTable } from './components/funds-expen
 import { AddFundsExpendituresRecordModal } from './components/common/add-funds-expenditures-record-modal/AddFundsExpendituresRecordModal';
 import { AddFundsExpendituresCategoryModal } from './components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal';
 import { DeleteRecordModal } from './components/common/delete-record-modal/DeleteRecordModal';
+import { DeleteFundsExpendituresCategoryModal } from './components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal';
+import { EditFundsExpendituresCategoryModal } from './components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal';
 import styles from './FundsExpendituresSection.module.scss';
 
 const enrichRecords = (
@@ -52,6 +54,10 @@ interface FundsExpenditureSectionProps {
     onExchangeRateValueChange?: (exchangeRate: string | null) => void;
     isAddCategoryModalOpen?: boolean;
     onAddCategoryModalClose?: () => void;
+    isDeleteCategoryModalOpen?: boolean;
+    onDeleteCategoryModalClose?: () => void;
+    isEditCategoryModalOpen?: boolean;
+    onEditCategoryModalClose?: () => void;
 }
 
 export const FundsExpenditureSection = ({
@@ -61,6 +67,10 @@ export const FundsExpenditureSection = ({
     onExchangeRateValueChange,
     isAddCategoryModalOpen = false,
     onAddCategoryModalClose,
+    isDeleteCategoryModalOpen = false,
+    onDeleteCategoryModalClose,
+    isEditCategoryModalOpen = false,
+    onEditCategoryModalClose,
 }: FundsExpenditureSectionProps = {}) => {
     const adminClient = useAdminClient();
     const { addToast } = useToast();
@@ -166,7 +176,11 @@ export const FundsExpenditureSection = ({
         onExchangeRateValueChange?.(settings?.exchangeRate ?? null);
     }, [onEditModeChange, onExchangeRateValueChange, settings?.exchangeRate]);
 
-    const { data: categories, isLoading: isCategoriesLoading } = useDataFetch<ReportFundsExpendituresCategory[]>({
+    const {
+        data: categories,
+        isLoading: isCategoriesLoading,
+        refetch: refetchCategories,
+    } = useDataFetch<ReportFundsExpendituresCategory[]>({
         initialData: [],
         fetchHandler: fetchCategories,
     });
@@ -226,7 +240,7 @@ export const FundsExpenditureSection = ({
 
         if (settings && !hasSeededEditingValuesRef.current) {
             const initialExchangeRateValue =
-                draftExchangeRate !== undefined ? (draftExchangeRate ?? '') : (settings.exchangeRate ?? '');
+                draftExchangeRate === undefined ? (settings.exchangeRate ?? '') : (draftExchangeRate ?? '');
 
             setDisclaimerValue((currentValue) => currentValue || (settings.disclaimerTitle ?? ''));
             setExchangeRateValue((currentValue) => currentValue || initialExchangeRateValue);
@@ -315,6 +329,53 @@ export const FundsExpenditureSection = ({
             }
         },
         [addToast, adminClient, refetchSummary],
+    );
+
+    const handleCreateCategory = useCallback(
+        async (data: { name: string; type: FundsExpendituresTransactionType }): Promise<boolean> => {
+            try {
+                await FundsExpendituresApi.createCategory(adminClient, data);
+                refetchCategories();
+                addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.CATEGORY_CREATED_SUCCESSFULLY, ToastType.Success);
+                return true;
+            } catch {
+                addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.CATEGORY_CREATE_FAILED_RETRY, ToastType.Error);
+                return false;
+            }
+        },
+        [addToast, adminClient, refetchCategories],
+    );
+
+    const handleEditCategory = useCallback(
+        async (categoryId: number, name: string): Promise<boolean> => {
+            const category = categories.find((c) => c.id === categoryId);
+            if (!category) return false;
+            try {
+                await FundsExpendituresApi.updateCategory(adminClient, categoryId, { name, type: category.type });
+                refetchCategories();
+                addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.CATEGORY_UPDATED_SUCCESSFULLY, ToastType.Success);
+                return true;
+            } catch {
+                addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.CATEGORY_UPDATE_FAILED_RETRY, ToastType.Error);
+                return false;
+            }
+        },
+        [addToast, adminClient, categories, refetchCategories],
+    );
+
+    const handleDeleteCategory = useCallback(
+        async (categoryId: number): Promise<boolean> => {
+            try {
+                await FundsExpendituresApi.deleteCategory(adminClient, categoryId);
+                refetchCategories();
+                addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.CATEGORY_DELETED_SUCCESSFULLY, ToastType.Success);
+                return true;
+            } catch {
+                addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.CATEGORY_DELETE_FAILED_RETRY, ToastType.Error);
+                return false;
+            }
+        },
+        [addToast, adminClient, refetchCategories],
     );
 
     const handleDeleteClick = (record: ReportFundsExpendituresRecord) => {
@@ -502,6 +563,23 @@ export const FundsExpenditureSection = ({
             <AddFundsExpendituresCategoryModal
                 isOpen={isAddCategoryModalOpen}
                 onClose={onAddCategoryModalClose ?? (() => {})}
+                categories={categories}
+                onSubmit={handleCreateCategory}
+            />
+
+            <EditFundsExpendituresCategoryModal
+                isOpen={isEditCategoryModalOpen}
+                onClose={onEditCategoryModalClose ?? (() => {})}
+                categories={categories}
+                onSubmit={handleEditCategory}
+            />
+
+            <DeleteFundsExpendituresCategoryModal
+                isOpen={isDeleteCategoryModalOpen}
+                onClose={onDeleteCategoryModalClose ?? (() => {})}
+                categories={categories}
+                records={recordsState}
+                onSubmit={handleDeleteCategory}
             />
 
             <DeleteRecordModal

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.module.scss
@@ -1,0 +1,178 @@
+@use '@/assets/sass/variables/colors' as c;
+@use '@/assets/sass/mixins/typography.mixins' as type;
+
+.form {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    width: 100%;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
+.label {
+    @include type.small-text-medium;
+    color: c.$bluish-black;
+    margin-bottom: 8px;
+}
+
+.required {
+    color: c.$error;
+    margin-right: 6px;
+}
+
+.selectContainer {
+    width: 100%;
+}
+
+.selectHead {
+    width: 100%;
+    height: 3rem;
+    padding: 0 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border: 1px solid c.$grey-700;
+    border-radius: 8px;
+    background: c.$white;
+}
+
+.input {
+    width: 100%;
+}
+
+.panel :global(.char-limit-input) {
+    width: 100%;
+}
+
+.panel :global(.select-options) {
+    width: 100%;
+}
+
+.modal {
+    width: 650px;
+
+    :global(.modal-container) {
+        width: 650px;
+        max-width: 650px;
+        border-radius: 8px;
+        background: c.$white;
+        padding: 0;
+    }
+
+    :global(.modal-header) {
+        margin-bottom: 0;
+        padding: 24px 24px 0;
+    }
+
+    :global(.modal-header .modal-title-wrapper) {
+        text-align: left;
+    }
+
+    :global(.modal-header .modal-header-text) {
+        font-size: inherit;
+        line-height: inherit;
+        text-align: left;
+    }
+
+    :global(.modal-header .close-icon) {
+        margin-bottom: 4px;
+        padding-right: 0;
+    }
+
+    :global(.modal-body) {
+        margin-bottom: 0;
+        padding: 18px 0 0;
+    }
+
+    :global(.modal-footer) {
+        padding: 16px 24px 24px;
+        gap: 24px;
+        flex-wrap: nowrap;
+        justify-content: center;
+    }
+
+    :global(.modal-footer button) {
+        width: 100%;
+    }
+}
+
+.header {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+}
+
+.title {
+    @include type.h4-bold;
+    line-height: 36px;
+    margin: 0;
+    color: c.$blue-900;
+}
+
+.subtitle {
+    @include type.body-1-regular;
+    line-height: 20px;
+    margin: 0;
+    color: c.$grey-400;
+}
+
+.content {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.panel {
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+    background: c.$grey-50;
+    border: 1px solid c.$grey-150;
+    padding: 20px 22px;
+    min-height: 180px;
+}
+
+.actions {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+}
+
+.submit {
+    @include type.subtitle-2-medium;
+    height: 60px;
+    width: 100%;
+}
+
+@media (max-width: 768px) {
+    .modal {
+        width: 100%;
+
+        :global(.modal-container) {
+            width: 100%;
+            max-width: 100%;
+        }
+
+        :global(.modal-header) {
+            padding: 12px 16px 0;
+        }
+
+        :global(.modal-footer) {
+            padding: 0 16px 16px;
+            flex-wrap: wrap;
+        }
+    }
+
+    .panel {
+        padding: 16px;
+        min-height: auto;
+    }
+}

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.test.tsx
@@ -1,0 +1,221 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { AddFundsExpendituresCategoryModal } from './AddFundsExpendituresCategoryModal';
+
+jest.mock('@/components/common/modal/Modal', () => {
+    const Modal = ({ isOpen, onClose, children }: any) => {
+        if (!isOpen) return null;
+        return (
+            <div data-testid="modal">
+                <button data-testid="modal-close" onClick={onClose} />
+                {children}
+            </div>
+        );
+    };
+    Modal.Title = ({ children }: any) => <>{children}</>;
+    Modal.Content = ({ children }: any) => <>{children}</>;
+    Modal.Actions = ({ children }: any) => <>{children}</>;
+    return { Modal };
+});
+
+jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
+    ConfirmationModal: ({ isOpen, title, onConfirm, onCancel, onClose }: any) => (
+        <div data-testid="confirm-modal" data-open={String(isOpen)}>
+            <span>{title}</span>
+            <button data-testid="confirm-yes" onClick={onConfirm}>
+                Yes
+            </button>
+            <button data-testid="confirm-no" onClick={onCancel}>
+                No
+            </button>
+            <button data-testid="confirm-close" onClick={onClose}>
+                Close
+            </button>
+        </div>
+    ),
+}));
+
+jest.mock('@/components/admin/input-with-character-limit/InputWithCharacterLimit', () => ({
+    InputWithCharacterLimit: ({ id, value, onChange, onBlur, placeholder }: any) => (
+        <input data-testid={id} value={value} onChange={onChange} onBlur={onBlur} placeholder={placeholder} />
+    ),
+}));
+
+jest.mock('@/components/common/select/Select', () => {
+    const React = require('react');
+
+    const Select = ({ value, onValueChange, placeholder, children }: any) => {
+        const options = React.Children.toArray(children)
+            .filter((child: any) => child?.props)
+            .map((child: any) => ({ value: child.props.value, name: child.props.name }));
+
+        return (
+            <select
+                data-testid={placeholder}
+                value={value ?? ''}
+                onChange={(e) => {
+                    const selected = options.find((item: any) => item.value === e.target.value);
+                    onValueChange(selected?.value);
+                }}
+            >
+                <option value="">placeholder</option>
+                {options.map((option: any) => (
+                    <option key={option.value} value={option.value}>
+                        {option.name}
+                    </option>
+                ))}
+            </select>
+        );
+    };
+
+    Select.Option = (_props: any) => null;
+
+    return { Select };
+});
+
+describe('AddFundsExpendituresCategoryModal', () => {
+    const TYPE_SELECT = FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.TYPE_PLACEHOLDER;
+    const NAME_INPUT = 'category-name';
+    const SUBMIT_BUTTON_NAME = FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.SUBMIT_BUTTON;
+
+    const renderOpen = (onClose = jest.fn()) =>
+        render(<AddFundsExpendituresCategoryModal isOpen={true} onClose={onClose} />);
+
+    const getSubmitButton = () => screen.getByRole('button', { name: SUBMIT_BUTTON_NAME });
+
+    it('renders nothing when isOpen is false', () => {
+        render(<AddFundsExpendituresCategoryModal isOpen={false} onClose={jest.fn()} />);
+        expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+    });
+
+    it('renders title and subtitle when open', () => {
+        renderOpen();
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.TITLE)).toBeInTheDocument();
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.SUBTITLE)).toBeInTheDocument();
+    });
+
+    it('renders submit button with correct label', () => {
+        renderOpen();
+        expect(getSubmitButton()).toBeInTheDocument();
+    });
+
+    describe('submit button disabled state', () => {
+        it('is disabled by default', () => {
+            renderOpen();
+            expect(getSubmitButton()).toBeDisabled();
+        });
+
+        it('is disabled when type is selected but name is empty', () => {
+            renderOpen();
+            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'expense' } });
+            expect(getSubmitButton()).toBeDisabled();
+        });
+
+        it('is disabled when name is entered but type is not selected', () => {
+            renderOpen();
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Category A' } });
+            expect(getSubmitButton()).toBeDisabled();
+        });
+
+        it('is disabled when name contains only whitespace', () => {
+            renderOpen();
+            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'income' } });
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: '   ' } });
+            expect(getSubmitButton()).toBeDisabled();
+        });
+
+        it('is enabled when both type and non-empty name are set', () => {
+            renderOpen();
+            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'expense' } });
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Category A' } });
+            expect(getSubmitButton()).not.toBeDisabled();
+        });
+    });
+
+    it('clicking submit does not throw when enabled', () => {
+        renderOpen();
+        fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'income' } });
+        fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Valid name' } });
+        expect(() => fireEvent.click(getSubmitButton())).not.toThrow();
+    });
+
+    it('normalizes whitespace in name input on blur', () => {
+        renderOpen();
+        const nameInput = screen.getByTestId(NAME_INPUT);
+        fireEvent.change(nameInput, { target: { value: '  foo   bar  ' } });
+        fireEvent.blur(nameInput);
+        expect(nameInput).toHaveValue('foo bar');
+    });
+
+    describe('close behavior', () => {
+        it('calls onClose directly when form is clean', () => {
+            const onClose = jest.fn();
+            renderOpen(onClose);
+            fireEvent.click(screen.getByTestId('modal-close'));
+            expect(onClose).toHaveBeenCalledTimes(1);
+            expect(screen.getByTestId('confirm-modal')).toHaveAttribute('data-open', 'false');
+        });
+
+        it('opens confirmation modal when type is dirty on close request', () => {
+            const onClose = jest.fn();
+            renderOpen(onClose);
+            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'expense' } });
+            fireEvent.click(screen.getByTestId('modal-close'));
+            expect(onClose).not.toHaveBeenCalled();
+            expect(screen.getByTestId('confirm-modal')).toHaveAttribute('data-open', 'true');
+        });
+
+        it('opens confirmation modal when name is dirty on close request', () => {
+            const onClose = jest.fn();
+            renderOpen(onClose);
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Some text' } });
+            fireEvent.click(screen.getByTestId('modal-close'));
+            expect(onClose).not.toHaveBeenCalled();
+            expect(screen.getByTestId('confirm-modal')).toHaveAttribute('data-open', 'true');
+        });
+
+        it('shows correct title in confirmation modal', () => {
+            renderOpen();
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'dirty' } });
+            fireEvent.click(screen.getByTestId('modal-close'));
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.CONFIRM_CLOSE_TITLE)).toBeInTheDocument();
+        });
+
+        it('dismisses confirmation and keeps modal open on cancel via onCancel', () => {
+            const onClose = jest.fn();
+            renderOpen(onClose);
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'dirty' } });
+            fireEvent.click(screen.getByTestId('modal-close'));
+            fireEvent.click(screen.getByTestId('confirm-no'));
+            expect(onClose).not.toHaveBeenCalled();
+            expect(screen.getByTestId('confirm-modal')).toHaveAttribute('data-open', 'false');
+            expect(screen.getByTestId('modal')).toBeInTheDocument();
+        });
+
+        it('dismisses confirmation and keeps modal open on cancel via onClose', () => {
+            const onClose = jest.fn();
+            renderOpen(onClose);
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'dirty' } });
+            fireEvent.click(screen.getByTestId('modal-close'));
+            fireEvent.click(screen.getByTestId('confirm-close'));
+            expect(onClose).not.toHaveBeenCalled();
+            expect(screen.getByTestId('confirm-modal')).toHaveAttribute('data-open', 'false');
+        });
+
+        it('calls onClose and resets form on confirm close', () => {
+            const onClose = jest.fn();
+            renderOpen(onClose);
+            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'expense' } });
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Category A' } });
+            expect(getSubmitButton()).not.toBeDisabled();
+
+            fireEvent.click(screen.getByTestId('modal-close'));
+            fireEvent.click(screen.getByTestId('confirm-yes'));
+
+            expect(onClose).toHaveBeenCalledTimes(1);
+            expect(screen.getByTestId('confirm-modal')).toHaveAttribute('data-open', 'false');
+            expect(screen.getByTestId(NAME_INPUT)).toHaveValue('');
+            expect(getSubmitButton()).toBeDisabled();
+        });
+    });
+});

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.test.tsx
@@ -42,34 +42,10 @@ jest.mock('@/components/admin/input-with-character-limit/InputWithCharacterLimit
 }));
 
 jest.mock('@/components/common/select/Select', () => {
-    const React = require('react');
-
-    const Select = ({ value, onValueChange, placeholder, children }: any) => {
-        const options = React.Children.toArray(children)
-            .filter((child: any) => child?.props)
-            .map((child: any) => ({ value: child.props.value, name: child.props.name }));
-
-        return (
-            <select
-                data-testid={placeholder}
-                value={value ?? ''}
-                onChange={(e) => {
-                    const selected = options.find((item: any) => item.value === e.target.value);
-                    onValueChange(selected?.value);
-                }}
-            >
-                <option value="">placeholder</option>
-                {options.map((option: any) => (
-                    <option key={option.value} value={option.value}>
-                        {option.name}
-                    </option>
-                ))}
-            </select>
-        );
-    };
-
+    const Select = ({ value, onValueChange, placeholder }: any) => (
+        <input data-testid={placeholder} value={value ?? ''} onChange={(e) => onValueChange(e.target.value)} />
+    );
     Select.Option = (_props: any) => null;
-
     return { Select };
 });
 
@@ -82,6 +58,11 @@ describe('AddFundsExpendituresCategoryModal', () => {
         render(<AddFundsExpendituresCategoryModal isOpen={true} onClose={onClose} />);
 
     const getSubmitButton = () => screen.getByRole('button', { name: SUBMIT_BUTTON_NAME });
+
+    const fillForm = (type = 'expense', name = 'Category A') => {
+        fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: type } });
+        fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: name } });
+    };
 
     it('renders nothing when isOpen is false', () => {
         render(<AddFundsExpendituresCategoryModal isOpen={false} onClose={jest.fn()} />);
@@ -119,23 +100,20 @@ describe('AddFundsExpendituresCategoryModal', () => {
 
         it('is disabled when name contains only whitespace', () => {
             renderOpen();
-            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'income' } });
-            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: '   ' } });
+            fillForm('income', '   ');
             expect(getSubmitButton()).toBeDisabled();
         });
 
         it('is enabled when both type and non-empty name are set', () => {
             renderOpen();
-            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'expense' } });
-            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Category A' } });
+            fillForm();
             expect(getSubmitButton()).not.toBeDisabled();
         });
     });
 
     it('clicking submit does not throw when enabled', () => {
         renderOpen();
-        fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'income' } });
-        fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Valid name' } });
+        fillForm('income', 'Valid name');
         expect(() => fireEvent.click(getSubmitButton())).not.toThrow();
     });
 
@@ -148,6 +126,13 @@ describe('AddFundsExpendituresCategoryModal', () => {
     });
 
     describe('close behavior', () => {
+        const triggerDirtyClose = (onClose = jest.fn()) => {
+            renderOpen(onClose);
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'dirty' } });
+            fireEvent.click(screen.getByTestId('modal-close'));
+            return onClose;
+        };
+
         it('calls onClose directly when form is clean', () => {
             const onClose = jest.fn();
             renderOpen(onClose);
@@ -166,26 +151,18 @@ describe('AddFundsExpendituresCategoryModal', () => {
         });
 
         it('opens confirmation modal when name is dirty on close request', () => {
-            const onClose = jest.fn();
-            renderOpen(onClose);
-            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Some text' } });
-            fireEvent.click(screen.getByTestId('modal-close'));
+            const onClose = triggerDirtyClose();
             expect(onClose).not.toHaveBeenCalled();
             expect(screen.getByTestId('confirm-modal')).toHaveAttribute('data-open', 'true');
         });
 
         it('shows correct title in confirmation modal', () => {
-            renderOpen();
-            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'dirty' } });
-            fireEvent.click(screen.getByTestId('modal-close'));
+            triggerDirtyClose();
             expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.CONFIRM_CLOSE_TITLE)).toBeInTheDocument();
         });
 
         it('dismisses confirmation and keeps modal open on cancel via onCancel', () => {
-            const onClose = jest.fn();
-            renderOpen(onClose);
-            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'dirty' } });
-            fireEvent.click(screen.getByTestId('modal-close'));
+            const onClose = triggerDirtyClose();
             fireEvent.click(screen.getByTestId('confirm-no'));
             expect(onClose).not.toHaveBeenCalled();
             expect(screen.getByTestId('confirm-modal')).toHaveAttribute('data-open', 'false');
@@ -193,10 +170,7 @@ describe('AddFundsExpendituresCategoryModal', () => {
         });
 
         it('dismisses confirmation and keeps modal open on cancel via onClose', () => {
-            const onClose = jest.fn();
-            renderOpen(onClose);
-            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'dirty' } });
-            fireEvent.click(screen.getByTestId('modal-close'));
+            const onClose = triggerDirtyClose();
             fireEvent.click(screen.getByTestId('confirm-close'));
             expect(onClose).not.toHaveBeenCalled();
             expect(screen.getByTestId('confirm-modal')).toHaveAttribute('data-open', 'false');
@@ -205,8 +179,7 @@ describe('AddFundsExpendituresCategoryModal', () => {
         it('calls onClose and resets form on confirm close', () => {
             const onClose = jest.fn();
             renderOpen(onClose);
-            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'expense' } });
-            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Category A' } });
+            fillForm();
             expect(getSubmitButton()).not.toBeDisabled();
 
             fireEvent.click(screen.getByTestId('modal-close'));

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.test.tsx
@@ -1,22 +1,8 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
 import { AddFundsExpendituresCategoryModal } from './AddFundsExpendituresCategoryModal';
-
-jest.mock('@/components/common/modal/Modal', () => {
-    const Modal = ({ isOpen, onClose, children }: any) => {
-        if (!isOpen) return null;
-        return (
-            <div data-testid="modal">
-                <button data-testid="modal-close" onClick={onClose} />
-                {children}
-            </div>
-        );
-    };
-    Modal.Title = ({ children }: any) => <>{children}</>;
-    Modal.Content = ({ children }: any) => <>{children}</>;
-    Modal.Actions = ({ children }: any) => <>{children}</>;
-    return { Modal };
-});
 
 jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
     ConfirmationModal: ({ isOpen, title, onConfirm, onCancel, onClose }: any) => (
@@ -53,9 +39,12 @@ describe('AddFundsExpendituresCategoryModal', () => {
     const TYPE_SELECT = FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.TYPE_PLACEHOLDER;
     const NAME_INPUT = 'category-name';
     const SUBMIT_BUTTON_NAME = FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.SUBMIT_BUTTON;
+    const REQUIRED_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
+    const MIN_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMin);
+    const DUPLICATE_ERROR = FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.ERROR.NAME_DUPLICATE;
 
-    const renderOpen = (onClose = jest.fn()) =>
-        render(<AddFundsExpendituresCategoryModal isOpen={true} onClose={onClose} />);
+    const renderOpen = (onClose = jest.fn(), categories: ReportFundsExpendituresCategory[] = []) =>
+        render(<AddFundsExpendituresCategoryModal isOpen={true} onClose={onClose} categories={categories} />);
 
     const getSubmitButton = () => screen.getByRole('button', { name: SUBMIT_BUTTON_NAME });
 
@@ -66,7 +55,7 @@ describe('AddFundsExpendituresCategoryModal', () => {
 
     it('renders nothing when isOpen is false', () => {
         render(<AddFundsExpendituresCategoryModal isOpen={false} onClose={jest.fn()} />);
-        expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('modal-overlay')).not.toBeInTheDocument();
     });
 
     it('renders title and subtitle when open', () => {
@@ -86,35 +75,162 @@ describe('AddFundsExpendituresCategoryModal', () => {
             expect(getSubmitButton()).toBeDisabled();
         });
 
-        it('is disabled when type is selected but name is empty', () => {
+        it('is disabled when form is incomplete', () => {
             renderOpen();
-            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'expense' } });
+            fillForm('expense', 'abc');
             expect(getSubmitButton()).toBeDisabled();
         });
 
-        it('is disabled when name is entered but type is not selected', () => {
-            renderOpen();
-            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Category A' } });
-            expect(getSubmitButton()).toBeDisabled();
-        });
-
-        it('is disabled when name contains only whitespace', () => {
-            renderOpen();
-            fillForm('income', '   ');
-            expect(getSubmitButton()).toBeDisabled();
-        });
-
-        it('is enabled when both type and non-empty name are set', () => {
+        it('is enabled when both type and valid name are set', () => {
             renderOpen();
             fillForm();
             expect(getSubmitButton()).not.toBeDisabled();
         });
     });
 
-    it('clicking submit does not throw when enabled', () => {
-        renderOpen();
-        fillForm('income', 'Valid name');
-        expect(() => fireEvent.click(getSubmitButton())).not.toThrow();
+    describe('name field validation', () => {
+        it('shows required error on blur when name is empty', () => {
+            renderOpen();
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(REQUIRED_ERROR)).toBeInTheDocument();
+        });
+
+        it('shows min length error on blur when name is too short', () => {
+            renderOpen();
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'abc' } });
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(MIN_ERROR)).toBeInTheDocument();
+        });
+
+        it('shows duplicate error on blur when name matches existing category for same type', () => {
+            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Приватні донори', type: 'income' }];
+            renderOpen(jest.fn(), categories);
+            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'income' } });
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Донори приватні' } });
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(DUPLICATE_ERROR)).toBeInTheDocument();
+        });
+
+        it('does not show duplicate error when type differs from existing category', () => {
+            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Приватні донори', type: 'expense' }];
+            renderOpen(jest.fn(), categories);
+            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'income' } });
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Приватні донори' } });
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.queryByText(DUPLICATE_ERROR)).not.toBeInTheDocument();
+        });
+
+        it('clears name error when name becomes valid on re-blur', () => {
+            renderOpen();
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'ab' } });
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(MIN_ERROR)).toBeInTheDocument();
+
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Valid name' } });
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.queryByText(MIN_ERROR)).not.toBeInTheDocument();
+        });
+    });
+
+    describe('name re-validation on type change', () => {
+        it('shows duplicate error when type changes to one that has the same name', () => {
+            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Category A', type: 'expense' }];
+            renderOpen(jest.fn(), categories);
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Category A' } });
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.queryByText(DUPLICATE_ERROR)).not.toBeInTheDocument();
+
+            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'expense' } });
+            expect(screen.getByText(DUPLICATE_ERROR)).toBeInTheDocument();
+        });
+
+        it('clears duplicate error when type changes to one without the same name', () => {
+            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Category A', type: 'income' }];
+            renderOpen(jest.fn(), categories);
+            fillForm('income', 'Category A');
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(DUPLICATE_ERROR)).toBeInTheDocument();
+
+            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'expense' } });
+            expect(screen.queryByText(DUPLICATE_ERROR)).not.toBeInTheDocument();
+        });
+
+        it('does not show name error on type change before name has been blurred', () => {
+            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Category A', type: 'expense' }];
+            renderOpen(jest.fn(), categories);
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Category A' } });
+
+            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'expense' } });
+            expect(screen.queryByText(DUPLICATE_ERROR)).not.toBeInTheDocument();
+        });
+    });
+
+    describe('type field validation', () => {
+        it('shows required error when type field loses focus without selection', () => {
+            renderOpen();
+            fireEvent.blur(screen.getByTestId(TYPE_SELECT));
+            expect(screen.getByText(REQUIRED_ERROR)).toBeInTheDocument();
+        });
+
+        it('clears type error when type is selected', () => {
+            renderOpen();
+            fireEvent.blur(screen.getByTestId(TYPE_SELECT));
+            expect(screen.getByText(REQUIRED_ERROR)).toBeInTheDocument();
+
+            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'income' } });
+            expect(screen.queryByText(REQUIRED_ERROR)).not.toBeInTheDocument();
+        });
+    });
+
+    describe('submit behaviour', () => {
+        const renderWithSubmit = (onSubmit: jest.Mock, onClose = jest.fn()) =>
+            render(<AddFundsExpendituresCategoryModal isOpen={true} onClose={onClose} onSubmit={onSubmit} />);
+
+        it('calls onSubmit with normalized name and type on click', async () => {
+            const onSubmit = jest.fn().mockResolvedValue(true);
+            renderWithSubmit(onSubmit);
+            fillForm('income', '  Valid name  ');
+            fireEvent.click(getSubmitButton());
+            await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ name: 'Valid name', type: 'income' }));
+        });
+
+        it('resets form and calls onClose when onSubmit resolves true', async () => {
+            const onClose = jest.fn();
+            const onSubmit = jest.fn().mockResolvedValue(true);
+            renderWithSubmit(onSubmit, onClose);
+            fillForm('expense', 'Valid name');
+            fireEvent.click(getSubmitButton());
+            await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+            expect(screen.getByTestId('category-name')).toHaveValue('');
+            expect(getSubmitButton()).toBeDisabled();
+        });
+
+        it('keeps modal open when onSubmit resolves false', async () => {
+            const onClose = jest.fn();
+            const onSubmit = jest.fn().mockResolvedValue(false);
+            renderWithSubmit(onSubmit, onClose);
+            fillForm('income', 'Valid name');
+            fireEvent.click(getSubmitButton());
+            await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+            expect(onClose).not.toHaveBeenCalled();
+            expect(screen.getByTestId('modal-overlay')).toBeInTheDocument();
+        });
+
+        it('disables submit button while submitting', async () => {
+            let resolve!: (v: boolean) => void;
+            const onSubmit = jest.fn().mockReturnValue(
+                new Promise<boolean>((r) => {
+                    resolve = r;
+                }),
+            );
+            renderWithSubmit(onSubmit);
+            fillForm('income', 'Valid name');
+            fireEvent.click(getSubmitButton());
+            expect(getSubmitButton()).toBeDisabled();
+            await act(async () => {
+                resolve(true);
+            });
+        });
     });
 
     it('normalizes whitespace in name input on blur', () => {
@@ -129,23 +245,32 @@ describe('AddFundsExpendituresCategoryModal', () => {
         const triggerDirtyClose = (onClose = jest.fn()) => {
             renderOpen(onClose);
             fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'dirty' } });
-            fireEvent.click(screen.getByTestId('modal-close'));
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
             return onClose;
         };
 
         it('calls onClose directly when form is clean', () => {
             const onClose = jest.fn();
             renderOpen(onClose);
-            fireEvent.click(screen.getByTestId('modal-close'));
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
             expect(onClose).toHaveBeenCalledTimes(1);
             expect(screen.getByTestId('confirm-modal')).toHaveAttribute('data-open', 'false');
+        });
+
+        it('resets errors when closing a clean form', () => {
+            renderOpen();
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(REQUIRED_ERROR)).toBeInTheDocument();
+
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+            expect(screen.queryByText(REQUIRED_ERROR)).not.toBeInTheDocument();
         });
 
         it('opens confirmation modal when type is dirty on close request', () => {
             const onClose = jest.fn();
             renderOpen(onClose);
             fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'expense' } });
-            fireEvent.click(screen.getByTestId('modal-close'));
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
             expect(onClose).not.toHaveBeenCalled();
             expect(screen.getByTestId('confirm-modal')).toHaveAttribute('data-open', 'true');
         });
@@ -166,7 +291,7 @@ describe('AddFundsExpendituresCategoryModal', () => {
             fireEvent.click(screen.getByTestId('confirm-no'));
             expect(onClose).not.toHaveBeenCalled();
             expect(screen.getByTestId('confirm-modal')).toHaveAttribute('data-open', 'false');
-            expect(screen.getByTestId('modal')).toBeInTheDocument();
+            expect(screen.getByTestId('modal-overlay')).toBeInTheDocument();
         });
 
         it('dismisses confirmation and keeps modal open on cancel via onClose', () => {
@@ -182,7 +307,7 @@ describe('AddFundsExpendituresCategoryModal', () => {
             fillForm();
             expect(getSubmitButton()).not.toBeDisabled();
 
-            fireEvent.click(screen.getByTestId('modal-close'));
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
             fireEvent.click(screen.getByTestId('confirm-yes'));
 
             expect(onClose).toHaveBeenCalledTimes(1);

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.tsx
@@ -1,0 +1,137 @@
+import { useCallback, useMemo, useState } from 'react';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { InputWithCharacterLimit } from '@/components/admin/input-with-character-limit/InputWithCharacterLimit';
+import { Select } from '@/components/common/select/Select';
+import { Modal } from '@/components/common/modal/Modal';
+import { Button } from '@/components/admin/button/Button';
+import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
+import { FundsExpendituresTransactionType } from '@/types/admin/reports';
+import styles from './AddFundsExpendituresCategoryModal.module.scss';
+
+interface AddFundsExpendituresCategoryModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+const normalizeForSave = (value: string) => value.replaceAll(/\s+/g, ' ').trim();
+
+export const AddFundsExpendituresCategoryModal = ({ isOpen, onClose }: AddFundsExpendituresCategoryModalProps) => {
+    const [type, setType] = useState<FundsExpendituresTransactionType | undefined>(undefined);
+    const [name, setName] = useState('');
+    const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false);
+
+    const nameMax = FUNDS_EXPENDITURES_VALIDATION.categoryNameMax;
+    const isDirty = type !== undefined || name.trim().length > 0;
+
+    const isSubmitDisabled = useMemo(() => {
+        return !type || normalizeForSave(name).length === 0;
+    }, [type, name]);
+
+    const resetForm = useCallback(() => {
+        setName('');
+        setType(undefined);
+    }, []);
+
+    const handleSubmit = () => {};
+
+    const handleRequestClose = useCallback(() => {
+        if (isDirty) {
+            setIsCloseConfirmOpen(true);
+            return;
+        }
+        onClose();
+    }, [isDirty, onClose]);
+
+    const handleConfirmClose = useCallback(() => {
+        setIsCloseConfirmOpen(false);
+        resetForm();
+        onClose();
+    }, [resetForm, onClose]);
+
+    const handleCancelClose = useCallback(() => {
+        setIsCloseConfirmOpen(false);
+    }, []);
+
+    return (
+        <>
+            <Modal isOpen={isOpen} onClose={handleRequestClose} className={styles.modal} maxWidth="650px">
+                <Modal.Title>
+                    <div className={styles.header}>
+                        <h2 className={styles.title}>{FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.TITLE}</h2>
+                        <p className={styles.subtitle}>{FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.SUBTITLE}</p>
+                    </div>
+                </Modal.Title>
+
+                <Modal.Content>
+                    <div className={styles.content}>
+                        <div className={styles.panel}>
+                            <div className={styles.form}>
+                                <div className={styles.field}>
+                                    <label className={styles.label}>
+                                        <span className={styles.required}>*</span>
+                                        {FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.TYPE_LABEL}
+                                    </label>
+                                    <Select<FundsExpendituresTransactionType>
+                                        value={type}
+                                        onValueChange={(v) => setType(v)}
+                                        placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.TYPE_PLACEHOLDER}
+                                        className={styles.selectContainer}
+                                        headClassName={styles.selectHead}
+                                    >
+                                        <Select.Option
+                                            value="expense"
+                                            name={FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.EXPENSE}
+                                        />
+                                        <Select.Option
+                                            value="income"
+                                            name={FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME}
+                                        />
+                                    </Select>
+                                </div>
+
+                                <div className={styles.field}>
+                                    <label className={styles.label}>
+                                        <span className={styles.required}>*</span>
+                                        {FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.NAME_LABEL}
+                                    </label>
+                                    <InputWithCharacterLimit
+                                        id="category-name"
+                                        name="categoryName"
+                                        value={name}
+                                        onChange={(e) => setName(e.target.value)}
+                                        onBlur={() => setName((s) => s.replaceAll(/\s+/g, ' ').trim())}
+                                        maxLength={nameMax}
+                                        placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.NAME_PLACEHOLDER}
+                                        showCounter={true}
+                                        className={styles.input}
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </Modal.Content>
+
+                <Modal.Actions>
+                    <div className={styles.actions}>
+                        <Button
+                            buttonStyle="primary"
+                            onClick={handleSubmit}
+                            disabled={isSubmitDisabled}
+                            className={styles.submit}
+                        >
+                            {FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.SUBMIT_BUTTON}
+                        </Button>
+                    </div>
+                </Modal.Actions>
+            </Modal>
+
+            <ConfirmationModal
+                isOpen={isCloseConfirmOpen}
+                title={FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.CONFIRM_CLOSE_TITLE}
+                onConfirm={handleConfirmClose}
+                onCancel={handleCancelClose}
+                onClose={handleCancelClose}
+            />
+        </>
+    );
+};

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.tsx
@@ -1,46 +1,118 @@
-import { useCallback, useMemo, useState } from 'react';
+import { FocusEvent, useCallback, useMemo, useRef, useState } from 'react';
+import cn from 'classnames';
 import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { InputWithCharacterLimit } from '@/components/admin/input-with-character-limit/InputWithCharacterLimit';
 import { Select } from '@/components/common/select/Select';
 import { Modal } from '@/components/common/modal/Modal';
 import { Button } from '@/components/admin/button/Button';
 import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
-import { FundsExpendituresTransactionType } from '@/types/admin/reports';
+import { FundsExpendituresTransactionType, ReportFundsExpendituresCategory } from '@/types/admin/reports';
+import { getNormalizedInputText } from '@/utils/functions/formatters/text-formatters';
+import {
+    validateFundsExpendituresCategoryName,
+    validateFundsExpendituresCategoryType,
+} from '@/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema';
 import styles from './AddFundsExpendituresCategoryModal.module.scss';
+
+const renderInputWithError = (
+    input: React.ReactNode,
+    error?: string,
+    inputErrorClass?: string,
+    errorClass?: string,
+) => (
+    <>
+        <div className={cn({ [inputErrorClass || '']: Boolean(error) })}>{input}</div>
+        <p className={cn(errorClass, { [styles.errorHidden]: !error })}>{error ?? ' '}</p>
+    </>
+);
 
 interface AddFundsExpendituresCategoryModalProps {
     isOpen: boolean;
     onClose: () => void;
+    categories?: ReportFundsExpendituresCategory[];
+    onSubmit?: (data: { name: string; type: FundsExpendituresTransactionType }) => Promise<boolean>;
 }
 
-const normalizeForSave = (value: string) => value.replaceAll(/\s+/g, ' ').trim();
-
-export const AddFundsExpendituresCategoryModal = ({ isOpen, onClose }: AddFundsExpendituresCategoryModalProps) => {
+export const AddFundsExpendituresCategoryModal = ({
+    isOpen,
+    onClose,
+    categories = [],
+    onSubmit,
+}: AddFundsExpendituresCategoryModalProps) => {
     const [type, setType] = useState<FundsExpendituresTransactionType | undefined>(undefined);
     const [name, setName] = useState('');
+    const [nameError, setNameError] = useState<string | undefined>(undefined);
+    const [typeError, setTypeError] = useState<string | undefined>(undefined);
+    const [hasNameBeenBlurred, setHasNameBeenBlurred] = useState(false);
     const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
 
-    const nameMax = FUNDS_EXPENDITURES_VALIDATION.categoryNameMax;
+    const typeSelectRef = useRef<HTMLDivElement | null>(null);
+
     const isDirty = type !== undefined || name.trim().length > 0;
 
-    const isSubmitDisabled = useMemo(() => {
-        return !type || normalizeForSave(name).length === 0;
-    }, [type, name]);
+    const isSubmitDisabled = useMemo(
+        () =>
+            validateFundsExpendituresCategoryType(type) !== undefined ||
+            validateFundsExpendituresCategoryName(name, type, categories) !== undefined,
+        [type, name, categories],
+    );
 
     const resetForm = useCallback(() => {
         setName('');
         setType(undefined);
+        setNameError(undefined);
+        setTypeError(undefined);
+        setHasNameBeenBlurred(false);
+        setIsSubmitting(false);
     }, []);
 
-    const handleSubmit = () => {};
+    const handleSubmit = useCallback(async () => {
+        if (!type || !onSubmit) return;
+        setIsSubmitting(true);
+        const success = await onSubmit({ name: getNormalizedInputText(name), type });
+        if (success) {
+            resetForm();
+            onClose();
+        } else {
+            setIsSubmitting(false);
+        }
+    }, [type, name, onSubmit, resetForm, onClose]);
+
+    const handleTypeChange = useCallback(
+        (newType: FundsExpendituresTransactionType) => {
+            setType(newType);
+            setTypeError(undefined);
+            if (hasNameBeenBlurred) {
+                setNameError(validateFundsExpendituresCategoryName(name, newType, categories));
+            }
+        },
+        [hasNameBeenBlurred, name, categories],
+    );
+
+    const handleTypeFieldBlur = useCallback(
+        (event: FocusEvent<HTMLDivElement>) => {
+            if (typeSelectRef.current?.contains(event.relatedTarget as Node | null)) return;
+            setTypeError(validateFundsExpendituresCategoryType(type));
+        },
+        [type],
+    );
+
+    const handleNameBlur = useCallback(() => {
+        setHasNameBeenBlurred(true);
+        setName(getNormalizedInputText(name));
+        setNameError(validateFundsExpendituresCategoryName(name, type, categories));
+    }, [name, type, categories]);
 
     const handleRequestClose = useCallback(() => {
         if (isDirty) {
             setIsCloseConfirmOpen(true);
             return;
         }
+        resetForm();
         onClose();
-    }, [isDirty, onClose]);
+    }, [isDirty, onClose, resetForm]);
 
     const handleConfirmClose = useCallback(() => {
         setIsCloseConfirmOpen(false);
@@ -66,17 +138,20 @@ export const AddFundsExpendituresCategoryModal = ({ isOpen, onClose }: AddFundsE
                     <div className={styles.content}>
                         <div className={styles.panel}>
                             <div className={styles.form}>
-                                <div className={styles.field}>
+                                <div className={styles.field} onBlurCapture={handleTypeFieldBlur}>
                                     <label className={styles.label}>
                                         <span className={styles.required}>*</span>
                                         {FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.TYPE_LABEL}
                                     </label>
                                     <Select<FundsExpendituresTransactionType>
                                         value={type}
-                                        onValueChange={(v) => setType(v)}
+                                        onValueChange={handleTypeChange}
+                                        selectContainerRef={typeSelectRef}
                                         placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.TYPE_PLACEHOLDER}
                                         className={styles.selectContainer}
-                                        headClassName={styles.selectHead}
+                                        headClassName={cn(styles.selectHead, {
+                                            [styles.selectHeadError]: Boolean(typeError),
+                                        })}
                                     >
                                         <Select.Option
                                             value="expense"
@@ -87,6 +162,9 @@ export const AddFundsExpendituresCategoryModal = ({ isOpen, onClose }: AddFundsE
                                             name={FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME}
                                         />
                                     </Select>
+                                    <p className={cn(styles.error, { [styles.errorHidden]: !typeError })}>
+                                        {typeError ?? ' '}
+                                    </p>
                                 </div>
 
                                 <div className={styles.field}>
@@ -94,17 +172,26 @@ export const AddFundsExpendituresCategoryModal = ({ isOpen, onClose }: AddFundsE
                                         <span className={styles.required}>*</span>
                                         {FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.NAME_LABEL}
                                     </label>
-                                    <InputWithCharacterLimit
-                                        id="category-name"
-                                        name="categoryName"
-                                        value={name}
-                                        onChange={(e) => setName(e.target.value)}
-                                        onBlur={() => setName((s) => s.replaceAll(/\s+/g, ' ').trim())}
-                                        maxLength={nameMax}
-                                        placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.NAME_PLACEHOLDER}
-                                        showCounter={true}
-                                        className={styles.input}
-                                    />
+                                    {renderInputWithError(
+                                        <InputWithCharacterLimit
+                                            id="category-name"
+                                            name="categoryName"
+                                            value={name}
+                                            onChange={(e) => setName(e.target.value)}
+                                            onBlur={handleNameBlur}
+                                            maxLength={FUNDS_EXPENDITURES_VALIDATION.categoryNameMax}
+                                            maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
+                                                FUNDS_EXPENDITURES_VALIDATION.categoryNameMax,
+                                            )}
+                                            placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.NAME_PLACEHOLDER}
+                                            showCounter={true}
+                                            hasError={Boolean(nameError)}
+                                            className={styles.input}
+                                        />,
+                                        nameError,
+                                        styles.inputError,
+                                        styles.error,
+                                    )}
                                 </div>
                             </div>
                         </div>
@@ -116,7 +203,7 @@ export const AddFundsExpendituresCategoryModal = ({ isOpen, onClose }: AddFundsE
                         <Button
                             buttonStyle="primary"
                             onClick={handleSubmit}
-                            disabled={isSubmitDisabled}
+                            disabled={isSubmitDisabled || isSubmitting}
                             className={styles.submit}
                         >
                             {FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.SUBMIT_BUTTON}

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.module.scss
@@ -1,66 +1,6 @@
 @use '@/assets/sass/variables/colors' as c;
 @use '@/assets/sass/mixins/typography.mixins' as type;
 
-.form {
-    display: flex;
-    flex-direction: column;
-    gap: 18px;
-    width: 100%;
-}
-
-.field {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-}
-
-.label {
-    @include type.small-text-medium;
-    color: c.$bluish-black;
-    margin-bottom: 8px;
-}
-
-.required {
-    color: c.$error;
-    margin-right: 6px;
-}
-
-.selectContainer {
-    width: 100%;
-}
-
-.selectHead {
-    width: 100%;
-    height: 48px;
-    padding: 0 16px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    border: 1px solid c.$grey-700;
-    border-radius: 8px;
-    background: c.$white;
-}
-
-.selectHeadError {
-    border-color: c.$error;
-}
-
-.input {
-    width: 100%;
-}
-
-.panel :global(.char-limit-input) {
-    width: 100%;
-}
-
-.inputError :global(.char-limit-input) {
-    border-color: c.$error;
-}
-
-.panel :global(.select-options) {
-    width: 100%;
-}
-
 .modal {
     width: 650px;
 
@@ -68,7 +8,7 @@
         width: 650px;
         max-width: 650px;
         border-radius: 8px;
-        background: c.$white;
+        background-color: c.$white;
         padding: 0;
     }
 
@@ -106,14 +46,8 @@
 
     :global(.modal-footer button) {
         width: 100%;
+        height: 40px;
     }
-}
-
-.header {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 14px;
 }
 
 .title {
@@ -121,16 +55,9 @@
     font-weight: 400;
     line-height: 24px;
     letter-spacing: -0.02em;
-    text-align: left;
+    text-align: center;
     margin: 0;
     color: c.$blue-900;
-}
-
-.subtitle {
-    @include type.body-1-regular;
-    line-height: 20px;
-    margin: 0;
-    color: c.$grey-900;
 }
 
 .content {
@@ -145,34 +72,79 @@
     flex-direction: column;
     align-items: stretch;
     width: 100%;
-    background: c.$grey-50;
+    background-color: c.$grey-50;
     border: 1px solid c.$grey-150;
     padding: 20px 22px;
     min-height: 180px;
+    gap: 12px;
 }
 
-.error {
-    @include type.small-text-regular;
-    margin: 4px 0 0;
-    min-height: 20px;
+.field {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
+.labelRow {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.label {
+    @include type.small-text-medium;
+    color: c.$bluish-black;
+}
+
+.required {
     color: c.$error;
-    visibility: visible;
+    margin-right: 6px;
 }
 
-.errorHidden {
-    visibility: hidden;
+.selectContainer {
+    width: 100%;
+}
+
+.selectHead {
+    width: 100%;
+    height: 48px;
+    padding: 0 16px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border: 1px solid c.$grey-700;
+    border-radius: 8px;
+    background-color: c.$white;
+}
+
+.panel :global(.select-options) {
+    width: 100%;
+}
+
+.panel :global(.hint-box) {
+    color: c.$blue-900;
+}
+
+.type {
+    @include type.small-text-regular;
+    margin: 0;
+    color: c.$blue-900;
 }
 
 .actions {
     width: 100%;
     display: flex;
+    gap: 24px;
     justify-content: center;
 }
 
-.submit {
-    @include type.subtitle-2-medium;
-    height: 60px;
-    width: 100%;
+.deleteButton {
+    background-color: c.$blue-900;
+
+    &:disabled {
+        background-color: c.$grey-700;
+    }
 }
 
 @media (max-width: 768px) {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.test.tsx
@@ -1,0 +1,262 @@
+import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { ReportFundsExpendituresCategory, ReportFundsExpendituresRecord } from '@/types/admin/reports';
+import { DeleteFundsExpendituresCategoryModal } from './DeleteFundsExpendituresCategoryModal';
+
+const CATEGORY_SELECT = FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.CATEGORY_PLACEHOLDER;
+const DELETE_BUTTON_NAME = COMMON_TEXT_ADMIN.BUTTON.DELETE;
+const CANCEL_BUTTON_NAME = COMMON_TEXT_ADMIN.BUTTON.CANCEL;
+const YES_BUTTON = COMMON_TEXT_ADMIN.BUTTON.YES;
+const NO_BUTTON = COMMON_TEXT_ADMIN.BUTTON.NO;
+
+const incomeCategory: ReportFundsExpendituresCategory = { id: 1, name: 'Донори', type: 'income' };
+const expenseCategory: ReportFundsExpendituresCategory = { id: 2, name: 'Оренда', type: 'expense' };
+
+const incomeRecord: ReportFundsExpendituresRecord = {
+    id: 10,
+    categoryId: 1,
+    type: 'income',
+    reportingYear: '2024',
+    amountUah: '1000',
+    amountUsd: '25',
+};
+
+const incomeRecord2: ReportFundsExpendituresRecord = {
+    id: 11,
+    categoryId: 1,
+    type: 'income',
+    reportingYear: '2023',
+    amountUah: '2000',
+    amountUsd: '50',
+};
+
+const expenseRecord: ReportFundsExpendituresRecord = {
+    id: 20,
+    categoryId: 2,
+    type: 'expense',
+    reportingYear: '2024',
+    amountUah: '500',
+    amountUsd: '12',
+};
+
+const renderModal = (
+    overrides: Partial<{
+        isOpen: boolean;
+        onClose: jest.Mock;
+        categories: ReportFundsExpendituresCategory[];
+        records: ReportFundsExpendituresRecord[];
+        onSubmit: jest.Mock;
+    }> = {},
+) => {
+    const props = {
+        isOpen: true,
+        onClose: jest.fn(),
+        categories: [incomeCategory, expenseCategory],
+        records: [],
+        onSubmit: jest.fn().mockResolvedValue(true),
+        ...overrides,
+    };
+    return { ...render(<DeleteFundsExpendituresCategoryModal {...props} />), ...props };
+};
+
+const getDeleteButton = () => screen.getByRole('button', { name: DELETE_BUTTON_NAME });
+const getCancelButton = () => screen.getByRole('button', { name: CANCEL_BUTTON_NAME });
+
+const selectCategory = (name: string) => {
+    fireEvent.click(screen.getByRole('button', { name: CATEGORY_SELECT }));
+    fireEvent.click(screen.getByRole('button', { name }));
+};
+
+const getConfirmOverlay = () =>
+    screen.getAllByTestId('modal-overlay').find((el) => within(el).queryByRole('button', { name: YES_BUTTON }))!;
+
+describe('DeleteFundsExpendituresCategoryModal', () => {
+    it('renders nothing when isOpen is false', () => {
+        renderModal({ isOpen: false });
+        expect(screen.queryByTestId('modal-overlay')).not.toBeInTheDocument();
+    });
+
+    it('renders modal title when open', () => {
+        renderModal();
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.TITLE)).toBeInTheDocument();
+    });
+
+    it('renders category select and action buttons', () => {
+        renderModal();
+        expect(screen.getByRole('button', { name: CATEGORY_SELECT })).toBeInTheDocument();
+        expect(getDeleteButton()).toBeInTheDocument();
+        expect(getCancelButton()).toBeInTheDocument();
+    });
+
+    describe('delete button disabled state', () => {
+        it('is disabled when no category is selected', () => {
+            renderModal();
+            expect(getDeleteButton()).toBeDisabled();
+        });
+
+        it('is enabled when a category with no record is selected', () => {
+            renderModal({ records: [] });
+            selectCategory(incomeCategory.name);
+            expect(getDeleteButton()).not.toBeDisabled();
+        });
+
+        it('is disabled when selected category has an income record', () => {
+            renderModal({ records: [incomeRecord] });
+            selectCategory(incomeCategory.name);
+            expect(getDeleteButton()).toBeDisabled();
+        });
+
+        it('is disabled when selected category has an expense record', () => {
+            renderModal({ records: [expenseRecord] });
+            selectCategory(expenseCategory.name);
+            expect(getDeleteButton()).toBeDisabled();
+        });
+    });
+
+    describe('record error hint', () => {
+        it('shows income record error when selected income category has a record', () => {
+            renderModal({ records: [incomeRecord] });
+            selectCategory(incomeCategory.name);
+            expect(
+                screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasIncomeRecordTitle(1)),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_RECORD_TEXT),
+            ).toBeInTheDocument();
+        });
+
+        it('shows expense record error when selected expense category has a record', () => {
+            renderModal({ records: [expenseRecord] });
+            selectCategory(expenseCategory.name);
+            expect(
+                screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasExpenseRecordTitle(1)),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_RECORD_TEXT),
+            ).toBeInTheDocument();
+        });
+
+        it('does not show hint box when selected category has no record', () => {
+            renderModal({ records: [] });
+            selectCategory(incomeCategory.name);
+            expect(
+                screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasIncomeRecordTitle(1)),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_RECORD_TEXT),
+            ).not.toBeInTheDocument();
+        });
+
+        it('does not show hint box when no category is selected', () => {
+            renderModal({ records: [incomeRecord] });
+            expect(
+                screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasIncomeRecordTitle(1)),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_RECORD_TEXT),
+            ).not.toBeInTheDocument();
+        });
+
+        it('shows correct plural form when category has multiple records', () => {
+            renderModal({ records: [incomeRecord, incomeRecord2] });
+            selectCategory(incomeCategory.name);
+            expect(
+                screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasIncomeRecordTitle(2)),
+            ).toBeInTheDocument();
+        });
+    });
+
+    describe('confirmation modal', () => {
+        it('opens confirmation when delete is clicked', () => {
+            renderModal();
+            selectCategory(incomeCategory.name);
+            fireEvent.click(getDeleteButton());
+            expect(getConfirmOverlay()).toBeInTheDocument();
+        });
+
+        it('shows correct confirm title', () => {
+            renderModal();
+            selectCategory(incomeCategory.name);
+            fireEvent.click(getDeleteButton());
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.CONFIRM_TITLE)).toBeInTheDocument();
+        });
+
+        it('closes confirmation on cancel', () => {
+            renderModal();
+            selectCategory(incomeCategory.name);
+            fireEvent.click(getDeleteButton());
+            fireEvent.click(within(getConfirmOverlay()).getByRole('button', { name: NO_BUTTON }));
+            expect(screen.queryAllByTestId('modal-overlay').length).toBe(1);
+        });
+    });
+
+    describe('submit behaviour', () => {
+        it('calls onSubmit with categoryId on confirm', async () => {
+            const onSubmit = jest.fn().mockResolvedValue(true);
+            renderModal({ onSubmit });
+            selectCategory(incomeCategory.name);
+            fireEvent.click(getDeleteButton());
+            fireEvent.click(within(getConfirmOverlay()).getByRole('button', { name: YES_BUTTON }));
+            await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(incomeCategory.id));
+        });
+
+        it('resets form and calls onClose when onSubmit resolves true', async () => {
+            const onClose = jest.fn();
+            const onSubmit = jest.fn().mockResolvedValue(true);
+            renderModal({ onClose, onSubmit });
+            selectCategory(incomeCategory.name);
+            fireEvent.click(getDeleteButton());
+            fireEvent.click(within(getConfirmOverlay()).getByRole('button', { name: YES_BUTTON }));
+            await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+            expect(getDeleteButton()).toBeDisabled();
+        });
+
+        it('keeps modal open and closes confirm when onSubmit resolves false', async () => {
+            const onClose = jest.fn();
+            const onSubmit = jest.fn().mockResolvedValue(false);
+            renderModal({ onClose, onSubmit });
+            selectCategory(incomeCategory.name);
+            fireEvent.click(getDeleteButton());
+            fireEvent.click(within(getConfirmOverlay()).getByRole('button', { name: YES_BUTTON }));
+            await waitFor(() => expect(screen.queryByRole('button', { name: YES_BUTTON })).not.toBeInTheDocument());
+            expect(onClose).not.toHaveBeenCalled();
+            expect(screen.getAllByTestId('modal-overlay').length).toBe(1);
+        });
+
+        it('disables confirm buttons while submitting', async () => {
+            let resolve!: (v: boolean) => void;
+            const onSubmit = jest.fn().mockReturnValue(
+                new Promise<boolean>((r) => {
+                    resolve = r;
+                }),
+            );
+            renderModal({ onSubmit });
+            selectCategory(incomeCategory.name);
+            fireEvent.click(getDeleteButton());
+            const yesBtn = within(getConfirmOverlay()).getByRole('button', { name: YES_BUTTON });
+            fireEvent.click(yesBtn);
+            expect(yesBtn).toBeDisabled();
+            await act(async () => {
+                resolve(true);
+            });
+        });
+    });
+
+    describe('cancel button', () => {
+        it('closes modal on cancel', () => {
+            const onClose = jest.fn();
+            renderModal({ onClose });
+            fireEvent.click(getCancelButton());
+            expect(onClose).toHaveBeenCalledTimes(1);
+        });
+
+        it('resets form on cancel', () => {
+            renderModal();
+            selectCategory(incomeCategory.name);
+            expect(getDeleteButton()).not.toBeDisabled();
+            fireEvent.click(getCancelButton());
+            expect(getDeleteButton()).toBeDisabled();
+        });
+    });
+});

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.tsx
@@ -1,0 +1,151 @@
+import { useCallback, useState } from 'react';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { Select } from '@/components/common/select/Select';
+import { Modal } from '@/components/common/modal/Modal';
+import { Button } from '@/components/admin/button/Button';
+import { HintBox } from '@/components/admin/hint-box/HintBox';
+import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
+import { ReportFundsExpendituresCategory, ReportFundsExpendituresRecord } from '@/types/admin/reports';
+import styles from './DeleteFundsExpendituresCategoryModal.module.scss';
+
+interface DeleteFundsExpendituresCategoryModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    categories: ReportFundsExpendituresCategory[];
+    records: ReportFundsExpendituresRecord[];
+    onSubmit: (categoryId: number) => Promise<boolean>;
+}
+
+export const DeleteFundsExpendituresCategoryModal = ({
+    isOpen,
+    onClose,
+    categories,
+    records,
+    onSubmit,
+}: DeleteFundsExpendituresCategoryModalProps) => {
+    const [selectedCategoryId, setSelectedCategoryId] = useState<number | undefined>(undefined);
+    const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const selectedCategory = categories.find((c) => c.id === selectedCategoryId);
+    const recordCount = records.filter((r) => r.categoryId === selectedCategoryId).length;
+    const hasRecord = recordCount > 0;
+
+    const recordErrorTitle =
+        selectedCategory && hasRecord
+            ? selectedCategory.type === 'income'
+                ? FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasIncomeRecordTitle(recordCount)
+                : FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasExpenseRecordTitle(recordCount)
+            : undefined;
+
+    const resetForm = useCallback(() => {
+        setSelectedCategoryId(undefined);
+        setIsConfirmOpen(false);
+        setIsSubmitting(false);
+    }, []);
+
+    const handleClose = useCallback(() => {
+        resetForm();
+        onClose();
+    }, [resetForm, onClose]);
+
+    const handleDeleteClick = useCallback(() => {
+        setIsConfirmOpen(true);
+    }, []);
+
+    const handleConfirm = useCallback(async () => {
+        if (!selectedCategoryId) return;
+        setIsSubmitting(true);
+        const success = await onSubmit(selectedCategoryId);
+        if (success) {
+            setIsConfirmOpen(false);
+            resetForm();
+            onClose();
+        } else {
+            setIsSubmitting(false);
+            setIsConfirmOpen(false);
+        }
+    }, [selectedCategoryId, onSubmit, resetForm, onClose]);
+
+    const handleCancelConfirm = useCallback(() => {
+        setIsConfirmOpen(false);
+    }, []);
+
+    const isDeleteDisabled = !selectedCategoryId || hasRecord || isSubmitting;
+
+    return (
+        <>
+            <Modal isOpen={isOpen} onClose={handleClose} className={styles.modal} maxWidth="650px">
+                <Modal.Title>
+                    <h2 className={styles.title}>{FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.TITLE}</h2>
+                </Modal.Title>
+
+                <Modal.Content>
+                    <div className={styles.content}>
+                        <div className={styles.panel}>
+                            <div className={styles.field}>
+                                <div className={styles.labelRow}>
+                                    <label className={styles.label}>
+                                        <span className={styles.required}>*</span>
+                                        {FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.CATEGORY_LABEL}
+                                    </label>
+                                    {selectedCategory && (
+                                        <span className={styles.type}>
+                                            {selectedCategory.type === 'income'
+                                                ? FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME
+                                                : FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.EXPENSE}
+                                        </span>
+                                    )}
+                                </div>
+                                <Select<number | undefined>
+                                    value={selectedCategoryId}
+                                    onValueChange={(val) => setSelectedCategoryId(val as number)}
+                                    placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.CATEGORY_PLACEHOLDER}
+                                    className={styles.selectContainer}
+                                    headClassName={styles.selectHead}
+                                >
+                                    {categories.map((c) => (
+                                        <Select.Option key={c.id} value={c.id} name={c.name} />
+                                    ))}
+                                </Select>
+                            </div>
+
+                            {recordErrorTitle && (
+                                <HintBox
+                                    title={recordErrorTitle}
+                                    text={FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_RECORD_TEXT}
+                                />
+                            )}
+                        </div>
+                    </div>
+                </Modal.Content>
+
+                <Modal.Actions>
+                    <div className={styles.actions}>
+                        <Button buttonStyle="secondary" onClick={handleClose} disabled={isSubmitting}>
+                            {COMMON_TEXT_ADMIN.BUTTON.CANCEL}
+                        </Button>
+                        <Button
+                            buttonStyle="primary"
+                            onClick={handleDeleteClick}
+                            disabled={isDeleteDisabled}
+                            className={styles.deleteButton}
+                        >
+                            {COMMON_TEXT_ADMIN.BUTTON.DELETE}
+                        </Button>
+                    </div>
+                </Modal.Actions>
+            </Modal>
+
+            <ConfirmationModal
+                isOpen={isConfirmOpen}
+                title={FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.CONFIRM_TITLE}
+                onConfirm={handleConfirm}
+                onCancel={handleCancelConfirm}
+                onClose={handleCancelConfirm}
+                isButtonsDisabled={isSubmitting}
+            />
+        </>
+    );
+};

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.module.scss
@@ -14,10 +14,21 @@
     width: 100%;
 }
 
+.labelRow {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
 .label {
     @include type.small-text-medium;
     color: c.$bluish-black;
     margin-bottom: 8px;
+}
+
+.labelRow .label {
+    margin-bottom: 0;
 }
 
 .required {
@@ -38,11 +49,7 @@
     justify-content: space-between;
     border: 1px solid c.$grey-700;
     border-radius: 8px;
-    background: c.$white;
-}
-
-.selectHeadError {
-    border-color: c.$error;
+    background-color: c.$white;
 }
 
 .input {
@@ -68,7 +75,7 @@
         width: 650px;
         max-width: 650px;
         border-radius: 8px;
-        background: c.$white;
+        background-color: c.$white;
         padding: 0;
     }
 
@@ -94,7 +101,7 @@
 
     :global(.modal-body) {
         margin-bottom: 0;
-        padding: 18px 0 0;
+        padding: 8px 0 0;
     }
 
     :global(.modal-footer) {
@@ -127,8 +134,7 @@
 }
 
 .subtitle {
-    @include type.body-1-regular;
-    line-height: 20px;
+    @include type.small-text-regular;
     margin: 0;
     color: c.$grey-900;
 }
@@ -145,10 +151,16 @@
     flex-direction: column;
     align-items: stretch;
     width: 100%;
-    background: c.$grey-50;
+    background-color: c.$grey-50;
     border: 1px solid c.$grey-150;
     padding: 20px 22px;
     min-height: 180px;
+}
+
+.type {
+    @include type.small-text-regular;
+    margin: 0;
+    color: c.$blue-900;
 }
 
 .error {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.test.tsx
@@ -1,0 +1,289 @@
+import { render, screen, fireEvent, within, waitFor, act } from '@testing-library/react';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
+import { EditFundsExpendituresCategoryModal } from './EditFundsExpendituresCategoryModal';
+
+jest.mock('@/components/admin/input-with-character-limit/InputWithCharacterLimit', () => ({
+    InputWithCharacterLimit: ({ id, value, onChange, onBlur, placeholder }: any) => (
+        <input data-testid={id} value={value} onChange={onChange} onBlur={onBlur} placeholder={placeholder} />
+    ),
+}));
+
+const CATEGORY_SELECT = FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CATEGORY_PLACEHOLDER;
+const NAME_INPUT = 'edit-category-name';
+const SAVE_BUTTON = FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.SUBMIT_BUTTON;
+const MIN_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMin);
+const REQUIRED_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
+const DUPLICATE_ERROR = FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.ERROR.NAME_DUPLICATE;
+const YES_BUTTON = COMMON_TEXT_ADMIN.BUTTON.YES;
+const NO_BUTTON = COMMON_TEXT_ADMIN.BUTTON.NO;
+
+const incomeCategory: ReportFundsExpendituresCategory = { id: 1, name: 'Донори', type: 'income' };
+const expenseCategory: ReportFundsExpendituresCategory = { id: 2, name: 'Оренда', type: 'expense' };
+
+const renderModal = (
+    overrides: Partial<{
+        isOpen: boolean;
+        onClose: jest.Mock;
+        categories: ReportFundsExpendituresCategory[];
+        onSubmit: jest.Mock;
+    }> = {},
+) => {
+    const props = {
+        isOpen: true,
+        onClose: jest.fn(),
+        categories: [incomeCategory, expenseCategory],
+        onSubmit: jest.fn().mockResolvedValue(true),
+        ...overrides,
+    };
+    return { ...render(<EditFundsExpendituresCategoryModal {...props} />), ...props };
+};
+
+const getSaveButton = () => screen.getByRole('button', { name: SAVE_BUTTON });
+
+const selectCategory = (name: string) => {
+    fireEvent.click(screen.getByRole('button', { name: CATEGORY_SELECT }));
+    fireEvent.click(screen.getByRole('button', { name }));
+};
+
+const typeName = (value: string) => {
+    fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value } });
+};
+
+const fillForm = (categoryName = incomeCategory.name, name = 'Valid name') => {
+    selectCategory(categoryName);
+    typeName(name);
+};
+
+const getConfirmOverlayWithTitle = (title: string) =>
+    screen.getAllByTestId('modal-overlay').find((el) => within(el).queryByText(title))!;
+
+const clickYesInConfirm = (title: string) =>
+    fireEvent.click(within(getConfirmOverlayWithTitle(title)).getByRole('button', { name: YES_BUTTON }));
+
+const clickNoInConfirm = (title: string) =>
+    fireEvent.click(within(getConfirmOverlayWithTitle(title)).getByRole('button', { name: NO_BUTTON }));
+
+describe('EditFundsExpendituresCategoryModal', () => {
+    it('renders nothing when isOpen is false', () => {
+        renderModal({ isOpen: false });
+        expect(screen.queryByTestId('modal-overlay')).not.toBeInTheDocument();
+    });
+
+    it('renders modal title when open', () => {
+        renderModal();
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.TITLE)).toBeInTheDocument();
+    });
+
+    it('renders category select, name input and save button', () => {
+        renderModal();
+        expect(screen.getByRole('button', { name: CATEGORY_SELECT })).toBeInTheDocument();
+        expect(screen.getByTestId(NAME_INPUT)).toBeInTheDocument();
+        expect(getSaveButton()).toBeInTheDocument();
+    });
+
+    describe('save button disabled state', () => {
+        it('is disabled by default', () => {
+            renderModal();
+            expect(getSaveButton()).toBeDisabled();
+        });
+
+        it('is disabled when only category is selected', () => {
+            renderModal();
+            selectCategory(incomeCategory.name);
+            expect(getSaveButton()).toBeDisabled();
+        });
+
+        it('is disabled when name is too short', () => {
+            renderModal();
+            fillForm(incomeCategory.name, 'abc');
+            expect(getSaveButton()).toBeDisabled();
+        });
+
+        it('is enabled when category is selected and name is valid', () => {
+            renderModal();
+            fillForm();
+            expect(getSaveButton()).not.toBeDisabled();
+        });
+
+        it('is not disabled when name matches a category of a different type', () => {
+            renderModal();
+            fillForm(incomeCategory.name, expenseCategory.name);
+            expect(getSaveButton()).not.toBeDisabled();
+        });
+
+        it('is disabled when name duplicates another category of the same type', () => {
+            const categories = [incomeCategory, expenseCategory, { id: 3, name: 'Гранти', type: 'income' as const }];
+            renderModal({ categories });
+            selectCategory(incomeCategory.name);
+            typeName('Гранти');
+            expect(getSaveButton()).toBeDisabled();
+        });
+    });
+
+    describe('name field validation on blur', () => {
+        it('shows required error when name is empty', () => {
+            renderModal();
+            selectCategory(incomeCategory.name);
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(REQUIRED_ERROR)).toBeInTheDocument();
+        });
+
+        it('shows min length error when name is too short', () => {
+            renderModal();
+            fillForm(incomeCategory.name, 'abc');
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(MIN_ERROR)).toBeInTheDocument();
+        });
+
+        it('shows duplicate error when name matches another category of the same type', () => {
+            const categories = [incomeCategory, expenseCategory, { id: 3, name: 'Гранти', type: 'income' as const }];
+            renderModal({ categories });
+            selectCategory(incomeCategory.name);
+            typeName('Гранти');
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(DUPLICATE_ERROR)).toBeInTheDocument();
+        });
+
+        it('does not show duplicate error when name matches selected category itself', () => {
+            renderModal();
+            selectCategory(incomeCategory.name);
+            typeName(incomeCategory.name);
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.queryByText(DUPLICATE_ERROR)).not.toBeInTheDocument();
+        });
+
+        it('clears error when name becomes valid on re-blur', () => {
+            renderModal();
+            selectCategory(incomeCategory.name);
+            typeName('ab');
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(MIN_ERROR)).toBeInTheDocument();
+
+            typeName('Valid name');
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.queryByText(MIN_ERROR)).not.toBeInTheDocument();
+        });
+    });
+
+    describe('confirmation save modal', () => {
+        it('opens save confirmation when save button is clicked', () => {
+            renderModal();
+            fillForm();
+            fireEvent.click(getSaveButton());
+            expect(
+                screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE),
+            ).toBeInTheDocument();
+        });
+
+        it('closes save confirmation on cancel', () => {
+            renderModal();
+            fillForm();
+            fireEvent.click(getSaveButton());
+            clickNoInConfirm(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE);
+            expect(
+                screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE),
+            ).not.toBeInTheDocument();
+        });
+    });
+
+    describe('submit behaviour', () => {
+        it('calls onSubmit with categoryId and normalized name on confirm', async () => {
+            const onSubmit = jest.fn().mockResolvedValue(true);
+            renderModal({ onSubmit });
+            fillForm(incomeCategory.name, '  Valid name  ');
+            fireEvent.click(getSaveButton());
+            clickYesInConfirm(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE);
+            await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(incomeCategory.id, 'Valid name'));
+        });
+
+        it('resets form and calls onClose when onSubmit resolves true', async () => {
+            const onClose = jest.fn();
+            const onSubmit = jest.fn().mockResolvedValue(true);
+            renderModal({ onClose, onSubmit });
+            fillForm();
+            fireEvent.click(getSaveButton());
+            clickYesInConfirm(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE);
+            await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+            expect(screen.getByTestId(NAME_INPUT)).toHaveValue('');
+            expect(getSaveButton()).toBeDisabled();
+        });
+
+        it('keeps modal open and closes confirm when onSubmit resolves false', async () => {
+            const onClose = jest.fn();
+            const onSubmit = jest.fn().mockResolvedValue(false);
+            renderModal({ onClose, onSubmit });
+            fillForm();
+            fireEvent.click(getSaveButton());
+            clickYesInConfirm(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE);
+            await waitFor(() => expect(screen.queryByRole('button', { name: YES_BUTTON })).not.toBeInTheDocument());
+            expect(onClose).not.toHaveBeenCalled();
+        });
+
+        it('disables confirm buttons while submitting', async () => {
+            let resolve!: (v: boolean) => void;
+            const onSubmit = jest.fn().mockReturnValue(
+                new Promise<boolean>((r) => {
+                    resolve = r;
+                }),
+            );
+            renderModal({ onSubmit });
+            fillForm();
+            fireEvent.click(getSaveButton());
+            const yesBtn = within(
+                getConfirmOverlayWithTitle(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE),
+            ).getByRole('button', { name: YES_BUTTON });
+            fireEvent.click(yesBtn);
+            expect(yesBtn).toBeDisabled();
+            await act(async () => {
+                resolve(true);
+            });
+        });
+    });
+
+    describe('close behaviour', () => {
+        it('closes directly when form is clean', () => {
+            const onClose = jest.fn();
+            renderModal({ onClose });
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+            expect(onClose).toHaveBeenCalledTimes(1);
+        });
+
+        it('opens close confirmation when name is dirty', () => {
+            const onClose = jest.fn();
+            renderModal({ onClose });
+            typeName('dirty');
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+            expect(onClose).not.toHaveBeenCalled();
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.CONFIRM_CLOSE_TITLE)).toBeInTheDocument();
+        });
+
+        it('calls onClose and resets form on confirm close', () => {
+            const onClose = jest.fn();
+            renderModal({ onClose });
+            fillForm();
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+            clickYesInConfirm(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.CONFIRM_CLOSE_TITLE);
+            expect(onClose).toHaveBeenCalledTimes(1);
+            expect(screen.getByTestId(NAME_INPUT)).toHaveValue('');
+        });
+
+        it('keeps modal open on cancel close', () => {
+            const onClose = jest.fn();
+            renderModal({ onClose });
+            typeName('dirty');
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+            clickNoInConfirm(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.CONFIRM_CLOSE_TITLE);
+            expect(onClose).not.toHaveBeenCalled();
+            expect(screen.getByTestId('modal-overlay')).toBeInTheDocument();
+        });
+    });
+
+    it('normalizes whitespace in name on blur', () => {
+        renderModal();
+        typeName('  foo   bar  ');
+        fireEvent.blur(screen.getByTestId(NAME_INPUT));
+        expect(screen.getByTestId(NAME_INPUT)).toHaveValue('foo bar');
+    });
+});

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.tsx
@@ -1,0 +1,237 @@
+import { useCallback, useMemo, useState } from 'react';
+import cn from 'classnames';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { InputWithCharacterLimit } from '@/components/admin/input-with-character-limit/InputWithCharacterLimit';
+import { Select } from '@/components/common/select/Select';
+import { Modal } from '@/components/common/modal/Modal';
+import { Button } from '@/components/admin/button/Button';
+import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
+import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
+import { getNormalizedInputText } from '@/utils/functions/formatters/text-formatters';
+import { validateFundsExpendituresCategoryName } from '@/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema';
+import styles from './EditFundsExpendituresCategoryModal.module.scss';
+
+const renderInputWithError = (
+    input: React.ReactNode,
+    error?: string,
+    inputErrorClass?: string,
+    errorClass?: string,
+) => (
+    <>
+        <div className={cn({ [inputErrorClass || '']: Boolean(error) })}>{input}</div>
+        <p className={cn(errorClass, { [styles.errorHidden]: !error })}>{error ?? ' '}</p>
+    </>
+);
+
+interface EditFundsExpendituresCategoryModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    categories: ReportFundsExpendituresCategory[];
+    onSubmit: (categoryId: number, name: string) => Promise<boolean>;
+}
+
+export const EditFundsExpendituresCategoryModal = ({
+    isOpen,
+    onClose,
+    categories,
+    onSubmit,
+}: EditFundsExpendituresCategoryModalProps) => {
+    const [selectedCategoryId, setSelectedCategoryId] = useState<number | undefined>(undefined);
+    const [name, setName] = useState('');
+    const [nameError, setNameError] = useState<string | undefined>(undefined);
+    const [hasNameBeenBlurred, setHasNameBeenBlurred] = useState(false);
+    const [isConfirmSaveOpen, setIsConfirmSaveOpen] = useState(false);
+    const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const selectedCategory = categories.find((c) => c.id === selectedCategoryId);
+
+    const otherCategories = useMemo(
+        () => categories.filter((c) => c.id !== selectedCategoryId),
+        [categories, selectedCategoryId],
+    );
+
+    const isDirty = name.trim().length > 0;
+
+    const isSubmitDisabled = useMemo(
+        () =>
+            !selectedCategoryId ||
+            name.trim() === selectedCategory?.name.trim() ||
+            validateFundsExpendituresCategoryName(name, selectedCategory?.type, otherCategories) !== undefined,
+        [selectedCategoryId, name, selectedCategory?.name, selectedCategory?.type, otherCategories],
+    );
+
+    const resetForm = useCallback(() => {
+        setSelectedCategoryId(undefined);
+        setName('');
+        setNameError(undefined);
+        setHasNameBeenBlurred(false);
+        setIsConfirmSaveOpen(false);
+        setIsCloseConfirmOpen(false);
+        setIsSubmitting(false);
+    }, []);
+
+    const handleCategoryChange = useCallback(
+        (id: number) => {
+            setSelectedCategoryId(id);
+            if (hasNameBeenBlurred) {
+                const newSelected = categories.find((c) => c.id === id);
+                const others = categories.filter((c) => c.id !== id);
+                setNameError(validateFundsExpendituresCategoryName(name, newSelected?.type, others));
+            }
+        },
+        [hasNameBeenBlurred, name, categories],
+    );
+
+    const handleNameBlur = useCallback(() => {
+        setHasNameBeenBlurred(true);
+        setName(getNormalizedInputText(name));
+        setNameError(validateFundsExpendituresCategoryName(name, selectedCategory?.type, otherCategories));
+    }, [name, selectedCategory?.type, otherCategories]);
+
+    const handleSaveClick = useCallback(() => {
+        setIsConfirmSaveOpen(true);
+    }, []);
+
+    const handleConfirmSave = useCallback(async () => {
+        if (!selectedCategoryId) return;
+        setIsSubmitting(true);
+        const success = await onSubmit(selectedCategoryId, getNormalizedInputText(name));
+        if (success) {
+            resetForm();
+            onClose();
+        } else {
+            setIsSubmitting(false);
+            setIsConfirmSaveOpen(false);
+        }
+    }, [selectedCategoryId, name, onSubmit, resetForm, onClose]);
+
+    const handleCancelSave = useCallback(() => {
+        setIsConfirmSaveOpen(false);
+    }, []);
+
+    const handleRequestClose = useCallback(() => {
+        if (isDirty) {
+            setIsCloseConfirmOpen(true);
+            return;
+        }
+        resetForm();
+        onClose();
+    }, [isDirty, resetForm, onClose]);
+
+    const handleConfirmClose = useCallback(() => {
+        setIsCloseConfirmOpen(false);
+        resetForm();
+        onClose();
+    }, [resetForm, onClose]);
+
+    const handleCancelClose = useCallback(() => {
+        setIsCloseConfirmOpen(false);
+    }, []);
+
+    return (
+        <>
+            <Modal isOpen={isOpen} onClose={handleRequestClose} className={styles.modal} maxWidth="650px">
+                <Modal.Title>
+                    <div className={styles.header}>
+                        <h2 className={styles.title}>{FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.TITLE}</h2>
+                        <p className={styles.subtitle}>{FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.SUBTITLE}</p>
+                    </div>
+                </Modal.Title>
+
+                <Modal.Content>
+                    <div className={styles.content}>
+                        <div className={styles.panel}>
+                            <div className={styles.form}>
+                                <div className={styles.field}>
+                                    <div className={styles.labelRow}>
+                                        <label className={styles.label}>
+                                            <span className={styles.required}>*</span>
+                                            {FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CATEGORY_LABEL}
+                                        </label>
+                                        {selectedCategory && (
+                                            <span className={styles.type}>
+                                                {selectedCategory.type === 'income'
+                                                    ? FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME
+                                                    : FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.EXPENSE}
+                                            </span>
+                                        )}
+                                    </div>
+                                    <Select<number | undefined>
+                                        value={selectedCategoryId}
+                                        onValueChange={(val) => handleCategoryChange(val as number)}
+                                        placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CATEGORY_PLACEHOLDER}
+                                        className={styles.selectContainer}
+                                        headClassName={styles.selectHead}
+                                    >
+                                        {categories.map((c) => (
+                                            <Select.Option key={c.id} value={c.id} name={c.name} />
+                                        ))}
+                                    </Select>
+                                </div>
+
+                                <div className={styles.field}>
+                                    <label className={styles.label}>
+                                        <span className={styles.required}>*</span>
+                                        {FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.NAME_LABEL}
+                                    </label>
+                                    {renderInputWithError(
+                                        <InputWithCharacterLimit
+                                            id="edit-category-name"
+                                            name="editCategoryName"
+                                            value={name}
+                                            onChange={(e) => setName(e.target.value)}
+                                            onBlur={handleNameBlur}
+                                            maxLength={FUNDS_EXPENDITURES_VALIDATION.categoryNameMax}
+                                            maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
+                                                FUNDS_EXPENDITURES_VALIDATION.categoryNameMax,
+                                            )}
+                                            placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.NAME_PLACEHOLDER}
+                                            showCounter={true}
+                                            hasError={Boolean(nameError)}
+                                            className={styles.input}
+                                        />,
+                                        nameError,
+                                        styles.inputError,
+                                        styles.error,
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </Modal.Content>
+
+                <Modal.Actions>
+                    <div className={styles.actions}>
+                        <Button
+                            buttonStyle="primary"
+                            onClick={handleSaveClick}
+                            disabled={isSubmitDisabled || isSubmitting}
+                            className={styles.submit}
+                        >
+                            {FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.SUBMIT_BUTTON}
+                        </Button>
+                    </div>
+                </Modal.Actions>
+            </Modal>
+
+            <ConfirmationModal
+                isOpen={isConfirmSaveOpen}
+                title={FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE}
+                onConfirm={handleConfirmSave}
+                onCancel={handleCancelSave}
+                onClose={handleCancelSave}
+                isButtonsDisabled={isSubmitting}
+            />
+
+            <ConfirmationModal
+                isOpen={isCloseConfirmOpen}
+                title={FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.CONFIRM_CLOSE_TITLE}
+                onConfirm={handleConfirmClose}
+                onCancel={handleCancelClose}
+                onClose={handleCancelClose}
+            />
+        </>
+    );
+};

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.module.scss
@@ -175,3 +175,53 @@
         background-color: rgba(c.$blue-500, 0.17);
     }
 }
+
+.category-menu {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+}
+
+.menu-button {
+    background: transparent;
+    border: none;
+    padding: 8px;
+    margin-left: 8px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+
+    :global(svg) {
+        width: 20px;
+        height: 20px;
+        fill: c.$blue-900;
+    }
+}
+
+.menu-popover {
+    position: absolute;
+    top: 40px;
+    right: 0;
+    background: c.$white;
+    border: 1px solid rgba(c.$black, 0.06);
+    box-shadow: 0 6px 16px rgba(c.$black, 0.08);
+    border-radius: 8px;
+    z-index: 20;
+    padding: 6px 8px;
+}
+
+.menu-item {
+    background: transparent;
+    border: none;
+    padding: 8px 12px;
+    width: 100%;
+    text-align: left;
+    @include type.small-text-regular;
+    color: c.$blue-900;
+    cursor: pointer;
+
+    &:hover {
+        background-color: rgba(c.$dropdown-hover, 0.1);
+    }
+}

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ReportAnalytics } from './ReportAnalytics';
-import { REPORTS_TEXT } from '@/const/admin/reports';
+import { FUNDS_EXPENDITURES_TEXT, REPORTS_TEXT } from '@/const/admin/reports';
 
 jest.mock('../pdf-files-section/PdfFilesSection', () => ({
     PdfFilesSection: () => <div data-testid="pdf-files-section">PdfFilesSection</div>,
@@ -12,16 +12,21 @@ jest.mock('../funds-expenditures-section/FundsExpendituresSection', () => ({
         draftExchangeRate,
         onEditModeChange,
         onExchangeRateValueChange,
+        isAddCategoryModalOpen,
+        onAddCategoryModalClose,
     }: {
         initialIsEditing?: boolean;
         draftExchangeRate?: string | null;
         onEditModeChange?: (isEditing: boolean) => void;
         onExchangeRateValueChange?: (exchangeRate: string | null) => void;
+        isAddCategoryModalOpen?: boolean;
+        onAddCategoryModalClose?: () => void;
     }) => (
         <div
             data-testid="funds-expenditure-section"
             data-initial-editing={String(initialIsEditing)}
             data-draft-exchange-rate={draftExchangeRate ?? ''}
+            data-category-modal-open={String(isAddCategoryModalOpen ?? false)}
         >
             FundsExpenditureSection
             <button
@@ -43,6 +48,9 @@ jest.mock('../funds-expenditures-section/FundsExpendituresSection', () => ({
             </button>
             <button type="button" data-testid="deactivate-funds-edit" onClick={() => onEditModeChange?.(false)}>
                 Deactivate edit
+            </button>
+            <button type="button" data-testid="close-category-modal" onClick={() => onAddCategoryModalClose?.()}>
+                Close category modal
             </button>
         </div>
     ),
@@ -131,5 +139,51 @@ describe('ReportAnalytics', () => {
         fireEvent.click(screen.getByText(REPORTS_TEXT.REPORT_AND_ANALYTICS.TAB.INCOME_EXPENSES));
 
         expect(screen.getByTestId('funds-expenditure-section')).toHaveAttribute('data-draft-exchange-rate', '44.20');
+    });
+
+    describe('add category modal', () => {
+        it('should show context menu button on income-expenses tab', () => {
+            render(<ReportAnalytics />);
+
+            expect(screen.getByTestId('context-menu')).toBeInTheDocument();
+        });
+
+        it('should not show context menu button on pdf-files tab', () => {
+            render(<ReportAnalytics />);
+
+            fireEvent.click(screen.getByText(REPORTS_TEXT.REPORT_AND_ANALYTICS.TAB.PDF_FILES));
+
+            expect(screen.queryByTestId('context-menu')).not.toBeInTheDocument();
+        });
+
+        it('should not show context menu button on program-expenses tab', () => {
+            render(<ReportAnalytics />);
+
+            fireEvent.click(screen.getByText(REPORTS_TEXT.REPORT_AND_ANALYTICS.TAB.PROGRAM_EXPENSES));
+
+            expect(screen.queryByTestId('context-menu')).not.toBeInTheDocument();
+        });
+
+        it('should open add category modal when "Додати категорію" option is selected', () => {
+            render(<ReportAnalytics />);
+
+            fireEvent.click(screen.getByTestId('context-menu'));
+            fireEvent.click(screen.getByRole('menuitem', { name: FUNDS_EXPENDITURES_TEXT.BUTTON.ADD_CATEGORY }));
+
+            expect(screen.getByTestId('funds-expenditure-section')).toHaveAttribute('data-category-modal-open', 'true');
+        });
+
+        it('should close add category modal when onAddCategoryModalClose is called', () => {
+            render(<ReportAnalytics />);
+
+            fireEvent.click(screen.getByTestId('context-menu'));
+            fireEvent.click(screen.getByRole('menuitem', { name: FUNDS_EXPENDITURES_TEXT.BUTTON.ADD_CATEGORY }));
+            fireEvent.click(screen.getByTestId('close-category-modal'));
+
+            expect(screen.getByTestId('funds-expenditure-section')).toHaveAttribute(
+                'data-category-modal-open',
+                'false',
+            );
+        });
     });
 });

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { CategoryBar } from '@/components/admin/category-bar/CategoryBar';
+import { useCallback, useMemo, useState } from 'react';
+import { CategoryBar, ContextMenuOption } from '@/components/admin/category-bar/CategoryBar';
 import { FUNDS_EXPENDITURES_TEXT, REPORTS_TEXT } from '@/const/admin/reports';
 import styles from './ReportAnalytics.module.scss';
 import './ReportAnalytics.scss';
@@ -23,6 +23,27 @@ export const ReportAnalytics = () => {
     const [isFundsEditing, setIsFundsEditing] = useState(false);
     const [fundsExchangeRateDraft, setFundsExchangeRateDraft] = useState<string | null>();
     const [isAddCategoryModalOpen, setIsAddCategoryModalOpen] = useState(false);
+    const [isDeleteCategoryModalOpen, setIsDeleteCategoryModalOpen] = useState(false);
+    const [isEditCategoryModalOpen, setIsEditCategoryModalOpen] = useState(false);
+
+    const categoryContextMenuOptions: ContextMenuOption[] = useMemo(
+        () => [
+            { id: 'add-category', name: FUNDS_EXPENDITURES_TEXT.BUTTON.ADD_CATEGORY },
+            { id: 'edit-category', name: FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT_CATEGORY },
+            { id: 'delete-category', name: FUNDS_EXPENDITURES_TEXT.BUTTON.DELETE_CATEGORY },
+        ],
+        [],
+    );
+
+    const handleCategoryContextMenuOption = useCallback((id: string) => {
+        if (id === 'add-category') {
+            setIsAddCategoryModalOpen(true);
+        } else if (id === 'edit-category') {
+            setIsEditCategoryModalOpen(true);
+        } else if (id === 'delete-category') {
+            setIsDeleteCategoryModalOpen(true);
+        }
+    }, []);
 
     return (
         <div className={styles['report-analytics']}>
@@ -35,12 +56,8 @@ export const ReportAnalytics = () => {
                 getCategoryKey={(tab) => tab.id}
                 onCategorySelect={setActiveTab}
                 displayContextMenuButton={activeTab.id === 'income-expenses'}
-                contextMenuOptions={[{ id: 'add-category', name: FUNDS_EXPENDITURES_TEXT.BUTTON.ADD_CATEGORY }]}
-                onContextMenuOptionSelected={(id: string) => {
-                    if (id === 'add-category') {
-                        setIsAddCategoryModalOpen(true);
-                    }
-                }}
+                contextMenuOptions={categoryContextMenuOptions}
+                onContextMenuOptionSelected={handleCategoryContextMenuOption}
             />
             <div className={styles['tab-content']}>
                 {activeTab.id === 'pdf-files' && <PdfFilesSection />}
@@ -52,6 +69,10 @@ export const ReportAnalytics = () => {
                         onExchangeRateValueChange={setFundsExchangeRateDraft}
                         isAddCategoryModalOpen={isAddCategoryModalOpen}
                         onAddCategoryModalClose={() => setIsAddCategoryModalOpen(false)}
+                        isEditCategoryModalOpen={isEditCategoryModalOpen}
+                        onEditCategoryModalClose={() => setIsEditCategoryModalOpen(false)}
+                        isDeleteCategoryModalOpen={isDeleteCategoryModalOpen}
+                        onDeleteCategoryModalClose={() => setIsDeleteCategoryModalOpen(false)}
                     />
                 )}
                 {activeTab.id === 'program-expenses' && <ProgramExpensesSection />}

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { CategoryBar } from '@/components/admin/category-bar/CategoryBar';
-import { REPORTS_TEXT } from '@/const/admin/reports';
+import { FUNDS_EXPENDITURES_TEXT, REPORTS_TEXT } from '@/const/admin/reports';
 import styles from './ReportAnalytics.module.scss';
 import './ReportAnalytics.scss';
 import { PdfFilesSection } from '../pdf-files-section/PdfFilesSection';
@@ -22,6 +22,7 @@ export const ReportAnalytics = () => {
     const [activeTab, setActiveTab] = useState<ReportAnalyticsTab>(ANALYTICS_TABS[0]);
     const [isFundsEditing, setIsFundsEditing] = useState(false);
     const [fundsExchangeRateDraft, setFundsExchangeRateDraft] = useState<string | null>();
+    const [isAddCategoryModalOpen, setIsAddCategoryModalOpen] = useState(false);
 
     return (
         <div className={styles['report-analytics']}>
@@ -33,6 +34,13 @@ export const ReportAnalytics = () => {
                 getCategoryDisplayName={(tab) => tab.label}
                 getCategoryKey={(tab) => tab.id}
                 onCategorySelect={setActiveTab}
+                displayContextMenuButton={activeTab.id === 'income-expenses'}
+                contextMenuOptions={[{ id: 'add-category', name: FUNDS_EXPENDITURES_TEXT.BUTTON.ADD_CATEGORY }]}
+                onContextMenuOptionSelected={(id: string) => {
+                    if (id === 'add-category') {
+                        setIsAddCategoryModalOpen(true);
+                    }
+                }}
             />
             <div className={styles['tab-content']}>
                 {activeTab.id === 'pdf-files' && <PdfFilesSection />}
@@ -42,6 +50,8 @@ export const ReportAnalytics = () => {
                         draftExchangeRate={fundsExchangeRateDraft}
                         onEditModeChange={setIsFundsEditing}
                         onExchangeRateValueChange={setFundsExchangeRateDraft}
+                        isAddCategoryModalOpen={isAddCategoryModalOpen}
+                        onAddCategoryModalClose={() => setIsAddCategoryModalOpen(false)}
                     />
                 )}
                 {activeTab.id === 'program-expenses' && <ProgramExpensesSection />}

--- a/src/utils/functions/normalize-for-unique/normalize-for-unique.test.ts
+++ b/src/utils/functions/normalize-for-unique/normalize-for-unique.test.ts
@@ -1,0 +1,27 @@
+import { normalizeForUnique } from './normalize-for-unique';
+
+describe('normalizeForUnique', () => {
+    it('lowercases the value', () => {
+        expect(normalizeForUnique('HELLO')).toBe('hello');
+    });
+
+    it('trims leading and trailing whitespace', () => {
+        expect(normalizeForUnique('  hello  ')).toBe('hello');
+    });
+
+    it('sorts words alphabetically', () => {
+        expect(normalizeForUnique('Приватні донори')).toBe('донори приватні');
+    });
+
+    it('produces the same result regardless of word order', () => {
+        expect(normalizeForUnique('Донори приватні')).toBe(normalizeForUnique('Приватні донори'));
+    });
+
+    it('applies lowercasing and word sorting together', () => {
+        expect(normalizeForUnique('ДОНОРИ ПРИВАТНІ')).toBe(normalizeForUnique('приватні донори'));
+    });
+
+    it('handles a single word', () => {
+        expect(normalizeForUnique('hello')).toBe('hello');
+    });
+});

--- a/src/utils/functions/normalize-for-unique/normalize-for-unique.ts
+++ b/src/utils/functions/normalize-for-unique/normalize-for-unique.ts
@@ -1,0 +1,7 @@
+export const normalizeForUnique = (value: string) =>
+    value
+        .toLowerCase()
+        .trim()
+        .split(/\s+/)
+        .sort((a, b) => a.localeCompare(b))
+        .join(' ');

--- a/src/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema.test.ts
@@ -1,0 +1,75 @@
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
+import {
+    validateFundsExpendituresCategoryName,
+    validateFundsExpendituresCategoryType,
+} from './funds-expenditures-category-schema';
+
+const REQUIRED = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
+const MIN_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMin);
+const MAX_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMax);
+const DUPLICATE_ERROR = FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.ERROR.NAME_DUPLICATE;
+
+const category = (name: string, type: 'income' | 'expense'): ReportFundsExpendituresCategory => ({
+    id: 1,
+    name,
+    type,
+});
+
+describe('validateFundsExpendituresCategoryName', () => {
+    it('returns required error for empty string', () => {
+        expect(validateFundsExpendituresCategoryName('', undefined, [])).toBe(REQUIRED);
+    });
+
+    it('returns required error for whitespace-only string', () => {
+        expect(validateFundsExpendituresCategoryName('   ', undefined, [])).toBe(REQUIRED);
+    });
+
+    it('returns min length error when name is shorter than minimum', () => {
+        expect(validateFundsExpendituresCategoryName('abc', undefined, [])).toBe(MIN_ERROR);
+    });
+
+    it('returns max length error when name exceeds maximum', () => {
+        const longName = 'а'.repeat(FUNDS_EXPENDITURES_VALIDATION.categoryNameMax + 1);
+        expect(validateFundsExpendituresCategoryName(longName, undefined, [])).toBe(MAX_ERROR);
+    });
+
+    it('returns duplicate error when name matches existing category for same type', () => {
+        const categories = [category('Приватні донори', 'income')];
+        expect(validateFundsExpendituresCategoryName('приватні донори', 'income', categories)).toBe(DUPLICATE_ERROR);
+    });
+
+    it('returns duplicate error when name matches with different word order', () => {
+        const categories = [category('Приватні донори', 'income')];
+        expect(validateFundsExpendituresCategoryName('Донори приватні', 'income', categories)).toBe(DUPLICATE_ERROR);
+    });
+
+    it('returns undefined when name matches category of different type', () => {
+        const categories = [category('Приватні донори', 'expense')];
+        expect(validateFundsExpendituresCategoryName('Приватні донори', 'income', categories)).toBeUndefined();
+    });
+
+    it('skips duplicate check when type is undefined', () => {
+        const categories = [category('Valid name', 'income')];
+        expect(validateFundsExpendituresCategoryName('Valid name', undefined, categories)).toBeUndefined();
+    });
+
+    it('returns undefined for valid name with no duplicates', () => {
+        expect(validateFundsExpendituresCategoryName('Valid name', 'income', [])).toBeUndefined();
+    });
+});
+
+describe('validateFundsExpendituresCategoryType', () => {
+    it('returns required error when type is undefined', () => {
+        expect(validateFundsExpendituresCategoryType(undefined)).toBe(REQUIRED);
+    });
+
+    it('returns undefined for income type', () => {
+        expect(validateFundsExpendituresCategoryType('income')).toBeUndefined();
+    });
+
+    it('returns undefined for expense type', () => {
+        expect(validateFundsExpendituresCategoryType('expense')).toBeUndefined();
+    });
+});

--- a/src/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema.ts
@@ -1,0 +1,31 @@
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { FundsExpendituresTransactionType, ReportFundsExpendituresCategory } from '@/types/admin/reports';
+import { getNormalizedInputText } from '@/utils/functions/formatters/text-formatters';
+import { normalizeForUnique } from '@/utils/functions/normalize-for-unique/normalize-for-unique';
+
+const isNameDuplicate = (
+    name: string,
+    type: FundsExpendituresTransactionType,
+    categories: ReportFundsExpendituresCategory[],
+) => categories.filter((c) => c.type === type).some((c) => normalizeForUnique(c.name) === normalizeForUnique(name));
+
+export const validateFundsExpendituresCategoryName = (
+    value: string,
+    type: FundsExpendituresTransactionType | undefined,
+    categories: ReportFundsExpendituresCategory[],
+): string | undefined => {
+    const normalized = getNormalizedInputText(value);
+    if (!normalized) return COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
+    if (normalized.length < FUNDS_EXPENDITURES_VALIDATION.categoryNameMin)
+        return COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMin);
+    if (normalized.length > FUNDS_EXPENDITURES_VALIDATION.categoryNameMax)
+        return COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMax);
+    if (type && isNameDuplicate(normalized, type, categories))
+        return FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.ERROR.NAME_DUPLICATE;
+    return undefined;
+};
+
+export const validateFundsExpendituresCategoryType = (
+    type: FundsExpendituresTransactionType | undefined,
+): string | undefined => (!type ? COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED : undefined);


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1439

## Description

This PR implements new modal component for creating categories for Funds and Expenditures.

## How it looks


https://github.com/user-attachments/assets/3b023b8b-8707-4b32-9770-becd95f67114


## Summary of change

Implemented the Add Category modal component for funds and expenditures

## How to recreate changes

1. Go to Звітність section
2. Click on the options icon
3. Select Додати категорію

## CHECK LIST
- [x] New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [x]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Add Category" modal to the admin funds expenditures section for creating new expense and income categories.
  * Category names are validated with a maximum 200-character limit.
  * Modal includes a category type selector and name input field.
  * Added confirmation dialog when closing the modal with unsaved changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->