### PR TITLE
fix/issue-2371: [Team][Admin] It's not possible to save a team member with apostrophe in their name

### DIFF
--- a/src/const/admin/team.ts
+++ b/src/const/admin/team.ts
@@ -58,7 +58,7 @@ export const TEAM_MEMBER_VALIDATION = {
     fullName: {
         min: 2,
         max: 50,
-        allowedCharsPattern: /^[A-Za-zА-Яа-яҐґЄєІіЇї''\-\s0-9]+$/,
+        allowedCharsPattern: /^[A-Za-zА-Яа-яҐґЄєІіЇї'’ʼ`\-\s0-9]+$/,
         digitsPattern: /\d/,
         getInvalidCharsError: () => 'Поле може містити лише літери, пробіли, ’ -',
         getDigitsError: () => 'Поле не може містити цифри',


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2371

## Description

Fixed a validation bug in the "Імʼя та Прізвище" (Full Name) field when adding a new team member. Expanded the regular expression to support various types of apostrophes, resolving input issues across different devices and keyboard layouts. Added support for standard (`'`), typographic (`’`), Ukrainian modifier letter (`ʼ`), and backtick (`` ` ``) apostrophes (the latter is frequently used by macOS users).

## How it looks

https://github.com/user-attachments/assets/1cde902e-00e9-4ee1-a17c-835f1ce538cf

## Summary of change

* Updated the `allowedCharsPattern` regex in `TEAM_MEMBER_VALIDATION` to include `'`, `’`, `ʼ`, and `` ` `` characters.

## How to recreate changes

1. Log in to the Admin panel.
2. Open the Team page. (`/admin-panel/team`)
3. Click the "Додати в команду" button.
4. Select a category from the dropdown.
5. Enter a name containing an apostrophe into the "Імʼя та Прізвище" field (e.g., Вʼячеслав, В'ячеслав, В'ячеслав, В`ячеслав) and remove focus from the field (blur).
6. Verify that the error message is no longer displayed and the new team member can be saved successfully.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded validation rules for team member names to accept additional apostrophe and quote character variants, improving support for names with diverse formatting styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->