### PR TITLE
Feature/issue 2057 - [Main] Display content presented in the 'Impact Statistics' block

### DIFF
--- a/src/const/admin/main-page.ts
+++ b/src/const/admin/main-page.ts
@@ -18,6 +18,16 @@ export const MAIN_PAGE_TEXT = {
             TITLE_LABEL: COMMON_TEXT_ADMIN.TYPE.TITLE,
             DESCRIPTION_LABEL: COMMON_TEXT_ADMIN.TYPE.DESCRIPTION,
         },
+        STATISTICS: {
+            TITLE_UA_LABEL: 'Заголовок (UA)',
+            TITLE_EN_LABEL: 'Заголовок (ENG)',
+            PREVIEW_TITLE: 'PREVIEW МЕТРИК',
+            METRICS_TITLE: 'МЕТРИКИ',
+            LANG: {
+                UKR: 'UKR',
+                ENG: 'ENG',
+            },
+        },
     },
 
     BUTTONS: {
@@ -57,6 +67,15 @@ export const MAIN_PAGE_VALIDATION = {
             max: 1000,
             getMinError: () => COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(10),
             getMaxError: () => COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(1000),
+        },
+    },
+
+    statisticsBlock: {
+        title: {
+            min: 5,
+            max: 100,
+            getMinError: () => COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(5),
+            getMaxError: () => COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(100),
         },
     },
 } as const;

--- a/src/pages/admin/main/components/about-us-block/AboutUsBlockForm.test.tsx
+++ b/src/pages/admin/main/components/about-us-block/AboutUsBlockForm.test.tsx
@@ -34,6 +34,7 @@ const mockInitialData: MainPage = {
         description: 'Про нас опис',
     },
     mainPartners: null,
+    impactStatistics: null,
 };
 
 describe('AboutUsBlockForm', () => {

--- a/src/pages/admin/main/components/common/image-upload-form/ImageUploadForm.module.scss
+++ b/src/pages/admin/main/components/common/image-upload-form/ImageUploadForm.module.scss
@@ -1,0 +1,18 @@
+@use '@/assets/sass/variables/colors' as c;
+
+.imageSection {
+    flex: 6;
+    width: 60%;
+}
+
+.imageWrapper {
+    width: 640px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.error {
+    color: c.$error;
+    margin: 0;
+}

--- a/src/pages/admin/main/components/common/image-upload-form/ImageUploadForm.test.tsx
+++ b/src/pages/admin/main/components/common/image-upload-form/ImageUploadForm.test.tsx
@@ -1,0 +1,72 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { ImageUploadForm } from './ImageUploadForm';
+
+jest.mock('@/components/admin/image-input/ImageInput', () => ({
+    ImageInput: ({ setError }: any) => (
+        <div data-testid="image-input-mock">
+            <button data-testid="trigger-image-error" type="button" onClick={() => setError('Image size error')}>
+                Set Error
+            </button>
+        </div>
+    ),
+}));
+
+type FormValues = { image: any };
+
+const IMAGE_CONFIG = {
+    cropWidth: 1440,
+    cropHeight: 860,
+    minWidth: 1440,
+    minHeight: 860,
+    label: 'Label',
+    subText: 'Subtext',
+    style: { width: '100%', aspectRatio: '1440 / 860' },
+};
+
+const Wrapper = ({
+    imageError = null,
+    errors = {},
+    setImageError = jest.fn(),
+}: {
+    imageError?: string | null;
+    errors?: any;
+    setImageError?: (val: string | null) => void;
+}) => {
+    const { control } = useForm<FormValues>({ defaultValues: { image: null } });
+
+    return (
+        <ImageUploadForm<FormValues>
+            control={control}
+            errors={errors}
+            imageError={imageError}
+            setImageError={setImageError}
+            imageConfig={IMAGE_CONFIG}
+        />
+    );
+};
+
+describe('ImageUploadForm', () => {
+    it('renders image input', () => {
+        render(<Wrapper />);
+        expect(screen.getByTestId('image-input-mock')).toBeInTheDocument();
+    });
+
+    it('shows error text from imageError', () => {
+        render(<Wrapper imageError="Image size error" />);
+        expect(screen.getByText('Image size error')).toBeInTheDocument();
+    });
+
+    it('shows error text from form errors', () => {
+        render(<Wrapper errors={{ image: { message: 'Form error' } }} />);
+        expect(screen.getByText('Form error')).toBeInTheDocument();
+    });
+
+    it('calls setImageError from ImageInput', () => {
+        const setImageError = jest.fn();
+        render(<Wrapper setImageError={setImageError} />);
+        fireEvent.click(screen.getByTestId('trigger-image-error'));
+        expect(setImageError).toHaveBeenCalledWith('Image size error');
+    });
+});

--- a/src/pages/admin/main/components/common/image-upload-form/ImageUploadForm.tsx
+++ b/src/pages/admin/main/components/common/image-upload-form/ImageUploadForm.tsx
@@ -1,0 +1,54 @@
+import { Controller, Control, FieldErrors, FieldValues } from 'react-hook-form';
+import { ImageInput, ImageInputVariant } from '@/components/admin/image-input/ImageInput';
+import styles from './ImageUploadForm.module.scss';
+
+type ImageUploadConfig = {
+    cropWidth: number;
+    cropHeight: number;
+    minWidth: number;
+    minHeight: number;
+    label: string;
+    subText: string;
+    style: React.CSSProperties;
+};
+
+interface ImageUploadFormProps<TFormValues extends FieldValues> {
+    control: Control<TFormValues>;
+    errors: FieldErrors<TFormValues>;
+    imageError: string | null;
+    setImageError: (error: string | null) => void;
+    imageConfig: ImageUploadConfig;
+    variant?: ImageInputVariant;
+    name?: string;
+}
+
+export const ImageUploadForm = <TFormValues extends FieldValues>({
+    control,
+    errors,
+    imageError,
+    setImageError,
+    imageConfig,
+    variant = 'whoWeAre',
+    name = 'image',
+}: ImageUploadFormProps<TFormValues>) => (
+    <div className={styles.imageSection}>
+        <Controller
+            name={name as never}
+            control={control}
+            render={({ field: { onChange, value } }) => (
+                <div className={styles.imageWrapper}>
+                    <ImageInput
+                        value={value}
+                        onChange={onChange}
+                        setError={setImageError}
+                        variant={variant}
+                        {...imageConfig}
+                    />
+                    {(imageError || errors?.image?.message) && (
+                        <p className={styles.error}>{imageError || (errors as any)?.image?.message}</p>
+                    )}
+                </div>
+            )}
+        />
+    </div>
+);

--- a/src/pages/admin/main/components/main-page-content/MainPageContent.test.tsx
+++ b/src/pages/admin/main/components/main-page-content/MainPageContent.test.tsx
@@ -57,9 +57,23 @@ describe('MainPageContent', () => {
         });
         jest.useRealTimers();
         jest.clearAllMocks();
+        jest.restoreAllMocks();
     });
 
     it('renders loader initially while data is "fetching"', () => {
+        render(<MainPageContent />);
+        expect(screen.getByTestId('page-loader')).toBeInTheDocument();
+    });
+
+    it('renders loader when data is null and isLoading is false', () => {
+        const useStateSpy = jest.spyOn(React, 'useState');
+        useStateSpy
+            .mockImplementationOnce(() => ['title', jest.fn()])
+            .mockImplementationOnce(() => [null, jest.fn()])
+            .mockImplementationOnce(() => [false, jest.fn()]);
+
+        jest.spyOn(React, 'useEffect').mockImplementation(() => undefined);
+
         render(<MainPageContent />);
         expect(screen.getByTestId('page-loader')).toBeInTheDocument();
     });

--- a/src/pages/admin/main/components/main-page-content/MainPageContent.test.tsx
+++ b/src/pages/admin/main/components/main-page-content/MainPageContent.test.tsx
@@ -15,6 +15,11 @@ jest.mock('../about-us-block/AboutUsBlockForm', () => ({
     AboutUsBlockForm: () => <div data-testid="about-us-block-form">About Us Form</div>,
 }));
 
+jest.mock('../statistics-block/StatisticsBlockForm', () => ({
+    __esModule: true,
+    StatisticsBlockForm: () => <div data-testid="statistics-block-form">Statistics Form</div>,
+}));
+
 jest.mock('@/components/admin/category-bar/CategoryBar', () => ({
     __esModule: true,
     CategoryBar: require('@/utils/test-mocks/main-page-mocks').MockMainPageCategoryBar,
@@ -36,6 +41,14 @@ const getByExactText = (text: string) =>
 describe('MainPageContent', () => {
     beforeEach(() => {
         jest.useFakeTimers();
+
+        if (!(global as any).crypto) {
+            Object.defineProperty(global, 'crypto', { value: {}, configurable: true });
+        }
+
+        if (!(global as any).crypto.randomUUID) {
+            (global as any).crypto.randomUUID = jest.fn(() => 'test-uuid');
+        }
     });
 
     afterEach(() => {
@@ -79,7 +92,7 @@ describe('MainPageContent', () => {
         expect(screen.queryByTestId('title-block-form')).not.toBeInTheDocument();
 
         fireEvent.click(screen.getByTestId('tab-btn-statistics'));
-        expect(getByExactText(`Блок "${MAIN_PAGE_TEXT.TABS.STATISTICS}" в розробці`)).toBeInTheDocument();
+        expect(screen.getByTestId('statistics-block-form')).toBeInTheDocument();
     });
 
     it('does not update state after unmount (cleanup isMounted)', async () => {

--- a/src/pages/admin/main/components/main-page-content/MainPageContent.tsx
+++ b/src/pages/admin/main/components/main-page-content/MainPageContent.tsx
@@ -3,6 +3,7 @@ import { CategoryBar } from '@/components/admin/category-bar/CategoryBar';
 import { PageLoader } from '@/components/common/page-loader/PageLoader';
 import { TitleBlockForm } from '../title-block/TitleBlockForm';
 import { AboutUsBlockForm } from '../about-us-block/AboutUsBlockForm';
+import { StatisticsBlockForm } from '../statistics-block/StatisticsBlockForm';
 import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
 import { MainPage } from '@/types/admin/main-page';
 import { MOCK_MAIN_PAGE_DATA } from '@/utils/mock-data/admin/main-page/main-page';
@@ -77,7 +78,7 @@ export const MainPageContent = () => {
             <div className={styles['main-content']}>
                 {activeTab === 'title' && <TitleBlockForm initialData={data} />}
                 {activeTab === 'about' && <AboutUsBlockForm initialData={data} />}
-                {activeTab === 'statistics' && <div>Блок "{MAIN_PAGE_TEXT.TABS.STATISTICS}" в розробці</div>}
+                {activeTab === 'statistics' && <StatisticsBlockForm />}
                 {activeTab === 'donations' && <div>Блок "{MAIN_PAGE_TEXT.TABS.DONATIONS}" в розробці</div>}
                 {activeTab === 'partners' && <div>Блок "{MAIN_PAGE_TEXT.TABS.PARTNERS}" в розробці</div>}
             </div>

--- a/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.module.scss
+++ b/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.module.scss
@@ -1,0 +1,57 @@
+@use '@/assets/sass/variables/colors' as c;
+
+.form {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
+.content {
+    display: flex;
+    gap: 40px;
+    align-items: flex-start;
+    margin-bottom: 40px;
+}
+
+.image-section {
+    flex: 6;
+    width: 60%;
+}
+
+.image-wrapper {
+    width: 640px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.error {
+    color: c.$error;
+    margin: 0;
+}
+
+.right-section {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 800px;
+}
+
+.title-section {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    background: c.$white;
+    border: 1px solid c.$grey-500;
+    border-radius: 8px;
+    padding: 16px;
+}
+
+.actions {
+    display: flex;
+    justify-content: center;
+}
+
+.publish-button {
+    width: 608px;
+}

--- a/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.test.tsx
@@ -13,17 +13,28 @@ jest.mock('@/components/admin/button/Button', () => ({
     Button: require('@/utils/test-mocks/main-page-mocks').MockSubmitButton,
 }));
 
-jest.mock('@/components/admin/image-input/ImageInput', () => ({
+jest.mock('@/pages/admin/main/components/common/image-upload-form/ImageUploadForm', () => ({
     __esModule: true,
-    ImageInput: require('@/utils/test-mocks/main-page-mocks').MockImageInput,
+    ImageUploadForm: require('@/utils/test-mocks/main-page-mocks').MockImageUploadForm,
 }));
 
 jest.mock('./components/statistics-preview/StatisticsPreview', () => ({
-    StatisticsPreview: ({ language }: any) => <div data-testid="statistics-preview">{language}</div>,
+    StatisticsPreview: ({ metrics, hiddenMetricIds }: any) => (
+        <div data-testid="statistics-preview" data-metrics={metrics.length} data-hidden={hiddenMetricIds.join(',')} />
+    ),
 }));
 
 jest.mock('./components/statistics-metrics-list/StatisticsMetricsList', () => ({
-    StatisticsMetricsList: () => <div data-testid="metrics-list" />,
+    StatisticsMetricsList: ({ metrics, onToggleVisibility, onReorder }: any) => (
+        <div data-testid="metrics-list">
+            <button
+                data-testid="toggle-first-metric"
+                onClick={() => onToggleVisibility(metrics[0]?.id ?? 0)}
+                type="button"
+            />
+            <button data-testid="reorder-metrics" onClick={() => onReorder([])} type="button" />
+        </div>
+    ),
 }));
 
 describe('StatisticsBlockForm', () => {
@@ -60,5 +71,30 @@ describe('StatisticsBlockForm', () => {
 
         fireEvent.click(screen.getByTestId('trigger-image-error'));
         await waitFor(() => expect(screen.getByTestId('submit-btn')).toBeDisabled());
+    });
+
+    it('updates hidden metrics state when toggling visibility', async () => {
+        render(<StatisticsBlockForm />);
+
+        const firstMetricId = MOCK_MAIN_PAGE_DATA.impactStatistics?.metrics?.[0]?.id ?? 0;
+
+        fireEvent.click(screen.getByTestId('toggle-first-metric'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('statistics-preview')).toHaveAttribute(
+                'data-hidden',
+                firstMetricId ? String(firstMetricId) : '0',
+            );
+        });
+    });
+
+    it('updates metrics order when reorder is triggered', async () => {
+        render(<StatisticsBlockForm />);
+
+        fireEvent.click(screen.getByTestId('reorder-metrics'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('statistics-preview')).toHaveAttribute('data-metrics', '0');
+        });
     });
 });

--- a/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.test.tsx
@@ -1,0 +1,64 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { StatisticsBlockForm } from './StatisticsBlockForm';
+import { MOCK_MAIN_PAGE_DATA } from '@/utils/mock-data/admin/main-page/main-page';
+
+jest.mock('@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup', () => ({
+    __esModule: true,
+    InputWithCharacterLimitGroup: require('@/utils/test-mocks/main-page-mocks').MockInputWithCharacterLimitGroup,
+}));
+
+jest.mock('@/components/admin/button/Button', () => ({
+    __esModule: true,
+    Button: require('@/utils/test-mocks/main-page-mocks').MockSubmitButton,
+}));
+
+jest.mock('@/components/admin/image-input/ImageInput', () => ({
+    __esModule: true,
+    ImageInput: require('@/utils/test-mocks/main-page-mocks').MockImageInput,
+}));
+
+jest.mock('./components/statistics-preview/StatisticsPreview', () => ({
+    StatisticsPreview: ({ language }: any) => <div data-testid="statistics-preview">{language}</div>,
+}));
+
+jest.mock('./components/statistics-metrics-list/StatisticsMetricsList', () => ({
+    StatisticsMetricsList: () => <div data-testid="metrics-list" />,
+}));
+
+describe('StatisticsBlockForm', () => {
+    it('renders and pre-fills titles from mock data', async () => {
+        render(<StatisticsBlockForm />);
+
+        const uaTitle = screen.getByTestId('statistics-title-ua') as HTMLInputElement;
+        const enTitle = screen.getByTestId('statistics-title-en') as HTMLInputElement;
+
+        await waitFor(() => {
+            expect(uaTitle.value).toBe(MOCK_MAIN_PAGE_DATA.impactStatistics?.title);
+            expect(enTitle.value).toBe(MOCK_MAIN_PAGE_DATA.impactStatistics?.title);
+        });
+    });
+
+    it('enables publish when form is valid and dirty', async () => {
+        render(<StatisticsBlockForm />);
+
+        const uaTitle = screen.getByTestId('statistics-title-ua');
+        fireEvent.change(uaTitle, { target: { value: 'Новий заголовок' } });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('submit-btn')).not.toBeDisabled();
+        });
+    });
+
+    it('disables publish when image error is set', async () => {
+        render(<StatisticsBlockForm />);
+
+        const uaTitle = screen.getByTestId('statistics-title-ua');
+        fireEvent.change(uaTitle, { target: { value: 'Новий заголовок' } });
+
+        await waitFor(() => expect(screen.getByTestId('submit-btn')).not.toBeDisabled());
+
+        fireEvent.click(screen.getByTestId('trigger-image-error'));
+        await waitFor(() => expect(screen.getByTestId('submit-btn')).toBeDisabled());
+    });
+});

--- a/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
+++ b/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useState } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { Button } from '@/components/admin/button/Button';
+import { ImageInput } from '@/components/admin/image-input/ImageInput';
+import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
+import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { MOCK_MAIN_PAGE_DATA } from '@/utils/mock-data/admin/main-page/main-page';
+import { StatisticsBlockValidationSchema } from '@/validation/admin/main-page-schema/main-page-schema';
+import { StatisticsBlockFormValues, STATISTICS_BLOCK_FORM_DEFAULTS, Metric } from '@/types/admin/main-page';
+import DefaultPlaceholder from '@/assets/images/man-facing-horse-forehead.webp';
+
+import { StatisticsPreview } from './components/statistics-preview/StatisticsPreview';
+import { StatisticsMetricsList } from './components/statistics-metrics-list/StatisticsMetricsList';
+
+import styles from './StatisticsBlockForm.module.scss';
+
+const IMAGE_CONFIG = {
+    cropWidth: 1440,
+    cropHeight: 860,
+    minWidth: 1440,
+    minHeight: 860,
+    label: 'Додайте файл сюди',
+    subText: 'Розмір: 1440x860',
+    style: {
+        width: '100%',
+        aspectRatio: '1440 / 860',
+        backgroundImage: `linear-gradient(rgba(245, 245, 245, 0.85), rgba(245, 245, 245, 0.85)), url(${DefaultPlaceholder})`,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+    },
+};
+
+export const StatisticsBlockForm = () => {
+    const [imageError, setImageError] = useState<string | null>(null);
+    const [previewLang, setPreviewLang] = useState<'UA' | 'EN'>('UA');
+
+    const impactStatistics = MOCK_MAIN_PAGE_DATA.impactStatistics;
+    const [metrics, setMetrics] = useState<Metric[]>(() => impactStatistics?.metrics ?? []);
+    const [hiddenMetricIds, setHiddenMetricIds] = useState<number[]>([]);
+
+    const {
+        control,
+        reset,
+        formState: { errors, isDirty, isValid },
+    } = useForm<StatisticsBlockFormValues>({
+        mode: 'onChange',
+        resolver: yupResolver(StatisticsBlockValidationSchema),
+        defaultValues: STATISTICS_BLOCK_FORM_DEFAULTS,
+    });
+
+    useEffect(() => {
+        const getTitle = (code: 'uk' | 'en') =>
+            impactStatistics?.localizations?.find((l) => l.language.code === code)?.title ??
+            impactStatistics?.title ??
+            '';
+
+        reset({
+            titleUa: getTitle('uk'),
+            titleEn: getTitle('en'),
+            image: impactStatistics?.image ?? null,
+        });
+    }, [impactStatistics, reset]);
+
+    const handleToggleVisibility = (id: number) => {
+        setHiddenMetricIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
+    };
+
+    const handleReorderMetrics = (items: Metric[]) => {
+        setMetrics(items);
+    };
+
+    return (
+        <div className={styles.form}>
+            <div className={styles.content}>
+                <div className={styles['image-section']}>
+                    <Controller
+                        name="image"
+                        control={control}
+                        render={({ field: { onChange, value } }) => (
+                            <div className={styles['image-wrapper']}>
+                                <ImageInput
+                                    value={value}
+                                    onChange={onChange}
+                                    setError={setImageError}
+                                    variant="whoWeAre"
+                                    {...IMAGE_CONFIG}
+                                />
+                                {(imageError || errors.image?.message) && (
+                                    <p className={styles.error}>{imageError || errors.image?.message}</p>
+                                )}
+                            </div>
+                        )}
+                    />
+                </div>
+
+                <div className={styles['right-section']}>
+                    <StatisticsPreview
+                        language={previewLang}
+                        onLanguageChange={setPreviewLang}
+                        metrics={metrics}
+                        hiddenMetricIds={hiddenMetricIds}
+                    />
+
+                    <div className={styles['title-section']}>
+                        <Controller
+                            name="titleUa"
+                            control={control}
+                            render={({ field: { onChange, value, onBlur } }) => (
+                                <InputWithCharacterLimitGroup
+                                    id="statistics-title-ua"
+                                    name={COMMON_TEXT_ADMIN.TYPE.TITLE}
+                                    label={MAIN_PAGE_TEXT.BLOCKS.STATISTICS.TITLE_UA_LABEL}
+                                    value={value}
+                                    onChange={onChange}
+                                    onBlur={onBlur}
+                                    error={errors.titleUa?.message}
+                                    maxLength={MAIN_PAGE_VALIDATION.statisticsBlock.title.max}
+                                    isRequired
+                                />
+                            )}
+                        />
+
+                        <Controller
+                            name="titleEn"
+                            control={control}
+                            render={({ field: { onChange, value, onBlur } }) => (
+                                <InputWithCharacterLimitGroup
+                                    id="statistics-title-en"
+                                    name={COMMON_TEXT_ADMIN.TYPE.TITLE}
+                                    label={MAIN_PAGE_TEXT.BLOCKS.STATISTICS.TITLE_EN_LABEL}
+                                    value={value}
+                                    onChange={onChange}
+                                    onBlur={onBlur}
+                                    error={errors.titleEn?.message}
+                                    maxLength={MAIN_PAGE_VALIDATION.statisticsBlock.title.max}
+                                    isRequired
+                                />
+                            )}
+                        />
+                    </div>
+
+                    <StatisticsMetricsList
+                        metrics={metrics}
+                        hiddenMetricIds={hiddenMetricIds}
+                        onToggleVisibility={handleToggleVisibility}
+                        onReorder={handleReorderMetrics}
+                    />
+                </div>
+            </div>
+
+            <div className={styles.actions}>
+                <Button
+                    type="button"
+                    buttonStyle="primary"
+                    disabled={!isDirty || !isValid || !!imageError}
+                    className={styles['publish-button']}
+                >
+                    {MAIN_PAGE_TEXT.BUTTONS.PUBLISH}
+                </Button>
+            </div>
+        </div>
+    );
+};

--- a/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
+++ b/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
@@ -64,7 +64,13 @@ export const StatisticsBlockForm = () => {
     }, [impactStatistics, reset]);
 
     const handleToggleVisibility = (id: number) => {
-        setHiddenMetricIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
+        setHiddenMetricIds((prev) => {
+            const isCurrentlyHidden = prev.includes(id);
+            if (!isCurrentlyHidden && metrics.length - prev.length <= 1) {
+                return prev;
+            }
+            return isCurrentlyHidden ? prev.filter((x) => x !== id) : [...prev, id];
+        });
     };
 
     const handleReorderMetrics = (items: Metric[]) => {

--- a/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
+++ b/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Button } from '@/components/admin/button/Button';
-import { ImageInput } from '@/components/admin/image-input/ImageInput';
 import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
 import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
@@ -10,6 +9,7 @@ import { MOCK_MAIN_PAGE_DATA } from '@/utils/mock-data/admin/main-page/main-page
 import { StatisticsBlockValidationSchema } from '@/validation/admin/main-page-schema/main-page-schema';
 import { StatisticsBlockFormValues, STATISTICS_BLOCK_FORM_DEFAULTS, Metric } from '@/types/admin/main-page';
 import DefaultPlaceholder from '@/assets/images/man-facing-horse-forehead.webp';
+import { ImageUploadForm } from '@/pages/admin/main/components/common/image-upload-form/ImageUploadForm';
 
 import { StatisticsPreview } from './components/statistics-preview/StatisticsPreview';
 import { StatisticsMetricsList } from './components/statistics-metrics-list/StatisticsMetricsList';
@@ -74,26 +74,14 @@ export const StatisticsBlockForm = () => {
     return (
         <div className={styles.form}>
             <div className={styles.content}>
-                <div className={styles['image-section']}>
-                    <Controller
-                        name="image"
-                        control={control}
-                        render={({ field: { onChange, value } }) => (
-                            <div className={styles['image-wrapper']}>
-                                <ImageInput
-                                    value={value}
-                                    onChange={onChange}
-                                    setError={setImageError}
-                                    variant="whoWeAre"
-                                    {...IMAGE_CONFIG}
-                                />
-                                {(imageError || errors.image?.message) && (
-                                    <p className={styles.error}>{imageError || errors.image?.message}</p>
-                                )}
-                            </div>
-                        )}
-                    />
-                </div>
+                <ImageUploadForm
+                    control={control}
+                    errors={errors}
+                    imageError={imageError}
+                    setImageError={setImageError}
+                    imageConfig={IMAGE_CONFIG}
+                    variant="whoWeAre"
+                />
 
                 <div className={styles['right-section']}>
                     <StatisticsPreview

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.module.scss
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.module.scss
@@ -97,3 +97,9 @@
     width: 24px;
     height: 24px;
 }
+
+.disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    pointer-events: none;
+}

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.module.scss
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.module.scss
@@ -103,3 +103,7 @@
     cursor: not-allowed;
     pointer-events: none;
 }
+
+.hiddenText {
+    color: c.$grey-700;
+}

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.module.scss
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.module.scss
@@ -1,0 +1,99 @@
+@use '@/assets/sass/variables/colors' as c;
+@use '@/assets/sass/mixins/typography.mixins' as type;
+
+.list {
+    background: c.$white;
+    border: 1px solid c.$grey-500;
+    border-radius: 8px;
+    padding: 12px;
+}
+
+.header {
+    @include type.small-text-medium;
+    color: c.$grey-900;
+    margin-bottom: 8px;
+}
+
+.table {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.table :global(.draggable-item-wrapper),
+.table :global(.draggable-item) {
+    width: 100%;
+}
+
+.table :global(.draggable-item),
+.table :global(.drag-preview-wrapper) {
+    height: 40px;
+    align-items: stretch;
+    box-shadow: none;
+    border-bottom: none;
+}
+
+.table :global(.draggable-item .item-data),
+.table :global(.drag-preview .item-data) {
+    padding: 0 10px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    width: 100%;
+}
+
+.table :global(.dragger) {
+    width: 32px;
+}
+
+.row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 140px 64px;
+    width: 100%;
+    align-items: center;
+    gap: 16px;
+    height: 40px;
+    padding: 0;
+    border: none;
+    border-radius: 8px;
+}
+
+.labels {
+    min-width: 0;
+}
+
+.ua {
+		@include type.body-2-medium;
+    margin: 0;
+}
+
+.values {
+    text-align: left;
+    justify-self: start;
+}
+
+.value {
+		@include type.body-2-medium;
+    margin: 0;
+}
+
+.actions {
+    display: flex;
+    gap: 6px;
+    justify-content: flex-end;
+}
+
+.iconButton {
+    border: none;
+    background: transparent;
+    padding: 0;
+    width: 24px;
+    height: 24px;
+    color: c.$blue-500;
+}
+
+.iconButton :global(svg),
+.iconButton :global(.icon-img) {
+    width: 24px;
+    height: 24px;
+}

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.module.scss
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.module.scss
@@ -63,7 +63,7 @@
 }
 
 .ua {
-		@include type.body-2-medium;
+    @include type.body-2-medium;
     margin: 0;
 }
 
@@ -73,7 +73,7 @@
 }
 
 .value {
-		@include type.body-2-medium;
+    @include type.body-2-medium;
     margin: 0;
 }
 

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
@@ -21,6 +21,14 @@ const metrics: Metric[] = [
             { language: { id: 1, code: 'uk' }, translationStatus: TranslationStatus.Relevant, name: 'Партнерів' },
         ],
     },
+    {
+        id: 2,
+        name: 'Engagement',
+        value: 50,
+        type: MetricType.Partners,
+        prefix: MetricPrefix.Percent,
+        localizations: [],
+    } as Metric,
 ];
 
 describe('StatisticsMetricsList', () => {
@@ -38,6 +46,45 @@ describe('StatisticsMetricsList', () => {
         expect(screen.getByText('20+')).toBeInTheDocument();
     });
 
+    it('falls back to metric name when localization is missing', () => {
+        render(
+            <StatisticsMetricsList
+                metrics={metrics}
+                hiddenMetricIds={[]}
+                onToggleVisibility={jest.fn()}
+                onReorder={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('Engagement')).toBeInTheDocument();
+    });
+
+    it('formats percent values', () => {
+        render(
+            <StatisticsMetricsList
+                metrics={metrics}
+                hiddenMetricIds={[]}
+                onToggleVisibility={jest.fn()}
+                onReorder={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('50%')).toBeInTheDocument();
+    });
+
+    it('uses "Show metric" label when metric is hidden', () => {
+        render(
+            <StatisticsMetricsList
+                metrics={metrics}
+                hiddenMetricIds={[2]}
+                onToggleVisibility={jest.fn()}
+                onReorder={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByLabelText('Show metric')).toBeInTheDocument();
+    });
+
     it('calls onToggleVisibility on eye click', () => {
         const onToggleVisibility = jest.fn();
         render(
@@ -52,5 +99,21 @@ describe('StatisticsMetricsList', () => {
         const buttons = screen.getAllByRole('button');
         fireEvent.click(buttons[1]); // eye button
         expect(onToggleVisibility).toHaveBeenCalledWith(1);
+    });
+
+    it('does not call onToggleVisibility when metric id is missing', () => {
+        const onToggleVisibility = jest.fn();
+        render(
+            <StatisticsMetricsList
+                metrics={[{ ...metrics[0], id: undefined } as Metric]}
+                hiddenMetricIds={[]}
+                onToggleVisibility={onToggleVisibility}
+                onReorder={jest.fn()}
+            />,
+        );
+
+        const buttons = screen.getAllByRole('button');
+        fireEvent.click(buttons[1]);
+        expect(onToggleVisibility).not.toHaveBeenCalled();
     });
 });

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
@@ -1,0 +1,56 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { StatisticsMetricsList } from './StatisticsMetricsList';
+import { Metric, MetricPrefix, MetricType } from '@/types/admin/main-page';
+import { TranslationStatus } from '@/types/common/language';
+
+jest.mock('@/components/admin/draggable-list-item/DraggableListItem', () => ({
+    DraggableListItem: ({ renderEntityComponent, entity }: any) => (
+        <div data-testid="draggable-row">{renderEntityComponent(entity)}</div>
+    ),
+}));
+
+const metrics: Metric[] = [
+    {
+        id: 1,
+        name: 'Партнерів',
+        value: 20,
+        type: MetricType.Partners,
+        prefix: MetricPrefix.Plus,
+        localizations: [
+            { language: { id: 1, code: 'uk' }, translationStatus: TranslationStatus.Relevant, name: 'Партнерів' },
+        ],
+    },
+];
+
+describe('StatisticsMetricsList', () => {
+    it('renders metrics list', () => {
+        render(
+            <StatisticsMetricsList
+                metrics={metrics}
+                hiddenMetricIds={[]}
+                onToggleVisibility={jest.fn()}
+                onReorder={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('Партнерів')).toBeInTheDocument();
+        expect(screen.getByText('20+')).toBeInTheDocument();
+    });
+
+    it('calls onToggleVisibility on eye click', () => {
+        const onToggleVisibility = jest.fn();
+        render(
+            <StatisticsMetricsList
+                metrics={metrics}
+                hiddenMetricIds={[]}
+                onToggleVisibility={onToggleVisibility}
+                onReorder={jest.fn()}
+            />,
+        );
+
+        const buttons = screen.getAllByRole('button');
+        fireEvent.click(buttons[1]); // eye button
+        expect(onToggleVisibility).toHaveBeenCalledWith(1);
+    });
+});

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
@@ -35,8 +35,11 @@ export const StatisticsMetricsList = ({
     onToggleVisibility,
     onReorder,
 }: StatisticsMetricsListProps) => {
+    const visibleMetricsCount = metrics.length - hiddenMetricIds.length;
     const renderRow = (metric: Metric) => {
         const isHidden = hiddenMetricIds.includes(metric.id ?? 0);
+        const isLastVisible = !isHidden && visibleMetricsCount <= 1;
+
         return (
             <div className={styles.row}>
                 <div className={styles.labels}>
@@ -52,7 +55,11 @@ export const StatisticsMetricsList = ({
                     <IconButton
                         type="button"
                         aria-label={isHidden ? 'Show metric' : 'Hide metric'}
-                        onClick={() => metric.id && onToggleVisibility(metric.id)}
+                        onClick={() => {
+                            if (isLastVisible) return;
+                            metric.id && onToggleVisibility(metric.id);
+                        }}
+                        disabled={isLastVisible}
                         DefaultIcon={isHidden ? EyeClosedIcon : EyeOpenedIcon}
                         className={styles.iconButton}
                     />

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
@@ -1,0 +1,83 @@
+import { IconButton } from '@/components/admin/icon-button/IconButton';
+import { ReactComponent as EditIcon } from '@/assets/icons/edit.svg';
+import { ReactComponent as EyeOpenedIcon } from '@/assets/icons/eye-opened.svg';
+import { ReactComponent as EyeClosedIcon } from '@/assets/icons/eye-closed.svg';
+import { DraggableListItem } from '@/components/admin/draggable-list-item/DraggableListItem';
+import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
+import { Metric, MetricPrefix } from '@/types/admin/main-page';
+import styles from './StatisticsMetricsList.module.scss';
+
+interface StatisticsMetricsListProps {
+    metrics: Metric[];
+    hiddenMetricIds: number[];
+    onToggleVisibility: (id: number) => void;
+    onReorder: (items: Metric[]) => void;
+}
+
+const getMetricName = (metric: Metric) =>
+    metric.localizations?.find((l) => l.language.code === 'uk')?.name ?? metric.name;
+
+const formatMetricValue = (metric: Metric, locale: 'uk-UA' | 'en-US') => {
+    const value = metric.value.toLocaleString(locale);
+    switch (metric.prefix) {
+        case MetricPrefix.Plus:
+            return `${value}+`;
+        case MetricPrefix.Percent:
+            return `${value}%`;
+        default:
+            return value;
+    }
+};
+
+export const StatisticsMetricsList = ({
+    metrics,
+    hiddenMetricIds,
+    onToggleVisibility,
+    onReorder,
+}: StatisticsMetricsListProps) => {
+    const renderRow = (metric: Metric) => {
+        const isHidden = hiddenMetricIds.includes(metric.id ?? 0);
+        return (
+            <div className={styles.row}>
+                <div className={styles.labels}>
+                    <p className={styles.ua}>{getMetricName(metric)}</p>
+                </div>
+
+                <div className={styles.values}>
+                    <p className={styles.value}>{formatMetricValue(metric, 'uk-UA')}</p>
+                </div>
+
+                <div className={styles.actions}>
+                    <IconButton type="button" DefaultIcon={EditIcon} className={styles.iconButton} />
+                    <IconButton
+                        type="button"
+                        onClick={() => metric.id && onToggleVisibility(metric.id)}
+                        DefaultIcon={isHidden ? EyeClosedIcon : EyeOpenedIcon}
+                        className={styles.iconButton}
+                    />
+                </div>
+            </div>
+        );
+    };
+
+    return (
+        <div className={styles.list}>
+            <div className={styles.header}>{MAIN_PAGE_TEXT.BLOCKS.STATISTICS.METRICS_TITLE}</div>
+
+            <div className={styles.table}>
+                {metrics.map((metric) => (
+                    <DraggableListItem
+                        key={metric.id ?? metric.name}
+                        id={metric.id ?? metric.name}
+                        entity={metric}
+                        entities={metrics}
+                        idSelector={(item) => item.id ?? item.name}
+                        onEntitiesReordered={onReorder}
+                        ariaLabel="Reorder metric"
+                        renderEntityComponent={renderRow}
+                    />
+                ))}
+            </div>
+        </div>
+    );
+};

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
@@ -51,6 +51,7 @@ export const StatisticsMetricsList = ({
                     <IconButton type="button" DefaultIcon={EditIcon} className={styles.iconButton} />
                     <IconButton
                         type="button"
+                        aria-label={isHidden ? 'Show metric' : 'Hide metric'}
                         onClick={() => metric.id && onToggleVisibility(metric.id)}
                         DefaultIcon={isHidden ? EyeClosedIcon : EyeOpenedIcon}
                         className={styles.iconButton}

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
@@ -43,11 +43,13 @@ export const StatisticsMetricsList = ({
         return (
             <div className={styles.row}>
                 <div className={styles.labels}>
-                    <p className={styles.ua}>{getMetricName(metric)}</p>
+                    <p className={`${styles.ua} ${isHidden ? styles.hiddenText : ''}`}>{getMetricName(metric)}</p>
                 </div>
 
                 <div className={styles.values}>
-                    <p className={styles.value}>{formatMetricValue(metric, 'uk-UA')}</p>
+                    <p className={`${styles.value} ${isHidden ? styles.hiddenText : ''}`}>
+                        {formatMetricValue(metric, 'uk-UA')}
+                    </p>
                 </div>
 
                 <div className={styles.actions}>
@@ -61,7 +63,7 @@ export const StatisticsMetricsList = ({
                         }}
                         disabled={isLastVisible}
                         DefaultIcon={isHidden ? EyeClosedIcon : EyeOpenedIcon}
-                        className={styles.iconButton}
+                        className={`${styles.iconButton} ${isLastVisible ? styles.disabled : ''}`}
                     />
                 </div>
             </div>

--- a/src/pages/admin/main/components/statistics-block/components/statistics-preview/StatisticsPreview.module.scss
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-preview/StatisticsPreview.module.scss
@@ -1,0 +1,72 @@
+@use '@/assets/sass/variables/colors' as c;
+@use '@/assets/sass/mixins/typography.mixins' as type;
+
+.preview {
+    background: c.$white;
+    border: 1px solid c.$grey-500;
+    border-radius: 8px;
+    padding: 12px;
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+}
+
+.title {
+	@include type.small-text-medium;
+    color: c.$grey-900;
+    margin: 0;
+}
+
+.toggle {
+    display: flex;
+    gap: 4px;
+}
+
+.tab {
+		@include type.small-text-medium;
+    background: transparent;
+    border: none;
+    padding: 4px 10px;
+    border-radius: 6px;
+    cursor: pointer;
+    color: c.$grey-900;
+}
+
+.active {
+    background: c.$white;
+    border: 1px solid c.$grey-500;
+    color: c.$black;
+}
+
+.panel {
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    background: c.$light-blue-500;
+    border-radius: 6px;
+    padding: 16px;
+    color: c.$white;
+}
+
+.metric {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.value {
+    @include type.subtitle-2-semibold;
+    margin: 0;
+    color: c.$black;
+}
+
+.label {
+		@include type.small-text-regular;
+    margin: 0;
+    opacity: 0.9;
+    color: c.$black;
+}

--- a/src/pages/admin/main/components/statistics-block/components/statistics-preview/StatisticsPreview.module.scss
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-preview/StatisticsPreview.module.scss
@@ -16,7 +16,7 @@
 }
 
 .title {
-	@include type.small-text-medium;
+    @include type.small-text-medium;
     color: c.$grey-900;
     margin: 0;
 }
@@ -27,7 +27,7 @@
 }
 
 .tab {
-		@include type.small-text-medium;
+    @include type.small-text-medium;
     background: transparent;
     border: none;
     padding: 4px 10px;
@@ -65,7 +65,7 @@
 }
 
 .label {
-		@include type.small-text-regular;
+    @include type.small-text-regular;
     margin: 0;
     opacity: 0.9;
     color: c.$black;

--- a/src/pages/admin/main/components/statistics-block/components/statistics-preview/StatisticsPreview.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-preview/StatisticsPreview.test.tsx
@@ -18,15 +18,12 @@ const metrics: Metric[] = [
     },
     {
         id: 2,
-        name: 'Програм',
-        value: 21,
+        name: 'Engagement',
+        value: 50,
         type: MetricType.Programs,
-        prefix: MetricPrefix.None,
-        localizations: [
-            { language: { id: 1, code: 'uk' }, translationStatus: TranslationStatus.Relevant, name: 'Програм' },
-            { language: { id: 2, code: 'en' }, translationStatus: TranslationStatus.Relevant, name: 'Programs' },
-        ],
-    },
+        prefix: MetricPrefix.Percent,
+        localizations: [],
+    } as Metric,
 ];
 
 describe('StatisticsPreview', () => {
@@ -35,8 +32,19 @@ describe('StatisticsPreview', () => {
 
         expect(screen.getByText(/preview/i)).toBeInTheDocument();
         expect(screen.getByText('Партнерів')).toBeInTheDocument();
-        expect(screen.getByText('Програм')).toBeInTheDocument();
         expect(screen.getByText('20+')).toBeInTheDocument();
+    });
+
+    it('falls back to metric name when localization is missing', () => {
+        render(<StatisticsPreview language="EN" onLanguageChange={() => {}} metrics={metrics} hiddenMetricIds={[]} />);
+
+        expect(screen.getByText('Engagement')).toBeInTheDocument();
+    });
+
+    it('formats percent values', () => {
+        render(<StatisticsPreview language="EN" onLanguageChange={() => {}} metrics={metrics} hiddenMetricIds={[]} />);
+
+        expect(screen.getByText('50%')).toBeInTheDocument();
     });
 
     it('switches language when tab is clicked', () => {
@@ -58,6 +66,6 @@ describe('StatisticsPreview', () => {
         render(<StatisticsPreview language="UA" onLanguageChange={() => {}} metrics={metrics} hiddenMetricIds={[2]} />);
 
         expect(screen.getByText('Партнерів')).toBeInTheDocument();
-        expect(screen.queryByText('Програм')).not.toBeInTheDocument();
+        expect(screen.queryByText('Engagement')).not.toBeInTheDocument();
     });
 });

--- a/src/pages/admin/main/components/statistics-block/components/statistics-preview/StatisticsPreview.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-preview/StatisticsPreview.test.tsx
@@ -1,0 +1,63 @@
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { StatisticsPreview } from './StatisticsPreview';
+import { Metric, MetricPrefix, MetricType } from '@/types/admin/main-page';
+import { TranslationStatus } from '@/types/common/language';
+
+const metrics: Metric[] = [
+    {
+        id: 1,
+        name: 'Партнерів',
+        value: 20,
+        type: MetricType.Partners,
+        prefix: MetricPrefix.Plus,
+        localizations: [
+            { language: { id: 1, code: 'uk' }, translationStatus: TranslationStatus.Relevant, name: 'Партнерів' },
+            { language: { id: 2, code: 'en' }, translationStatus: TranslationStatus.Relevant, name: 'Partners' },
+        ],
+    },
+    {
+        id: 2,
+        name: 'Програм',
+        value: 21,
+        type: MetricType.Programs,
+        prefix: MetricPrefix.None,
+        localizations: [
+            { language: { id: 1, code: 'uk' }, translationStatus: TranslationStatus.Relevant, name: 'Програм' },
+            { language: { id: 2, code: 'en' }, translationStatus: TranslationStatus.Relevant, name: 'Programs' },
+        ],
+    },
+];
+
+describe('StatisticsPreview', () => {
+    it('renders preview title and metrics', () => {
+        render(<StatisticsPreview language="UA" onLanguageChange={() => {}} metrics={metrics} hiddenMetricIds={[]} />);
+
+        expect(screen.getByText(/preview/i)).toBeInTheDocument();
+        expect(screen.getByText('Партнерів')).toBeInTheDocument();
+        expect(screen.getByText('Програм')).toBeInTheDocument();
+        expect(screen.getByText('20+')).toBeInTheDocument();
+    });
+
+    it('switches language when tab is clicked', () => {
+        const onLanguageChange = jest.fn();
+        render(
+            <StatisticsPreview
+                language="UA"
+                onLanguageChange={onLanguageChange}
+                metrics={metrics}
+                hiddenMetricIds={[]}
+            />,
+        );
+
+        fireEvent.click(screen.getByText('ENG'));
+        expect(onLanguageChange).toHaveBeenCalledWith('EN');
+    });
+
+    it('hides metrics by hiddenMetricIds', () => {
+        render(<StatisticsPreview language="UA" onLanguageChange={() => {}} metrics={metrics} hiddenMetricIds={[2]} />);
+
+        expect(screen.getByText('Партнерів')).toBeInTheDocument();
+        expect(screen.queryByText('Програм')).not.toBeInTheDocument();
+    });
+});

--- a/src/pages/admin/main/components/statistics-block/components/statistics-preview/StatisticsPreview.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-preview/StatisticsPreview.tsx
@@ -1,0 +1,65 @@
+import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
+import { Metric, MetricPrefix } from '@/types/admin/main-page';
+import styles from './StatisticsPreview.module.scss';
+
+interface StatisticsPreviewProps {
+    language: 'UA' | 'EN';
+    onLanguageChange: (lang: 'UA' | 'EN') => void;
+    metrics: Metric[];
+    hiddenMetricIds: number[];
+}
+
+const getMetricName = (metric: Metric, language: 'UA' | 'EN') => {
+    const code = language === 'UA' ? 'uk' : 'en';
+    return metric.localizations?.find((l) => l.language.code === code)?.name ?? metric.name;
+};
+
+const formatMetricValue = (metric: Metric, language: 'UA' | 'EN') => {
+    const locale = language === 'UA' ? 'uk-UA' : 'en-US';
+    const value = metric.value.toLocaleString(locale);
+    switch (metric.prefix) {
+        case MetricPrefix.Plus:
+            return `${value}+`;
+        case MetricPrefix.Percent:
+            return `${value}%`;
+        default:
+            return value;
+    }
+};
+
+export const StatisticsPreview = ({ language, onLanguageChange, metrics, hiddenMetricIds }: StatisticsPreviewProps) => {
+    const visibleMetrics = metrics.filter((metric) => !hiddenMetricIds.includes(metric.id ?? 0));
+
+    return (
+        <div className={styles.preview}>
+            <div className={styles.header}>
+                <p className={styles.title}>{MAIN_PAGE_TEXT.BLOCKS.STATISTICS.PREVIEW_TITLE}</p>
+                <div className={styles.toggle}>
+                    <button
+                        type="button"
+                        onClick={() => onLanguageChange('UA')}
+                        className={`${styles.tab} ${language === 'UA' ? styles.active : ''}`}
+                    >
+                        {MAIN_PAGE_TEXT.BLOCKS.STATISTICS.LANG.UKR}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => onLanguageChange('EN')}
+                        className={`${styles.tab} ${language === 'EN' ? styles.active : ''}`}
+                    >
+                        {MAIN_PAGE_TEXT.BLOCKS.STATISTICS.LANG.ENG}
+                    </button>
+                </div>
+            </div>
+
+            <div className={styles.panel}>
+                {visibleMetrics.map((metric) => (
+                    <div key={metric.id ?? metric.name} className={styles.metric}>
+                        <p className={styles.value}>{formatMetricValue(metric, language)}</p>
+                        <p className={styles.label}>{getMetricName(metric, language)}</p>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};

--- a/src/pages/admin/main/components/title-block/TitleBlockForm.test.tsx
+++ b/src/pages/admin/main/components/title-block/TitleBlockForm.test.tsx
@@ -23,21 +23,9 @@ jest.mock('@/components/admin/button/Button', () => ({
     Button: require('@/utils/test-mocks/main-page-mocks').MockSubmitButton,
 }));
 
-jest.mock('@/components/admin/image-input/ImageInput', () => ({
+jest.mock('@/pages/admin/main/components/common/image-upload-form/ImageUploadForm', () => ({
     __esModule: true,
-    ImageInput: ({ setError, onChange }: any) => (
-        <div data-testid="image-input-mock">
-            <button data-testid="trigger-image-change" type="button" onClick={() => onChange({ file: 'fake.jpg' })}>
-                Change Image
-            </button>
-            <button data-testid="trigger-image-error" type="button" onClick={() => setError('Image size error')}>
-                Set Error
-            </button>
-            <button data-testid="clear-image-error" type="button" onClick={() => setError(null)}>
-                Clear Error
-            </button>
-        </div>
-    ),
+    ImageUploadForm: require('@/utils/test-mocks/main-page-mocks').MockImageUploadForm,
 }));
 
 const mockInitialData: MainPage = {
@@ -103,7 +91,7 @@ describe('TitleBlockForm', () => {
         });
     });
 
-    it('disables submit button when ImageInput sets an error', async () => {
+    it('disables submit button when ImageUploadForm sets an error', async () => {
         render(<TitleBlockForm initialData={mockInitialData} />);
 
         const titleInput = screen.getByTestId('title-block-title');

--- a/src/pages/admin/main/components/title-block/TitleBlockForm.test.tsx
+++ b/src/pages/admin/main/components/title-block/TitleBlockForm.test.tsx
@@ -47,6 +47,7 @@ const mockInitialData: MainPage = {
     image: null,
     mainAboutUs: null,
     mainPartners: null,
+    impactStatistics: null,
 };
 
 describe('TitleBlockForm', () => {

--- a/src/pages/admin/main/components/title-block/TitleBlockForm.tsx
+++ b/src/pages/admin/main/components/title-block/TitleBlockForm.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Button } from '@/components/admin/button/Button';
-import { ImageInput } from '@/components/admin/image-input/ImageInput';
 import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
 import { TextAreaWithCharacterLimitGroup } from '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup';
 import { TitleBlockValidationSchema } from '@/validation/admin/main-page-schema/main-page-schema';
@@ -10,6 +9,7 @@ import { MainPage, TitleBlockFormValues, TITLE_BLOCK_FORM_DEFAULTS } from '@/typ
 import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import DefaultPlaceholder from '@/assets/images/man-facing-horse-forehead.webp';
+import { ImageUploadForm } from '@/pages/admin/main/components/common/image-upload-form/ImageUploadForm';
 
 import styles from './TitleBlockForm.module.scss';
 
@@ -67,26 +67,14 @@ export const TitleBlockForm = ({ initialData }: TitleBlockFormProps) => {
     return (
         <form className={styles.form} onSubmit={handleSubmit(onSubmit)}>
             <div className={styles.content}>
-                <div className={styles['image-section']}>
-                    <Controller
-                        name="image"
-                        control={control}
-                        render={({ field: { onChange, value } }) => (
-                            <div className={styles['image-wrapper']}>
-                                <ImageInput
-                                    value={value}
-                                    onChange={onChange}
-                                    setError={setImageError}
-                                    variant="whoWeAre"
-                                    {...IMAGE_CONFIG}
-                                />
-                                {(imageError || errors.image?.message) && (
-                                    <p className={styles.error}> {imageError || errors.image?.message}</p>
-                                )}
-                            </div>
-                        )}
-                    />
-                </div>
+                <ImageUploadForm
+                    control={control}
+                    errors={errors}
+                    imageError={imageError}
+                    setImageError={setImageError}
+                    imageConfig={IMAGE_CONFIG}
+                    variant="whoWeAre"
+                />
 
                 <div className={styles['text-section']}>
                     <Controller

--- a/src/types/admin/main-page.ts
+++ b/src/types/admin/main-page.ts
@@ -1,4 +1,62 @@
 import { Image, ImageValues } from '../common/image';
+import {
+    EntityLocalization,
+    EntityLocalizationDto,
+    EntityWithDtoLocalizations,
+    EntityWithLocalizations,
+} from '@/types/common/language';
+
+export type LocaleCode = 'uk' | 'en';
+
+export enum MetricPrefix {
+    None = 'None',
+    Plus = 'Plus',
+    Percent = 'Percent',
+}
+
+export enum MetricType {
+    Partners = 'Partners',
+    Programs = 'Programs',
+    Raised = 'Raised',
+    TherapyHours = 'TherapyHours',
+}
+
+export interface ImpactStatisticLocalization extends EntityLocalization {
+    entityId?: number;
+    languageId?: number;
+    title?: string;
+}
+
+export interface MetricLocalization extends EntityLocalization {
+    entityId?: number;
+    languageId?: number;
+    name?: string;
+}
+
+export interface ImpactStatisticLocalizationDto extends EntityLocalizationDto {
+    entityId?: number;
+    title?: string | null;
+}
+
+export interface MetricLocalizationDto extends EntityLocalizationDto {
+    entityId?: number;
+    name?: string | null;
+}
+
+export interface Metric extends EntityWithLocalizations<MetricLocalization> {
+    id?: number;
+    value: number;
+    name: string;
+    type: MetricType;
+    prefix?: MetricPrefix | null;
+}
+
+export interface ImpactStatistic extends EntityWithLocalizations<ImpactStatisticLocalization> {
+    id?: number;
+    title: string;
+    image?: Image | ImageValues | null;
+    metrics: Metric[];
+}
 
 export interface MainAboutUs {
     id: number;
@@ -19,6 +77,84 @@ export interface MainPage {
     image: Image | ImageValues | null;
     mainAboutUs: MainAboutUs | null;
     mainPartners: MainPartners | null;
+    impactStatistics: ImpactStatistic | null;
+}
+
+export interface MetricDto extends EntityWithDtoLocalizations<MetricLocalizationDto> {
+    id?: number;
+    value?: number | null;
+    name?: string | null;
+    type?: MetricType | null;
+    prefix?: MetricPrefix | null;
+}
+
+export interface ImpactStatisticDto extends EntityWithDtoLocalizations<ImpactStatisticLocalizationDto> {
+    id?: number;
+    title?: string | null;
+    image?: Image | ImageValues | null;
+    metrics?: MetricDto[] | null;
+}
+
+export interface MainPageDto {
+    id?: number;
+    title?: string | null;
+    description?: string | null;
+    image?: Image | ImageValues | null;
+    mainAboutUs?: MainAboutUs | null;
+    mainPartners?: MainPartners | null;
+    impactStatistics?: ImpactStatisticDto | null;
+}
+
+export interface CreateMetricLocalizationDto {
+    languageId?: number;
+    name?: string;
+}
+
+export interface UpdateMetricLocalizationDto {
+    languageId?: number;
+    name?: string;
+}
+
+export interface CreateMetricDto {
+    value: number;
+    name: string;
+    type: MetricType;
+    prefix?: MetricPrefix | null;
+    localization?: CreateMetricLocalizationDto | null;
+}
+
+export interface UpdateMetricDto {
+    id?: number;
+    value: number;
+    name: string;
+    type: MetricType;
+    prefix?: MetricPrefix | null;
+    localization?: UpdateMetricLocalizationDto | null;
+}
+
+export interface CreateImpactStatisticLocalizationDto {
+    languageId?: number;
+    title?: string;
+}
+
+export interface UpdateImpactStatisticLocalizationDto {
+    languageId?: number;
+    title?: string;
+}
+
+export interface CreateImpactStatisticDto {
+    title: string;
+    imageId?: number | null;
+    metrics: CreateMetricDto[];
+    localization?: CreateImpactStatisticLocalizationDto | null;
+}
+
+export interface UpdateImpactStatisticDto {
+    id?: number;
+    title: string;
+    imageId?: number | null;
+    metrics: UpdateMetricDto[];
+    localization?: UpdateImpactStatisticLocalizationDto | null;
 }
 
 export interface TitleBlockFormValues {
@@ -41,4 +177,16 @@ export interface AboutUsBlockFormValues {
 export const ABOUT_US_BLOCK_FORM_DEFAULTS: AboutUsBlockFormValues = {
     title: '',
     description: '',
+};
+
+export interface StatisticsBlockFormValues {
+    titleUa: string;
+    titleEn: string;
+    image: Image | ImageValues | null;
+}
+
+export const STATISTICS_BLOCK_FORM_DEFAULTS: StatisticsBlockFormValues = {
+    titleUa: '',
+    titleEn: '',
+    image: null,
 };

--- a/src/utils/mock-data/admin/main-page/main-page.ts
+++ b/src/utils/mock-data/admin/main-page/main-page.ts
@@ -1,4 +1,5 @@
-import { MainPage } from '@/types/admin/main-page';
+import { MainPage, MetricPrefix, MetricType } from '@/types/admin/main-page';
+import { TranslationStatus } from '@/types/common/language';
 
 export const MOCK_MAIN_PAGE_DATA: MainPage = {
     id: 1,
@@ -14,5 +15,89 @@ export const MOCK_MAIN_PAGE_DATA: MainPage = {
         id: 1,
         title: 'Наші партнери',
         description: 'Коли тіло та душа відновлюються — народжується справжня сила.',
+    },
+    impactStatistics: {
+        id: 1,
+        title: 'Зміни, які можна виміряти',
+        image: null,
+        localizations: [],
+        metrics: [
+            {
+                id: 1,
+                name: 'Партнерів',
+                value: 20,
+                type: MetricType.Partners,
+                prefix: MetricPrefix.Plus,
+                localizations: [
+                    {
+                        language: { id: 1, code: 'uk' },
+                        translationStatus: TranslationStatus.Relevant,
+                        name: 'Партнерів',
+                    },
+                    {
+                        language: { id: 2, code: 'en' },
+                        translationStatus: TranslationStatus.Relevant,
+                        name: 'Partners',
+                    },
+                ],
+            },
+            {
+                id: 2,
+                name: 'Програм',
+                value: 21,
+                type: MetricType.Programs,
+                prefix: MetricPrefix.None,
+                localizations: [
+                    {
+                        language: { id: 1, code: 'uk' },
+                        translationStatus: TranslationStatus.Relevant,
+                        name: 'Програм',
+                    },
+                    {
+                        language: { id: 2, code: 'en' },
+                        translationStatus: TranslationStatus.Relevant,
+                        name: 'Programs',
+                    },
+                ],
+            },
+            {
+                id: 3,
+                name: 'Зібрано',
+                value: 51644000,
+                type: MetricType.Raised,
+                prefix: MetricPrefix.None,
+                localizations: [
+                    {
+                        language: { id: 1, code: 'uk' },
+                        translationStatus: TranslationStatus.Relevant,
+                        name: 'Зібрано',
+                    },
+                    {
+                        language: { id: 2, code: 'en' },
+                        translationStatus: TranslationStatus.Relevant,
+                        name: 'Raised',
+                    },
+                ],
+            },
+            {
+                id: 4,
+                name: 'Годин терапії',
+                value: 140,
+                type: MetricType.TherapyHours,
+                prefix: MetricPrefix.Plus,
+                localizations: [
+                    {
+                        language: { id: 1, code: 'uk' },
+                        translationStatus: TranslationStatus.Relevant,
+                        name: 'Годин терапії',
+                    },
+                    {
+                        language: { id: 2, code: 'en' },
+                        translationStatus: TranslationStatus.Relevant,
+                        name: 'Therapy hours',
+                    },
+                ],
+            },
+        ],
     },
 };

--- a/src/utils/test-mocks/main-page-mocks.tsx
+++ b/src/utils/test-mocks/main-page-mocks.tsx
@@ -14,6 +14,20 @@ export const MockSubmitButton = ({ children, disabled, type }: any) => (
     </button>
 );
 
+export const MockImageInput = ({ setError, onChange }: any) => (
+    <div data-testid="image-input-mock">
+        <button data-testid="trigger-image-change" type="button" onClick={() => onChange({ file: 'fake.jpg' })}>
+            Change Image
+        </button>
+        <button data-testid="trigger-image-error" type="button" onClick={() => setError('Image size error')}>
+            Set Error
+        </button>
+        <button data-testid="clear-image-error" type="button" onClick={() => setError(null)}>
+            Clear Error
+        </button>
+    </div>
+);
+
 export const MockMainPageCategoryBar = ({ categories, onCategorySelect, selectedCategory }: any) => (
     <div data-testid="category-bar">
         {categories.map((c: any) => (

--- a/src/utils/test-mocks/main-page-mocks.tsx
+++ b/src/utils/test-mocks/main-page-mocks.tsx
@@ -14,15 +14,12 @@ export const MockSubmitButton = ({ children, disabled, type }: any) => (
     </button>
 );
 
-export const MockImageInput = ({ setError, onChange }: any) => (
-    <div data-testid="image-input-mock">
-        <button data-testid="trigger-image-change" type="button" onClick={() => onChange({ file: 'fake.jpg' })}>
-            Change Image
-        </button>
-        <button data-testid="trigger-image-error" type="button" onClick={() => setError('Image size error')}>
+export const MockImageUploadForm = ({ setImageError }: any) => (
+    <div data-testid="image-upload-form">
+        <button data-testid="trigger-image-error" type="button" onClick={() => setImageError('Image size error')}>
             Set Error
         </button>
-        <button data-testid="clear-image-error" type="button" onClick={() => setError(null)}>
+        <button data-testid="clear-image-error" type="button" onClick={() => setImageError(null)}>
             Clear Error
         </button>
     </div>

--- a/src/validation/admin/main-page-schema/main-page-schema.test.ts
+++ b/src/validation/admin/main-page-schema/main-page-schema.test.ts
@@ -79,4 +79,68 @@ describe('MAIN_PAGE_VALIDATION_FUNCTIONS', () => {
             expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateImage(mockImage as any)).toBeUndefined();
         });
     });
+
+    describe('validateStatisticsTitleUa', () => {
+        it('returns undefined for valid UA title', () => {
+            expect(
+                MAIN_PAGE_VALIDATION_FUNCTIONS.validateStatisticsTitleUa('Зміни, які можна виміряти'),
+            ).toBeUndefined();
+        });
+
+        it('returns required error for empty UA title', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateStatisticsTitleUa('')).toBe(
+                MAIN_PAGE_VALIDATION.common.REQUIRED,
+            );
+        });
+
+        it('treats spaces as empty and returns required error for UA title', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateStatisticsTitleUa('   ')).toBe(
+                MAIN_PAGE_VALIDATION.common.REQUIRED,
+            );
+        });
+
+        it('returns min error for UA title shorter than min', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateStatisticsTitleUa('Коро')).toBe(
+                MAIN_PAGE_VALIDATION.statisticsBlock.title.getMinError(),
+            );
+        });
+
+        it('returns max error for UA title longer than max', () => {
+            const longTitle = 'a'.repeat(MAIN_PAGE_VALIDATION.statisticsBlock.title.max + 1);
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateStatisticsTitleUa(longTitle)).toBe(
+                MAIN_PAGE_VALIDATION.statisticsBlock.title.getMaxError(),
+            );
+        });
+    });
+
+    describe('validateStatisticsTitleEn', () => {
+        it('returns undefined for valid EN title', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateStatisticsTitleEn('Changes you can measure')).toBeUndefined();
+        });
+
+        it('returns required error for empty EN title', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateStatisticsTitleEn('')).toBe(
+                MAIN_PAGE_VALIDATION.common.REQUIRED,
+            );
+        });
+
+        it('treats spaces as empty and returns required error for EN title', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateStatisticsTitleEn('   ')).toBe(
+                MAIN_PAGE_VALIDATION.common.REQUIRED,
+            );
+        });
+
+        it('returns min error for EN title shorter than min', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateStatisticsTitleEn('Shor')).toBe(
+                MAIN_PAGE_VALIDATION.statisticsBlock.title.getMinError(),
+            );
+        });
+
+        it('returns max error for EN title longer than max', () => {
+            const longTitle = 'a'.repeat(MAIN_PAGE_VALIDATION.statisticsBlock.title.max + 1);
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateStatisticsTitleEn(longTitle)).toBe(
+                MAIN_PAGE_VALIDATION.statisticsBlock.title.getMaxError(),
+            );
+        });
+    });
 });

--- a/src/validation/admin/main-page-schema/main-page-schema.ts
+++ b/src/validation/admin/main-page-schema/main-page-schema.ts
@@ -1,6 +1,6 @@
 import * as Yup from 'yup';
 import { MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
-import { AboutUsBlockFormValues, TitleBlockFormValues } from '@/types/admin/main-page';
+import { AboutUsBlockFormValues, TitleBlockFormValues, StatisticsBlockFormValues } from '@/types/admin/main-page';
 import { Image, ImageValues } from '@/types/common/image';
 import { getNormalizedInputText } from '@/utils/functions/formatters/text-formatters';
 
@@ -17,22 +17,30 @@ const buildStringValidation = (config: {
         .max(config.max, config.getMaxError());
 };
 
+const imageSchema = Yup.mixed<Image | ImageValues>()
+    .transform((value) => {
+        if (value === null || typeof value === 'string') return undefined;
+        return value;
+    })
+    .nullable()
+    .notRequired()
+    .default(null);
+
 export const TitleBlockValidationSchema: Yup.ObjectSchema<TitleBlockFormValues> = Yup.object({
     title: buildStringValidation(MAIN_PAGE_VALIDATION.titleBlock.title),
     description: buildStringValidation(MAIN_PAGE_VALIDATION.titleBlock.description),
-    image: Yup.mixed<Image | ImageValues>()
-        .transform((value) => {
-            if (value === null || typeof value === 'string') return undefined;
-            return value;
-        })
-        .nullable()
-        .notRequired()
-        .default(null),
+    image: imageSchema,
 });
 
 export const AboutUsBlockValidationSchema: Yup.ObjectSchema<AboutUsBlockFormValues> = Yup.object({
     title: buildStringValidation(MAIN_PAGE_VALIDATION.aboutUsBlock.title),
     description: buildStringValidation(MAIN_PAGE_VALIDATION.aboutUsBlock.description),
+});
+
+export const StatisticsBlockValidationSchema: Yup.ObjectSchema<StatisticsBlockFormValues> = Yup.object({
+    titleUa: buildStringValidation(MAIN_PAGE_VALIDATION.statisticsBlock.title),
+    titleEn: buildStringValidation(MAIN_PAGE_VALIDATION.statisticsBlock.title),
+    image: imageSchema,
 });
 
 export const MAIN_PAGE_VALIDATION_FUNCTIONS = {
@@ -57,6 +65,24 @@ export const MAIN_PAGE_VALIDATION_FUNCTIONS = {
     validateImage: (value: Image | ImageValues | null): string | undefined => {
         try {
             TitleBlockValidationSchema.validateSyncAt('image', { image: value });
+            return undefined;
+        } catch (error: any) {
+            return error.message;
+        }
+    },
+
+    validateStatisticsTitleUa: (value: string): string | undefined => {
+        try {
+            StatisticsBlockValidationSchema.validateSyncAt('titleUa', { titleUa: value });
+            return undefined;
+        } catch (error: any) {
+            return error.message;
+        }
+    },
+
+    validateStatisticsTitleEn: (value: string): string | undefined => {
+        try {
+            StatisticsBlockValidationSchema.validateSyncAt('titleEn', { titleEn: value });
             return undefined;
         } catch (error: any) {
             return error.message;


### PR DESCRIPTION
## Github tickets

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2057
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2338
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2339
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2340
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2337
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2334
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2058
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2399
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2400
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2402
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2403
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2342

## Description

This PR introduces the **Main -> Statistics** admin block UI and aligns the frontend DTO types with the backend contracts.  
It also refactors mock data and component logic to use the new types (ImpactStatistics + Metrics), adds preview language toggling, and updates styles to match the mockups.

**Notes:**
- Some of the issues are done (e.g. Image, Drag) because default components already cover tasks mentioned in description of issues.
- Localization is planned for the upcoming PRs.
- The flow still uses mock data (no API integration yet).
- The **Publish** button is intentionally non-functional (display-only); it becomes enabled only when all validations pass.

## How it looks

https://github.com/user-attachments/assets/6007d042-fb7b-4cc6-8d05-f92d2a279432

## Summary of change

### DTOs / Types
- Updated types to match backend DTO structure.
- Added `MetricType` and `MetricPrefix` enums on the client side.
- Added localization DTO structures for ImpactStatistics and Metrics.

### Statistics block UI
- Preview section with UKR/ENG toggle.
- Metric list uses new types.
- Visibility toggling works via local state (mock only).
- Adjusted styles and spacing to match the provided mockups.

### Validation & Form behavior
- Added statistics block validation schema for UA/EN titles.
- `Publish` button is enabled only if the form is dirty, valid, and has no image error.
- Image validation uses existing ImageInput validation rules.

### Tests
- Added tests for:
  - `StatisticsBlockForm`
  - `StatisticsPreview`
  - `StatisticsMetricsList`
- Updated existing tests to include new `impactStatistics` field in `MainPage` mocks.

## How to recreate changes

1. Go to Admin -> Main Page (`/admin-panel/main`) -> Statistics tab.
2. Review preview and metrics list UI with mock data.
3. Toggle preview language tabs and visibility icons.
4. Update title fields and observe Publish button enable/disable.

## Notes / Out of scope
- API integration is deferred.
- Localization persistence will be introduced in a separate PR.
- Publish button triggers no backend action (display-only).

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin Statistics section to manage impact metrics with UA/EN titles, image support, visibility toggles, reordering, and live preview.
  * Title inputs enforce length limits; publish control enabled only when form is valid.

* **Validation**
  * New validators for statistics titles with min/max rules and error messages.

* **Tests**
  * Added unit tests covering form interactions, image errors, metrics list, preview, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->