### PR TITLE
Feature/issue-1327: Implement translation status indicator for PDF

### DIFF
--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
@@ -13,6 +13,7 @@ jest.mock('@/services/api/admin/reports/pdf-section/pdf-section-api');
 jest.mock('@/services/api/admin/reports/pdf-reports/pdf-reports-api');
 jest.mock('@/hooks/common/use-data-fetch/useDataFetch');
 jest.mock('@/contexts/admin/toast-context-provider/ToastContextProvider');
+jest.mock('@/hooks/admin/use-localization-toolkit/useLocalizationToolkit');
 
 jest.mock('./components/pdf-section-content-block/PdfSectionContentBlock', () => ({
     PdfSectionContentBlock: ({ onSave }: any) => (
@@ -65,7 +66,7 @@ jest.mock('@/components/common/inline-loader/InlineLoader', () => ({
 describe('PdfFilesSection', () => {
     const mockClient = { get: jest.fn() };
     const mockAddToast = jest.fn();
-    const mockSectionData = { title: 'Test Title', description: 'Test Desc' };
+    const mockSectionData = { title: 'Test Title', description: 'Test Desc', localizations: [] };
     const mockFilesResponse = { items: [{ id: 1 }, { id: 2 }], totalItemsCount: 2 };
     const mockRefetch = jest.fn();
     const mockCreateObjectURL = jest.fn(() => 'blob:http://localhost/mock-blob-url');
@@ -81,6 +82,8 @@ describe('PdfFilesSection', () => {
         global.window.open = mockWindowOpen as any;
         (useAdminClient as jest.Mock).mockReturnValue(mockClient);
         (useToast as jest.Mock).mockReturnValue({ addToast: mockAddToast });
+        const { useLocalizationToolkit } = require('@/hooks/admin/use-localization-toolkit/useLocalizationToolkit');
+        (useLocalizationToolkit as jest.Mock).mockReturnValue({ translationLanguages: [] });
         mockCreateObjectURL.mockReturnValue('blob:http://localhost/mock-blob-url');
     });
 

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
@@ -16,8 +16,8 @@ jest.mock('@/contexts/admin/toast-context-provider/ToastContextProvider');
 jest.mock('@/hooks/admin/use-localization-toolkit/useLocalizationToolkit');
 
 jest.mock('./components/pdf-section-content-block/PdfSectionContentBlock', () => ({
-    PdfSectionContentBlock: ({ onSave }: any) => (
-        <button data-testid="content-block" onClick={onSave}>
+    PdfSectionContentBlock: ({ onAfterSave }: any) => (
+        <button data-testid="content-block" onClick={onAfterSave}>
             ContentBlock
         </button>
     ),

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
@@ -13,8 +13,9 @@ import { PdfDropzone } from './components/pdf-dropzone/PdfDropzone';
 import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextProvider';
 import { ToastType } from '@/types/admin/toast';
 import { PDF_FILES_SECTION_TEXT } from '@/const/admin/reports';
+import { useLocalizationToolkit } from '@/hooks/admin/use-localization-toolkit/useLocalizationToolkit';
 
-const EMPTY_SECTION = { title: '', description: '' };
+const EMPTY_SECTION = { title: '', description: '', localizations: [] };
 
 export const PdfFilesSection = () => {
     const client = useAdminClient();
@@ -23,6 +24,10 @@ export const PdfFilesSection = () => {
     const [currentLanguage, setCurrentLanguage] = useState<'uk' | 'en'>('uk');
     const [isDeleting, setIsDeleting] = useState(false);
     const [isRenaming, setIsRenaming] = useState(false);
+
+    const { translationLanguages } = useLocalizationToolkit({
+        setErrorState: useCallback(() => {}, []),
+    });
 
     const fetchSection = useCallback(async () => {
         return PdfSectionApi.getPdfSection(client);
@@ -140,7 +145,11 @@ export const PdfFilesSection = () => {
     return (
         <div className={styles.root}>
             <div className={styles['top-section']}>
-                <PdfSectionContentBlock content={sectionData ?? EMPTY_SECTION} onSave={handleSaveSection} />
+                <PdfSectionContentBlock
+                    content={sectionData ?? EMPTY_SECTION}
+                    onSave={handleSaveSection}
+                    translationLanguages={translationLanguages}
+                />{' '}
             </div>
             <div className={styles['language-switcher-container']}>
                 <LanguageSwitcherButtons currentLanguage={currentLanguage} onLanguageChange={setCurrentLanguage} />

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
@@ -147,7 +147,7 @@ export const PdfFilesSection = () => {
             <div className={styles['top-section']}>
                 <PdfSectionContentBlock
                     content={sectionData ?? EMPTY_SECTION}
-                    onSave={handleSaveSection}
+                    onAfterSave={handleSaveSection}
                     translationLanguages={translationLanguages}
                 />{' '}
             </div>

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.module.scss
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.module.scss
@@ -57,10 +57,12 @@
     }
 }
 
-.edit-button-container {
+.buttons-container {
     display: flex;
-    justify-content: end;
+    justify-content: space-between;
+    align-items: center;
     margin-right: 20px;
+    margin-bottom: 7px;
 }
 
 .edit-button {

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.test.tsx
@@ -11,6 +11,9 @@ jest.mock('@/contexts/admin/toast-context-provider/ToastContextProvider');
 jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
     useAdminClient: () => ({}),
 }));
+jest.mock('@/components/admin/localization-statuses/LocalizationStatuses', () => ({
+    LocalizationStatuses: () => <div data-testid="localization-statuses" />,
+}));
 jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
     ConfirmationModal: ({ isOpen, onConfirm, onCancel, title, isButtonsDisabled }: any) =>
         isOpen ? (
@@ -31,6 +34,12 @@ const mockUseToast = useToast as jest.MockedFunction<typeof useToast>;
 const MOCK_CONTENT = {
     title: 'Test Section Title',
     description: 'Test Section Description',
+    localizations: [],
+};
+
+const DEFAULT_PROPS = {
+    content: MOCK_CONTENT,
+    translationLanguages: [],
 };
 
 async function enterEditMode(user: ReturnType<typeof userEvent.setup>) {
@@ -62,7 +71,11 @@ async function openPublishModal(
     title = 'Updated Title',
     props: Partial<React.ComponentProps<typeof PdfSectionContentBlock>> = {},
 ) {
-    render(<PdfSectionContentBlock content={MOCK_CONTENT} {...props} />);
+    const defaultProps = {
+        content: MOCK_CONTENT,
+        translationLanguages: [],
+    };
+    render(<PdfSectionContentBlock {...DEFAULT_PROPS} {...props} />);
     await enterEditMode(user);
     await changeTitle(user, title);
     await clickPublish(user);
@@ -79,7 +92,7 @@ describe('PdfSectionContentBlock', () => {
 
     describe('View Mode', () => {
         it('should render title and description in view mode', () => {
-            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+            render(<PdfSectionContentBlock {...DEFAULT_PROPS} />);
             expect(screen.getByText(PDF_FILES_SECTION_TEXT.TITLE)).toBeInTheDocument();
             expect(screen.getByText(MOCK_CONTENT.title)).toBeInTheDocument();
             expect(screen.getByText(PDF_FILES_SECTION_TEXT.DESCRIPTION)).toBeInTheDocument();
@@ -87,19 +100,19 @@ describe('PdfSectionContentBlock', () => {
         });
 
         it('should apply correct classes for view mode', () => {
-            const { container } = render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+            const { container } = render(<PdfSectionContentBlock {...DEFAULT_PROPS} />);
             expect(container.firstChild).toHaveClass('root', 'view-root');
             expect(screen.getByText(MOCK_CONTENT.title)).toHaveClass('view-text', 'view-text-title');
         });
 
         it('should render edit button', () => {
-            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+            render(<PdfSectionContentBlock {...DEFAULT_PROPS} />);
             expect(screen.getByRole('button', { name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT })).toBeInTheDocument();
         });
     });
 
-    async function renderAndEnterEditMode(): Promise<ReturnType<typeof userEvent.setup>> {
-        render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+    async function renderAndEnterEditMode() {
+        render(<PdfSectionContentBlock {...DEFAULT_PROPS} />);
         const user = userEvent.setup();
         await enterEditMode(user);
         return user;
@@ -107,7 +120,7 @@ describe('PdfSectionContentBlock', () => {
 
     describe('Edit Mode', () => {
         it('should switch to edit mode when edit button is clicked', async () => {
-            render(<PdfSectionContentBlock content={MOCK_CONTENT} />);
+            render(<PdfSectionContentBlock {...DEFAULT_PROPS} />);
             const user = userEvent.setup();
             await enterEditMode(user);
             expect(screen.getByDisplayValue(MOCK_CONTENT.title)).toBeInTheDocument();
@@ -155,12 +168,7 @@ describe('PdfSectionContentBlock', () => {
             const user = userEvent.setup();
             await openPublishModal(user, 'Updated Title', { onSave: mockOnSave });
             await confirmModal(user);
-            await waitFor(() =>
-                expect(mockOnSave).toHaveBeenCalledWith({
-                    title: 'Updated Title',
-                    description: MOCK_CONTENT.description,
-                }),
-            );
+            await waitFor(() => expect(mockOnSave).toHaveBeenCalledWith());
         });
 
         it('should have character counters for both fields', async () => {
@@ -193,12 +201,7 @@ describe('PdfSectionContentBlock', () => {
             const user = userEvent.setup();
             await openPublishModal(user, 'Updated Title', { onSave: mockOnSave });
             await confirmModal(user);
-            await waitFor(() =>
-                expect(mockOnSave).toHaveBeenCalledWith({
-                    title: 'Updated Title',
-                    description: MOCK_CONTENT.description,
-                }),
-            );
+            await waitFor(() => expect(mockOnSave).toHaveBeenCalledWith());
             expect(mockAddToast).toHaveBeenCalledWith('Зміни успішно опубліковані', ToastType.Success);
         });
 

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.test.tsx
@@ -71,10 +71,6 @@ async function openPublishModal(
     title = 'Updated Title',
     props: Partial<React.ComponentProps<typeof PdfSectionContentBlock>> = {},
 ) {
-    const defaultProps = {
-        content: MOCK_CONTENT,
-        translationLanguages: [],
-    };
     render(<PdfSectionContentBlock {...DEFAULT_PROPS} {...props} />);
     await enterEditMode(user);
     await changeTitle(user, title);

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.test.tsx
@@ -159,12 +159,12 @@ describe('PdfSectionContentBlock', () => {
             expect(screen.getByText(MOCK_CONTENT.title)).toBeInTheDocument();
         });
 
-        it('should call onSave when publish button is clicked with valid data', async () => {
-            const mockOnSave = jest.fn().mockResolvedValue(undefined);
+        it('should call onAfterSave when publish button is clicked with valid data', async () => {
+            const mockOnAfterSave = jest.fn().mockResolvedValue(undefined);
             const user = userEvent.setup();
-            await openPublishModal(user, 'Updated Title', { onSave: mockOnSave });
+            await openPublishModal(user, 'Updated Title', { onAfterSave: mockOnAfterSave });
             await confirmModal(user);
-            await waitFor(() => expect(mockOnSave).toHaveBeenCalledWith());
+            await waitFor(() => expect(mockOnAfterSave).toHaveBeenCalledWith());
         });
 
         it('should have character counters for both fields', async () => {
@@ -182,29 +182,29 @@ describe('PdfSectionContentBlock', () => {
         });
 
         it('should close modal and not save when clicking НІ button', async () => {
-            const mockOnSave = jest.fn().mockResolvedValue(undefined);
+            const mockOnAfterSave = jest.fn().mockResolvedValue(undefined);
             const user = userEvent.setup();
-            await openPublishModal(user, 'Updated Title', { onSave: mockOnSave });
+            await openPublishModal(user, 'Updated Title', { onAfterSave: mockOnAfterSave });
             const modal = await screen.findByTestId('confirmation-modal');
             await user.click(screen.getByText('НІ'));
             await waitFor(() => expect(modal).not.toBeInTheDocument());
-            expect(mockOnSave).not.toHaveBeenCalled();
+            expect(mockOnAfterSave).not.toHaveBeenCalled();
             expect(mockAddToast).not.toHaveBeenCalled();
         });
 
         it('should save and show success toast when clicking ТАК button', async () => {
-            const mockOnSave = jest.fn().mockResolvedValue(undefined);
+            const mockOnAfterSave = jest.fn().mockResolvedValue(undefined);
             const user = userEvent.setup();
-            await openPublishModal(user, 'Updated Title', { onSave: mockOnSave });
+            await openPublishModal(user, 'Updated Title', { onAfterSave: mockOnAfterSave });
             await confirmModal(user);
-            await waitFor(() => expect(mockOnSave).toHaveBeenCalledWith());
+            await waitFor(() => expect(mockOnAfterSave).toHaveBeenCalledWith());
             expect(mockAddToast).toHaveBeenCalledWith('Зміни успішно опубліковані', ToastType.Success);
         });
 
         it('should revert to view mode after successful save', async () => {
-            const mockOnSave = jest.fn().mockResolvedValue(undefined);
+            const mockOnAfterSave = jest.fn().mockResolvedValue(undefined);
             const user = userEvent.setup();
-            await openPublishModal(user, 'Updated Title', { onSave: mockOnSave });
+            await openPublishModal(user, 'Updated Title', { onAfterSave: mockOnAfterSave });
             await confirmModal(user);
             await waitFor(() => expect(screen.queryByDisplayValue('Updated Title')).not.toBeInTheDocument());
             expect(screen.getByRole('button', { name: PDF_FILES_SECTION_TEXT.ACTIONS.EDIT })).toBeInTheDocument();

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.tsx
@@ -31,7 +31,7 @@ interface PdfSectionContent {
 
 interface PdfSectionContentBlockProps {
     content: PdfSectionContent;
-    onSave?: () => Promise<void>;
+    onAfterSave?: () => Promise<void>;
     translationLanguages: LocalizationLanguage[];
 }
 
@@ -39,7 +39,7 @@ type ConfirmationModalType = 'publish' | 'cancel' | null;
 
 export const PdfSectionContentBlock: React.FC<PdfSectionContentBlockProps> = ({
     content,
-    onSave,
+    onAfterSave,
     translationLanguages,
 }) => {
     const client = useAdminClient();
@@ -114,8 +114,8 @@ export const PdfSectionContentBlock: React.FC<PdfSectionContentBlockProps> = ({
 
             await PdfSectionApi.updatePdfSection(client, normalizedData);
 
-            if (onSave) {
-                await onSave();
+            if (onAfterSave) {
+                await onAfterSave();
             }
 
             setIsEditMode(false);
@@ -125,7 +125,7 @@ export const PdfSectionContentBlock: React.FC<PdfSectionContentBlockProps> = ({
         } finally {
             setIsSaving(false);
         }
-    }, [formData.title, formData.description, client, onSave, addToast]);
+    }, [formData.title, formData.description, client, onAfterSave, addToast]);
 
     const handleConfirmPublish = useCallback(() => {
         setIsConfirmationModalOpen(false);

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.tsx
@@ -19,20 +19,29 @@ import cn from 'classnames';
 import { ACTION_ICONS } from '@/const/common/action-icons';
 import { IconButton } from '@/components/admin/icon-button/IconButton';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { LocalizationLanguage } from '@/types/common/language';
+import { PdfSectionLocalizationDto } from '@/types/admin/pdf-section';
+import { LocalizationStatuses } from '@/components/admin/localization-statuses/LocalizationStatuses';
 
 interface PdfSectionContent {
     title: string;
     description: string;
+    localizations: PdfSectionLocalizationDto[];
 }
 
 interface PdfSectionContentBlockProps {
     content: PdfSectionContent;
-    onSave?: (data: PdfSectionContent) => Promise<void>;
+    onSave?: () => Promise<void>;
+    translationLanguages: LocalizationLanguage[];
 }
 
 type ConfirmationModalType = 'publish' | 'cancel' | null;
 
-export const PdfSectionContentBlock: React.FC<PdfSectionContentBlockProps> = ({ content, onSave }) => {
+export const PdfSectionContentBlock: React.FC<PdfSectionContentBlockProps> = ({
+    content,
+    onSave,
+    translationLanguages,
+}) => {
     const client = useAdminClient();
     const [isEditMode, setIsEditMode] = useState(false);
     const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
@@ -106,7 +115,7 @@ export const PdfSectionContentBlock: React.FC<PdfSectionContentBlockProps> = ({ 
             await PdfSectionApi.updatePdfSection(client, normalizedData);
 
             if (onSave) {
-                await onSave(normalizedData);
+                await onSave();
             }
 
             setIsEditMode(false);
@@ -201,7 +210,16 @@ export const PdfSectionContentBlock: React.FC<PdfSectionContentBlockProps> = ({ 
 
         return (
             <div className={cn(styles.root, styles['view-root'])}>
-                <div className={styles['edit-button-container']}>
+                <div className={styles['buttons-container']}>
+                    <LocalizationStatuses
+                        languages={translationLanguages}
+                        localizedEntity={{
+                            translationStatuses: (content.localizations ?? []).map((l) => ({
+                                languageId: l.languageId,
+                                translationStatus: l.translationStatus,
+                            })),
+                        }}
+                    />
                     <IconButton
                         aria-label={PDF_FILES_SECTION_TEXT.ACTIONS.EDIT}
                         type="button"

--- a/src/services/api/admin/reports/pdf-section/pdf-section-api.test.ts
+++ b/src/services/api/admin/reports/pdf-section/pdf-section-api.test.ts
@@ -1,17 +1,21 @@
 import { AxiosInstance } from 'axios';
 import { PdfSectionApi } from './pdf-section-api';
 import { API_ROUTES } from '@/const/common/api-routes/main-api';
-import { PdfSection } from '@/types/admin/pdf-section';
+import { PdfSection, PdfSectionLocalizableFields } from '@/types/admin/pdf-section';
 
 describe('PdfSectionApi', () => {
     let mockClient: jest.Mocked<AxiosInstance>;
 
     const mockPdfSection: PdfSection = {
-        id: 1,
         title: 'Test PDF Section',
         description: 'Test Description',
-        isActive: true,
-    } as any;
+        localizations: [],
+    };
+
+    const mockUpdateData: PdfSectionLocalizableFields = {
+        title: 'Test PDF Section',
+        description: 'Test Description',
+    };
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -58,37 +62,30 @@ describe('PdfSectionApi', () => {
     describe('updatePdfSection', () => {
         it('should update pdf section successfully', async () => {
             mockClient.put.mockResolvedValueOnce({ data: mockPdfSection });
-
-            const result = await PdfSectionApi.updatePdfSection(mockClient, mockPdfSection);
-
-            expect(mockClient.put).toHaveBeenCalledWith(API_ROUTES.PDF_SECTION.BASE, mockPdfSection);
+            const result = await PdfSectionApi.updatePdfSection(mockClient, mockUpdateData);
+            expect(mockClient.put).toHaveBeenCalledWith(API_ROUTES.PDF_SECTION.BASE, mockUpdateData);
             expect(result).toEqual(mockPdfSection);
         });
 
         it('should call the correct API endpoint', async () => {
             mockClient.put.mockResolvedValueOnce({ data: mockPdfSection });
-
-            await PdfSectionApi.updatePdfSection(mockClient, mockPdfSection);
-
+            await PdfSectionApi.updatePdfSection(mockClient, mockUpdateData);
             expect(mockClient.put).toHaveBeenCalledWith(
                 expect.stringContaining(API_ROUTES.PDF_SECTION.BASE),
-                mockPdfSection,
+                mockUpdateData,
             );
         });
 
         it('should throw an error when the API request fails', async () => {
             const errorMessage = 'Internal Server Error';
             mockClient.put.mockRejectedValueOnce(new Error(errorMessage));
-
-            await expect(PdfSectionApi.updatePdfSection(mockClient, mockPdfSection)).rejects.toThrow(errorMessage);
+            await expect(PdfSectionApi.updatePdfSection(mockClient, mockUpdateData)).rejects.toThrow(errorMessage);
         });
 
         it('should return updated data from response', async () => {
-            const updatedSection = { ...mockPdfSection, title: 'Updated Title' };
+            const updatedSection: PdfSection = { ...mockPdfSection, title: 'Updated Title' };
             mockClient.put.mockResolvedValueOnce({ data: updatedSection });
-
-            const result = await PdfSectionApi.updatePdfSection(mockClient, updatedSection);
-
+            const result = await PdfSectionApi.updatePdfSection(mockClient, { ...mockUpdateData, title: 'Updated Title' });
             expect(result).toEqual(updatedSection);
         });
     });

--- a/src/services/api/admin/reports/pdf-section/pdf-section-api.test.ts
+++ b/src/services/api/admin/reports/pdf-section/pdf-section-api.test.ts
@@ -85,7 +85,10 @@ describe('PdfSectionApi', () => {
         it('should return updated data from response', async () => {
             const updatedSection: PdfSection = { ...mockPdfSection, title: 'Updated Title' };
             mockClient.put.mockResolvedValueOnce({ data: updatedSection });
-            const result = await PdfSectionApi.updatePdfSection(mockClient, { ...mockUpdateData, title: 'Updated Title' });
+            const result = await PdfSectionApi.updatePdfSection(mockClient, {
+                ...mockUpdateData,
+                title: 'Updated Title',
+            });
             expect(result).toEqual(updatedSection);
         });
     });

--- a/src/services/api/admin/reports/pdf-section/pdf-section-api.ts
+++ b/src/services/api/admin/reports/pdf-section/pdf-section-api.ts
@@ -1,5 +1,5 @@
 import { API_ROUTES } from '@/const/common/api-routes/main-api';
-import { PdfSection } from '@/types/admin/pdf-section';
+import { PdfSection, PdfSectionLocalizableFields } from '@/types/admin/pdf-section';
 import { AxiosInstance } from 'axios';
 
 export const PdfSectionApi = {
@@ -8,7 +8,7 @@ export const PdfSectionApi = {
         return response.data;
     },
 
-    updatePdfSection: async (client: AxiosInstance, data: PdfSection): Promise<PdfSection> => {
+    updatePdfSection: async (client: AxiosInstance, data: PdfSectionLocalizableFields): Promise<PdfSection> => {
         const response = await client.put(API_ROUTES.PDF_SECTION.BASE, data);
         return response.data;
     },

--- a/src/types/admin/pdf-section.ts
+++ b/src/types/admin/pdf-section.ts
@@ -1,6 +1,17 @@
-export interface PdfSection {
+import { TranslationStatus } from '@/types/common/language';
+
+export interface PdfSectionLocalizableFields {
     title: string;
     description: string;
+}
+
+export interface PdfSection extends PdfSectionLocalizableFields {
+    localizations: PdfSectionLocalizationDto[];
+}
+
+export interface PdfSectionLocalizationDto extends PdfSectionLocalizableFields {
+    languageId: number;
+    translationStatus: TranslationStatus;
 }
 
 export interface PdfReportDto {


### PR DESCRIPTION
## Github ticket

* [Ticket 1327](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1327)

## Description

This PR implements translation status indicators for the PDF section description. Admins can now see the translation status of the PDF section content at a glance, without navigating to the translation management screen.

## How it looks

The translation is relevant
<img width="1280" height="395" alt="image" src="https://github.com/user-attachments/assets/b23e10db-9be7-4d01-88c9-e437a01030fb" />
The translation is outdated
<img width="1280" height="395" alt="image" src="https://github.com/user-attachments/assets/c16a6e9e-b98b-4067-8ba1-61c49f44dac4" />
The translation is missed
<img width="1280" height="396" alt="image" src="https://github.com/user-attachments/assets/b98c738f-9efe-49be-9370-7287647b7c99" />

## Summary of change

- Added localizations field to PdfSection type and introduced PdfSectionLocalizableFields and PdfSectionLocalizationDto interfaces
- Updated GetPdfSectionHandler to include localizations in the response and set TranslationStatus to Outdated when the base content is updated
- Updated PdfSectionApi.updatePdfSection to accept PdfSectionLocalizableFields instead of the full PdfSection object, aligning with the backend contract
- Added LocalizationStatuses indicator component to PdfSectionContentBlock view mode, displayed alongside the edit button
- Integrated useLocalizationToolkit in PdfFilesSection to provide translation languages to the content block
- Updated unit tests for PdfFilesSection, PdfSectionContentBlock, and PdfSectionApi to reflect the new types and component interface

## How to recreate changes

1. Navigate to the admin panel and open the PDF Files tab
2. Observe the translation status indicators displayed next to the edit button in the PDF section content block
3. To verify indicator colors:
    - Red — no translation exists for the given language
    - Green — translation exists and is up to date
    - Orange — translation exists but is outdated (edit the base Ukrainian content and save to trigger this state)

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Translation controls for PDF file sections: translate action, modal form, and per-language translation status shown in the UI.
  * Success/error toasts updated for file actions (delete/view/rename/translate).

* **Refactor**
  * Simplified update payloads for PDF section requests.
  * Improved button layout and spacing; added validation for translated title/description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->