### PR TITLE
Feature/issue-1883-1885: Add modal for adding program expenses and update related components

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -250,6 +250,17 @@ export const PROGRAM_EXPENSES_TEXT = {
     BUTTON: {
         ADD_PROGRAM_EXPENSE: 'Витрата по програмі',
     },
+    MODAL: {
+        ADD: {
+            TITLE: 'Додати витрату по програмі',
+            SUBTITLE: 'Розподіл програмних витрат по програмах',
+            PROGRAM_LABEL: 'Категорія програми',
+            PROGRAM_PLACEHOLDER: 'Оберіть програму',
+            SUBMIT_BUTTON: 'Додати витрату',
+            CONFIRM_CLOSE_TITLE: 'Дані буде втрачено. Бажаєте продовжити?',
+            PROGRAM_NO_AVAILABLE: 'Немає доступних програм',
+        },
+    },
     FILTER: {
         PROGRAMS_PLACEHOLDER: 'Програми',
         ALL_OPTION: 'Всі',

--- a/src/hooks/admin/use-dirty-modal-close-confirmation/useDirtyModalCloseConfirmation.test.ts
+++ b/src/hooks/admin/use-dirty-modal-close-confirmation/useDirtyModalCloseConfirmation.test.ts
@@ -1,0 +1,74 @@
+import { act, renderHook } from '@testing-library/react';
+import { useDirtyModalCloseConfirmation } from './useDirtyModalCloseConfirmation';
+
+describe('useDirtyModalCloseConfirmation', () => {
+    it('should close immediately when modal is clean', () => {
+        const onClose = jest.fn();
+        const { result } = renderHook(() =>
+            useDirtyModalCloseConfirmation({
+                isDirty: false,
+                onClose,
+            }),
+        );
+
+        act(() => {
+            result.current.handleRequestClose();
+        });
+
+        expect(result.current.isCloseConfirmOpen).toBe(false);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should request confirmation when modal is dirty', () => {
+        const onClose = jest.fn();
+        const { result } = renderHook(() =>
+            useDirtyModalCloseConfirmation({
+                isDirty: true,
+                onClose,
+            }),
+        );
+
+        act(() => {
+            result.current.handleRequestClose();
+        });
+
+        expect(result.current.isCloseConfirmOpen).toBe(true);
+        expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('should close dirty modal only after confirmation', () => {
+        const onClose = jest.fn();
+        const { result } = renderHook(() =>
+            useDirtyModalCloseConfirmation({
+                isDirty: true,
+                onClose,
+            }),
+        );
+
+        act(() => {
+            result.current.handleRequestClose();
+            result.current.handleConfirmClose();
+        });
+
+        expect(result.current.isCloseConfirmOpen).toBe(false);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should keep dirty modal open when confirmation is canceled', () => {
+        const onClose = jest.fn();
+        const { result } = renderHook(() =>
+            useDirtyModalCloseConfirmation({
+                isDirty: true,
+                onClose,
+            }),
+        );
+
+        act(() => {
+            result.current.handleRequestClose();
+            result.current.handleCancelClose();
+        });
+
+        expect(result.current.isCloseConfirmOpen).toBe(false);
+        expect(onClose).not.toHaveBeenCalled();
+    });
+});

--- a/src/hooks/admin/use-dirty-modal-close-confirmation/useDirtyModalCloseConfirmation.ts
+++ b/src/hooks/admin/use-dirty-modal-close-confirmation/useDirtyModalCloseConfirmation.ts
@@ -1,0 +1,45 @@
+import { useCallback, useState } from 'react';
+
+interface UseDirtyModalCloseConfirmationParams {
+    isDirty: boolean;
+    onClose: () => void;
+}
+
+interface UseDirtyModalCloseConfirmationResult {
+    isCloseConfirmOpen: boolean;
+    handleRequestClose: () => void;
+    handleConfirmClose: () => void;
+    handleCancelClose: () => void;
+}
+
+export const useDirtyModalCloseConfirmation = ({
+    isDirty,
+    onClose,
+}: UseDirtyModalCloseConfirmationParams): UseDirtyModalCloseConfirmationResult => {
+    const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false);
+
+    const handleRequestClose = useCallback(() => {
+        if (isDirty) {
+            setIsCloseConfirmOpen(true);
+            return;
+        }
+
+        onClose();
+    }, [isDirty, onClose]);
+
+    const handleConfirmClose = useCallback(() => {
+        setIsCloseConfirmOpen(false);
+        onClose();
+    }, [onClose]);
+
+    const handleCancelClose = useCallback(() => {
+        setIsCloseConfirmOpen(false);
+    }, []);
+
+    return {
+        isCloseConfirmOpen,
+        handleRequestClose,
+        handleConfirmClose,
+        handleCancelClose,
+    };
+};

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/funds-expenditures-record-modal/FundsExpendituresRecordModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/funds-expenditures-record-modal/FundsExpendituresRecordModal.tsx
@@ -1,8 +1,9 @@
-import { ReactNode, useCallback, useState } from 'react';
+import { ReactNode } from 'react';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { Button } from '@/components/admin/button/Button';
 import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
 import { Modal } from '@/components/common/modal/Modal';
+import { useDirtyModalCloseConfirmation } from '@/hooks/admin/use-dirty-modal-close-confirmation/useDirtyModalCloseConfirmation';
 import styles from './FundsExpendituresRecordModal.module.scss';
 
 interface FundsExpendituresRecordModalProps {
@@ -30,25 +31,11 @@ export const FundsExpendituresRecordModal = ({
     closeConfirmationTitle,
     children,
 }: FundsExpendituresRecordModalProps) => {
-    const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false);
-
-    const handleRequestClose = useCallback(() => {
-        if (isDirty) {
-            setIsCloseConfirmOpen(true);
-            return;
-        }
-
-        onClose();
-    }, [isDirty, onClose]);
-
-    const handleConfirmClose = useCallback(() => {
-        setIsCloseConfirmOpen(false);
-        onClose();
-    }, [onClose]);
-
-    const handleCancelClose = useCallback(() => {
-        setIsCloseConfirmOpen(false);
-    }, []);
+    const { isCloseConfirmOpen, handleRequestClose, handleConfirmClose, handleCancelClose } =
+        useDirtyModalCloseConfirmation({
+            isDirty,
+            onClose,
+        });
 
     return (
         <>

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
@@ -86,6 +86,14 @@ jest.mock('@/assets/icons/plus.svg', () => ({
     ReactComponent: () => <svg data-testid="plus-icon" />,
 }));
 
+jest.mock('./components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal', () => ({
+    AddProgramExpenseRecordModal: ({ isOpen, exchangeRate }: { isOpen: boolean; exchangeRate: string | null }) => (
+        <div data-testid="add-program-expense-modal" data-open={String(isOpen)} data-exchange-rate={exchangeRate ?? ''}>
+            AddProgramExpenseRecordModal
+        </div>
+    ),
+}));
+
 jest.mock('@/components/admin/multi-select-input/MultiSelectInput', () => ({
     MultiSelectInput: ({
         options,
@@ -272,7 +280,7 @@ describe('ProgramExpensesSection', () => {
 
         expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.TITLE)).toBeInTheDocument();
         expect(screen.getByText(PROGRAM_EXPENSES_TEXT.EMPTY_STATE.ADD_RECORD)).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE })).toBeEnabled();
+        expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE })).toBeDisabled();
     });
 
     it('should pass fetch handler that calls ProgramExpensesApi.getReadOnlyData', async () => {
@@ -300,18 +308,11 @@ describe('ProgramExpensesSection', () => {
         expect(screen.getByText(PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.ACTIONS)).toBeInTheDocument();
     });
 
-    it('should display synced exchange rate in edit mode', () => {
-        render(<ProgramExpensesSection isEditing syncedExchangeRate="44.20" />);
+    it('should display mock exchange rate in edit mode', () => {
+        render(<ProgramExpensesSection isEditing />);
 
-        expect(screen.getByText('44.20')).toBeInTheDocument();
-        expect(screen.queryByText('41.25')).not.toBeInTheDocument();
-    });
-
-    it('should display empty synced exchange rate in edit mode when the funds value is cleared', () => {
-        render(<ProgramExpensesSection isEditing syncedExchangeRate={null} />);
-
-        expect(screen.getByText('-')).toBeInTheDocument();
-        expect(screen.queryByText('41.25')).not.toBeInTheDocument();
+        expect(screen.getByText('41.25')).toBeInTheDocument();
+        expect(screen.getByTestId('add-program-expense-modal')).toHaveAttribute('data-exchange-rate', '41.25');
     });
 
     it('should disable add program expense button when four records exist', () => {

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
@@ -23,7 +23,6 @@ const MAX_PROGRAM_EXPENSE_RECORDS = 4;
 
 interface ProgramExpensesSectionProps {
     isEditing?: boolean;
-    syncedExchangeRate?: string | null;
 }
 
 export const ProgramExpensesSection = ({ isEditing = false }: ProgramExpensesSectionProps) => {
@@ -104,7 +103,7 @@ export const ProgramExpensesSection = ({ isEditing = false }: ProgramExpensesSec
                     records={filteredRecords}
                     hasAnyProgramExpenseRecords={hasAnyProgramExpenseRecords}
                     isEditing={isEditing}
-                    isAddProgramExpenseDisabled={isAddProgramExpenseDisabled}
+                    isAddProgramExpenseDisabled={isAddProgramExpenseDisabled || !isEditing}
                     onAddProgramExpense={isEditing ? handleOpenAddProgramExpenseModal : undefined}
                 />
             </div>

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
@@ -6,6 +6,7 @@ import { ProgramExpensesReadOnlyData } from '@/types/admin/reports';
 import { ProgramExpensesToolbar } from './components/program-expenses-toolbar/ProgramExpensesToolbar';
 import { ProgramExpensesSummaryCard } from './components/program-expenses-summary-card/ProgramExpensesSummaryCard';
 import { ProgramExpensesTable } from './components/program-expenses-table/ProgramExpensesTable';
+import { AddProgramExpenseRecordModal } from './components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal';
 import styles from './ProgramExpensesSection.module.scss';
 
 const INITIAL_PROGRAM_EXPENSES_DATA: ProgramExpensesReadOnlyData = {
@@ -25,8 +26,9 @@ interface ProgramExpensesSectionProps {
     syncedExchangeRate?: string | null;
 }
 
-export const ProgramExpensesSection = ({ isEditing = false, syncedExchangeRate }: ProgramExpensesSectionProps) => {
+export const ProgramExpensesSection = ({ isEditing = false }: ProgramExpensesSectionProps) => {
     const [selectedProgramIds, setSelectedProgramIds] = useState<number[]>([]);
+    const [isAddProgramExpenseModalOpen, setIsAddProgramExpenseModalOpen] = useState(false);
 
     const fetchReadOnlyData = useCallback((options = {}) => ProgramExpensesApi.getReadOnlyData(options), []);
 
@@ -46,6 +48,12 @@ export const ProgramExpensesSection = ({ isEditing = false, syncedExchangeRate }
         });
     }, [data.programs]);
 
+    useEffect(() => {
+        if (!isEditing) {
+            setIsAddProgramExpenseModalOpen(false);
+        }
+    }, [isEditing]);
+
     const filteredRecords = useMemo(() => {
         if (selectedProgramIds.length === 0) {
             return data.records;
@@ -57,8 +65,16 @@ export const ProgramExpensesSection = ({ isEditing = false, syncedExchangeRate }
     const programExpenseRecordsCount = data.records.length;
     const hasAnyProgramExpenseRecords = programExpenseRecordsCount > 0;
     const isInitialLoading = isLoading && programExpenseRecordsCount === 0 && data.programs.length === 0;
-    const exchangeRate = isEditing ? (syncedExchangeRate ?? null) : data.exchangeRate;
+    const exchangeRate = data.exchangeRate;
     const isAddProgramExpenseDisabled = programExpenseRecordsCount >= MAX_PROGRAM_EXPENSE_RECORDS;
+
+    const handleOpenAddProgramExpenseModal = useCallback(() => {
+        setIsAddProgramExpenseModalOpen(true);
+    }, []);
+
+    const handleCloseAddProgramExpenseModal = useCallback(() => {
+        setIsAddProgramExpenseModalOpen(false);
+    }, []);
 
     if (isInitialLoading) {
         return (
@@ -82,13 +98,23 @@ export const ProgramExpensesSection = ({ isEditing = false, syncedExchangeRate }
                     isEditing={isEditing}
                     isAddProgramExpenseDisabled={isAddProgramExpenseDisabled}
                     onProgramChange={setSelectedProgramIds}
+                    onAddProgramExpense={handleOpenAddProgramExpenseModal}
                 />
                 <ProgramExpensesTable
                     records={filteredRecords}
                     hasAnyProgramExpenseRecords={hasAnyProgramExpenseRecords}
                     isEditing={isEditing}
+                    isAddProgramExpenseDisabled={isAddProgramExpenseDisabled}
+                    onAddProgramExpense={isEditing ? handleOpenAddProgramExpenseModal : undefined}
                 />
             </div>
+
+            <AddProgramExpenseRecordModal
+                isOpen={isAddProgramExpenseModalOpen}
+                programs={data.programs}
+                exchangeRate={exchangeRate}
+                onClose={handleCloseAddProgramExpenseModal}
+            />
         </div>
     );
 };

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.module.scss
@@ -3,8 +3,9 @@
 @use '@/assets/sass/variables/typography' as t;
 
 .modal {
-    width: 650px;
-    height: 718px;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
     max-height: calc(100vh - 32px);
     padding: 0;
     border-radius: 8px;
@@ -31,8 +32,12 @@
             height: 24px;
             padding: 0;
             border: none;
-            outline: none;
             background-size: 24px 24px;
+
+            &:focus-visible {
+                outline: 2px solid c.$blue-500;
+                outline-offset: 3px;
+            }
         }
     }
 
@@ -47,8 +52,11 @@
     }
 
     :global(.modal-body) {
+        flex: 1 1 auto;
+        min-height: 0;
         margin-bottom: 0;
         padding: 18px 0 0;
+        overflow-y: auto;
     }
 
     :global(.modal-footer) {
@@ -60,8 +68,7 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    width: 602px;
-    height: 75px;
+    width: 100%;
     padding: 0;
 }
 
@@ -70,8 +77,7 @@
 
     display: flex;
     align-items: center;
-    width: 602px;
-    height: 48px;
+    width: 100%;
     margin: 0;
     line-height: 36px;
     color: c.$blue-900;
@@ -82,8 +88,7 @@
 
     display: flex;
     align-items: center;
-    width: 602px;
-    height: 27px;
+    width: 100%;
     margin: 0;
     line-height: 36px;
     color: #b3b7be;
@@ -94,8 +99,8 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    width: 650px;
-    height: 559px;
+    width: 100%;
+    min-height: 0;
     padding: 23px 25px;
     border: 1px solid #f3f4f6;
     background: c.$grey-50;
@@ -106,7 +111,6 @@
     flex-direction: column;
     align-items: flex-start;
     width: 100%;
-    height: 420px;
     gap: 20px;
 }
 
@@ -251,8 +255,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    width: 600px;
-    height: 60px;
+    width: 100%;
     margin-top: 40px;
     gap: 24px;
 }
@@ -279,10 +282,6 @@
 
 @media (max-width: 768px) {
     .modal {
-        width: 100%;
-        height: auto;
-        min-height: 718px;
-
         :global(.modal-header) {
             padding: 23px 16px 0;
         }
@@ -295,9 +294,6 @@
     }
 
     .panel {
-        width: 100%;
-        height: auto;
-        min-height: 559px;
         padding: 23px 16px;
     }
 

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.module.scss
@@ -1,0 +1,319 @@
+@use '@/assets/sass/variables/colors' as c;
+@use '@/assets/sass/mixins/typography.mixins' as type;
+@use '@/assets/sass/variables/typography' as t;
+
+.modal {
+    width: 650px;
+    height: 718px;
+    max-height: calc(100vh - 32px);
+    padding: 0;
+    border-radius: 8px;
+    background: c.$white;
+    box-shadow: 0 24px 48px -12px rgba(c.$bluish-black, 0.2);
+    overflow: hidden;
+
+    :global(.modal-header) {
+        position: relative;
+        margin-bottom: 0;
+        padding: 23px 24px 0;
+    }
+
+    :global(.modal-header .close-icon) {
+        position: absolute;
+        top: 24px;
+        right: 24px;
+        width: 24px;
+        margin: 0;
+        padding: 0;
+
+        button {
+            width: 24px;
+            height: 24px;
+            padding: 0;
+            border: none;
+            outline: none;
+            background-size: 24px 24px;
+        }
+    }
+
+    :global(.modal-header .modal-title-wrapper) {
+        text-align: left;
+    }
+
+    :global(.modal-header .modal-header-text) {
+        font-size: inherit;
+        line-height: inherit;
+        text-align: left;
+    }
+
+    :global(.modal-body) {
+        margin-bottom: 0;
+        padding: 18px 0 0;
+    }
+
+    :global(.modal-footer) {
+        display: none;
+    }
+}
+
+.header {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    width: 602px;
+    height: 75px;
+    padding: 0;
+}
+
+.title {
+    @include type.h4-bold;
+
+    display: flex;
+    align-items: center;
+    width: 602px;
+    height: 48px;
+    margin: 0;
+    line-height: 36px;
+    color: c.$blue-900;
+}
+
+.subtitle {
+    @include type.body-1-regular;
+
+    display: flex;
+    align-items: center;
+    width: 602px;
+    height: 27px;
+    margin: 0;
+    line-height: 36px;
+    color: #b3b7be;
+}
+
+.panel {
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    width: 650px;
+    height: 559px;
+    padding: 23px 25px;
+    border: 1px solid #f3f4f6;
+    background: c.$grey-50;
+}
+
+.form {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    width: 100%;
+    height: 420px;
+    gap: 20px;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    width: 100%;
+
+    :global(.char-limit-input-wrapper) {
+        width: 100%;
+    }
+
+    :global(.char-limit-input) {
+        width: 100%;
+        height: 50px;
+        border: 1px solid c.$grey-700;
+        border-radius: 8px;
+        padding: 10px 17px 10px 10px;
+        background: c.$white;
+        filter: drop-shadow(0 1px 2px rgba(c.$bluish-black, 0.05));
+    }
+}
+
+.label {
+    @include type.body-2-regular;
+
+    color: c.$grey-900;
+}
+
+.input {
+    @include type.body-2-medium;
+
+    width: 100%;
+    border: none;
+    padding: 0;
+    color: c.$grey-900;
+    background: transparent;
+}
+
+.select {
+    width: 100%;
+
+    :global(.select) {
+        width: 100%;
+    }
+
+    :global(.select-head) {
+        width: 100%;
+        height: 50px;
+        border: 1px solid c.$grey-700;
+        border-radius: 8px;
+        padding: 10px 17px 10px 10px;
+        color: c.$grey-900;
+        background: c.$white;
+        filter: drop-shadow(0 1px 2px rgba(c.$bluish-black, 0.05));
+    }
+
+    :global(.select-head .empty) {
+        @include type.body-2-medium;
+
+        color: c.$grey-900;
+    }
+
+    :global(.select-head svg) {
+        width: 24px;
+        height: 24px;
+    }
+
+    :global(.select-head svg path) {
+        stroke: c.$blue-900;
+    }
+
+    :global(.select-head:hover) {
+        background: c.$grey-50;
+    }
+
+    :global(.select-options) {
+        min-width: 100%;
+        max-height: 220px;
+        overflow-y: auto;
+    }
+}
+
+.select-option {
+    @include type.body-2-regular;
+}
+
+.disabled-select-placeholder {
+    @include type.body-2-regular;
+
+    width: 100%;
+    height: 50px;
+    display: flex;
+    align-items: center;
+    border: 1px solid c.$grey-700;
+    border-radius: 8px;
+    padding: 10px;
+    color: c.$grey-800;
+    background-color: c.$grey-600;
+    cursor: not-allowed;
+    filter: drop-shadow(0 1px 2px rgba(c.$bluish-black, 0.05));
+}
+
+.amount-usd-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.exchange-rate-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.exchange-rate-chip-label {
+    font-family: 'Roboto', sans-serif;
+    font-weight: 500;
+    font-size: 14px;
+    line-height: 20px;
+    letter-spacing: 0.1px;
+
+    color: c.$grey-900;
+}
+
+.exchange-rate-value {
+    @include type.body-2-medium;
+
+    width: 119px;
+    height: 32px;
+    border: 1px solid c.$bluish-black;
+    border-radius: 8px;
+    text-align: center;
+    background: c.$grey-600;
+    color: c.$blue-900;
+    padding: 6px 12px;
+}
+
+.actions {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    width: 600px;
+    height: 60px;
+    margin-top: 40px;
+    gap: 24px;
+}
+
+.submit,
+.cancel {
+    height: 60px;
+    font-family: t.$font-family-base;
+    font-weight: t.$fw-regular;
+    font-size: 20px;
+    line-height: 24px;
+    letter-spacing: t.$ls-tight;
+}
+
+.submit {
+    width: 391px;
+    padding: 8px 24px;
+}
+
+.cancel {
+    width: 185px;
+    padding: 8px 20px 8px 24px;
+}
+
+@media (max-width: 768px) {
+    .modal {
+        width: 100%;
+        height: auto;
+        min-height: 718px;
+
+        :global(.modal-header) {
+            padding: 23px 16px 0;
+        }
+    }
+
+    .header,
+    .title,
+    .subtitle {
+        width: 100%;
+    }
+
+    .panel {
+        width: 100%;
+        height: auto;
+        min-height: 559px;
+        padding: 23px 16px;
+    }
+
+    .amount-usd-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .actions {
+        width: 100%;
+        flex-direction: column;
+        height: auto;
+    }
+
+    .submit,
+    .cancel {
+        width: 100%;
+    }
+}

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.module.scss
@@ -1,6 +1,5 @@
 @use '@/assets/sass/variables/colors' as c;
 @use '@/assets/sass/mixins/typography.mixins' as type;
-@use '@/assets/sass/variables/typography' as t;
 
 .modal {
     display: flex;
@@ -91,7 +90,7 @@
     width: 100%;
     margin: 0;
     line-height: 36px;
-    color: #b3b7be;
+    color: c.$grey-700;
 }
 
 .panel {
@@ -102,7 +101,7 @@
     width: 100%;
     min-height: 0;
     padding: 23px 25px;
-    border: 1px solid #f3f4f6;
+    border: 1px solid c.$grey-150;
     background: c.$grey-50;
 }
 
@@ -229,12 +228,7 @@
 }
 
 .exchange-rate-chip-label {
-    font-family: 'Roboto', sans-serif;
-    font-weight: 500;
-    font-size: 14px;
-    line-height: 20px;
-    letter-spacing: 0.1px;
-
+    @include type.small-text-medium;
     color: c.$grey-900;
 }
 
@@ -262,12 +256,9 @@
 
 .submit,
 .cancel {
+    @include type.body-2-regular;
+
     height: 60px;
-    font-family: t.$font-family-base;
-    font-weight: t.$fw-regular;
-    font-size: 20px;
-    line-height: 24px;
-    letter-spacing: t.$ls-tight;
 }
 
 .submit {

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.test.tsx
@@ -1,0 +1,213 @@
+import { ChangeEvent, ComponentProps, ReactNode } from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+import { AddProgramExpenseRecordModal } from './AddProgramExpenseRecordModal';
+
+interface ModalProps {
+    children: ReactNode;
+    isOpen: boolean;
+}
+
+jest.mock('@/components/common/modal/Modal', () => {
+    const Modal = ({ children, isOpen }: ModalProps) =>
+        isOpen ? <div data-testid="add-program-expense-modal">{children}</div> : null;
+
+    Modal.Title = ({ children }: { children: ReactNode }) => <div data-testid="modal-title">{children}</div>;
+    Modal.Content = ({ children }: { children: ReactNode }) => <div data-testid="modal-content">{children}</div>;
+    Modal.Actions = ({ children }: { children: ReactNode }) => <div data-testid="modal-actions">{children}</div>;
+
+    return { Modal };
+});
+
+jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
+    ConfirmationModal: ({
+        isOpen,
+        title,
+        onConfirm,
+        onCancel,
+    }: {
+        isOpen: boolean;
+        title: string;
+        onConfirm: () => void;
+        onCancel: () => void;
+    }) =>
+        isOpen ? (
+            <div data-testid="close-confirmation">
+                <p>{title}</p>
+                <button type="button" onClick={onConfirm}>
+                    Confirm
+                </button>
+                <button type="button" onClick={onCancel}>
+                    Cancel confirmation
+                </button>
+            </div>
+        ) : null,
+}));
+
+jest.mock('@/components/admin/input-with-character-limit/InputWithCharacterLimit', () => ({
+    InputWithCharacterLimit: ({
+        id,
+        value,
+        onChange,
+    }: {
+        id: string;
+        value: string;
+        onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+    }) => <input data-testid={id} value={value} onChange={onChange} />,
+}));
+
+jest.mock('@/components/common/select/Select', () => {
+    const React = require('react');
+
+    const Select = ({ value, onValueChange, placeholder, children }: any) => {
+        const options = React.Children.toArray(children)
+            .filter((child: any) => child?.props)
+            .map((child: any) => ({ value: child.props.value, name: child.props.name }));
+
+        return (
+            <select
+                data-testid={placeholder}
+                value={value ?? ''}
+                onChange={(event) => {
+                    const selectedOption = options.find((option: any) => String(option.value) === event.target.value);
+                    onValueChange(selectedOption?.value);
+                }}
+            >
+                <option value="">placeholder</option>
+                {options.map((option: any) => (
+                    <option key={String(option.value)} value={option.value}>
+                        {option.name}
+                    </option>
+                ))}
+            </select>
+        );
+    };
+
+    Select.Option = (_props: any) => null;
+
+    return { Select };
+});
+
+jest.mock('@/utils/functions/get-reporting-year-options/get-reporting-year-options', () => ({
+    getReportingYearOptions: () => ['2026', '2025'],
+}));
+
+const PROGRAMS = [
+    { id: 2, name: 'Program B' },
+    { id: 1, name: 'Program A' },
+];
+
+const renderModal = (props: Partial<ComponentProps<typeof AddProgramExpenseRecordModal>> = {}) =>
+    render(
+        <AddProgramExpenseRecordModal isOpen programs={PROGRAMS} exchangeRate="42.15" onClose={jest.fn()} {...props} />,
+    );
+
+describe('AddProgramExpenseRecordModal', () => {
+    it('renders modal content, disabled submit button and sorted programs', () => {
+        renderModal();
+
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.MODAL.ADD.TITLE)).toBeInTheDocument();
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.MODAL.ADD.SUBTITLE)).toBeInTheDocument();
+        expect(screen.getByLabelText(FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL)).toHaveValue('42.15');
+        expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.MODAL.ADD.SUBMIT_BUTTON })).toBeDisabled();
+
+        const programSelect = screen.getByTestId(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER);
+        const programOptions = within(programSelect)
+            .getAllByRole('option')
+            .map((option) => option.textContent);
+
+        expect(programOptions).toEqual(['placeholder', 'Program A', 'Program B']);
+    });
+
+    it('renders disabled program placeholder when programs are unavailable', () => {
+        renderModal({ programs: [] });
+
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_NO_AVAILABLE)).toBeInTheDocument();
+        expect(screen.queryByTestId(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER)).not.toBeInTheDocument();
+    });
+
+    it('normalizes program expense amount inputs', () => {
+        renderModal();
+
+        const amountUahInput = screen.getByTestId('add-program-expense-amount-uah');
+        const amountUsdInput = screen.getByTestId('add-program-expense-amount-usd');
+
+        fireEvent.change(amountUahInput, { target: { value: '123 456 789 0' } });
+        fireEvent.change(amountUsdInput, { target: { value: '12.345abc' } });
+
+        expect(amountUahInput).toHaveValue('123456789');
+        expect(amountUsdInput).toHaveValue('12,34');
+
+        fireEvent.change(amountUsdInput, { target: { value: ',50' } });
+
+        expect(amountUsdInput).toHaveValue('');
+    });
+
+    it('updates selected program value', () => {
+        renderModal();
+
+        const programSelect = screen.getByTestId(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER);
+
+        fireEvent.change(programSelect, { target: { value: '1' } });
+
+        expect(programSelect).toHaveValue('1');
+    });
+
+    it('closes immediately when the form is clean', () => {
+        const onClose = jest.fn();
+        renderModal({ onClose });
+
+        fireEvent.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+        expect(screen.queryByTestId('close-confirmation')).not.toBeInTheDocument();
+    });
+
+    it('asks for confirmation before closing dirty form and handles cancel or confirm', () => {
+        const onClose = jest.fn();
+        renderModal({ onClose });
+
+        fireEvent.change(screen.getByTestId(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER), {
+            target: { value: '2025' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
+
+        expect(screen.getByTestId('close-confirmation')).toHaveTextContent(
+            PROGRAM_EXPENSES_TEXT.MODAL.ADD.CONFIRM_CLOSE_TITLE,
+        );
+        expect(onClose).not.toHaveBeenCalled();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel confirmation' }));
+
+        expect(screen.queryByTestId('close-confirmation')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
+        fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('resets form state and close confirmation when modal closes', () => {
+        const { rerender } = render(
+            <AddProgramExpenseRecordModal isOpen programs={PROGRAMS} exchangeRate={null} onClose={jest.fn()} />,
+        );
+
+        const amountUahInput = screen.getByTestId('add-program-expense-amount-uah');
+
+        fireEvent.change(amountUahInput, { target: { value: '100' } });
+        fireEvent.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
+
+        expect(screen.getByTestId('close-confirmation')).toBeInTheDocument();
+
+        rerender(
+            <AddProgramExpenseRecordModal isOpen={false} programs={PROGRAMS} exchangeRate={null} onClose={jest.fn()} />,
+        );
+        rerender(<AddProgramExpenseRecordModal isOpen programs={PROGRAMS} exchangeRate={null} onClose={jest.fn()} />);
+
+        expect(screen.getByTestId('add-program-expense-amount-uah')).toHaveValue('');
+        expect(screen.queryByTestId('close-confirmation')).not.toBeInTheDocument();
+        expect(screen.getByLabelText(FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL)).toHaveValue('');
+    });
+});

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.test.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, ComponentProps, ReactNode } from 'react';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
@@ -58,38 +58,6 @@ jest.mock('@/components/admin/input-with-character-limit/InputWithCharacterLimit
     }) => <input data-testid={id} value={value} onChange={onChange} />,
 }));
 
-jest.mock('@/components/common/select/Select', () => {
-    const React = require('react');
-
-    const Select = ({ value, onValueChange, placeholder, children }: any) => {
-        const options = React.Children.toArray(children)
-            .filter((child: any) => child?.props)
-            .map((child: any) => ({ value: child.props.value, name: child.props.name }));
-
-        return (
-            <select
-                data-testid={placeholder}
-                value={value ?? ''}
-                onChange={(event) => {
-                    const selectedOption = options.find((option: any) => String(option.value) === event.target.value);
-                    onValueChange(selectedOption?.value);
-                }}
-            >
-                <option value="">placeholder</option>
-                {options.map((option: any) => (
-                    <option key={String(option.value)} value={option.value}>
-                        {option.name}
-                    </option>
-                ))}
-            </select>
-        );
-    };
-
-    Select.Option = (_props: any) => null;
-
-    return { Select };
-});
-
 jest.mock('@/utils/functions/get-reporting-year-options/get-reporting-year-options', () => ({
     getReportingYearOptions: () => ['2026', '2025'],
 }));
@@ -104,6 +72,21 @@ const renderModal = (props: Partial<ComponentProps<typeof AddProgramExpenseRecor
         <AddProgramExpenseRecordModal isOpen programs={PROGRAMS} exchangeRate="42.15" onClose={jest.fn()} {...props} />,
     );
 
+const getSelectToggle = (displayValue: string): HTMLButtonElement => {
+    const button = screen.getByText(displayValue).closest('button');
+
+    if (!(button instanceof HTMLButtonElement)) {
+        throw new Error(`Select toggle for "${displayValue}" was not found`);
+    }
+
+    return button;
+};
+
+const selectOption = (currentDisplayValue: string, nextDisplayValue: string) => {
+    fireEvent.click(getSelectToggle(currentDisplayValue));
+    fireEvent.click(screen.getByRole('button', { name: nextDisplayValue }));
+};
+
 describe('AddProgramExpenseRecordModal', () => {
     it('renders modal content, disabled submit button and sorted programs', () => {
         renderModal();
@@ -113,19 +96,19 @@ describe('AddProgramExpenseRecordModal', () => {
         expect(screen.getByLabelText(FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL)).toHaveValue('42.15');
         expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.MODAL.ADD.SUBMIT_BUTTON })).toBeDisabled();
 
-        const programSelect = screen.getByTestId(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER);
-        const programOptions = within(programSelect)
-            .getAllByRole('option')
+        fireEvent.click(getSelectToggle(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER));
+        const programOptions = screen
+            .getAllByRole('button', { name: /^Program [AB]$/ })
             .map((option) => option.textContent);
 
-        expect(programOptions).toEqual(['placeholder', 'Program A', 'Program B']);
+        expect(programOptions).toEqual(['Program A', 'Program B']);
     });
 
     it('renders disabled program placeholder when programs are unavailable', () => {
         renderModal({ programs: [] });
 
         expect(screen.getByText(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_NO_AVAILABLE)).toBeInTheDocument();
-        expect(screen.queryByTestId(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER)).not.toBeInTheDocument();
+        expect(screen.queryByText(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER)).not.toBeInTheDocument();
     });
 
     it('normalizes program expense amount inputs', () => {
@@ -148,11 +131,9 @@ describe('AddProgramExpenseRecordModal', () => {
     it('updates selected program value', () => {
         renderModal();
 
-        const programSelect = screen.getByTestId(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER);
+        selectOption(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER, 'Program A');
 
-        fireEvent.change(programSelect, { target: { value: '1' } });
-
-        expect(programSelect).toHaveValue('1');
+        expect(getSelectToggle('Program A')).toBeInTheDocument();
     });
 
     it('closes immediately when the form is clean', () => {
@@ -169,9 +150,7 @@ describe('AddProgramExpenseRecordModal', () => {
         const onClose = jest.fn();
         renderModal({ onClose });
 
-        fireEvent.change(screen.getByTestId(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER), {
-            target: { value: '2025' },
-        });
+        selectOption(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER, '2025');
         fireEvent.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
 
         expect(screen.getByTestId('close-confirmation')).toHaveTextContent(

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.tsx
@@ -1,0 +1,245 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button } from '@/components/admin/button/Button';
+import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
+import { InputWithCharacterLimit } from '@/components/admin/input-with-character-limit/InputWithCharacterLimit';
+import { Select } from '@/components/common/select/Select';
+import { Modal } from '@/components/common/modal/Modal';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+import { ProgramExpensesProgram } from '@/types/admin/reports';
+import { getReportingYearOptions } from '@/utils/functions/get-reporting-year-options/get-reporting-year-options';
+import styles from './AddProgramExpenseRecordModal.module.scss';
+
+interface AddProgramExpenseRecordModalProps {
+    isOpen: boolean;
+    programs: ProgramExpensesProgram[];
+    exchangeRate: string | null;
+    onClose: () => void;
+}
+
+interface ProgramExpenseFormState {
+    reportingYear: string | undefined;
+    programId: number | undefined;
+    amountUah: string;
+    amountUsd: string;
+}
+
+const INITIAL_FORM_STATE: ProgramExpenseFormState = {
+    reportingYear: undefined,
+    programId: undefined,
+    amountUah: '',
+    amountUsd: '',
+};
+
+const PROGRAM_EXPENSE_AMOUNT_MAX_LENGTH = 12;
+
+const normalizeProgramExpenseAmountInput = (value: string): string => {
+    const withCommaSeparator = value.replaceAll('.', ',').replaceAll(/\s/g, '');
+    const firstCommaIndex = withCommaSeparator.indexOf(',');
+    const integerSource = firstCommaIndex === -1 ? withCommaSeparator : withCommaSeparator.slice(0, firstCommaIndex);
+    const integerPart = integerSource.replaceAll(/\D/g, '').slice(0, 9);
+
+    if (firstCommaIndex === -1) {
+        return integerPart;
+    }
+
+    if (!integerPart) {
+        return '';
+    }
+
+    const decimalPart = withCommaSeparator
+        .slice(firstCommaIndex + 1)
+        .replaceAll(/\D/g, '')
+        .slice(0, 2);
+
+    return `${integerPart},${decimalPart}`;
+};
+
+export const AddProgramExpenseRecordModal = ({
+    isOpen,
+    programs,
+    exchangeRate,
+    onClose,
+}: AddProgramExpenseRecordModalProps) => {
+    const yearOptions = useMemo(() => getReportingYearOptions(), []);
+    const programOptions = useMemo(
+        () =>
+            [...programs].sort((firstProgram, secondProgram) =>
+                firstProgram.name.localeCompare(secondProgram.name, 'uk'),
+            ),
+        [programs],
+    );
+
+    const [formState, setFormState] = useState<ProgramExpenseFormState>(INITIAL_FORM_STATE);
+    const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false);
+
+    useEffect(() => {
+        if (!isOpen) {
+            setFormState(INITIAL_FORM_STATE);
+            setIsCloseConfirmOpen(false);
+        }
+    }, [isOpen]);
+
+    const isDirty =
+        Boolean(formState.reportingYear) ||
+        Boolean(formState.programId) ||
+        formState.amountUah.trim() !== '' ||
+        formState.amountUsd.trim() !== '';
+
+    const handleAmountChange = (field: 'amountUah' | 'amountUsd', value: string) => {
+        const normalizedValue = normalizeProgramExpenseAmountInput(value);
+
+        setFormState((previousState) => ({
+            ...previousState,
+            [field]: normalizedValue,
+        }));
+    };
+
+    const handleRequestClose = useCallback(() => {
+        if (isDirty) {
+            setIsCloseConfirmOpen(true);
+            return;
+        }
+
+        onClose();
+    }, [isDirty, onClose]);
+
+    const handleConfirmClose = useCallback(() => {
+        setIsCloseConfirmOpen(false);
+        onClose();
+    }, [onClose]);
+
+    const handleCancelClose = useCallback(() => {
+        setIsCloseConfirmOpen(false);
+    }, []);
+
+    return (
+        <>
+            <Modal isOpen={isOpen} onClose={handleRequestClose} className={styles.modal} maxWidth="650px">
+                <Modal.Title>
+                    <div className={styles.header}>
+                        <h2 className={styles.title}>{PROGRAM_EXPENSES_TEXT.MODAL.ADD.TITLE}</h2>
+                        <p className={styles.subtitle}>{PROGRAM_EXPENSES_TEXT.MODAL.ADD.SUBTITLE}</p>
+                    </div>
+                </Modal.Title>
+                <Modal.Content>
+                    <div className={styles.panel}>
+                        <div className={styles.form}>
+                            <div className={styles.field}>
+                                <label className={styles.label}>
+                                    {FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_LABEL}
+                                </label>
+                                <Select<string>
+                                    value={formState.reportingYear}
+                                    onValueChange={(reportingYear) =>
+                                        setFormState((previousState) => ({
+                                            ...previousState,
+                                            reportingYear,
+                                        }))
+                                    }
+                                    placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER}
+                                    className={styles.select}
+                                    optionClassName={styles['select-option']}
+                                >
+                                    {yearOptions.map((year) => (
+                                        <Select.Option key={year} value={year} name={year} />
+                                    ))}
+                                </Select>
+                            </div>
+
+                            <div className={styles.field}>
+                                <label className={styles.label}>{PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_LABEL}</label>
+                                {programOptions.length === 0 ? (
+                                    <div className={styles['disabled-select-placeholder']}>
+                                        {PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_NO_AVAILABLE}
+                                    </div>
+                                ) : (
+                                    <Select<number>
+                                        value={formState.programId}
+                                        onValueChange={(programId) =>
+                                            setFormState((previousState) => ({
+                                                ...previousState,
+                                                programId,
+                                            }))
+                                        }
+                                        placeholder={PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER}
+                                        className={styles.select}
+                                        optionClassName={styles['select-option']}
+                                    >
+                                        {programOptions.map((program) => (
+                                            <Select.Option key={program.id} value={program.id} name={program.name} />
+                                        ))}
+                                    </Select>
+                                )}
+                            </div>
+
+                            <div className={styles.field}>
+                                <label className={styles.label}>
+                                    {FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.AMOUNT_UAH_LABEL}
+                                </label>
+                                <InputWithCharacterLimit
+                                    id="add-program-expense-amount-uah"
+                                    name="amountUah"
+                                    type="text"
+                                    value={formState.amountUah}
+                                    onChange={(event) => handleAmountChange('amountUah', event.target.value)}
+                                    maxLength={PROGRAM_EXPENSE_AMOUNT_MAX_LENGTH}
+                                    showCounter={false}
+                                    className={styles.input}
+                                />
+                            </div>
+
+                            <div className={styles.field}>
+                                <div className={styles['amount-usd-header']}>
+                                    <label className={styles.label}>
+                                        {FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.AMOUNT_USD_LABEL}
+                                    </label>
+                                    <div className={styles['exchange-rate-chip']}>
+                                        <span className={styles['exchange-rate-chip-label']}>
+                                            {FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL}
+                                        </span>
+                                        <input
+                                            type="text"
+                                            value={exchangeRate ?? ''}
+                                            disabled
+                                            className={styles['exchange-rate-value']}
+                                            aria-label={FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL}
+                                        />
+                                    </div>
+                                </div>
+                                <InputWithCharacterLimit
+                                    id="add-program-expense-amount-usd"
+                                    name="amountUsd"
+                                    type="text"
+                                    value={formState.amountUsd}
+                                    onChange={(event) => handleAmountChange('amountUsd', event.target.value)}
+                                    maxLength={PROGRAM_EXPENSE_AMOUNT_MAX_LENGTH}
+                                    showCounter={false}
+                                    className={styles.input}
+                                />
+                            </div>
+                        </div>
+
+                        <div className={styles.actions}>
+                            <Button buttonStyle="primary" disabled className={styles.submit}>
+                                {PROGRAM_EXPENSES_TEXT.MODAL.ADD.SUBMIT_BUTTON}
+                            </Button>
+                            <Button buttonStyle="secondary" onClick={handleRequestClose} className={styles.cancel}>
+                                {COMMON_TEXT_ADMIN.BUTTON.CANCEL}
+                            </Button>
+                        </div>
+                    </div>
+                </Modal.Content>
+                <Modal.Actions>{null}</Modal.Actions>
+            </Modal>
+
+            <ConfirmationModal
+                isOpen={isCloseConfirmOpen}
+                title={PROGRAM_EXPENSES_TEXT.MODAL.ADD.CONFIRM_CLOSE_TITLE}
+                onConfirm={handleConfirmClose}
+                onCancel={handleCancelClose}
+                onClose={handleCancelClose}
+            />
+        </>
+    );
+};

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/admin/button/Button';
 import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
 import { InputWithCharacterLimit } from '@/components/admin/input-with-character-limit/InputWithCharacterLimit';
@@ -6,6 +6,7 @@ import { Select } from '@/components/common/select/Select';
 import { Modal } from '@/components/common/modal/Modal';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+import { useDirtyModalCloseConfirmation } from '@/hooks/admin/use-dirty-modal-close-confirmation/useDirtyModalCloseConfirmation';
 import { ProgramExpensesProgram } from '@/types/admin/reports';
 import { getReportingYearOptions } from '@/utils/functions/get-reporting-year-options/get-reporting-year-options';
 import styles from './AddProgramExpenseRecordModal.module.scss';
@@ -71,20 +72,25 @@ export const AddProgramExpenseRecordModal = ({
     );
 
     const [formState, setFormState] = useState<ProgramExpenseFormState>(INITIAL_FORM_STATE);
-    const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false);
-
-    useEffect(() => {
-        if (!isOpen) {
-            setFormState(INITIAL_FORM_STATE);
-            setIsCloseConfirmOpen(false);
-        }
-    }, [isOpen]);
 
     const isDirty =
         Boolean(formState.reportingYear) ||
         Boolean(formState.programId) ||
         formState.amountUah.trim() !== '' ||
         formState.amountUsd.trim() !== '';
+
+    const { isCloseConfirmOpen, handleRequestClose, handleConfirmClose, handleCancelClose } =
+        useDirtyModalCloseConfirmation({
+            isDirty,
+            onClose,
+        });
+
+    useEffect(() => {
+        if (!isOpen) {
+            setFormState(INITIAL_FORM_STATE);
+            handleCancelClose();
+        }
+    }, [handleCancelClose, isOpen]);
 
     const handleAmountChange = (field: 'amountUah' | 'amountUsd', value: string) => {
         const normalizedValue = normalizeProgramExpenseAmountInput(value);
@@ -94,24 +100,6 @@ export const AddProgramExpenseRecordModal = ({
             [field]: normalizedValue,
         }));
     };
-
-    const handleRequestClose = useCallback(() => {
-        if (isDirty) {
-            setIsCloseConfirmOpen(true);
-            return;
-        }
-
-        onClose();
-    }, [isDirty, onClose]);
-
-    const handleConfirmClose = useCallback(() => {
-        setIsCloseConfirmOpen(false);
-        onClose();
-    }, [onClose]);
-
-    const handleCancelClose = useCallback(() => {
-        setIsCloseConfirmOpen(false);
-    }, []);
 
     return (
         <>

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState.tsx
@@ -8,9 +8,16 @@ import styles from './ProgramExpensesEmptyState.module.scss';
 interface ProgramExpensesEmptyStateProps {
     colSpan: number;
     variant: 'filtered' | 'program-expenses';
+    isAddProgramExpenseDisabled?: boolean;
+    onAddProgramExpense?: () => void;
 }
 
-export const ProgramExpensesEmptyState = ({ colSpan, variant }: ProgramExpensesEmptyStateProps) => {
+export const ProgramExpensesEmptyState = ({
+    colSpan,
+    variant,
+    isAddProgramExpenseDisabled = false,
+    onAddProgramExpense,
+}: ProgramExpensesEmptyStateProps) => {
     if (variant === 'program-expenses') {
         return (
             <tr className={styles['empty-row-program-expenses']}>
@@ -24,7 +31,12 @@ export const ProgramExpensesEmptyState = ({ colSpan, variant }: ProgramExpensesE
                         <p className={styles['empty-state-title']}>{FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.TITLE}</p>
                         <p className={styles['empty-state-message']}>{PROGRAM_EXPENSES_TEXT.EMPTY_STATE.ADD_RECORD}</p>
                         <div className={styles['empty-state-actions']}>
-                            <Button buttonStyle="primary" className={styles['add-program-expense-button']}>
+                            <Button
+                                buttonStyle="primary"
+                                className={styles['add-program-expense-button']}
+                                disabled={isAddProgramExpenseDisabled}
+                                onClick={onAddProgramExpense}
+                            >
                                 <PlusIcon aria-hidden="true" className={styles['plus-icon']} focusable="false" />
                                 {PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE}
                             </Button>

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.tsx
@@ -13,6 +13,8 @@ interface ProgramExpensesTableProps {
     records: ProgramExpensesRecord[];
     hasAnyProgramExpenseRecords: boolean;
     isEditing?: boolean;
+    isAddProgramExpenseDisabled?: boolean;
+    onAddProgramExpense?: () => void;
     onEditRecord?: (record: ProgramExpensesRecord) => void;
     onDeleteRecord?: (record: ProgramExpensesRecord) => void;
 }
@@ -24,6 +26,8 @@ export const ProgramExpensesTable = ({
     records,
     hasAnyProgramExpenseRecords,
     isEditing = false,
+    isAddProgramExpenseDisabled = false,
+    onAddProgramExpense,
     onEditRecord,
     onDeleteRecord,
 }: ProgramExpensesTableProps) => {
@@ -112,6 +116,8 @@ export const ProgramExpensesTable = ({
                         <ProgramExpensesEmptyState
                             colSpan={tableColumnsCount}
                             variant={hasAnyProgramExpenseRecords ? 'filtered' : 'program-expenses'}
+                            isAddProgramExpenseDisabled={isAddProgramExpenseDisabled}
+                            onAddProgramExpense={onAddProgramExpense}
                         />
                     ) : (
                         records.map((record) => (

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
@@ -49,18 +49,8 @@ jest.mock('../funds-expenditures-section/FundsExpendituresSection', () => ({
 }));
 
 jest.mock('../program-expenses-section/ProgramExpensesSection', () => ({
-    ProgramExpensesSection: ({
-        isEditing = false,
-        syncedExchangeRate,
-    }: {
-        isEditing?: boolean;
-        syncedExchangeRate?: string | null;
-    }) => (
-        <div
-            data-testid="program-expenses-section"
-            data-editing={String(isEditing)}
-            data-exchange-rate={syncedExchangeRate ?? ''}
-        >
+    ProgramExpensesSection: ({ isEditing = false }: { isEditing?: boolean }) => (
+        <div data-testid="program-expenses-section" data-editing={String(isEditing)}>
             ProgramExpensesSection
         </div>
     ),
@@ -102,14 +92,13 @@ describe('ReportAnalytics', () => {
         expect(screen.queryByTestId('pdf-files-section')).not.toBeInTheDocument();
     });
 
-    it('should render program expenses mock independently from funds edit mode', () => {
+    it('should not pass funds exchange rate draft to program expenses mock', () => {
         render(<ReportAnalytics />);
 
         fireEvent.click(screen.getByTestId('activate-funds-edit'));
         fireEvent.click(screen.getByText(REPORTS_TEXT.REPORT_AND_ANALYTICS.TAB.PROGRAM_EXPENSES));
 
-        expect(screen.getByTestId('program-expenses-section')).toHaveAttribute('data-editing', 'false');
-        expect(screen.getByTestId('program-expenses-section')).toHaveAttribute('data-exchange-rate', '');
+        expect(screen.getByTestId('program-expenses-section')).toHaveAttribute('data-editing', 'true');
     });
 
     it('should restore funds edit mode after returning from another tab', () => {

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
@@ -92,7 +92,7 @@ describe('ReportAnalytics', () => {
         expect(screen.queryByTestId('pdf-files-section')).not.toBeInTheDocument();
     });
 
-    it('should not pass funds exchange rate draft to program expenses mock', () => {
+    it('sets program expenses section to editing mode when funds edit is activated', () => {
         render(<ReportAnalytics />);
 
         fireEvent.click(screen.getByTestId('activate-funds-edit'));

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
@@ -44,7 +44,7 @@ export const ReportAnalytics = () => {
                         onExchangeRateValueChange={setFundsExchangeRateDraft}
                     />
                 )}
-                {activeTab.id === 'program-expenses' && <ProgramExpensesSection />}
+                {activeTab.id === 'program-expenses' && <ProgramExpensesSection isEditing={isFundsEditing} />}
             </div>
         </div>
     );

--- a/src/utils/mock-data/admin/reports/program-expenses.ts
+++ b/src/utils/mock-data/admin/reports/program-expenses.ts
@@ -27,16 +27,6 @@ export const MOCK_PROGRAM_EXPENSES_PROGRAMS: ProgramExpensesProgram[] = [
 
 export const MOCK_PROGRAM_EXPENSES_RECORDS: MockProgramExpensesRecord[] = [
     {
-        id: 1,
-        programId: 101,
-        programName: 'Дитяча реабілітація',
-        type: 'expense',
-        reportingYear: '2025',
-        amountUah: '1500',
-        amountUsd: '1000',
-        isPublished: true,
-    },
-    {
         id: 2,
         programId: 101,
         programName: 'Дитяча реабілітація',


### PR DESCRIPTION
## Github Tickets

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1883
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1885

## Description
Added a create modal and a button to open it, implementing the UI flow required for issues #1883 and #1885.

## How it looks
<img width="1492" height="817" alt="image" src="https://github.com/user-attachments/assets/2968f27f-4ead-4c22-b7e8-6fcc04caf8e4" />

## How to recreate changes
1. Open Admin Panel → “Звітність” → “Звіт та аналітика”.
2. Go to “Доходи та витрати”.
3. Click “Редагувати доходи та витрати”.
4. Switch to the “Програмні витрати” tab.
5. Click "+ Витрата по програмі"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a modal to create program expense records (reporting year, program, UAH/USD amounts) with exchange-rate display.
  * Input formatting/validation for amount fields and an unsaved-changes confirmation when closing.
* **Bug Fixes / UX**
  * “Add program expense” action is only available in edit mode and is disabled when no programs or the record limit is reached.
* **Style**
  * New responsive modal styling for desktop and mobile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->