### PR TITLE
Feature/issue-1440: [Reports] Implement validation for Add Funds or Expenditures category modal

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -161,6 +161,12 @@ export const FUNDS_EXPENDITURES_TEXT = {
         RECORD_DELETED_SUCCESSFULLY: 'Запис успішно видалено',
         RECORD_DELETE_FAILED_RETRY: 'Не вдалося видалити запис. Спробуйте ще раз',
         AMOUNT_USD_NOT_MATCH: 'Сума в USD не відповідає сумі в UAH',
+        CATEGORY_CREATED_SUCCESSFULLY: 'Категорію додано успішно',
+        CATEGORY_CREATE_FAILED_RETRY: 'Виникла помилка, спробуйте ще раз',
+        CATEGORY_DELETED_SUCCESSFULLY: 'Категорію видалено успішно',
+        CATEGORY_DELETE_FAILED_RETRY: 'Виникла помилка, спробуйте ще раз',
+        CATEGORY_UPDATED_SUCCESSFULLY: 'Категорію оновлено успішно',
+        CATEGORY_UPDATE_FAILED_RETRY: 'Виникла помилка, спробуйте ще раз',
     },
     MODAL: {
         SHARED: {
@@ -190,6 +196,29 @@ export const FUNDS_EXPENDITURES_TEXT = {
             SUBMIT_BUTTON: 'Додати витрату',
             CONFIRM_ADD_TITLE: 'Додати нову витрату?',
         },
+        EDIT_CATEGORY: {
+            TITLE: 'Редагувати категорію',
+            SUBTITLE: 'Редагування категорії витрат/надходжень для формування звітності',
+            CATEGORY_LABEL: 'Категорія',
+            CATEGORY_PLACEHOLDER: 'Оберіть категорію',
+            NAME_LABEL: 'Редагувати назву',
+            NAME_PLACEHOLDER: 'Введіть назву категорії',
+            SUBMIT_BUTTON: 'Зберегти',
+            CONFIRM_SAVE_TITLE: 'Зберегти зміни?',
+        },
+        DELETE_CATEGORY: {
+            TITLE: 'Видалити категорію',
+            CATEGORY_LABEL: 'Категорія',
+            CATEGORY_PLACEHOLDER: 'Оберіть категорію',
+            CONFIRM_TITLE: 'Видалити категорію?',
+            ERROR: {
+                getHasIncomeRecordTitle: (count: number) =>
+                    `Категорія використовується в надходженнях, ${count} ${count === 1 ? 'запис' : count < 5 ? 'записи' : 'записів'}`,
+                getHasExpenseRecordTitle: (count: number) =>
+                    `Категорія використовується у витратах, ${count} ${count === 1 ? 'запис' : count < 5 ? 'записи' : 'записів'}`,
+                HAS_RECORD_TEXT: 'Видаліть або змініть їх',
+            },
+        },
         CATEGORY: {
             TITLE: 'Додати категорію',
             SUBTITLE: 'Додавання категорії витрат/надходжень для формування звітності',
@@ -208,6 +237,8 @@ export const FUNDS_EXPENDITURES_TEXT = {
         ADD_INCOME: 'Надходження',
         ADD_EXPENSE: 'Витрати',
         ADD_CATEGORY: 'Додати категорію',
+        DELETE_CATEGORY: 'Видалити',
+        EDIT_CATEGORY: 'Редагувати',
     },
     FILTER: {
         TYPE_PLACEHOLDER: 'Тип',

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -146,6 +146,7 @@ export const FUNDS_EXPENDITURES_VALIDATION = {
         maxDecimalDigits: 6,
     },
     maxCategoriesPerType: 4,
+    categoryNameMin: 5,
     categoryNameMax: 200,
 };
 
@@ -197,6 +198,9 @@ export const FUNDS_EXPENDITURES_TEXT = {
             NAME_LABEL: 'Назва',
             NAME_PLACEHOLDER: 'Введіть назву категорії',
             SUBMIT_BUTTON: 'Зберегти',
+            ERROR: {
+                NAME_DUPLICATE: 'Категорія з такою назвою вже існує',
+            },
         },
     },
     BUTTON: {

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -502,6 +502,7 @@ export const FundsExpenditureSection = ({
             <AddFundsExpendituresCategoryModal
                 isOpen={isAddCategoryModalOpen}
                 onClose={onAddCategoryModalClose ?? (() => {})}
+                categories={categories}
             />
 
             <DeleteRecordModal

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -32,6 +32,8 @@ import { EnrichedRecord, FundsExpendituresTable } from './components/funds-expen
 import { AddFundsExpendituresRecordModal } from './components/common/add-funds-expenditures-record-modal/AddFundsExpendituresRecordModal';
 import { AddFundsExpendituresCategoryModal } from './components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal';
 import { DeleteRecordModal } from './components/common/delete-record-modal/DeleteRecordModal';
+import { DeleteFundsExpendituresCategoryModal } from './components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal';
+import { EditFundsExpendituresCategoryModal } from './components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal';
 import styles from './FundsExpendituresSection.module.scss';
 
 const enrichRecords = (
@@ -52,6 +54,10 @@ interface FundsExpenditureSectionProps {
     onExchangeRateValueChange?: (exchangeRate: string | null) => void;
     isAddCategoryModalOpen?: boolean;
     onAddCategoryModalClose?: () => void;
+    isDeleteCategoryModalOpen?: boolean;
+    onDeleteCategoryModalClose?: () => void;
+    isEditCategoryModalOpen?: boolean;
+    onEditCategoryModalClose?: () => void;
 }
 
 export const FundsExpenditureSection = ({
@@ -61,6 +67,10 @@ export const FundsExpenditureSection = ({
     onExchangeRateValueChange,
     isAddCategoryModalOpen = false,
     onAddCategoryModalClose,
+    isDeleteCategoryModalOpen = false,
+    onDeleteCategoryModalClose,
+    isEditCategoryModalOpen = false,
+    onEditCategoryModalClose,
 }: FundsExpenditureSectionProps = {}) => {
     const adminClient = useAdminClient();
     const { addToast } = useToast();
@@ -166,7 +176,11 @@ export const FundsExpenditureSection = ({
         onExchangeRateValueChange?.(settings?.exchangeRate ?? null);
     }, [onEditModeChange, onExchangeRateValueChange, settings?.exchangeRate]);
 
-    const { data: categories, isLoading: isCategoriesLoading } = useDataFetch<ReportFundsExpendituresCategory[]>({
+    const {
+        data: categories,
+        isLoading: isCategoriesLoading,
+        refetch: refetchCategories,
+    } = useDataFetch<ReportFundsExpendituresCategory[]>({
         initialData: [],
         fetchHandler: fetchCategories,
     });
@@ -315,6 +329,53 @@ export const FundsExpenditureSection = ({
             }
         },
         [addToast, adminClient, refetchSummary],
+    );
+
+    const handleCreateCategory = useCallback(
+        async (data: { name: string; type: FundsExpendituresTransactionType }): Promise<boolean> => {
+            try {
+                await FundsExpendituresApi.createCategory(adminClient, data);
+                refetchCategories();
+                addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.CATEGORY_CREATED_SUCCESSFULLY, ToastType.Success);
+                return true;
+            } catch {
+                addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.CATEGORY_CREATE_FAILED_RETRY, ToastType.Error);
+                return false;
+            }
+        },
+        [addToast, adminClient, refetchCategories],
+    );
+
+    const handleEditCategory = useCallback(
+        async (categoryId: number, name: string): Promise<boolean> => {
+            const category = categories.find((c) => c.id === categoryId);
+            if (!category) return false;
+            try {
+                await FundsExpendituresApi.updateCategory(adminClient, categoryId, { name, type: category.type });
+                refetchCategories();
+                addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.CATEGORY_UPDATED_SUCCESSFULLY, ToastType.Success);
+                return true;
+            } catch {
+                addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.CATEGORY_UPDATE_FAILED_RETRY, ToastType.Error);
+                return false;
+            }
+        },
+        [addToast, adminClient, categories, refetchCategories],
+    );
+
+    const handleDeleteCategory = useCallback(
+        async (categoryId: number): Promise<boolean> => {
+            try {
+                await FundsExpendituresApi.deleteCategory(adminClient, categoryId);
+                refetchCategories();
+                addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.CATEGORY_DELETED_SUCCESSFULLY, ToastType.Success);
+                return true;
+            } catch {
+                addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.CATEGORY_DELETE_FAILED_RETRY, ToastType.Error);
+                return false;
+            }
+        },
+        [addToast, adminClient, refetchCategories],
     );
 
     const handleDeleteClick = (record: ReportFundsExpendituresRecord) => {
@@ -503,6 +564,22 @@ export const FundsExpenditureSection = ({
                 isOpen={isAddCategoryModalOpen}
                 onClose={onAddCategoryModalClose ?? (() => {})}
                 categories={categories}
+                onSubmit={handleCreateCategory}
+            />
+
+            <EditFundsExpendituresCategoryModal
+                isOpen={isEditCategoryModalOpen}
+                onClose={onEditCategoryModalClose ?? (() => {})}
+                categories={categories}
+                onSubmit={handleEditCategory}
+            />
+
+            <DeleteFundsExpendituresCategoryModal
+                isOpen={isDeleteCategoryModalOpen}
+                onClose={onDeleteCategoryModalClose ?? (() => {})}
+                categories={categories}
+                records={recordsState}
+                onSubmit={handleDeleteCategory}
             />
 
             <DeleteRecordModal

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -226,7 +226,7 @@ export const FundsExpenditureSection = ({
 
         if (settings && !hasSeededEditingValuesRef.current) {
             const initialExchangeRateValue =
-                draftExchangeRate !== undefined ? (draftExchangeRate ?? '') : (settings.exchangeRate ?? '');
+                draftExchangeRate === undefined ? (settings.exchangeRate ?? '') : (draftExchangeRate ?? '');
 
             setDisclaimerValue((currentValue) => currentValue || (settings.disclaimerTitle ?? ''));
             setExchangeRateValue((currentValue) => currentValue || initialExchangeRateValue);

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.module.scss
@@ -41,12 +41,20 @@
     background: c.$white;
 }
 
+.selectHeadError {
+    border-color: c.$error;
+}
+
 .input {
     width: 100%;
 }
 
 .panel :global(.char-limit-input) {
     width: 100%;
+}
+
+.inputError :global(.char-limit-input) {
+    border-color: c.$error;
 }
 
 .panel :global(.select-options) {
@@ -138,6 +146,18 @@
     border: 1px solid c.$grey-150;
     padding: 20px 22px;
     min-height: 180px;
+}
+
+.error {
+    @include type.small-text-regular;
+    margin: 4px 0 0;
+    min-height: 20px;
+    color: c.$error;
+    visibility: visible;
+}
+
+.errorHidden {
+    visibility: hidden;
 }
 
 .actions {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
 import { AddFundsExpendituresCategoryModal } from './AddFundsExpendituresCategoryModal';
 
 jest.mock('@/components/common/modal/Modal', () => {
@@ -53,9 +55,12 @@ describe('AddFundsExpendituresCategoryModal', () => {
     const TYPE_SELECT = FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.TYPE_PLACEHOLDER;
     const NAME_INPUT = 'category-name';
     const SUBMIT_BUTTON_NAME = FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.SUBMIT_BUTTON;
+    const REQUIRED_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
+    const MIN_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMin);
+    const DUPLICATE_ERROR = FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.ERROR.NAME_DUPLICATE;
 
-    const renderOpen = (onClose = jest.fn()) =>
-        render(<AddFundsExpendituresCategoryModal isOpen={true} onClose={onClose} />);
+    const renderOpen = (onClose = jest.fn(), categories: ReportFundsExpendituresCategory[] = []) =>
+        render(<AddFundsExpendituresCategoryModal isOpen={true} onClose={onClose} categories={categories} />);
 
     const getSubmitButton = () => screen.getByRole('button', { name: SUBMIT_BUTTON_NAME });
 
@@ -104,10 +109,131 @@ describe('AddFundsExpendituresCategoryModal', () => {
             expect(getSubmitButton()).toBeDisabled();
         });
 
-        it('is enabled when both type and non-empty name are set', () => {
+        it('is disabled when name is shorter than minimum length', () => {
+            renderOpen();
+            fillForm('expense', 'abc');
+            expect(getSubmitButton()).toBeDisabled();
+        });
+
+        it('is disabled when name matches an existing category for the same type (case-insensitive)', () => {
+            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Приватні донори', type: 'income' }];
+            renderOpen(jest.fn(), categories);
+            fillForm('income', 'приватні донори');
+            expect(getSubmitButton()).toBeDisabled();
+        });
+
+        it('is disabled when name matches an existing category with different word order', () => {
+            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Приватні донори', type: 'income' }];
+            renderOpen(jest.fn(), categories);
+            fillForm('income', 'Донори приватні');
+            expect(getSubmitButton()).toBeDisabled();
+        });
+
+        it('is enabled when name matches a category of a different type', () => {
+            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Приватні донори', type: 'expense' }];
+            renderOpen(jest.fn(), categories);
+            fillForm('income', 'Приватні донори');
+            expect(getSubmitButton()).not.toBeDisabled();
+        });
+
+        it('is enabled when both type and valid name are set', () => {
             renderOpen();
             fillForm();
             expect(getSubmitButton()).not.toBeDisabled();
+        });
+    });
+
+    describe('name field validation', () => {
+        it('shows required error on blur when name is empty', () => {
+            renderOpen();
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(REQUIRED_ERROR)).toBeInTheDocument();
+        });
+
+        it('shows min length error on blur when name is too short', () => {
+            renderOpen();
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'abc' } });
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(MIN_ERROR)).toBeInTheDocument();
+        });
+
+        it('shows duplicate error on blur when name matches existing category for same type', () => {
+            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Приватні донори', type: 'income' }];
+            renderOpen(jest.fn(), categories);
+            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'income' } });
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Донори приватні' } });
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(DUPLICATE_ERROR)).toBeInTheDocument();
+        });
+
+        it('does not show duplicate error when type differs from existing category', () => {
+            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Приватні донори', type: 'expense' }];
+            renderOpen(jest.fn(), categories);
+            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'income' } });
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Приватні донори' } });
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.queryByText(DUPLICATE_ERROR)).not.toBeInTheDocument();
+        });
+
+        it('clears name error when name becomes valid on re-blur', () => {
+            renderOpen();
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'ab' } });
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(MIN_ERROR)).toBeInTheDocument();
+
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Valid name' } });
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.queryByText(MIN_ERROR)).not.toBeInTheDocument();
+        });
+    });
+
+    describe('name re-validation on type change', () => {
+        it('shows duplicate error when type changes to one that has the same name', () => {
+            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Category A', type: 'expense' }];
+            renderOpen(jest.fn(), categories);
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Category A' } });
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.queryByText(DUPLICATE_ERROR)).not.toBeInTheDocument();
+
+            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'expense' } });
+            expect(screen.getByText(DUPLICATE_ERROR)).toBeInTheDocument();
+        });
+
+        it('clears duplicate error when type changes to one without the same name', () => {
+            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Category A', type: 'income' }];
+            renderOpen(jest.fn(), categories);
+            fillForm('income', 'Category A');
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(DUPLICATE_ERROR)).toBeInTheDocument();
+
+            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'expense' } });
+            expect(screen.queryByText(DUPLICATE_ERROR)).not.toBeInTheDocument();
+        });
+
+        it('does not show name error on type change before name has been blurred', () => {
+            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Category A', type: 'expense' }];
+            renderOpen(jest.fn(), categories);
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Category A' } });
+
+            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'expense' } });
+            expect(screen.queryByText(DUPLICATE_ERROR)).not.toBeInTheDocument();
+        });
+    });
+
+    describe('type field validation', () => {
+        it('shows required error when type field loses focus without selection', () => {
+            renderOpen();
+            fireEvent.blur(screen.getByTestId(TYPE_SELECT));
+            expect(screen.getByText(REQUIRED_ERROR)).toBeInTheDocument();
+        });
+
+        it('clears type error when type is selected', () => {
+            renderOpen();
+            fireEvent.blur(screen.getByTestId(TYPE_SELECT));
+            expect(screen.getByText(REQUIRED_ERROR)).toBeInTheDocument();
+
+            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'income' } });
+            expect(screen.queryByText(REQUIRED_ERROR)).not.toBeInTheDocument();
         });
     });
 
@@ -139,6 +265,15 @@ describe('AddFundsExpendituresCategoryModal', () => {
             fireEvent.click(screen.getByTestId('modal-close'));
             expect(onClose).toHaveBeenCalledTimes(1);
             expect(screen.getByTestId('confirm-modal')).toHaveAttribute('data-open', 'false');
+        });
+
+        it('resets errors when closing a clean form', () => {
+            renderOpen();
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(REQUIRED_ERROR)).toBeInTheDocument();
+
+            fireEvent.click(screen.getByTestId('modal-close'));
+            expect(screen.queryByText(REQUIRED_ERROR)).not.toBeInTheDocument();
         });
 
         it('opens confirmation modal when type is dirty on close request', () => {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.test.tsx
@@ -91,49 +91,10 @@ describe('AddFundsExpendituresCategoryModal', () => {
             expect(getSubmitButton()).toBeDisabled();
         });
 
-        it('is disabled when type is selected but name is empty', () => {
-            renderOpen();
-            fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'expense' } });
-            expect(getSubmitButton()).toBeDisabled();
-        });
-
-        it('is disabled when name is entered but type is not selected', () => {
-            renderOpen();
-            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Category A' } });
-            expect(getSubmitButton()).toBeDisabled();
-        });
-
-        it('is disabled when name contains only whitespace', () => {
-            renderOpen();
-            fillForm('income', '   ');
-            expect(getSubmitButton()).toBeDisabled();
-        });
-
-        it('is disabled when name is shorter than minimum length', () => {
+        it('is disabled when form is incomplete', () => {
             renderOpen();
             fillForm('expense', 'abc');
             expect(getSubmitButton()).toBeDisabled();
-        });
-
-        it('is disabled when name matches an existing category for the same type (case-insensitive)', () => {
-            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Приватні донори', type: 'income' }];
-            renderOpen(jest.fn(), categories);
-            fillForm('income', 'приватні донори');
-            expect(getSubmitButton()).toBeDisabled();
-        });
-
-        it('is disabled when name matches an existing category with different word order', () => {
-            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Приватні донори', type: 'income' }];
-            renderOpen(jest.fn(), categories);
-            fillForm('income', 'Донори приватні');
-            expect(getSubmitButton()).toBeDisabled();
-        });
-
-        it('is enabled when name matches a category of a different type', () => {
-            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Приватні донори', type: 'expense' }];
-            renderOpen(jest.fn(), categories);
-            fillForm('income', 'Приватні донори');
-            expect(getSubmitButton()).not.toBeDisabled();
         });
 
         it('is enabled when both type and valid name are set', () => {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.test.tsx
@@ -1,24 +1,8 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
 import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
 import { AddFundsExpendituresCategoryModal } from './AddFundsExpendituresCategoryModal';
-
-jest.mock('@/components/common/modal/Modal', () => {
-    const Modal = ({ isOpen, onClose, children }: any) => {
-        if (!isOpen) return null;
-        return (
-            <div data-testid="modal">
-                <button data-testid="modal-close" onClick={onClose} />
-                {children}
-            </div>
-        );
-    };
-    Modal.Title = ({ children }: any) => <>{children}</>;
-    Modal.Content = ({ children }: any) => <>{children}</>;
-    Modal.Actions = ({ children }: any) => <>{children}</>;
-    return { Modal };
-});
 
 jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
     ConfirmationModal: ({ isOpen, title, onConfirm, onCancel, onClose }: any) => (
@@ -71,7 +55,7 @@ describe('AddFundsExpendituresCategoryModal', () => {
 
     it('renders nothing when isOpen is false', () => {
         render(<AddFundsExpendituresCategoryModal isOpen={false} onClose={jest.fn()} />);
-        expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('modal-overlay')).not.toBeInTheDocument();
     });
 
     it('renders title and subtitle when open', () => {
@@ -198,10 +182,55 @@ describe('AddFundsExpendituresCategoryModal', () => {
         });
     });
 
-    it('clicking submit does not throw when enabled', () => {
-        renderOpen();
-        fillForm('income', 'Valid name');
-        expect(() => fireEvent.click(getSubmitButton())).not.toThrow();
+    describe('submit behaviour', () => {
+        const renderWithSubmit = (onSubmit: jest.Mock, onClose = jest.fn()) =>
+            render(<AddFundsExpendituresCategoryModal isOpen={true} onClose={onClose} onSubmit={onSubmit} />);
+
+        it('calls onSubmit with normalized name and type on click', async () => {
+            const onSubmit = jest.fn().mockResolvedValue(true);
+            renderWithSubmit(onSubmit);
+            fillForm('income', '  Valid name  ');
+            fireEvent.click(getSubmitButton());
+            await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ name: 'Valid name', type: 'income' }));
+        });
+
+        it('resets form and calls onClose when onSubmit resolves true', async () => {
+            const onClose = jest.fn();
+            const onSubmit = jest.fn().mockResolvedValue(true);
+            renderWithSubmit(onSubmit, onClose);
+            fillForm('expense', 'Valid name');
+            fireEvent.click(getSubmitButton());
+            await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+            expect(screen.getByTestId('category-name')).toHaveValue('');
+            expect(getSubmitButton()).toBeDisabled();
+        });
+
+        it('keeps modal open when onSubmit resolves false', async () => {
+            const onClose = jest.fn();
+            const onSubmit = jest.fn().mockResolvedValue(false);
+            renderWithSubmit(onSubmit, onClose);
+            fillForm('income', 'Valid name');
+            fireEvent.click(getSubmitButton());
+            await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+            expect(onClose).not.toHaveBeenCalled();
+            expect(screen.getByTestId('modal-overlay')).toBeInTheDocument();
+        });
+
+        it('disables submit button while submitting', async () => {
+            let resolve!: (v: boolean) => void;
+            const onSubmit = jest.fn().mockReturnValue(
+                new Promise<boolean>((r) => {
+                    resolve = r;
+                }),
+            );
+            renderWithSubmit(onSubmit);
+            fillForm('income', 'Valid name');
+            fireEvent.click(getSubmitButton());
+            expect(getSubmitButton()).toBeDisabled();
+            await act(async () => {
+                resolve(true);
+            });
+        });
     });
 
     it('normalizes whitespace in name input on blur', () => {
@@ -216,14 +245,14 @@ describe('AddFundsExpendituresCategoryModal', () => {
         const triggerDirtyClose = (onClose = jest.fn()) => {
             renderOpen(onClose);
             fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'dirty' } });
-            fireEvent.click(screen.getByTestId('modal-close'));
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
             return onClose;
         };
 
         it('calls onClose directly when form is clean', () => {
             const onClose = jest.fn();
             renderOpen(onClose);
-            fireEvent.click(screen.getByTestId('modal-close'));
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
             expect(onClose).toHaveBeenCalledTimes(1);
             expect(screen.getByTestId('confirm-modal')).toHaveAttribute('data-open', 'false');
         });
@@ -233,7 +262,7 @@ describe('AddFundsExpendituresCategoryModal', () => {
             fireEvent.blur(screen.getByTestId(NAME_INPUT));
             expect(screen.getByText(REQUIRED_ERROR)).toBeInTheDocument();
 
-            fireEvent.click(screen.getByTestId('modal-close'));
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
             expect(screen.queryByText(REQUIRED_ERROR)).not.toBeInTheDocument();
         });
 
@@ -241,7 +270,7 @@ describe('AddFundsExpendituresCategoryModal', () => {
             const onClose = jest.fn();
             renderOpen(onClose);
             fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'expense' } });
-            fireEvent.click(screen.getByTestId('modal-close'));
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
             expect(onClose).not.toHaveBeenCalled();
             expect(screen.getByTestId('confirm-modal')).toHaveAttribute('data-open', 'true');
         });
@@ -262,7 +291,7 @@ describe('AddFundsExpendituresCategoryModal', () => {
             fireEvent.click(screen.getByTestId('confirm-no'));
             expect(onClose).not.toHaveBeenCalled();
             expect(screen.getByTestId('confirm-modal')).toHaveAttribute('data-open', 'false');
-            expect(screen.getByTestId('modal')).toBeInTheDocument();
+            expect(screen.getByTestId('modal-overlay')).toBeInTheDocument();
         });
 
         it('dismisses confirmation and keeps modal open on cancel via onClose', () => {
@@ -278,7 +307,7 @@ describe('AddFundsExpendituresCategoryModal', () => {
             fillForm();
             expect(getSubmitButton()).not.toBeDisabled();
 
-            fireEvent.click(screen.getByTestId('modal-close'));
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
             fireEvent.click(screen.getByTestId('confirm-yes'));
 
             expect(onClose).toHaveBeenCalledTimes(1);

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.tsx
@@ -1,46 +1,92 @@
-import { useCallback, useMemo, useState } from 'react';
+import { FocusEvent, useCallback, useMemo, useRef, useState } from 'react';
+import cn from 'classnames';
 import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { InputWithCharacterLimit } from '@/components/admin/input-with-character-limit/InputWithCharacterLimit';
 import { Select } from '@/components/common/select/Select';
 import { Modal } from '@/components/common/modal/Modal';
 import { Button } from '@/components/admin/button/Button';
 import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
-import { FundsExpendituresTransactionType } from '@/types/admin/reports';
+import { FundsExpendituresTransactionType, ReportFundsExpendituresCategory } from '@/types/admin/reports';
+import { getNormalizedInputText } from '@/utils/functions/formatters/text-formatters';
+import {
+    validateFundsExpendituresCategoryName,
+    validateFundsExpendituresCategoryType,
+} from '@/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema';
 import styles from './AddFundsExpendituresCategoryModal.module.scss';
 
 interface AddFundsExpendituresCategoryModalProps {
     isOpen: boolean;
     onClose: () => void;
+    categories?: ReportFundsExpendituresCategory[];
 }
 
-const normalizeForSave = (value: string) => value.replaceAll(/\s+/g, ' ').trim();
-
-export const AddFundsExpendituresCategoryModal = ({ isOpen, onClose }: AddFundsExpendituresCategoryModalProps) => {
+export const AddFundsExpendituresCategoryModal = ({
+    isOpen,
+    onClose,
+    categories = [],
+}: AddFundsExpendituresCategoryModalProps) => {
     const [type, setType] = useState<FundsExpendituresTransactionType | undefined>(undefined);
     const [name, setName] = useState('');
+    const [nameError, setNameError] = useState<string | undefined>(undefined);
+    const [typeError, setTypeError] = useState<string | undefined>(undefined);
+    const [hasNameBeenBlurred, setHasNameBeenBlurred] = useState(false);
     const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false);
 
-    const nameMax = FUNDS_EXPENDITURES_VALIDATION.categoryNameMax;
+    const typeSelectRef = useRef<HTMLDivElement | null>(null);
+
     const isDirty = type !== undefined || name.trim().length > 0;
 
-    const isSubmitDisabled = useMemo(() => {
-        return !type || normalizeForSave(name).length === 0;
-    }, [type, name]);
+    const isSubmitDisabled = useMemo(
+        () =>
+            validateFundsExpendituresCategoryType(type) !== undefined ||
+            validateFundsExpendituresCategoryName(name, type, categories) !== undefined,
+        [type, name, categories],
+    );
 
     const resetForm = useCallback(() => {
         setName('');
         setType(undefined);
+        setNameError(undefined);
+        setTypeError(undefined);
+        setHasNameBeenBlurred(false);
     }, []);
 
     const handleSubmit = () => {};
+
+    const handleTypeChange = useCallback(
+        (newType: FundsExpendituresTransactionType) => {
+            setType(newType);
+            setTypeError(undefined);
+            if (hasNameBeenBlurred) {
+                setNameError(validateFundsExpendituresCategoryName(name, newType, categories));
+            }
+        },
+        [hasNameBeenBlurred, name, categories],
+    );
+
+    const handleTypeFieldBlur = useCallback(
+        (event: FocusEvent<HTMLDivElement>) => {
+            if (typeSelectRef.current?.contains(event.relatedTarget as Node | null)) return;
+            setTypeError(validateFundsExpendituresCategoryType(type));
+        },
+        [type],
+    );
+
+    const handleNameBlur = useCallback(() => {
+        setHasNameBeenBlurred(true);
+        setName(getNormalizedInputText(name));
+        setNameError(validateFundsExpendituresCategoryName(name, type, categories));
+    }, [name, type, categories]);
 
     const handleRequestClose = useCallback(() => {
         if (isDirty) {
             setIsCloseConfirmOpen(true);
             return;
         }
+        resetForm();
         onClose();
-    }, [isDirty, onClose]);
+    }, [isDirty, onClose, resetForm]);
 
     const handleConfirmClose = useCallback(() => {
         setIsCloseConfirmOpen(false);
@@ -66,17 +112,20 @@ export const AddFundsExpendituresCategoryModal = ({ isOpen, onClose }: AddFundsE
                     <div className={styles.content}>
                         <div className={styles.panel}>
                             <div className={styles.form}>
-                                <div className={styles.field}>
+                                <div className={styles.field} onBlurCapture={handleTypeFieldBlur}>
                                     <label className={styles.label}>
                                         <span className={styles.required}>*</span>
                                         {FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.TYPE_LABEL}
                                     </label>
                                     <Select<FundsExpendituresTransactionType>
                                         value={type}
-                                        onValueChange={(v) => setType(v)}
+                                        onValueChange={handleTypeChange}
+                                        selectContainerRef={typeSelectRef}
                                         placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.TYPE_PLACEHOLDER}
                                         className={styles.selectContainer}
-                                        headClassName={styles.selectHead}
+                                        headClassName={cn(styles.selectHead, {
+                                            [styles.selectHeadError]: Boolean(typeError),
+                                        })}
                                     >
                                         <Select.Option
                                             value="expense"
@@ -87,6 +136,9 @@ export const AddFundsExpendituresCategoryModal = ({ isOpen, onClose }: AddFundsE
                                             name={FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME}
                                         />
                                     </Select>
+                                    <p className={cn(styles.error, { [styles.errorHidden]: !typeError })}>
+                                        {typeError ?? ' '}
+                                    </p>
                                 </div>
 
                                 <div className={styles.field}>
@@ -94,17 +146,26 @@ export const AddFundsExpendituresCategoryModal = ({ isOpen, onClose }: AddFundsE
                                         <span className={styles.required}>*</span>
                                         {FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.NAME_LABEL}
                                     </label>
-                                    <InputWithCharacterLimit
-                                        id="category-name"
-                                        name="categoryName"
-                                        value={name}
-                                        onChange={(e) => setName(e.target.value)}
-                                        onBlur={() => setName((s) => s.replaceAll(/\s+/g, ' ').trim())}
-                                        maxLength={nameMax}
-                                        placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.NAME_PLACEHOLDER}
-                                        showCounter={true}
-                                        className={styles.input}
-                                    />
+                                    <div className={cn({ [styles.inputError]: Boolean(nameError) })}>
+                                        <InputWithCharacterLimit
+                                            id="category-name"
+                                            name="categoryName"
+                                            value={name}
+                                            onChange={(e) => setName(e.target.value)}
+                                            onBlur={handleNameBlur}
+                                            maxLength={FUNDS_EXPENDITURES_VALIDATION.categoryNameMax}
+                                            maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
+                                                FUNDS_EXPENDITURES_VALIDATION.categoryNameMax,
+                                            )}
+                                            placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.NAME_PLACEHOLDER}
+                                            showCounter={true}
+                                            hasError={Boolean(nameError)}
+                                            className={styles.input}
+                                        />
+                                    </div>
+                                    <p className={cn(styles.error, { [styles.errorHidden]: !nameError })}>
+                                        {nameError ?? ' '}
+                                    </p>
                                 </div>
                             </div>
                         </div>

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.tsx
@@ -15,16 +15,30 @@ import {
 } from '@/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema';
 import styles from './AddFundsExpendituresCategoryModal.module.scss';
 
+const renderInputWithError = (
+    input: React.ReactNode,
+    error?: string,
+    inputErrorClass?: string,
+    errorClass?: string,
+) => (
+    <>
+        <div className={cn({ [inputErrorClass || '']: Boolean(error) })}>{input}</div>
+        <p className={cn(errorClass, { [styles.errorHidden]: !error })}>{error ?? ' '}</p>
+    </>
+);
+
 interface AddFundsExpendituresCategoryModalProps {
     isOpen: boolean;
     onClose: () => void;
     categories?: ReportFundsExpendituresCategory[];
+    onSubmit?: (data: { name: string; type: FundsExpendituresTransactionType }) => Promise<boolean>;
 }
 
 export const AddFundsExpendituresCategoryModal = ({
     isOpen,
     onClose,
     categories = [],
+    onSubmit,
 }: AddFundsExpendituresCategoryModalProps) => {
     const [type, setType] = useState<FundsExpendituresTransactionType | undefined>(undefined);
     const [name, setName] = useState('');
@@ -32,6 +46,7 @@ export const AddFundsExpendituresCategoryModal = ({
     const [typeError, setTypeError] = useState<string | undefined>(undefined);
     const [hasNameBeenBlurred, setHasNameBeenBlurred] = useState(false);
     const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
 
     const typeSelectRef = useRef<HTMLDivElement | null>(null);
 
@@ -50,9 +65,20 @@ export const AddFundsExpendituresCategoryModal = ({
         setNameError(undefined);
         setTypeError(undefined);
         setHasNameBeenBlurred(false);
+        setIsSubmitting(false);
     }, []);
 
-    const handleSubmit = () => {};
+    const handleSubmit = useCallback(async () => {
+        if (!type || !onSubmit) return;
+        setIsSubmitting(true);
+        const success = await onSubmit({ name: getNormalizedInputText(name), type });
+        if (success) {
+            resetForm();
+            onClose();
+        } else {
+            setIsSubmitting(false);
+        }
+    }, [type, name, onSubmit, resetForm, onClose]);
 
     const handleTypeChange = useCallback(
         (newType: FundsExpendituresTransactionType) => {
@@ -146,7 +172,7 @@ export const AddFundsExpendituresCategoryModal = ({
                                         <span className={styles.required}>*</span>
                                         {FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.NAME_LABEL}
                                     </label>
-                                    <div className={cn({ [styles.inputError]: Boolean(nameError) })}>
+                                    {renderInputWithError(
                                         <InputWithCharacterLimit
                                             id="category-name"
                                             name="categoryName"
@@ -161,11 +187,11 @@ export const AddFundsExpendituresCategoryModal = ({
                                             showCounter={true}
                                             hasError={Boolean(nameError)}
                                             className={styles.input}
-                                        />
-                                    </div>
-                                    <p className={cn(styles.error, { [styles.errorHidden]: !nameError })}>
-                                        {nameError ?? ' '}
-                                    </p>
+                                        />,
+                                        nameError,
+                                        styles.inputError,
+                                        styles.error,
+                                    )}
                                 </div>
                             </div>
                         </div>
@@ -177,7 +203,7 @@ export const AddFundsExpendituresCategoryModal = ({
                         <Button
                             buttonStyle="primary"
                             onClick={handleSubmit}
-                            disabled={isSubmitDisabled}
+                            disabled={isSubmitDisabled || isSubmitting}
                             className={styles.submit}
                         >
                             {FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.SUBMIT_BUTTON}

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.module.scss
@@ -1,66 +1,6 @@
 @use '@/assets/sass/variables/colors' as c;
 @use '@/assets/sass/mixins/typography.mixins' as type;
 
-.form {
-    display: flex;
-    flex-direction: column;
-    gap: 18px;
-    width: 100%;
-}
-
-.field {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-}
-
-.label {
-    @include type.small-text-medium;
-    color: c.$bluish-black;
-    margin-bottom: 8px;
-}
-
-.required {
-    color: c.$error;
-    margin-right: 6px;
-}
-
-.selectContainer {
-    width: 100%;
-}
-
-.selectHead {
-    width: 100%;
-    height: 48px;
-    padding: 0 16px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    border: 1px solid c.$grey-700;
-    border-radius: 8px;
-    background: c.$white;
-}
-
-.selectHeadError {
-    border-color: c.$error;
-}
-
-.input {
-    width: 100%;
-}
-
-.panel :global(.char-limit-input) {
-    width: 100%;
-}
-
-.inputError :global(.char-limit-input) {
-    border-color: c.$error;
-}
-
-.panel :global(.select-options) {
-    width: 100%;
-}
-
 .modal {
     width: 650px;
 
@@ -68,7 +8,7 @@
         width: 650px;
         max-width: 650px;
         border-radius: 8px;
-        background: c.$white;
+        background-color: c.$white;
         padding: 0;
     }
 
@@ -106,14 +46,8 @@
 
     :global(.modal-footer button) {
         width: 100%;
+        height: 40px;
     }
-}
-
-.header {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 14px;
 }
 
 .title {
@@ -121,16 +55,9 @@
     font-weight: 400;
     line-height: 24px;
     letter-spacing: -0.02em;
-    text-align: left;
+    text-align: center;
     margin: 0;
     color: c.$blue-900;
-}
-
-.subtitle {
-    @include type.body-1-regular;
-    line-height: 20px;
-    margin: 0;
-    color: c.$grey-900;
 }
 
 .content {
@@ -145,34 +72,79 @@
     flex-direction: column;
     align-items: stretch;
     width: 100%;
-    background: c.$grey-50;
+    background-color: c.$grey-50;
     border: 1px solid c.$grey-150;
     padding: 20px 22px;
     min-height: 180px;
+    gap: 12px;
 }
 
-.error {
-    @include type.small-text-regular;
-    margin: 4px 0 0;
-    min-height: 20px;
+.field {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
+.labelRow {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.label {
+    @include type.small-text-medium;
+    color: c.$bluish-black;
+}
+
+.required {
     color: c.$error;
-    visibility: visible;
+    margin-right: 6px;
 }
 
-.errorHidden {
-    visibility: hidden;
+.selectContainer {
+    width: 100%;
+}
+
+.selectHead {
+    width: 100%;
+    height: 48px;
+    padding: 0 16px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border: 1px solid c.$grey-700;
+    border-radius: 8px;
+    background-color: c.$white;
+}
+
+.panel :global(.select-options) {
+    width: 100%;
+}
+
+.panel :global(.hint-box) {
+    color: c.$blue-900;
+}
+
+.type {
+    @include type.small-text-regular;
+    margin: 0;
+    color: c.$blue-900;
 }
 
 .actions {
     width: 100%;
     display: flex;
+    gap: 24px;
     justify-content: center;
 }
 
-.submit {
-    @include type.subtitle-2-medium;
-    height: 60px;
-    width: 100%;
+.deleteButton {
+    background-color: c.$blue-900;
+
+    &:disabled {
+        background-color: c.$grey-700;
+    }
 }
 
 @media (max-width: 768px) {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.test.tsx
@@ -1,0 +1,262 @@
+import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { ReportFundsExpendituresCategory, ReportFundsExpendituresRecord } from '@/types/admin/reports';
+import { DeleteFundsExpendituresCategoryModal } from './DeleteFundsExpendituresCategoryModal';
+
+const CATEGORY_SELECT = FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.CATEGORY_PLACEHOLDER;
+const DELETE_BUTTON_NAME = COMMON_TEXT_ADMIN.BUTTON.DELETE;
+const CANCEL_BUTTON_NAME = COMMON_TEXT_ADMIN.BUTTON.CANCEL;
+const YES_BUTTON = COMMON_TEXT_ADMIN.BUTTON.YES;
+const NO_BUTTON = COMMON_TEXT_ADMIN.BUTTON.NO;
+
+const incomeCategory: ReportFundsExpendituresCategory = { id: 1, name: 'Донори', type: 'income' };
+const expenseCategory: ReportFundsExpendituresCategory = { id: 2, name: 'Оренда', type: 'expense' };
+
+const incomeRecord: ReportFundsExpendituresRecord = {
+    id: 10,
+    categoryId: 1,
+    type: 'income',
+    reportingYear: '2024',
+    amountUah: '1000',
+    amountUsd: '25',
+};
+
+const incomeRecord2: ReportFundsExpendituresRecord = {
+    id: 11,
+    categoryId: 1,
+    type: 'income',
+    reportingYear: '2023',
+    amountUah: '2000',
+    amountUsd: '50',
+};
+
+const expenseRecord: ReportFundsExpendituresRecord = {
+    id: 20,
+    categoryId: 2,
+    type: 'expense',
+    reportingYear: '2024',
+    amountUah: '500',
+    amountUsd: '12',
+};
+
+const renderModal = (
+    overrides: Partial<{
+        isOpen: boolean;
+        onClose: jest.Mock;
+        categories: ReportFundsExpendituresCategory[];
+        records: ReportFundsExpendituresRecord[];
+        onSubmit: jest.Mock;
+    }> = {},
+) => {
+    const props = {
+        isOpen: true,
+        onClose: jest.fn(),
+        categories: [incomeCategory, expenseCategory],
+        records: [],
+        onSubmit: jest.fn().mockResolvedValue(true),
+        ...overrides,
+    };
+    return { ...render(<DeleteFundsExpendituresCategoryModal {...props} />), ...props };
+};
+
+const getDeleteButton = () => screen.getByRole('button', { name: DELETE_BUTTON_NAME });
+const getCancelButton = () => screen.getByRole('button', { name: CANCEL_BUTTON_NAME });
+
+const selectCategory = (name: string) => {
+    fireEvent.click(screen.getByRole('button', { name: CATEGORY_SELECT }));
+    fireEvent.click(screen.getByRole('button', { name }));
+};
+
+const getConfirmOverlay = () =>
+    screen.getAllByTestId('modal-overlay').find((el) => within(el).queryByRole('button', { name: YES_BUTTON }))!;
+
+describe('DeleteFundsExpendituresCategoryModal', () => {
+    it('renders nothing when isOpen is false', () => {
+        renderModal({ isOpen: false });
+        expect(screen.queryByTestId('modal-overlay')).not.toBeInTheDocument();
+    });
+
+    it('renders modal title when open', () => {
+        renderModal();
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.TITLE)).toBeInTheDocument();
+    });
+
+    it('renders category select and action buttons', () => {
+        renderModal();
+        expect(screen.getByRole('button', { name: CATEGORY_SELECT })).toBeInTheDocument();
+        expect(getDeleteButton()).toBeInTheDocument();
+        expect(getCancelButton()).toBeInTheDocument();
+    });
+
+    describe('delete button disabled state', () => {
+        it('is disabled when no category is selected', () => {
+            renderModal();
+            expect(getDeleteButton()).toBeDisabled();
+        });
+
+        it('is enabled when a category with no record is selected', () => {
+            renderModal({ records: [] });
+            selectCategory(incomeCategory.name);
+            expect(getDeleteButton()).not.toBeDisabled();
+        });
+
+        it('is disabled when selected category has an income record', () => {
+            renderModal({ records: [incomeRecord] });
+            selectCategory(incomeCategory.name);
+            expect(getDeleteButton()).toBeDisabled();
+        });
+
+        it('is disabled when selected category has an expense record', () => {
+            renderModal({ records: [expenseRecord] });
+            selectCategory(expenseCategory.name);
+            expect(getDeleteButton()).toBeDisabled();
+        });
+    });
+
+    describe('record error hint', () => {
+        it('shows income record error when selected income category has a record', () => {
+            renderModal({ records: [incomeRecord] });
+            selectCategory(incomeCategory.name);
+            expect(
+                screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasIncomeRecordTitle(1)),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_RECORD_TEXT),
+            ).toBeInTheDocument();
+        });
+
+        it('shows expense record error when selected expense category has a record', () => {
+            renderModal({ records: [expenseRecord] });
+            selectCategory(expenseCategory.name);
+            expect(
+                screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasExpenseRecordTitle(1)),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_RECORD_TEXT),
+            ).toBeInTheDocument();
+        });
+
+        it('does not show hint box when selected category has no record', () => {
+            renderModal({ records: [] });
+            selectCategory(incomeCategory.name);
+            expect(
+                screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasIncomeRecordTitle(1)),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_RECORD_TEXT),
+            ).not.toBeInTheDocument();
+        });
+
+        it('does not show hint box when no category is selected', () => {
+            renderModal({ records: [incomeRecord] });
+            expect(
+                screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasIncomeRecordTitle(1)),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_RECORD_TEXT),
+            ).not.toBeInTheDocument();
+        });
+
+        it('shows correct plural form when category has multiple records', () => {
+            renderModal({ records: [incomeRecord, incomeRecord2] });
+            selectCategory(incomeCategory.name);
+            expect(
+                screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasIncomeRecordTitle(2)),
+            ).toBeInTheDocument();
+        });
+    });
+
+    describe('confirmation modal', () => {
+        it('opens confirmation when delete is clicked', () => {
+            renderModal();
+            selectCategory(incomeCategory.name);
+            fireEvent.click(getDeleteButton());
+            expect(getConfirmOverlay()).toBeInTheDocument();
+        });
+
+        it('shows correct confirm title', () => {
+            renderModal();
+            selectCategory(incomeCategory.name);
+            fireEvent.click(getDeleteButton());
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.CONFIRM_TITLE)).toBeInTheDocument();
+        });
+
+        it('closes confirmation on cancel', () => {
+            renderModal();
+            selectCategory(incomeCategory.name);
+            fireEvent.click(getDeleteButton());
+            fireEvent.click(within(getConfirmOverlay()).getByRole('button', { name: NO_BUTTON }));
+            expect(screen.queryAllByTestId('modal-overlay').length).toBe(1);
+        });
+    });
+
+    describe('submit behaviour', () => {
+        it('calls onSubmit with categoryId on confirm', async () => {
+            const onSubmit = jest.fn().mockResolvedValue(true);
+            renderModal({ onSubmit });
+            selectCategory(incomeCategory.name);
+            fireEvent.click(getDeleteButton());
+            fireEvent.click(within(getConfirmOverlay()).getByRole('button', { name: YES_BUTTON }));
+            await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(incomeCategory.id));
+        });
+
+        it('resets form and calls onClose when onSubmit resolves true', async () => {
+            const onClose = jest.fn();
+            const onSubmit = jest.fn().mockResolvedValue(true);
+            renderModal({ onClose, onSubmit });
+            selectCategory(incomeCategory.name);
+            fireEvent.click(getDeleteButton());
+            fireEvent.click(within(getConfirmOverlay()).getByRole('button', { name: YES_BUTTON }));
+            await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+            expect(getDeleteButton()).toBeDisabled();
+        });
+
+        it('keeps modal open and closes confirm when onSubmit resolves false', async () => {
+            const onClose = jest.fn();
+            const onSubmit = jest.fn().mockResolvedValue(false);
+            renderModal({ onClose, onSubmit });
+            selectCategory(incomeCategory.name);
+            fireEvent.click(getDeleteButton());
+            fireEvent.click(within(getConfirmOverlay()).getByRole('button', { name: YES_BUTTON }));
+            await waitFor(() => expect(screen.queryByRole('button', { name: YES_BUTTON })).not.toBeInTheDocument());
+            expect(onClose).not.toHaveBeenCalled();
+            expect(screen.getAllByTestId('modal-overlay').length).toBe(1);
+        });
+
+        it('disables confirm buttons while submitting', async () => {
+            let resolve!: (v: boolean) => void;
+            const onSubmit = jest.fn().mockReturnValue(
+                new Promise<boolean>((r) => {
+                    resolve = r;
+                }),
+            );
+            renderModal({ onSubmit });
+            selectCategory(incomeCategory.name);
+            fireEvent.click(getDeleteButton());
+            const yesBtn = within(getConfirmOverlay()).getByRole('button', { name: YES_BUTTON });
+            fireEvent.click(yesBtn);
+            expect(yesBtn).toBeDisabled();
+            await act(async () => {
+                resolve(true);
+            });
+        });
+    });
+
+    describe('cancel button', () => {
+        it('closes modal on cancel', () => {
+            const onClose = jest.fn();
+            renderModal({ onClose });
+            fireEvent.click(getCancelButton());
+            expect(onClose).toHaveBeenCalledTimes(1);
+        });
+
+        it('resets form on cancel', () => {
+            renderModal();
+            selectCategory(incomeCategory.name);
+            expect(getDeleteButton()).not.toBeDisabled();
+            fireEvent.click(getCancelButton());
+            expect(getDeleteButton()).toBeDisabled();
+        });
+    });
+});

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.tsx
@@ -1,0 +1,151 @@
+import { useCallback, useState } from 'react';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { Select } from '@/components/common/select/Select';
+import { Modal } from '@/components/common/modal/Modal';
+import { Button } from '@/components/admin/button/Button';
+import { HintBox } from '@/components/admin/hint-box/HintBox';
+import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
+import { ReportFundsExpendituresCategory, ReportFundsExpendituresRecord } from '@/types/admin/reports';
+import styles from './DeleteFundsExpendituresCategoryModal.module.scss';
+
+interface DeleteFundsExpendituresCategoryModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    categories: ReportFundsExpendituresCategory[];
+    records: ReportFundsExpendituresRecord[];
+    onSubmit: (categoryId: number) => Promise<boolean>;
+}
+
+export const DeleteFundsExpendituresCategoryModal = ({
+    isOpen,
+    onClose,
+    categories,
+    records,
+    onSubmit,
+}: DeleteFundsExpendituresCategoryModalProps) => {
+    const [selectedCategoryId, setSelectedCategoryId] = useState<number | undefined>(undefined);
+    const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const selectedCategory = categories.find((c) => c.id === selectedCategoryId);
+    const recordCount = records.filter((r) => r.categoryId === selectedCategoryId).length;
+    const hasRecord = recordCount > 0;
+
+    const recordErrorTitle =
+        selectedCategory && hasRecord
+            ? selectedCategory.type === 'income'
+                ? FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasIncomeRecordTitle(recordCount)
+                : FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasExpenseRecordTitle(recordCount)
+            : undefined;
+
+    const resetForm = useCallback(() => {
+        setSelectedCategoryId(undefined);
+        setIsConfirmOpen(false);
+        setIsSubmitting(false);
+    }, []);
+
+    const handleClose = useCallback(() => {
+        resetForm();
+        onClose();
+    }, [resetForm, onClose]);
+
+    const handleDeleteClick = useCallback(() => {
+        setIsConfirmOpen(true);
+    }, []);
+
+    const handleConfirm = useCallback(async () => {
+        if (!selectedCategoryId) return;
+        setIsSubmitting(true);
+        const success = await onSubmit(selectedCategoryId);
+        if (success) {
+            setIsConfirmOpen(false);
+            resetForm();
+            onClose();
+        } else {
+            setIsSubmitting(false);
+            setIsConfirmOpen(false);
+        }
+    }, [selectedCategoryId, onSubmit, resetForm, onClose]);
+
+    const handleCancelConfirm = useCallback(() => {
+        setIsConfirmOpen(false);
+    }, []);
+
+    const isDeleteDisabled = !selectedCategoryId || hasRecord || isSubmitting;
+
+    return (
+        <>
+            <Modal isOpen={isOpen} onClose={handleClose} className={styles.modal} maxWidth="650px">
+                <Modal.Title>
+                    <h2 className={styles.title}>{FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.TITLE}</h2>
+                </Modal.Title>
+
+                <Modal.Content>
+                    <div className={styles.content}>
+                        <div className={styles.panel}>
+                            <div className={styles.field}>
+                                <div className={styles.labelRow}>
+                                    <label className={styles.label}>
+                                        <span className={styles.required}>*</span>
+                                        {FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.CATEGORY_LABEL}
+                                    </label>
+                                    {selectedCategory && (
+                                        <span className={styles.type}>
+                                            {selectedCategory.type === 'income'
+                                                ? FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME
+                                                : FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.EXPENSE}
+                                        </span>
+                                    )}
+                                </div>
+                                <Select<number | undefined>
+                                    value={selectedCategoryId}
+                                    onValueChange={(val) => setSelectedCategoryId(val as number)}
+                                    placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.CATEGORY_PLACEHOLDER}
+                                    className={styles.selectContainer}
+                                    headClassName={styles.selectHead}
+                                >
+                                    {categories.map((c) => (
+                                        <Select.Option key={c.id} value={c.id} name={c.name} />
+                                    ))}
+                                </Select>
+                            </div>
+
+                            {recordErrorTitle && (
+                                <HintBox
+                                    title={recordErrorTitle}
+                                    text={FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_RECORD_TEXT}
+                                />
+                            )}
+                        </div>
+                    </div>
+                </Modal.Content>
+
+                <Modal.Actions>
+                    <div className={styles.actions}>
+                        <Button buttonStyle="secondary" onClick={handleClose} disabled={isSubmitting}>
+                            {COMMON_TEXT_ADMIN.BUTTON.CANCEL}
+                        </Button>
+                        <Button
+                            buttonStyle="primary"
+                            onClick={handleDeleteClick}
+                            disabled={isDeleteDisabled}
+                            className={styles.deleteButton}
+                        >
+                            {COMMON_TEXT_ADMIN.BUTTON.DELETE}
+                        </Button>
+                    </div>
+                </Modal.Actions>
+            </Modal>
+
+            <ConfirmationModal
+                isOpen={isConfirmOpen}
+                title={FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.CONFIRM_TITLE}
+                onConfirm={handleConfirm}
+                onCancel={handleCancelConfirm}
+                onClose={handleCancelConfirm}
+                isButtonsDisabled={isSubmitting}
+            />
+        </>
+    );
+};

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.module.scss
@@ -14,10 +14,21 @@
     width: 100%;
 }
 
+.labelRow {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
 .label {
     @include type.small-text-medium;
     color: c.$bluish-black;
     margin-bottom: 8px;
+}
+
+.labelRow .label {
+    margin-bottom: 0;
 }
 
 .required {
@@ -38,11 +49,7 @@
     justify-content: space-between;
     border: 1px solid c.$grey-700;
     border-radius: 8px;
-    background: c.$white;
-}
-
-.selectHeadError {
-    border-color: c.$error;
+    background-color: c.$white;
 }
 
 .input {
@@ -68,7 +75,7 @@
         width: 650px;
         max-width: 650px;
         border-radius: 8px;
-        background: c.$white;
+        background-color: c.$white;
         padding: 0;
     }
 
@@ -94,7 +101,7 @@
 
     :global(.modal-body) {
         margin-bottom: 0;
-        padding: 18px 0 0;
+        padding: 8px 0 0;
     }
 
     :global(.modal-footer) {
@@ -127,8 +134,7 @@
 }
 
 .subtitle {
-    @include type.body-1-regular;
-    line-height: 20px;
+    @include type.small-text-regular;
     margin: 0;
     color: c.$grey-900;
 }
@@ -145,10 +151,16 @@
     flex-direction: column;
     align-items: stretch;
     width: 100%;
-    background: c.$grey-50;
+    background-color: c.$grey-50;
     border: 1px solid c.$grey-150;
     padding: 20px 22px;
     min-height: 180px;
+}
+
+.type {
+    @include type.small-text-regular;
+    margin: 0;
+    color: c.$blue-900;
 }
 
 .error {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.test.tsx
@@ -1,0 +1,289 @@
+import { render, screen, fireEvent, within, waitFor, act } from '@testing-library/react';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
+import { EditFundsExpendituresCategoryModal } from './EditFundsExpendituresCategoryModal';
+
+jest.mock('@/components/admin/input-with-character-limit/InputWithCharacterLimit', () => ({
+    InputWithCharacterLimit: ({ id, value, onChange, onBlur, placeholder }: any) => (
+        <input data-testid={id} value={value} onChange={onChange} onBlur={onBlur} placeholder={placeholder} />
+    ),
+}));
+
+const CATEGORY_SELECT = FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CATEGORY_PLACEHOLDER;
+const NAME_INPUT = 'edit-category-name';
+const SAVE_BUTTON = FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.SUBMIT_BUTTON;
+const MIN_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMin);
+const REQUIRED_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
+const DUPLICATE_ERROR = FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.ERROR.NAME_DUPLICATE;
+const YES_BUTTON = COMMON_TEXT_ADMIN.BUTTON.YES;
+const NO_BUTTON = COMMON_TEXT_ADMIN.BUTTON.NO;
+
+const incomeCategory: ReportFundsExpendituresCategory = { id: 1, name: 'Донори', type: 'income' };
+const expenseCategory: ReportFundsExpendituresCategory = { id: 2, name: 'Оренда', type: 'expense' };
+
+const renderModal = (
+    overrides: Partial<{
+        isOpen: boolean;
+        onClose: jest.Mock;
+        categories: ReportFundsExpendituresCategory[];
+        onSubmit: jest.Mock;
+    }> = {},
+) => {
+    const props = {
+        isOpen: true,
+        onClose: jest.fn(),
+        categories: [incomeCategory, expenseCategory],
+        onSubmit: jest.fn().mockResolvedValue(true),
+        ...overrides,
+    };
+    return { ...render(<EditFundsExpendituresCategoryModal {...props} />), ...props };
+};
+
+const getSaveButton = () => screen.getByRole('button', { name: SAVE_BUTTON });
+
+const selectCategory = (name: string) => {
+    fireEvent.click(screen.getByRole('button', { name: CATEGORY_SELECT }));
+    fireEvent.click(screen.getByRole('button', { name }));
+};
+
+const typeName = (value: string) => {
+    fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value } });
+};
+
+const fillForm = (categoryName = incomeCategory.name, name = 'Valid name') => {
+    selectCategory(categoryName);
+    typeName(name);
+};
+
+const getConfirmOverlayWithTitle = (title: string) =>
+    screen.getAllByTestId('modal-overlay').find((el) => within(el).queryByText(title))!;
+
+const clickYesInConfirm = (title: string) =>
+    fireEvent.click(within(getConfirmOverlayWithTitle(title)).getByRole('button', { name: YES_BUTTON }));
+
+const clickNoInConfirm = (title: string) =>
+    fireEvent.click(within(getConfirmOverlayWithTitle(title)).getByRole('button', { name: NO_BUTTON }));
+
+describe('EditFundsExpendituresCategoryModal', () => {
+    it('renders nothing when isOpen is false', () => {
+        renderModal({ isOpen: false });
+        expect(screen.queryByTestId('modal-overlay')).not.toBeInTheDocument();
+    });
+
+    it('renders modal title when open', () => {
+        renderModal();
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.TITLE)).toBeInTheDocument();
+    });
+
+    it('renders category select, name input and save button', () => {
+        renderModal();
+        expect(screen.getByRole('button', { name: CATEGORY_SELECT })).toBeInTheDocument();
+        expect(screen.getByTestId(NAME_INPUT)).toBeInTheDocument();
+        expect(getSaveButton()).toBeInTheDocument();
+    });
+
+    describe('save button disabled state', () => {
+        it('is disabled by default', () => {
+            renderModal();
+            expect(getSaveButton()).toBeDisabled();
+        });
+
+        it('is disabled when only category is selected', () => {
+            renderModal();
+            selectCategory(incomeCategory.name);
+            expect(getSaveButton()).toBeDisabled();
+        });
+
+        it('is disabled when name is too short', () => {
+            renderModal();
+            fillForm(incomeCategory.name, 'abc');
+            expect(getSaveButton()).toBeDisabled();
+        });
+
+        it('is enabled when category is selected and name is valid', () => {
+            renderModal();
+            fillForm();
+            expect(getSaveButton()).not.toBeDisabled();
+        });
+
+        it('is not disabled when name matches a category of a different type', () => {
+            renderModal();
+            fillForm(incomeCategory.name, expenseCategory.name);
+            expect(getSaveButton()).not.toBeDisabled();
+        });
+
+        it('is disabled when name duplicates another category of the same type', () => {
+            const categories = [incomeCategory, expenseCategory, { id: 3, name: 'Гранти', type: 'income' as const }];
+            renderModal({ categories });
+            selectCategory(incomeCategory.name);
+            typeName('Гранти');
+            expect(getSaveButton()).toBeDisabled();
+        });
+    });
+
+    describe('name field validation on blur', () => {
+        it('shows required error when name is empty', () => {
+            renderModal();
+            selectCategory(incomeCategory.name);
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(REQUIRED_ERROR)).toBeInTheDocument();
+        });
+
+        it('shows min length error when name is too short', () => {
+            renderModal();
+            fillForm(incomeCategory.name, 'abc');
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(MIN_ERROR)).toBeInTheDocument();
+        });
+
+        it('shows duplicate error when name matches another category of the same type', () => {
+            const categories = [incomeCategory, expenseCategory, { id: 3, name: 'Гранти', type: 'income' as const }];
+            renderModal({ categories });
+            selectCategory(incomeCategory.name);
+            typeName('Гранти');
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(DUPLICATE_ERROR)).toBeInTheDocument();
+        });
+
+        it('does not show duplicate error when name matches selected category itself', () => {
+            renderModal();
+            selectCategory(incomeCategory.name);
+            typeName(incomeCategory.name);
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.queryByText(DUPLICATE_ERROR)).not.toBeInTheDocument();
+        });
+
+        it('clears error when name becomes valid on re-blur', () => {
+            renderModal();
+            selectCategory(incomeCategory.name);
+            typeName('ab');
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(MIN_ERROR)).toBeInTheDocument();
+
+            typeName('Valid name');
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.queryByText(MIN_ERROR)).not.toBeInTheDocument();
+        });
+    });
+
+    describe('confirmation save modal', () => {
+        it('opens save confirmation when save button is clicked', () => {
+            renderModal();
+            fillForm();
+            fireEvent.click(getSaveButton());
+            expect(
+                screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE),
+            ).toBeInTheDocument();
+        });
+
+        it('closes save confirmation on cancel', () => {
+            renderModal();
+            fillForm();
+            fireEvent.click(getSaveButton());
+            clickNoInConfirm(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE);
+            expect(
+                screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE),
+            ).not.toBeInTheDocument();
+        });
+    });
+
+    describe('submit behaviour', () => {
+        it('calls onSubmit with categoryId and normalized name on confirm', async () => {
+            const onSubmit = jest.fn().mockResolvedValue(true);
+            renderModal({ onSubmit });
+            fillForm(incomeCategory.name, '  Valid name  ');
+            fireEvent.click(getSaveButton());
+            clickYesInConfirm(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE);
+            await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(incomeCategory.id, 'Valid name'));
+        });
+
+        it('resets form and calls onClose when onSubmit resolves true', async () => {
+            const onClose = jest.fn();
+            const onSubmit = jest.fn().mockResolvedValue(true);
+            renderModal({ onClose, onSubmit });
+            fillForm();
+            fireEvent.click(getSaveButton());
+            clickYesInConfirm(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE);
+            await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+            expect(screen.getByTestId(NAME_INPUT)).toHaveValue('');
+            expect(getSaveButton()).toBeDisabled();
+        });
+
+        it('keeps modal open and closes confirm when onSubmit resolves false', async () => {
+            const onClose = jest.fn();
+            const onSubmit = jest.fn().mockResolvedValue(false);
+            renderModal({ onClose, onSubmit });
+            fillForm();
+            fireEvent.click(getSaveButton());
+            clickYesInConfirm(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE);
+            await waitFor(() => expect(screen.queryByRole('button', { name: YES_BUTTON })).not.toBeInTheDocument());
+            expect(onClose).not.toHaveBeenCalled();
+        });
+
+        it('disables confirm buttons while submitting', async () => {
+            let resolve!: (v: boolean) => void;
+            const onSubmit = jest.fn().mockReturnValue(
+                new Promise<boolean>((r) => {
+                    resolve = r;
+                }),
+            );
+            renderModal({ onSubmit });
+            fillForm();
+            fireEvent.click(getSaveButton());
+            const yesBtn = within(
+                getConfirmOverlayWithTitle(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE),
+            ).getByRole('button', { name: YES_BUTTON });
+            fireEvent.click(yesBtn);
+            expect(yesBtn).toBeDisabled();
+            await act(async () => {
+                resolve(true);
+            });
+        });
+    });
+
+    describe('close behaviour', () => {
+        it('closes directly when form is clean', () => {
+            const onClose = jest.fn();
+            renderModal({ onClose });
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+            expect(onClose).toHaveBeenCalledTimes(1);
+        });
+
+        it('opens close confirmation when name is dirty', () => {
+            const onClose = jest.fn();
+            renderModal({ onClose });
+            typeName('dirty');
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+            expect(onClose).not.toHaveBeenCalled();
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.CONFIRM_CLOSE_TITLE)).toBeInTheDocument();
+        });
+
+        it('calls onClose and resets form on confirm close', () => {
+            const onClose = jest.fn();
+            renderModal({ onClose });
+            fillForm();
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+            clickYesInConfirm(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.CONFIRM_CLOSE_TITLE);
+            expect(onClose).toHaveBeenCalledTimes(1);
+            expect(screen.getByTestId(NAME_INPUT)).toHaveValue('');
+        });
+
+        it('keeps modal open on cancel close', () => {
+            const onClose = jest.fn();
+            renderModal({ onClose });
+            typeName('dirty');
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+            clickNoInConfirm(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.CONFIRM_CLOSE_TITLE);
+            expect(onClose).not.toHaveBeenCalled();
+            expect(screen.getByTestId('modal-overlay')).toBeInTheDocument();
+        });
+    });
+
+    it('normalizes whitespace in name on blur', () => {
+        renderModal();
+        typeName('  foo   bar  ');
+        fireEvent.blur(screen.getByTestId(NAME_INPUT));
+        expect(screen.getByTestId(NAME_INPUT)).toHaveValue('foo bar');
+    });
+});

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.tsx
@@ -1,0 +1,237 @@
+import { useCallback, useMemo, useState } from 'react';
+import cn from 'classnames';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { InputWithCharacterLimit } from '@/components/admin/input-with-character-limit/InputWithCharacterLimit';
+import { Select } from '@/components/common/select/Select';
+import { Modal } from '@/components/common/modal/Modal';
+import { Button } from '@/components/admin/button/Button';
+import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
+import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
+import { getNormalizedInputText } from '@/utils/functions/formatters/text-formatters';
+import { validateFundsExpendituresCategoryName } from '@/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema';
+import styles from './EditFundsExpendituresCategoryModal.module.scss';
+
+const renderInputWithError = (
+    input: React.ReactNode,
+    error?: string,
+    inputErrorClass?: string,
+    errorClass?: string,
+) => (
+    <>
+        <div className={cn({ [inputErrorClass || '']: Boolean(error) })}>{input}</div>
+        <p className={cn(errorClass, { [styles.errorHidden]: !error })}>{error ?? ' '}</p>
+    </>
+);
+
+interface EditFundsExpendituresCategoryModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    categories: ReportFundsExpendituresCategory[];
+    onSubmit: (categoryId: number, name: string) => Promise<boolean>;
+}
+
+export const EditFundsExpendituresCategoryModal = ({
+    isOpen,
+    onClose,
+    categories,
+    onSubmit,
+}: EditFundsExpendituresCategoryModalProps) => {
+    const [selectedCategoryId, setSelectedCategoryId] = useState<number | undefined>(undefined);
+    const [name, setName] = useState('');
+    const [nameError, setNameError] = useState<string | undefined>(undefined);
+    const [hasNameBeenBlurred, setHasNameBeenBlurred] = useState(false);
+    const [isConfirmSaveOpen, setIsConfirmSaveOpen] = useState(false);
+    const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const selectedCategory = categories.find((c) => c.id === selectedCategoryId);
+
+    const otherCategories = useMemo(
+        () => categories.filter((c) => c.id !== selectedCategoryId),
+        [categories, selectedCategoryId],
+    );
+
+    const isDirty = name.trim().length > 0;
+
+    const isSubmitDisabled = useMemo(
+        () =>
+            !selectedCategoryId ||
+            name.trim() === selectedCategory?.name.trim() ||
+            validateFundsExpendituresCategoryName(name, selectedCategory?.type, otherCategories) !== undefined,
+        [selectedCategoryId, name, selectedCategory?.name, selectedCategory?.type, otherCategories],
+    );
+
+    const resetForm = useCallback(() => {
+        setSelectedCategoryId(undefined);
+        setName('');
+        setNameError(undefined);
+        setHasNameBeenBlurred(false);
+        setIsConfirmSaveOpen(false);
+        setIsCloseConfirmOpen(false);
+        setIsSubmitting(false);
+    }, []);
+
+    const handleCategoryChange = useCallback(
+        (id: number) => {
+            setSelectedCategoryId(id);
+            if (hasNameBeenBlurred) {
+                const newSelected = categories.find((c) => c.id === id);
+                const others = categories.filter((c) => c.id !== id);
+                setNameError(validateFundsExpendituresCategoryName(name, newSelected?.type, others));
+            }
+        },
+        [hasNameBeenBlurred, name, categories],
+    );
+
+    const handleNameBlur = useCallback(() => {
+        setHasNameBeenBlurred(true);
+        setName(getNormalizedInputText(name));
+        setNameError(validateFundsExpendituresCategoryName(name, selectedCategory?.type, otherCategories));
+    }, [name, selectedCategory?.type, otherCategories]);
+
+    const handleSaveClick = useCallback(() => {
+        setIsConfirmSaveOpen(true);
+    }, []);
+
+    const handleConfirmSave = useCallback(async () => {
+        if (!selectedCategoryId) return;
+        setIsSubmitting(true);
+        const success = await onSubmit(selectedCategoryId, getNormalizedInputText(name));
+        if (success) {
+            resetForm();
+            onClose();
+        } else {
+            setIsSubmitting(false);
+            setIsConfirmSaveOpen(false);
+        }
+    }, [selectedCategoryId, name, onSubmit, resetForm, onClose]);
+
+    const handleCancelSave = useCallback(() => {
+        setIsConfirmSaveOpen(false);
+    }, []);
+
+    const handleRequestClose = useCallback(() => {
+        if (isDirty) {
+            setIsCloseConfirmOpen(true);
+            return;
+        }
+        resetForm();
+        onClose();
+    }, [isDirty, resetForm, onClose]);
+
+    const handleConfirmClose = useCallback(() => {
+        setIsCloseConfirmOpen(false);
+        resetForm();
+        onClose();
+    }, [resetForm, onClose]);
+
+    const handleCancelClose = useCallback(() => {
+        setIsCloseConfirmOpen(false);
+    }, []);
+
+    return (
+        <>
+            <Modal isOpen={isOpen} onClose={handleRequestClose} className={styles.modal} maxWidth="650px">
+                <Modal.Title>
+                    <div className={styles.header}>
+                        <h2 className={styles.title}>{FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.TITLE}</h2>
+                        <p className={styles.subtitle}>{FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.SUBTITLE}</p>
+                    </div>
+                </Modal.Title>
+
+                <Modal.Content>
+                    <div className={styles.content}>
+                        <div className={styles.panel}>
+                            <div className={styles.form}>
+                                <div className={styles.field}>
+                                    <div className={styles.labelRow}>
+                                        <label className={styles.label}>
+                                            <span className={styles.required}>*</span>
+                                            {FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CATEGORY_LABEL}
+                                        </label>
+                                        {selectedCategory && (
+                                            <span className={styles.type}>
+                                                {selectedCategory.type === 'income'
+                                                    ? FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME
+                                                    : FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.EXPENSE}
+                                            </span>
+                                        )}
+                                    </div>
+                                    <Select<number | undefined>
+                                        value={selectedCategoryId}
+                                        onValueChange={(val) => handleCategoryChange(val as number)}
+                                        placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CATEGORY_PLACEHOLDER}
+                                        className={styles.selectContainer}
+                                        headClassName={styles.selectHead}
+                                    >
+                                        {categories.map((c) => (
+                                            <Select.Option key={c.id} value={c.id} name={c.name} />
+                                        ))}
+                                    </Select>
+                                </div>
+
+                                <div className={styles.field}>
+                                    <label className={styles.label}>
+                                        <span className={styles.required}>*</span>
+                                        {FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.NAME_LABEL}
+                                    </label>
+                                    {renderInputWithError(
+                                        <InputWithCharacterLimit
+                                            id="edit-category-name"
+                                            name="editCategoryName"
+                                            value={name}
+                                            onChange={(e) => setName(e.target.value)}
+                                            onBlur={handleNameBlur}
+                                            maxLength={FUNDS_EXPENDITURES_VALIDATION.categoryNameMax}
+                                            maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
+                                                FUNDS_EXPENDITURES_VALIDATION.categoryNameMax,
+                                            )}
+                                            placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.NAME_PLACEHOLDER}
+                                            showCounter={true}
+                                            hasError={Boolean(nameError)}
+                                            className={styles.input}
+                                        />,
+                                        nameError,
+                                        styles.inputError,
+                                        styles.error,
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </Modal.Content>
+
+                <Modal.Actions>
+                    <div className={styles.actions}>
+                        <Button
+                            buttonStyle="primary"
+                            onClick={handleSaveClick}
+                            disabled={isSubmitDisabled || isSubmitting}
+                            className={styles.submit}
+                        >
+                            {FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.SUBMIT_BUTTON}
+                        </Button>
+                    </div>
+                </Modal.Actions>
+            </Modal>
+
+            <ConfirmationModal
+                isOpen={isConfirmSaveOpen}
+                title={FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE}
+                onConfirm={handleConfirmSave}
+                onCancel={handleCancelSave}
+                onClose={handleCancelSave}
+                isButtonsDisabled={isSubmitting}
+            />
+
+            <ConfirmationModal
+                isOpen={isCloseConfirmOpen}
+                title={FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.CONFIRM_CLOSE_TITLE}
+                onConfirm={handleConfirmClose}
+                onCancel={handleCancelClose}
+                onClose={handleCancelClose}
+            />
+        </>
+    );
+};

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { CategoryBar } from '@/components/admin/category-bar/CategoryBar';
+import { useCallback, useMemo, useState } from 'react';
+import { CategoryBar, ContextMenuOption } from '@/components/admin/category-bar/CategoryBar';
 import { FUNDS_EXPENDITURES_TEXT, REPORTS_TEXT } from '@/const/admin/reports';
 import styles from './ReportAnalytics.module.scss';
 import './ReportAnalytics.scss';
@@ -23,6 +23,27 @@ export const ReportAnalytics = () => {
     const [isFundsEditing, setIsFundsEditing] = useState(false);
     const [fundsExchangeRateDraft, setFundsExchangeRateDraft] = useState<string | null>();
     const [isAddCategoryModalOpen, setIsAddCategoryModalOpen] = useState(false);
+    const [isDeleteCategoryModalOpen, setIsDeleteCategoryModalOpen] = useState(false);
+    const [isEditCategoryModalOpen, setIsEditCategoryModalOpen] = useState(false);
+
+    const categoryContextMenuOptions: ContextMenuOption[] = useMemo(
+        () => [
+            { id: 'add-category', name: FUNDS_EXPENDITURES_TEXT.BUTTON.ADD_CATEGORY },
+            { id: 'edit-category', name: FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT_CATEGORY },
+            { id: 'delete-category', name: FUNDS_EXPENDITURES_TEXT.BUTTON.DELETE_CATEGORY },
+        ],
+        [],
+    );
+
+    const handleCategoryContextMenuOption = useCallback((id: string) => {
+        if (id === 'add-category') {
+            setIsAddCategoryModalOpen(true);
+        } else if (id === 'edit-category') {
+            setIsEditCategoryModalOpen(true);
+        } else if (id === 'delete-category') {
+            setIsDeleteCategoryModalOpen(true);
+        }
+    }, []);
 
     return (
         <div className={styles['report-analytics']}>
@@ -35,12 +56,8 @@ export const ReportAnalytics = () => {
                 getCategoryKey={(tab) => tab.id}
                 onCategorySelect={setActiveTab}
                 displayContextMenuButton={activeTab.id === 'income-expenses'}
-                contextMenuOptions={[{ id: 'add-category', name: FUNDS_EXPENDITURES_TEXT.BUTTON.ADD_CATEGORY }]}
-                onContextMenuOptionSelected={(id: string) => {
-                    if (id === 'add-category') {
-                        setIsAddCategoryModalOpen(true);
-                    }
-                }}
+                contextMenuOptions={categoryContextMenuOptions}
+                onContextMenuOptionSelected={handleCategoryContextMenuOption}
             />
             <div className={styles['tab-content']}>
                 {activeTab.id === 'pdf-files' && <PdfFilesSection />}
@@ -52,6 +69,10 @@ export const ReportAnalytics = () => {
                         onExchangeRateValueChange={setFundsExchangeRateDraft}
                         isAddCategoryModalOpen={isAddCategoryModalOpen}
                         onAddCategoryModalClose={() => setIsAddCategoryModalOpen(false)}
+                        isEditCategoryModalOpen={isEditCategoryModalOpen}
+                        onEditCategoryModalClose={() => setIsEditCategoryModalOpen(false)}
+                        isDeleteCategoryModalOpen={isDeleteCategoryModalOpen}
+                        onDeleteCategoryModalClose={() => setIsDeleteCategoryModalOpen(false)}
                     />
                 )}
                 {activeTab.id === 'program-expenses' && <ProgramExpensesSection />}

--- a/src/utils/functions/normalize-for-unique/normalize-for-unique.test.ts
+++ b/src/utils/functions/normalize-for-unique/normalize-for-unique.test.ts
@@ -1,0 +1,27 @@
+import { normalizeForUnique } from './normalize-for-unique';
+
+describe('normalizeForUnique', () => {
+    it('lowercases the value', () => {
+        expect(normalizeForUnique('HELLO')).toBe('hello');
+    });
+
+    it('trims leading and trailing whitespace', () => {
+        expect(normalizeForUnique('  hello  ')).toBe('hello');
+    });
+
+    it('sorts words alphabetically', () => {
+        expect(normalizeForUnique('Приватні донори')).toBe('донори приватні');
+    });
+
+    it('produces the same result regardless of word order', () => {
+        expect(normalizeForUnique('Донори приватні')).toBe(normalizeForUnique('Приватні донори'));
+    });
+
+    it('applies lowercasing and word sorting together', () => {
+        expect(normalizeForUnique('ДОНОРИ ПРИВАТНІ')).toBe(normalizeForUnique('приватні донори'));
+    });
+
+    it('handles a single word', () => {
+        expect(normalizeForUnique('hello')).toBe('hello');
+    });
+});

--- a/src/utils/functions/normalize-for-unique/normalize-for-unique.ts
+++ b/src/utils/functions/normalize-for-unique/normalize-for-unique.ts
@@ -1,0 +1,7 @@
+export const normalizeForUnique = (value: string) =>
+    value
+        .toLowerCase()
+        .trim()
+        .split(/\s+/)
+        .sort((a, b) => a.localeCompare(b))
+        .join(' ');

--- a/src/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema.test.ts
@@ -1,0 +1,69 @@
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
+import {
+    validateFundsExpendituresCategoryName,
+    validateFundsExpendituresCategoryType,
+} from './funds-expenditures-category-schema';
+
+const REQUIRED = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
+const MIN_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMin);
+const DUPLICATE_ERROR = FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.ERROR.NAME_DUPLICATE;
+
+const category = (name: string, type: 'income' | 'expense'): ReportFundsExpendituresCategory => ({
+    id: 1,
+    name,
+    type,
+});
+
+describe('validateFundsExpendituresCategoryName', () => {
+    it('returns required error for empty string', () => {
+        expect(validateFundsExpendituresCategoryName('', undefined, [])).toBe(REQUIRED);
+    });
+
+    it('returns required error for whitespace-only string', () => {
+        expect(validateFundsExpendituresCategoryName('   ', undefined, [])).toBe(REQUIRED);
+    });
+
+    it('returns min length error when name is shorter than minimum', () => {
+        expect(validateFundsExpendituresCategoryName('abc', undefined, [])).toBe(MIN_ERROR);
+    });
+
+    it('returns duplicate error when name matches existing category for same type', () => {
+        const categories = [category('Приватні донори', 'income')];
+        expect(validateFundsExpendituresCategoryName('приватні донори', 'income', categories)).toBe(DUPLICATE_ERROR);
+    });
+
+    it('returns duplicate error when name matches with different word order', () => {
+        const categories = [category('Приватні донори', 'income')];
+        expect(validateFundsExpendituresCategoryName('Донори приватні', 'income', categories)).toBe(DUPLICATE_ERROR);
+    });
+
+    it('returns undefined when name matches category of different type', () => {
+        const categories = [category('Приватні донори', 'expense')];
+        expect(validateFundsExpendituresCategoryName('Приватні донори', 'income', categories)).toBeUndefined();
+    });
+
+    it('skips duplicate check when type is undefined', () => {
+        const categories = [category('Valid name', 'income')];
+        expect(validateFundsExpendituresCategoryName('Valid name', undefined, categories)).toBeUndefined();
+    });
+
+    it('returns undefined for valid name with no duplicates', () => {
+        expect(validateFundsExpendituresCategoryName('Valid name', 'income', [])).toBeUndefined();
+    });
+});
+
+describe('validateFundsExpendituresCategoryType', () => {
+    it('returns required error when type is undefined', () => {
+        expect(validateFundsExpendituresCategoryType(undefined)).toBe(REQUIRED);
+    });
+
+    it('returns undefined for income type', () => {
+        expect(validateFundsExpendituresCategoryType('income')).toBeUndefined();
+    });
+
+    it('returns undefined for expense type', () => {
+        expect(validateFundsExpendituresCategoryType('expense')).toBeUndefined();
+    });
+});

--- a/src/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema.test.ts
@@ -8,6 +8,7 @@ import {
 
 const REQUIRED = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
 const MIN_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMin);
+const MAX_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMax);
 const DUPLICATE_ERROR = FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.ERROR.NAME_DUPLICATE;
 
 const category = (name: string, type: 'income' | 'expense'): ReportFundsExpendituresCategory => ({
@@ -27,6 +28,11 @@ describe('validateFundsExpendituresCategoryName', () => {
 
     it('returns min length error when name is shorter than minimum', () => {
         expect(validateFundsExpendituresCategoryName('abc', undefined, [])).toBe(MIN_ERROR);
+    });
+
+    it('returns max length error when name exceeds maximum', () => {
+        const longName = 'а'.repeat(FUNDS_EXPENDITURES_VALIDATION.categoryNameMax + 1);
+        expect(validateFundsExpendituresCategoryName(longName, undefined, [])).toBe(MAX_ERROR);
     });
 
     it('returns duplicate error when name matches existing category for same type', () => {

--- a/src/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema.ts
@@ -1,0 +1,29 @@
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { FundsExpendituresTransactionType, ReportFundsExpendituresCategory } from '@/types/admin/reports';
+import { getNormalizedInputText } from '@/utils/functions/formatters/text-formatters';
+import { normalizeForUnique } from '@/utils/functions/normalize-for-unique/normalize-for-unique';
+
+const isNameDuplicate = (
+    name: string,
+    type: FundsExpendituresTransactionType,
+    categories: ReportFundsExpendituresCategory[],
+) => categories.filter((c) => c.type === type).some((c) => normalizeForUnique(c.name) === normalizeForUnique(name));
+
+export const validateFundsExpendituresCategoryName = (
+    value: string,
+    type: FundsExpendituresTransactionType | undefined,
+    categories: ReportFundsExpendituresCategory[],
+): string | undefined => {
+    const normalized = getNormalizedInputText(value);
+    if (!normalized) return COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
+    if (normalized.length < FUNDS_EXPENDITURES_VALIDATION.categoryNameMin)
+        return COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMin);
+    if (type && isNameDuplicate(normalized, type, categories))
+        return FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.ERROR.NAME_DUPLICATE;
+    return undefined;
+};
+
+export const validateFundsExpendituresCategoryType = (
+    type: FundsExpendituresTransactionType | undefined,
+): string | undefined => (!type ? COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED : undefined);

--- a/src/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema.ts
@@ -19,6 +19,8 @@ export const validateFundsExpendituresCategoryName = (
     if (!normalized) return COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
     if (normalized.length < FUNDS_EXPENDITURES_VALIDATION.categoryNameMin)
         return COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMin);
+    if (normalized.length > FUNDS_EXPENDITURES_VALIDATION.categoryNameMax)
+        return COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMax);
     if (type && isNameDuplicate(normalized, type, categories))
         return FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.ERROR.NAME_DUPLICATE;
     return undefined;


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1440

## Description

This PR introduces validation for category names to ensure data consistency and prevent duplicates within Витрата and Надходження categories.

## How it looks


https://github.com/user-attachments/assets/d6241edd-093d-4784-a847-58f268482e4e


## Summary of change

Added validation logic for category name field:
- Min length (5 characters)
- Max length (200 characters)
- Required field validation
Implemented uniqueness check:
- Case-insensitive
- Word order insensitive (via normalization helper)
- Scoped per category type (Витрата / Надходження)

Added real-time validation for max length
Added on-blur validation for other rules
Controlled "Зберегти" button state based on validation result
Introduced helper function for string normalization and comparison

## How to recreate changes

1. Open category creation form as Admin
2. Try entering:
- 3. Less than 5 characters - bserve error
- More than 200 characters -  observe error in real-time
- Empty value → blur field  -  observe error
3. Create a category e.g.
4. Try entering:
приватні донори
Донори приватні
5. observe uniqueness validation error
6. Switch between Витрата / Надходження and verify uniqueness is scoped per type

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [x]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions
