### PR TITLE
Feature/issue-1443-1444: [Reports] Implement category renaming functionality

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -212,8 +212,11 @@ export const FUNDS_EXPENDITURES_TEXT = {
             CATEGORY_PLACEHOLDER: 'Оберіть категорію',
             CONFIRM_TITLE: 'Видалити категорію?',
             ERROR: {
-                HAS_INCOME_RECORD: 'Категорія використовується в надходженнях, 1 запис. Видаліть або змініть його',
-                HAS_EXPENSE_RECORD: 'Категорія використовується у витратах, 1 запис. Видаліть або змініть його',
+                getHasIncomeRecordTitle: (count: number) =>
+                    `Категорія використовується в надходженнях, ${count} ${count === 1 ? 'запис' : 'записи'}`,
+                getHasExpenseRecordTitle: (count: number) =>
+                    `Категорія використовується у витратах, ${count} ${count === 1 ? 'запис' : 'записи'}`,
+                HAS_RECORD_TEXT: 'Видаліть або змініть їх',
             },
         },
         CATEGORY: {

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -213,9 +213,9 @@ export const FUNDS_EXPENDITURES_TEXT = {
             CONFIRM_TITLE: 'Видалити категорію?',
             ERROR: {
                 getHasIncomeRecordTitle: (count: number) =>
-                    `Категорія використовується в надходженнях, ${count} ${count === 1 ? 'запис' : 'записи'}`,
+                    `Категорія використовується в надходженнях, ${count} ${count === 1 ? 'запис' : count < 5 ? 'записи' : 'записів'}`,
                 getHasExpenseRecordTitle: (count: number) =>
-                    `Категорія використовується у витратах, ${count} ${count === 1 ? 'запис' : 'записи'}`,
+                    `Категорія використовується у витратах, ${count} ${count === 1 ? 'запис' : count < 5 ? 'записи' : 'записів'}`,
                 HAS_RECORD_TEXT: 'Видаліть або змініть їх',
             },
         },

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -165,6 +165,8 @@ export const FUNDS_EXPENDITURES_TEXT = {
         CATEGORY_CREATE_FAILED_RETRY: 'Виникла помилка, спробуйте ще раз',
         CATEGORY_DELETED_SUCCESSFULLY: 'Категорію видалено успішно',
         CATEGORY_DELETE_FAILED_RETRY: 'Виникла помилка, спробуйте ще раз',
+        CATEGORY_UPDATED_SUCCESSFULLY: 'Категорію оновлено успішно',
+        CATEGORY_UPDATE_FAILED_RETRY: 'Виникла помилка, спробуйте ще раз',
     },
     MODAL: {
         SHARED: {
@@ -193,6 +195,16 @@ export const FUNDS_EXPENDITURES_TEXT = {
             CATEGORY_PLACEHOLDER: 'Оберіть категорію витрат',
             SUBMIT_BUTTON: 'Додати витрату',
             CONFIRM_ADD_TITLE: 'Додати нову витрату?',
+        },
+        EDIT_CATEGORY: {
+            TITLE: 'Редагувати категорію',
+            SUBTITLE: 'Редагування категорії витрат/надходжень для формування звітності',
+            CATEGORY_LABEL: 'Категорія',
+            CATEGORY_PLACEHOLDER: 'Оберіть категорію',
+            NAME_LABEL: 'Редагувати назву',
+            NAME_PLACEHOLDER: 'Введіть назву категорії',
+            SUBMIT_BUTTON: 'Зберегти',
+            CONFIRM_SAVE_TITLE: 'Зберегти зміни?',
         },
         DELETE_CATEGORY: {
             TITLE: 'Видалити категорію',
@@ -223,6 +235,7 @@ export const FUNDS_EXPENDITURES_TEXT = {
         ADD_EXPENSE: 'Витрати',
         ADD_CATEGORY: 'Додати категорію',
         DELETE_CATEGORY: 'Видалити',
+        EDIT_CATEGORY: 'Редагувати',
     },
     FILTER: {
         TYPE_PLACEHOLDER: 'Тип',

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -33,6 +33,7 @@ import { AddFundsExpendituresRecordModal } from './components/common/add-funds-e
 import { AddFundsExpendituresCategoryModal } from './components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal';
 import { DeleteRecordModal } from './components/common/delete-record-modal/DeleteRecordModal';
 import { DeleteFundsExpendituresCategoryModal } from './components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal';
+import { EditFundsExpendituresCategoryModal } from './components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal';
 import styles from './FundsExpendituresSection.module.scss';
 
 const enrichRecords = (
@@ -55,6 +56,8 @@ interface FundsExpenditureSectionProps {
     onAddCategoryModalClose?: () => void;
     isDeleteCategoryModalOpen?: boolean;
     onDeleteCategoryModalClose?: () => void;
+    isEditCategoryModalOpen?: boolean;
+    onEditCategoryModalClose?: () => void;
 }
 
 export const FundsExpenditureSection = ({
@@ -66,6 +69,8 @@ export const FundsExpenditureSection = ({
     onAddCategoryModalClose,
     isDeleteCategoryModalOpen = false,
     onDeleteCategoryModalClose,
+    isEditCategoryModalOpen = false,
+    onEditCategoryModalClose,
 }: FundsExpenditureSectionProps = {}) => {
     const adminClient = useAdminClient();
     const { addToast } = useToast();
@@ -341,6 +346,23 @@ export const FundsExpenditureSection = ({
         [addToast, adminClient, refetchCategories],
     );
 
+    const handleEditCategory = useCallback(
+        async (categoryId: number, name: string): Promise<boolean> => {
+            const category = categories.find((c) => c.id === categoryId);
+            if (!category) return false;
+            try {
+                await FundsExpendituresApi.updateCategory(adminClient, categoryId, { name, type: category.type });
+                refetchCategories();
+                addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.CATEGORY_UPDATED_SUCCESSFULLY, ToastType.Success);
+                return true;
+            } catch {
+                addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.CATEGORY_UPDATE_FAILED_RETRY, ToastType.Error);
+                return false;
+            }
+        },
+        [addToast, adminClient, categories, refetchCategories],
+    );
+
     const handleDeleteCategory = useCallback(
         async (categoryId: number): Promise<boolean> => {
             try {
@@ -543,6 +565,13 @@ export const FundsExpenditureSection = ({
                 onClose={onAddCategoryModalClose ?? (() => {})}
                 categories={categories}
                 onSubmit={handleCreateCategory}
+            />
+
+            <EditFundsExpendituresCategoryModal
+                isOpen={isEditCategoryModalOpen}
+                onClose={onEditCategoryModalClose ?? (() => {})}
+                categories={categories}
+                onSubmit={handleEditCategory}
             />
 
             <DeleteFundsExpendituresCategoryModal

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.module.scss
@@ -31,8 +31,8 @@
 
 .selectHead {
     width: 100%;
-    height: 3rem;
-    padding: 0 1rem;
+    height: 48px;
+    padding: 0 16px;
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.module.scss
@@ -113,12 +113,15 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 6px;
+    gap: 14px;
 }
 
 .title {
-    @include type.h4-bold;
-    line-height: 36px;
+    font-size: 32px;
+    font-weight: 400;
+    line-height: 24px;
+    letter-spacing: -0.02em;
+    text-align: left;
     margin: 0;
     color: c.$blue-900;
 }

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.tsx
@@ -15,6 +15,18 @@ import {
 } from '@/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema';
 import styles from './AddFundsExpendituresCategoryModal.module.scss';
 
+const renderInputWithError = (
+    input: React.ReactNode,
+    error?: string,
+    inputErrorClass?: string,
+    errorClass?: string,
+) => (
+    <>
+        <div className={cn({ [inputErrorClass || '']: Boolean(error) })}>{input}</div>
+        <p className={cn(errorClass, { [styles.errorHidden]: !error })}>{error ?? ' '}</p>
+    </>
+);
+
 interface AddFundsExpendituresCategoryModalProps {
     isOpen: boolean;
     onClose: () => void;
@@ -160,7 +172,7 @@ export const AddFundsExpendituresCategoryModal = ({
                                         <span className={styles.required}>*</span>
                                         {FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.NAME_LABEL}
                                     </label>
-                                    <div className={cn({ [styles.inputError]: Boolean(nameError) })}>
+                                    {renderInputWithError(
                                         <InputWithCharacterLimit
                                             id="category-name"
                                             name="categoryName"
@@ -175,11 +187,11 @@ export const AddFundsExpendituresCategoryModal = ({
                                             showCounter={true}
                                             hasError={Boolean(nameError)}
                                             className={styles.input}
-                                        />
-                                    </div>
-                                    <p className={cn(styles.error, { [styles.errorHidden]: !nameError })}>
-                                        {nameError ?? ' '}
-                                    </p>
+                                        />,
+                                        nameError,
+                                        styles.inputError,
+                                        styles.error,
+                                    )}
                                 </div>
                             </div>
                         </div>

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.module.scss
@@ -99,8 +99,8 @@
 
 .selectHead {
     width: 100%;
-    height: 3rem;
-    padding: 0 1rem;
+    height: 48px;
+    padding: 0 16px;
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.module.scss
@@ -51,8 +51,11 @@
 }
 
 .title {
-    @include type.h4-bold;
-    line-height: 36px;
+    font-size: 32px;
+    font-weight: 400;
+    line-height: 24px;
+    letter-spacing: -0.02em;
+    text-align: center;
     margin: 0;
     color: c.$blue-900;
 }
@@ -117,6 +120,10 @@
 
 .panel :global(.select-options) {
     width: 100%;
+}
+
+.panel :global(.hint-box) {
+    color: c.$blue-900;
 }
 
 .type {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.module.scss
@@ -93,6 +93,11 @@
     color: c.$bluish-black;
 }
 
+.required {
+    color: c.$error;
+    margin-right: 6px;
+}
+
 .selectContainer {
     width: 100%;
 }

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.module.scss
@@ -46,6 +46,7 @@
 
     :global(.modal-footer button) {
         width: 100%;
+        height: 40px;
     }
 }
 

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.module.scss
@@ -81,10 +81,16 @@
     width: 100%;
 }
 
+.labelRow {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
 .label {
     @include type.small-text-medium;
     color: c.$bluish-black;
-    margin-bottom: 8px;
 }
 
 .selectContainer {
@@ -110,7 +116,7 @@
 .type {
     @include type.small-text-regular;
     margin: 0;
-    color: c.$grey-900;
+    color: c.$blue-900;
 }
 
 .actions {
@@ -118,6 +124,14 @@
     display: flex;
     gap: 24px;
     justify-content: center;
+}
+
+.deleteButton {
+    background-color: c.$blue-900;
+
+    &:disabled {
+        background-color: c.$grey-700;
+    }
 }
 
 @media (max-width: 768px) {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.test.tsx
@@ -1,47 +1,14 @@
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act, within } from '@testing-library/react';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
 import { ReportFundsExpendituresCategory, ReportFundsExpendituresRecord } from '@/types/admin/reports';
 import { DeleteFundsExpendituresCategoryModal } from './DeleteFundsExpendituresCategoryModal';
 
-jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
-    ConfirmationModal: ({ isOpen, title, onConfirm, onCancel, onClose, isButtonsDisabled }: any) => (
-        <div data-testid="confirm-modal" data-open={String(isOpen)}>
-            <span>{title}</span>
-            <button data-testid="confirm-yes" onClick={onConfirm} disabled={isButtonsDisabled}>
-                Yes
-            </button>
-            <button data-testid="confirm-no" onClick={onCancel} disabled={isButtonsDisabled}>
-                No
-            </button>
-            <button data-testid="confirm-close" onClick={onClose} disabled={isButtonsDisabled}>
-                Close
-            </button>
-        </div>
-    ),
-}));
-
-jest.mock('@/components/common/select/Select', () => {
-    const Select = ({ value, onValueChange, placeholder, children }: any) => (
-        <>
-            <input
-                data-testid={placeholder}
-                value={value ?? ''}
-                onChange={(e) => {
-                    const parsed = parseInt(e.target.value, 10);
-                    onValueChange(isNaN(parsed) ? undefined : parsed);
-                }}
-            />
-            {children}
-        </>
-    );
-    Select.Option = ({ value, name }: any) => <option value={value}>{name}</option>;
-    return { Select };
-});
-
 const CATEGORY_SELECT = FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.CATEGORY_PLACEHOLDER;
 const DELETE_BUTTON_NAME = COMMON_TEXT_ADMIN.BUTTON.DELETE;
 const CANCEL_BUTTON_NAME = COMMON_TEXT_ADMIN.BUTTON.CANCEL;
+const YES_BUTTON = COMMON_TEXT_ADMIN.BUTTON.YES;
+const NO_BUTTON = COMMON_TEXT_ADMIN.BUTTON.NO;
 
 const incomeCategory: ReportFundsExpendituresCategory = { id: 1, name: 'Донори', type: 'income' };
 const expenseCategory: ReportFundsExpendituresCategory = { id: 2, name: 'Оренда', type: 'expense' };
@@ -87,9 +54,13 @@ const renderModal = (
 const getDeleteButton = () => screen.getByRole('button', { name: DELETE_BUTTON_NAME });
 const getCancelButton = () => screen.getByRole('button', { name: CANCEL_BUTTON_NAME });
 
-const selectCategory = (id: number) => {
-    fireEvent.change(screen.getByTestId(CATEGORY_SELECT), { target: { value: String(id) } });
+const selectCategory = (name: string) => {
+    fireEvent.click(screen.getByRole('button', { name: CATEGORY_SELECT }));
+    fireEvent.click(screen.getByRole('button', { name }));
 };
+
+const getConfirmOverlay = () =>
+    screen.getAllByTestId('modal-overlay').find((el) => within(el).queryByRole('button', { name: YES_BUTTON }))!;
 
 describe('DeleteFundsExpendituresCategoryModal', () => {
     it('renders nothing when isOpen is false', () => {
@@ -104,7 +75,7 @@ describe('DeleteFundsExpendituresCategoryModal', () => {
 
     it('renders category select and action buttons', () => {
         renderModal();
-        expect(screen.getByTestId(CATEGORY_SELECT)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: CATEGORY_SELECT })).toBeInTheDocument();
         expect(getDeleteButton()).toBeInTheDocument();
         expect(getCancelButton()).toBeInTheDocument();
     });
@@ -117,47 +88,27 @@ describe('DeleteFundsExpendituresCategoryModal', () => {
 
         it('is enabled when a category with no record is selected', () => {
             renderModal({ records: [] });
-            selectCategory(incomeCategory.id);
+            selectCategory(incomeCategory.name);
             expect(getDeleteButton()).not.toBeDisabled();
         });
 
         it('is disabled when selected category has an income record', () => {
             renderModal({ records: [incomeRecord] });
-            selectCategory(incomeCategory.id);
+            selectCategory(incomeCategory.name);
             expect(getDeleteButton()).toBeDisabled();
         });
 
         it('is disabled when selected category has an expense record', () => {
             renderModal({ records: [expenseRecord] });
-            selectCategory(expenseCategory.id);
+            selectCategory(expenseCategory.name);
             expect(getDeleteButton()).toBeDisabled();
-        });
-    });
-
-    describe('type label display', () => {
-        it('shows income type label when income category is selected', () => {
-            renderModal();
-            selectCategory(incomeCategory.id);
-            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME)).toBeInTheDocument();
-        });
-
-        it('shows expense type label when expense category is selected', () => {
-            renderModal();
-            selectCategory(expenseCategory.id);
-            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.EXPENSE)).toBeInTheDocument();
-        });
-
-        it('does not show type label when no category is selected', () => {
-            renderModal();
-            expect(screen.queryByText(FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME)).not.toBeInTheDocument();
-            expect(screen.queryByText(FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.EXPENSE)).not.toBeInTheDocument();
         });
     });
 
     describe('record error hint', () => {
         it('shows income record error when selected income category has a record', () => {
             renderModal({ records: [incomeRecord] });
-            selectCategory(incomeCategory.id);
+            selectCategory(incomeCategory.name);
             expect(
                 screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_INCOME_RECORD),
             ).toBeInTheDocument();
@@ -165,7 +116,7 @@ describe('DeleteFundsExpendituresCategoryModal', () => {
 
         it('shows expense record error when selected expense category has a record', () => {
             renderModal({ records: [expenseRecord] });
-            selectCategory(expenseCategory.id);
+            selectCategory(expenseCategory.name);
             expect(
                 screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_EXPENSE_RECORD),
             ).toBeInTheDocument();
@@ -173,7 +124,7 @@ describe('DeleteFundsExpendituresCategoryModal', () => {
 
         it('does not show hint box when selected category has no record', () => {
             renderModal({ records: [] });
-            selectCategory(incomeCategory.id);
+            selectCategory(incomeCategory.name);
             expect(
                 screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_INCOME_RECORD),
             ).not.toBeInTheDocument();
@@ -188,45 +139,36 @@ describe('DeleteFundsExpendituresCategoryModal', () => {
     });
 
     describe('confirmation modal', () => {
-        it('opens confirmation modal when delete is clicked', () => {
+        it('opens confirmation when delete is clicked', () => {
             renderModal();
-            selectCategory(incomeCategory.id);
+            selectCategory(incomeCategory.name);
             fireEvent.click(getDeleteButton());
-            expect(screen.getByTestId('confirm-modal')).toHaveAttribute('data-open', 'true');
+            expect(getConfirmOverlay()).toBeInTheDocument();
         });
 
-        it('shows correct title in confirmation modal', () => {
+        it('shows correct confirm title', () => {
             renderModal();
-            selectCategory(incomeCategory.id);
+            selectCategory(incomeCategory.name);
             fireEvent.click(getDeleteButton());
             expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.CONFIRM_TITLE)).toBeInTheDocument();
         });
 
-        it('closes confirmation modal when cancel is clicked inside confirm', () => {
+        it('closes confirmation on cancel', () => {
             renderModal();
-            selectCategory(incomeCategory.id);
+            selectCategory(incomeCategory.name);
             fireEvent.click(getDeleteButton());
-            fireEvent.click(screen.getByTestId('confirm-no'));
-            expect(screen.getByTestId('confirm-modal')).toHaveAttribute('data-open', 'false');
-            expect(screen.getByTestId('modal-overlay')).toBeInTheDocument();
-        });
-
-        it('closes confirmation modal when close is triggered inside confirm', () => {
-            renderModal();
-            selectCategory(incomeCategory.id);
-            fireEvent.click(getDeleteButton());
-            fireEvent.click(screen.getByTestId('confirm-close'));
-            expect(screen.getByTestId('confirm-modal')).toHaveAttribute('data-open', 'false');
+            fireEvent.click(within(getConfirmOverlay()).getByRole('button', { name: NO_BUTTON }));
+            expect(screen.queryAllByTestId('modal-overlay').length).toBe(1);
         });
     });
 
     describe('submit behaviour', () => {
-        it('calls onSubmit with the selected categoryId on confirm', async () => {
+        it('calls onSubmit with categoryId on confirm', async () => {
             const onSubmit = jest.fn().mockResolvedValue(true);
             renderModal({ onSubmit });
-            selectCategory(incomeCategory.id);
+            selectCategory(incomeCategory.name);
             fireEvent.click(getDeleteButton());
-            fireEvent.click(screen.getByTestId('confirm-yes'));
+            fireEvent.click(within(getConfirmOverlay()).getByRole('button', { name: YES_BUTTON }));
             await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(incomeCategory.id));
         });
 
@@ -234,11 +176,10 @@ describe('DeleteFundsExpendituresCategoryModal', () => {
             const onClose = jest.fn();
             const onSubmit = jest.fn().mockResolvedValue(true);
             renderModal({ onClose, onSubmit });
-            selectCategory(incomeCategory.id);
+            selectCategory(incomeCategory.name);
             fireEvent.click(getDeleteButton());
-            fireEvent.click(screen.getByTestId('confirm-yes'));
+            fireEvent.click(within(getConfirmOverlay()).getByRole('button', { name: YES_BUTTON }));
             await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
-            expect(screen.getByTestId(CATEGORY_SELECT)).toHaveValue('');
             expect(getDeleteButton()).toBeDisabled();
         });
 
@@ -246,12 +187,12 @@ describe('DeleteFundsExpendituresCategoryModal', () => {
             const onClose = jest.fn();
             const onSubmit = jest.fn().mockResolvedValue(false);
             renderModal({ onClose, onSubmit });
-            selectCategory(incomeCategory.id);
+            selectCategory(incomeCategory.name);
             fireEvent.click(getDeleteButton());
-            fireEvent.click(screen.getByTestId('confirm-yes'));
-            await waitFor(() => expect(screen.getByTestId('confirm-modal')).toHaveAttribute('data-open', 'false'));
+            fireEvent.click(within(getConfirmOverlay()).getByRole('button', { name: YES_BUTTON }));
+            await waitFor(() => expect(screen.queryByRole('button', { name: YES_BUTTON })).not.toBeInTheDocument());
             expect(onClose).not.toHaveBeenCalled();
-            expect(screen.getByTestId('modal-overlay')).toBeInTheDocument();
+            expect(screen.getAllByTestId('modal-overlay').length).toBe(1);
         });
 
         it('disables confirm buttons while submitting', async () => {
@@ -262,49 +203,31 @@ describe('DeleteFundsExpendituresCategoryModal', () => {
                 }),
             );
             renderModal({ onSubmit });
-            selectCategory(incomeCategory.id);
+            selectCategory(incomeCategory.name);
             fireEvent.click(getDeleteButton());
-            fireEvent.click(screen.getByTestId('confirm-yes'));
-            expect(screen.getByTestId('confirm-yes')).toBeDisabled();
+            const yesBtn = within(getConfirmOverlay()).getByRole('button', { name: YES_BUTTON });
+            fireEvent.click(yesBtn);
+            expect(yesBtn).toBeDisabled();
             await act(async () => {
                 resolve(true);
             });
         });
     });
 
-    describe('close (cancel) behaviour', () => {
-        it('calls onClose and resets form when cancel button is clicked', () => {
+    describe('cancel button', () => {
+        it('closes modal on cancel', () => {
             const onClose = jest.fn();
             renderModal({ onClose });
-            selectCategory(incomeCategory.id);
-            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME)).toBeInTheDocument();
             fireEvent.click(getCancelButton());
             expect(onClose).toHaveBeenCalledTimes(1);
         });
 
-        it('resets selection when modal close button is clicked', () => {
-            const onClose = jest.fn();
-            renderModal({ onClose });
-            selectCategory(incomeCategory.id);
-            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
-            expect(onClose).toHaveBeenCalledTimes(1);
-        });
-
-        it('cancel button is disabled while submitting', async () => {
-            let resolve!: (v: boolean) => void;
-            const onSubmit = jest.fn().mockReturnValue(
-                new Promise<boolean>((r) => {
-                    resolve = r;
-                }),
-            );
-            renderModal({ onSubmit });
-            selectCategory(incomeCategory.id);
-            fireEvent.click(getDeleteButton());
-            fireEvent.click(screen.getByTestId('confirm-yes'));
-            expect(getCancelButton()).toBeDisabled();
-            await act(async () => {
-                resolve(true);
-            });
+        it('resets form on cancel', () => {
+            renderModal();
+            selectCategory(incomeCategory.name);
+            expect(getDeleteButton()).not.toBeDisabled();
+            fireEvent.click(getCancelButton());
+            expect(getDeleteButton()).toBeDisabled();
         });
     });
 });

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.test.tsx
@@ -22,6 +22,15 @@ const incomeRecord: ReportFundsExpendituresRecord = {
     amountUsd: '25',
 };
 
+const incomeRecord2: ReportFundsExpendituresRecord = {
+    id: 11,
+    categoryId: 1,
+    type: 'income',
+    reportingYear: '2023',
+    amountUah: '2000',
+    amountUsd: '50',
+};
+
 const expenseRecord: ReportFundsExpendituresRecord = {
     id: 20,
     categoryId: 2,
@@ -147,6 +156,14 @@ describe('DeleteFundsExpendituresCategoryModal', () => {
             expect(
                 screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_RECORD_TEXT),
             ).not.toBeInTheDocument();
+        });
+
+        it('shows correct plural form when category has multiple records', () => {
+            renderModal({ records: [incomeRecord, incomeRecord2] });
+            selectCategory(incomeCategory.name);
+            expect(
+                screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasIncomeRecordTitle(2)),
+            ).toBeInTheDocument();
         });
     });
 

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.test.tsx
@@ -110,7 +110,10 @@ describe('DeleteFundsExpendituresCategoryModal', () => {
             renderModal({ records: [incomeRecord] });
             selectCategory(incomeCategory.name);
             expect(
-                screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_INCOME_RECORD),
+                screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasIncomeRecordTitle(1)),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_RECORD_TEXT),
             ).toBeInTheDocument();
         });
 
@@ -118,7 +121,10 @@ describe('DeleteFundsExpendituresCategoryModal', () => {
             renderModal({ records: [expenseRecord] });
             selectCategory(expenseCategory.name);
             expect(
-                screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_EXPENSE_RECORD),
+                screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasExpenseRecordTitle(1)),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_RECORD_TEXT),
             ).toBeInTheDocument();
         });
 
@@ -126,14 +132,20 @@ describe('DeleteFundsExpendituresCategoryModal', () => {
             renderModal({ records: [] });
             selectCategory(incomeCategory.name);
             expect(
-                screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_INCOME_RECORD),
+                screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasIncomeRecordTitle(1)),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_RECORD_TEXT),
             ).not.toBeInTheDocument();
         });
 
         it('does not show hint box when no category is selected', () => {
             renderModal({ records: [incomeRecord] });
             expect(
-                screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_INCOME_RECORD),
+                screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasIncomeRecordTitle(1)),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_RECORD_TEXT),
             ).not.toBeInTheDocument();
         });
     });

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.tsx
@@ -29,13 +29,14 @@ export const DeleteFundsExpendituresCategoryModal = ({
     const [isSubmitting, setIsSubmitting] = useState(false);
 
     const selectedCategory = categories.find((c) => c.id === selectedCategoryId);
-    const hasRecord = records.some((r) => r.categoryId === selectedCategoryId);
+    const recordCount = records.filter((r) => r.categoryId === selectedCategoryId).length;
+    const hasRecord = recordCount > 0;
 
-    const recordError =
+    const recordErrorTitle =
         selectedCategory && hasRecord
             ? selectedCategory.type === 'income'
-                ? FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_INCOME_RECORD
-                : FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_EXPENSE_RECORD
+                ? FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasIncomeRecordTitle(recordCount)
+                : FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.getHasExpenseRecordTitle(recordCount)
             : undefined;
 
     const resetForm = useCallback(() => {
@@ -110,7 +111,12 @@ export const DeleteFundsExpendituresCategoryModal = ({
                                 </Select>
                             </div>
 
-                            {recordError && <HintBox title={recordError} />}
+                            {recordErrorTitle && (
+                                <HintBox
+                                    title={recordErrorTitle}
+                                    text={FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.ERROR.HAS_RECORD_TEXT}
+                                />
+                            )}
                         </div>
                     </div>
                 </Modal.Content>

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.tsx
@@ -86,6 +86,7 @@ export const DeleteFundsExpendituresCategoryModal = ({
                             <div className={styles.field}>
                                 <div className={styles.labelRow}>
                                     <label className={styles.label}>
+                                        <span className={styles.required}>*</span>
                                         {FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.CATEGORY_LABEL}
                                     </label>
                                     {selectedCategory && (

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.tsx
@@ -84,9 +84,18 @@ export const DeleteFundsExpendituresCategoryModal = ({
                     <div className={styles.content}>
                         <div className={styles.panel}>
                             <div className={styles.field}>
-                                <label className={styles.label}>
-                                    {FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.CATEGORY_LABEL}
-                                </label>
+                                <div className={styles.labelRow}>
+                                    <label className={styles.label}>
+                                        {FUNDS_EXPENDITURES_TEXT.MODAL.DELETE_CATEGORY.CATEGORY_LABEL}
+                                    </label>
+                                    {selectedCategory && (
+                                        <span className={styles.type}>
+                                            {selectedCategory.type === 'income'
+                                                ? FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME
+                                                : FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.EXPENSE}
+                                        </span>
+                                    )}
+                                </div>
                                 <Select<number | undefined>
                                     value={selectedCategoryId}
                                     onValueChange={(val) => setSelectedCategoryId(val as number)}
@@ -100,14 +109,6 @@ export const DeleteFundsExpendituresCategoryModal = ({
                                 </Select>
                             </div>
 
-                            {selectedCategory && (
-                                <p className={styles.type}>
-                                    {selectedCategory.type === 'income'
-                                        ? FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME
-                                        : FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.EXPENSE}
-                                </p>
-                            )}
-
                             {recordError && <HintBox title={recordError} />}
                         </div>
                     </div>
@@ -118,7 +119,12 @@ export const DeleteFundsExpendituresCategoryModal = ({
                         <Button buttonStyle="secondary" onClick={handleClose} disabled={isSubmitting}>
                             {COMMON_TEXT_ADMIN.BUTTON.CANCEL}
                         </Button>
-                        <Button buttonStyle="primary" onClick={handleDeleteClick} disabled={isDeleteDisabled}>
+                        <Button
+                            buttonStyle="primary"
+                            onClick={handleDeleteClick}
+                            disabled={isDeleteDisabled}
+                            className={styles.deleteButton}
+                        >
                             {COMMON_TEXT_ADMIN.BUTTON.DELETE}
                         </Button>
                     </div>

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.module.scss
@@ -1,0 +1,209 @@
+@use '@/assets/sass/variables/colors' as c;
+@use '@/assets/sass/mixins/typography.mixins' as type;
+
+.form {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    width: 100%;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
+.labelRow {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.label {
+    @include type.small-text-medium;
+    color: c.$bluish-black;
+    margin-bottom: 8px;
+}
+
+.labelRow .label {
+    margin-bottom: 0;
+}
+
+.required {
+    color: c.$error;
+    margin-right: 6px;
+}
+
+.selectContainer {
+    width: 100%;
+}
+
+.selectHead {
+    width: 100%;
+    height: 3rem;
+    padding: 0 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border: 1px solid c.$grey-700;
+    border-radius: 8px;
+    background-color: c.$white;
+}
+
+.input {
+    width: 100%;
+}
+
+.panel :global(.char-limit-input) {
+    width: 100%;
+}
+
+.inputError :global(.char-limit-input) {
+    border-color: c.$error;
+}
+
+.panel :global(.select-options) {
+    width: 100%;
+}
+
+.modal {
+    width: 650px;
+
+    :global(.modal-container) {
+        width: 650px;
+        max-width: 650px;
+        border-radius: 8px;
+        background-color: c.$white;
+        padding: 0;
+    }
+
+    :global(.modal-header) {
+        margin-bottom: 0;
+        padding: 24px 24px 0;
+    }
+
+    :global(.modal-header .modal-title-wrapper) {
+        text-align: left;
+    }
+
+    :global(.modal-header .modal-header-text) {
+        font-size: inherit;
+        line-height: inherit;
+        text-align: left;
+    }
+
+    :global(.modal-header .close-icon) {
+        margin-bottom: 4px;
+        padding-right: 0;
+    }
+
+    :global(.modal-body) {
+        margin-bottom: 0;
+        padding: 18px 0 0;
+    }
+
+    :global(.modal-footer) {
+        padding: 16px 24px 24px;
+        gap: 24px;
+        flex-wrap: nowrap;
+        justify-content: center;
+    }
+
+    :global(.modal-footer button) {
+        width: 100%;
+    }
+}
+
+.header {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.title {
+    @include type.h4-bold;
+    line-height: 36px;
+    margin: 0;
+    color: c.$blue-900;
+}
+
+.subtitle {
+    @include type.small-text-regular;
+    margin: 0;
+    color: c.$grey-900;
+}
+
+.content {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.panel {
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+    background-color: c.$grey-50;
+    border: 1px solid c.$grey-150;
+    padding: 20px 22px;
+    min-height: 180px;
+}
+
+.type {
+    @include type.small-text-regular;
+    margin: 0;
+    color: c.$blue-900;
+}
+
+.error {
+    @include type.small-text-regular;
+    margin: 4px 0 0;
+    min-height: 20px;
+    color: c.$error;
+    visibility: visible;
+}
+
+.errorHidden {
+    visibility: hidden;
+}
+
+.actions {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+}
+
+.submit {
+    @include type.subtitle-2-medium;
+    height: 60px;
+    width: 100%;
+}
+
+@media (max-width: 768px) {
+    .modal {
+        width: 100%;
+
+        :global(.modal-container) {
+            width: 100%;
+            max-width: 100%;
+        }
+
+        :global(.modal-header) {
+            padding: 12px 16px 0;
+        }
+
+        :global(.modal-footer) {
+            padding: 0 16px 16px;
+            flex-wrap: wrap;
+        }
+    }
+
+    .panel {
+        padding: 16px;
+        min-height: auto;
+    }
+}

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.module.scss
@@ -42,8 +42,8 @@
 
 .selectHead {
     width: 100%;
-    height: 3rem;
-    padding: 0 1rem;
+    height: 48px;
+    padding: 0 16px;
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.module.scss
@@ -101,7 +101,7 @@
 
     :global(.modal-body) {
         margin-bottom: 0;
-        padding: 18px 0 0;
+        padding: 8px 0 0;
     }
 
     :global(.modal-footer) {
@@ -119,12 +119,16 @@
 .header {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    align-items: flex-start;
+    gap: 14px;
 }
 
 .title {
-    @include type.h4-bold;
-    line-height: 36px;
+    font-size: 32px;
+    font-weight: 400;
+    line-height: 24px;
+    letter-spacing: -0.02em;
+    text-align: left;
     margin: 0;
     color: c.$blue-900;
 }

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.test.tsx
@@ -4,41 +4,6 @@ import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/
 import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
 import { EditFundsExpendituresCategoryModal } from './EditFundsExpendituresCategoryModal';
 
-jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
-    ConfirmationModal: ({ isOpen, title, onConfirm, onCancel, onClose, isButtonsDisabled }: any) => (
-        <div data-testid="confirm-modal" data-open={String(isOpen)}>
-            <span>{title}</span>
-            <button data-testid="confirm-yes" onClick={onConfirm} disabled={isButtonsDisabled}>
-                Yes
-            </button>
-            <button data-testid="confirm-no" onClick={onCancel} disabled={isButtonsDisabled}>
-                No
-            </button>
-            <button data-testid="confirm-close" onClick={onClose} disabled={isButtonsDisabled}>
-                Close
-            </button>
-        </div>
-    ),
-}));
-
-jest.mock('@/components/common/select/Select', () => {
-    const Select = ({ value, onValueChange, placeholder, children }: any) => (
-        <>
-            <input
-                data-testid={placeholder}
-                value={value ?? ''}
-                onChange={(e) => {
-                    const parsed = parseInt(e.target.value, 10);
-                    onValueChange(isNaN(parsed) ? undefined : parsed);
-                }}
-            />
-            {children}
-        </>
-    );
-    Select.Option = ({ value, name }: any) => <option value={value}>{name}</option>;
-    return { Select };
-});
-
 jest.mock('@/components/admin/input-with-character-limit/InputWithCharacterLimit', () => ({
     InputWithCharacterLimit: ({ id, value, onChange, onBlur, placeholder }: any) => (
         <input data-testid={id} value={value} onChange={onChange} onBlur={onBlur} placeholder={placeholder} />
@@ -51,6 +16,8 @@ const SAVE_BUTTON = FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.SUBMIT_BUTTON;
 const MIN_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMin);
 const REQUIRED_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
 const DUPLICATE_ERROR = FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.ERROR.NAME_DUPLICATE;
+const YES_BUTTON = COMMON_TEXT_ADMIN.BUTTON.YES;
+const NO_BUTTON = COMMON_TEXT_ADMIN.BUTTON.NO;
 
 const incomeCategory: ReportFundsExpendituresCategory = { id: 1, name: 'Донори', type: 'income' };
 const expenseCategory: ReportFundsExpendituresCategory = { id: 2, name: 'Оренда', type: 'expense' };
@@ -74,22 +41,29 @@ const renderModal = (
 };
 
 const getSaveButton = () => screen.getByRole('button', { name: SAVE_BUTTON });
-const getOpenConfirmModal = () => screen.getAllByTestId('confirm-modal').find((el) => el.getAttribute('data-open') === 'true')!;
-const clickConfirmYes = () => fireEvent.click(within(getOpenConfirmModal()).getByTestId('confirm-yes'));
-const clickConfirmNo = () => fireEvent.click(within(getOpenConfirmModal()).getByTestId('confirm-no'));
 
-const selectCategory = (id: number) => {
-    fireEvent.change(screen.getByTestId(CATEGORY_SELECT), { target: { value: String(id) } });
+const selectCategory = (name: string) => {
+    fireEvent.click(screen.getByRole('button', { name: CATEGORY_SELECT }));
+    fireEvent.click(screen.getByRole('button', { name }));
 };
 
 const typeName = (value: string) => {
     fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value } });
 };
 
-const fillForm = (id = incomeCategory.id, name = 'Valid name') => {
-    selectCategory(id);
+const fillForm = (categoryName = incomeCategory.name, name = 'Valid name') => {
+    selectCategory(categoryName);
     typeName(name);
 };
+
+const getConfirmOverlayWithTitle = (title: string) =>
+    screen.getAllByTestId('modal-overlay').find((el) => within(el).queryByText(title))!;
+
+const clickYesInConfirm = (title: string) =>
+    fireEvent.click(within(getConfirmOverlayWithTitle(title)).getByRole('button', { name: YES_BUTTON }));
+
+const clickNoInConfirm = (title: string) =>
+    fireEvent.click(within(getConfirmOverlayWithTitle(title)).getByRole('button', { name: NO_BUTTON }));
 
 describe('EditFundsExpendituresCategoryModal', () => {
     it('renders nothing when isOpen is false', () => {
@@ -104,7 +78,7 @@ describe('EditFundsExpendituresCategoryModal', () => {
 
     it('renders category select, name input and save button', () => {
         renderModal();
-        expect(screen.getByTestId(CATEGORY_SELECT)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: CATEGORY_SELECT })).toBeInTheDocument();
         expect(screen.getByTestId(NAME_INPUT)).toBeInTheDocument();
         expect(getSaveButton()).toBeInTheDocument();
     });
@@ -117,13 +91,13 @@ describe('EditFundsExpendituresCategoryModal', () => {
 
         it('is disabled when only category is selected', () => {
             renderModal();
-            selectCategory(incomeCategory.id);
+            selectCategory(incomeCategory.name);
             expect(getSaveButton()).toBeDisabled();
         });
 
         it('is disabled when name is too short', () => {
             renderModal();
-            fillForm(incomeCategory.id, 'abc');
+            fillForm(incomeCategory.name, 'abc');
             expect(getSaveButton()).toBeDisabled();
         });
 
@@ -135,50 +109,30 @@ describe('EditFundsExpendituresCategoryModal', () => {
 
         it('is not disabled when name matches a category of a different type', () => {
             renderModal();
-            fillForm(incomeCategory.id, expenseCategory.name);
+            fillForm(incomeCategory.name, expenseCategory.name);
             expect(getSaveButton()).not.toBeDisabled();
         });
 
         it('is disabled when name duplicates another category of the same type', () => {
             const categories = [incomeCategory, expenseCategory, { id: 3, name: 'Гранти', type: 'income' as const }];
             renderModal({ categories });
-            selectCategory(incomeCategory.id);
+            selectCategory(incomeCategory.name);
             typeName('Гранти');
             expect(getSaveButton()).toBeDisabled();
-        });
-    });
-
-    describe('type label display', () => {
-        it('shows income type label when income category is selected', () => {
-            renderModal();
-            selectCategory(incomeCategory.id);
-            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME)).toBeInTheDocument();
-        });
-
-        it('shows expense type label when expense category is selected', () => {
-            renderModal();
-            selectCategory(expenseCategory.id);
-            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.EXPENSE)).toBeInTheDocument();
-        });
-
-        it('does not show type label when no category is selected', () => {
-            renderModal();
-            expect(screen.queryByText(FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME)).not.toBeInTheDocument();
-            expect(screen.queryByText(FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.EXPENSE)).not.toBeInTheDocument();
         });
     });
 
     describe('name field validation on blur', () => {
         it('shows required error when name is empty', () => {
             renderModal();
-            selectCategory(incomeCategory.id);
+            selectCategory(incomeCategory.name);
             fireEvent.blur(screen.getByTestId(NAME_INPUT));
             expect(screen.getByText(REQUIRED_ERROR)).toBeInTheDocument();
         });
 
         it('shows min length error when name is too short', () => {
             renderModal();
-            fillForm(incomeCategory.id, 'abc');
+            fillForm(incomeCategory.name, 'abc');
             fireEvent.blur(screen.getByTestId(NAME_INPUT));
             expect(screen.getByText(MIN_ERROR)).toBeInTheDocument();
         });
@@ -186,7 +140,7 @@ describe('EditFundsExpendituresCategoryModal', () => {
         it('shows duplicate error when name matches another category of the same type', () => {
             const categories = [incomeCategory, expenseCategory, { id: 3, name: 'Гранти', type: 'income' as const }];
             renderModal({ categories });
-            selectCategory(incomeCategory.id);
+            selectCategory(incomeCategory.name);
             typeName('Гранти');
             fireEvent.blur(screen.getByTestId(NAME_INPUT));
             expect(screen.getByText(DUPLICATE_ERROR)).toBeInTheDocument();
@@ -194,7 +148,7 @@ describe('EditFundsExpendituresCategoryModal', () => {
 
         it('does not show duplicate error when name matches selected category itself', () => {
             renderModal();
-            selectCategory(incomeCategory.id);
+            selectCategory(incomeCategory.name);
             typeName(incomeCategory.name);
             fireEvent.blur(screen.getByTestId(NAME_INPUT));
             expect(screen.queryByText(DUPLICATE_ERROR)).not.toBeInTheDocument();
@@ -202,7 +156,7 @@ describe('EditFundsExpendituresCategoryModal', () => {
 
         it('clears error when name becomes valid on re-blur', () => {
             renderModal();
-            selectCategory(incomeCategory.id);
+            selectCategory(incomeCategory.name);
             typeName('ab');
             fireEvent.blur(screen.getByTestId(NAME_INPUT));
             expect(screen.getByText(MIN_ERROR)).toBeInTheDocument();
@@ -218,13 +172,6 @@ describe('EditFundsExpendituresCategoryModal', () => {
             renderModal();
             fillForm();
             fireEvent.click(getSaveButton());
-            expect(getOpenConfirmModal()).toBeInTheDocument();
-        });
-
-        it('shows correct title in save confirmation', () => {
-            renderModal();
-            fillForm();
-            fireEvent.click(getSaveButton());
             expect(
                 screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE),
             ).toBeInTheDocument();
@@ -234,10 +181,10 @@ describe('EditFundsExpendituresCategoryModal', () => {
             renderModal();
             fillForm();
             fireEvent.click(getSaveButton());
-            clickConfirmNo();
-            expect(screen.getAllByTestId('confirm-modal').every((el) => el.getAttribute('data-open') === 'false')).toBe(
-                true,
-            );
+            clickNoInConfirm(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE);
+            expect(
+                screen.queryByText(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE),
+            ).not.toBeInTheDocument();
         });
     });
 
@@ -245,9 +192,9 @@ describe('EditFundsExpendituresCategoryModal', () => {
         it('calls onSubmit with categoryId and normalized name on confirm', async () => {
             const onSubmit = jest.fn().mockResolvedValue(true);
             renderModal({ onSubmit });
-            fillForm(incomeCategory.id, '  Valid name  ');
+            fillForm(incomeCategory.name, '  Valid name  ');
             fireEvent.click(getSaveButton());
-            clickConfirmYes();
+            clickYesInConfirm(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE);
             await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(incomeCategory.id, 'Valid name'));
         });
 
@@ -257,7 +204,7 @@ describe('EditFundsExpendituresCategoryModal', () => {
             renderModal({ onClose, onSubmit });
             fillForm();
             fireEvent.click(getSaveButton());
-            clickConfirmYes();
+            clickYesInConfirm(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE);
             await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
             expect(screen.getByTestId(NAME_INPUT)).toHaveValue('');
             expect(getSaveButton()).toBeDisabled();
@@ -269,24 +216,29 @@ describe('EditFundsExpendituresCategoryModal', () => {
             renderModal({ onClose, onSubmit });
             fillForm();
             fireEvent.click(getSaveButton());
-            clickConfirmYes();
-            await waitFor(() =>
-                expect(screen.getAllByTestId('confirm-modal').every((el) => el.getAttribute('data-open') === 'false')).toBe(true),
-            );
+            clickYesInConfirm(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE);
+            await waitFor(() => expect(screen.queryByRole('button', { name: YES_BUTTON })).not.toBeInTheDocument());
             expect(onClose).not.toHaveBeenCalled();
-            expect(screen.getByTestId('modal-overlay')).toBeInTheDocument();
         });
 
         it('disables confirm buttons while submitting', async () => {
             let resolve!: (v: boolean) => void;
-            const onSubmit = jest.fn().mockReturnValue(new Promise<boolean>((r) => { resolve = r; }));
+            const onSubmit = jest.fn().mockReturnValue(
+                new Promise<boolean>((r) => {
+                    resolve = r;
+                }),
+            );
             renderModal({ onSubmit });
             fillForm();
             fireEvent.click(getSaveButton());
-            const yesBtn = within(getOpenConfirmModal()).getByTestId('confirm-yes');
+            const yesBtn = within(
+                getConfirmOverlayWithTitle(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE),
+            ).getByRole('button', { name: YES_BUTTON });
             fireEvent.click(yesBtn);
             expect(yesBtn).toBeDisabled();
-            await act(async () => { resolve(true); });
+            await act(async () => {
+                resolve(true);
+            });
         });
     });
 
@@ -304,13 +256,6 @@ describe('EditFundsExpendituresCategoryModal', () => {
             typeName('dirty');
             fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
             expect(onClose).not.toHaveBeenCalled();
-            expect(getOpenConfirmModal()).toBeInTheDocument();
-        });
-
-        it('shows correct title in close confirmation', () => {
-            renderModal();
-            typeName('dirty');
-            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
             expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.CONFIRM_CLOSE_TITLE)).toBeInTheDocument();
         });
 
@@ -319,7 +264,7 @@ describe('EditFundsExpendituresCategoryModal', () => {
             renderModal({ onClose });
             fillForm();
             fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
-            clickConfirmYes();
+            clickYesInConfirm(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.CONFIRM_CLOSE_TITLE);
             expect(onClose).toHaveBeenCalledTimes(1);
             expect(screen.getByTestId(NAME_INPUT)).toHaveValue('');
         });
@@ -329,7 +274,7 @@ describe('EditFundsExpendituresCategoryModal', () => {
             renderModal({ onClose });
             typeName('dirty');
             fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
-            clickConfirmNo();
+            clickNoInConfirm(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.CONFIRM_CLOSE_TITLE);
             expect(onClose).not.toHaveBeenCalled();
             expect(screen.getByTestId('modal-overlay')).toBeInTheDocument();
         });

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.test.tsx
@@ -1,0 +1,344 @@
+import { render, screen, fireEvent, within, waitFor, act } from '@testing-library/react';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
+import { EditFundsExpendituresCategoryModal } from './EditFundsExpendituresCategoryModal';
+
+jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
+    ConfirmationModal: ({ isOpen, title, onConfirm, onCancel, onClose, isButtonsDisabled }: any) => (
+        <div data-testid="confirm-modal" data-open={String(isOpen)}>
+            <span>{title}</span>
+            <button data-testid="confirm-yes" onClick={onConfirm} disabled={isButtonsDisabled}>
+                Yes
+            </button>
+            <button data-testid="confirm-no" onClick={onCancel} disabled={isButtonsDisabled}>
+                No
+            </button>
+            <button data-testid="confirm-close" onClick={onClose} disabled={isButtonsDisabled}>
+                Close
+            </button>
+        </div>
+    ),
+}));
+
+jest.mock('@/components/common/select/Select', () => {
+    const Select = ({ value, onValueChange, placeholder, children }: any) => (
+        <>
+            <input
+                data-testid={placeholder}
+                value={value ?? ''}
+                onChange={(e) => {
+                    const parsed = parseInt(e.target.value, 10);
+                    onValueChange(isNaN(parsed) ? undefined : parsed);
+                }}
+            />
+            {children}
+        </>
+    );
+    Select.Option = ({ value, name }: any) => <option value={value}>{name}</option>;
+    return { Select };
+});
+
+jest.mock('@/components/admin/input-with-character-limit/InputWithCharacterLimit', () => ({
+    InputWithCharacterLimit: ({ id, value, onChange, onBlur, placeholder }: any) => (
+        <input data-testid={id} value={value} onChange={onChange} onBlur={onBlur} placeholder={placeholder} />
+    ),
+}));
+
+const CATEGORY_SELECT = FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CATEGORY_PLACEHOLDER;
+const NAME_INPUT = 'edit-category-name';
+const SAVE_BUTTON = FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.SUBMIT_BUTTON;
+const MIN_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMin);
+const REQUIRED_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
+const DUPLICATE_ERROR = FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.ERROR.NAME_DUPLICATE;
+
+const incomeCategory: ReportFundsExpendituresCategory = { id: 1, name: 'Донори', type: 'income' };
+const expenseCategory: ReportFundsExpendituresCategory = { id: 2, name: 'Оренда', type: 'expense' };
+
+const renderModal = (
+    overrides: Partial<{
+        isOpen: boolean;
+        onClose: jest.Mock;
+        categories: ReportFundsExpendituresCategory[];
+        onSubmit: jest.Mock;
+    }> = {},
+) => {
+    const props = {
+        isOpen: true,
+        onClose: jest.fn(),
+        categories: [incomeCategory, expenseCategory],
+        onSubmit: jest.fn().mockResolvedValue(true),
+        ...overrides,
+    };
+    return { ...render(<EditFundsExpendituresCategoryModal {...props} />), ...props };
+};
+
+const getSaveButton = () => screen.getByRole('button', { name: SAVE_BUTTON });
+const getOpenConfirmModal = () => screen.getAllByTestId('confirm-modal').find((el) => el.getAttribute('data-open') === 'true')!;
+const clickConfirmYes = () => fireEvent.click(within(getOpenConfirmModal()).getByTestId('confirm-yes'));
+const clickConfirmNo = () => fireEvent.click(within(getOpenConfirmModal()).getByTestId('confirm-no'));
+
+const selectCategory = (id: number) => {
+    fireEvent.change(screen.getByTestId(CATEGORY_SELECT), { target: { value: String(id) } });
+};
+
+const typeName = (value: string) => {
+    fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value } });
+};
+
+const fillForm = (id = incomeCategory.id, name = 'Valid name') => {
+    selectCategory(id);
+    typeName(name);
+};
+
+describe('EditFundsExpendituresCategoryModal', () => {
+    it('renders nothing when isOpen is false', () => {
+        renderModal({ isOpen: false });
+        expect(screen.queryByTestId('modal-overlay')).not.toBeInTheDocument();
+    });
+
+    it('renders modal title when open', () => {
+        renderModal();
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.TITLE)).toBeInTheDocument();
+    });
+
+    it('renders category select, name input and save button', () => {
+        renderModal();
+        expect(screen.getByTestId(CATEGORY_SELECT)).toBeInTheDocument();
+        expect(screen.getByTestId(NAME_INPUT)).toBeInTheDocument();
+        expect(getSaveButton()).toBeInTheDocument();
+    });
+
+    describe('save button disabled state', () => {
+        it('is disabled by default', () => {
+            renderModal();
+            expect(getSaveButton()).toBeDisabled();
+        });
+
+        it('is disabled when only category is selected', () => {
+            renderModal();
+            selectCategory(incomeCategory.id);
+            expect(getSaveButton()).toBeDisabled();
+        });
+
+        it('is disabled when name is too short', () => {
+            renderModal();
+            fillForm(incomeCategory.id, 'abc');
+            expect(getSaveButton()).toBeDisabled();
+        });
+
+        it('is enabled when category is selected and name is valid', () => {
+            renderModal();
+            fillForm();
+            expect(getSaveButton()).not.toBeDisabled();
+        });
+
+        it('is not disabled when name matches a category of a different type', () => {
+            renderModal();
+            fillForm(incomeCategory.id, expenseCategory.name);
+            expect(getSaveButton()).not.toBeDisabled();
+        });
+
+        it('is disabled when name duplicates another category of the same type', () => {
+            const categories = [incomeCategory, expenseCategory, { id: 3, name: 'Гранти', type: 'income' as const }];
+            renderModal({ categories });
+            selectCategory(incomeCategory.id);
+            typeName('Гранти');
+            expect(getSaveButton()).toBeDisabled();
+        });
+    });
+
+    describe('type label display', () => {
+        it('shows income type label when income category is selected', () => {
+            renderModal();
+            selectCategory(incomeCategory.id);
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME)).toBeInTheDocument();
+        });
+
+        it('shows expense type label when expense category is selected', () => {
+            renderModal();
+            selectCategory(expenseCategory.id);
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.EXPENSE)).toBeInTheDocument();
+        });
+
+        it('does not show type label when no category is selected', () => {
+            renderModal();
+            expect(screen.queryByText(FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME)).not.toBeInTheDocument();
+            expect(screen.queryByText(FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.EXPENSE)).not.toBeInTheDocument();
+        });
+    });
+
+    describe('name field validation on blur', () => {
+        it('shows required error when name is empty', () => {
+            renderModal();
+            selectCategory(incomeCategory.id);
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(REQUIRED_ERROR)).toBeInTheDocument();
+        });
+
+        it('shows min length error when name is too short', () => {
+            renderModal();
+            fillForm(incomeCategory.id, 'abc');
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(MIN_ERROR)).toBeInTheDocument();
+        });
+
+        it('shows duplicate error when name matches another category of the same type', () => {
+            const categories = [incomeCategory, expenseCategory, { id: 3, name: 'Гранти', type: 'income' as const }];
+            renderModal({ categories });
+            selectCategory(incomeCategory.id);
+            typeName('Гранти');
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(DUPLICATE_ERROR)).toBeInTheDocument();
+        });
+
+        it('does not show duplicate error when name matches selected category itself', () => {
+            renderModal();
+            selectCategory(incomeCategory.id);
+            typeName(incomeCategory.name);
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.queryByText(DUPLICATE_ERROR)).not.toBeInTheDocument();
+        });
+
+        it('clears error when name becomes valid on re-blur', () => {
+            renderModal();
+            selectCategory(incomeCategory.id);
+            typeName('ab');
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(MIN_ERROR)).toBeInTheDocument();
+
+            typeName('Valid name');
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.queryByText(MIN_ERROR)).not.toBeInTheDocument();
+        });
+    });
+
+    describe('confirmation save modal', () => {
+        it('opens save confirmation when save button is clicked', () => {
+            renderModal();
+            fillForm();
+            fireEvent.click(getSaveButton());
+            expect(getOpenConfirmModal()).toBeInTheDocument();
+        });
+
+        it('shows correct title in save confirmation', () => {
+            renderModal();
+            fillForm();
+            fireEvent.click(getSaveButton());
+            expect(
+                screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE),
+            ).toBeInTheDocument();
+        });
+
+        it('closes save confirmation on cancel', () => {
+            renderModal();
+            fillForm();
+            fireEvent.click(getSaveButton());
+            clickConfirmNo();
+            expect(screen.getAllByTestId('confirm-modal').every((el) => el.getAttribute('data-open') === 'false')).toBe(
+                true,
+            );
+        });
+    });
+
+    describe('submit behaviour', () => {
+        it('calls onSubmit with categoryId and normalized name on confirm', async () => {
+            const onSubmit = jest.fn().mockResolvedValue(true);
+            renderModal({ onSubmit });
+            fillForm(incomeCategory.id, '  Valid name  ');
+            fireEvent.click(getSaveButton());
+            clickConfirmYes();
+            await waitFor(() => expect(onSubmit).toHaveBeenCalledWith(incomeCategory.id, 'Valid name'));
+        });
+
+        it('resets form and calls onClose when onSubmit resolves true', async () => {
+            const onClose = jest.fn();
+            const onSubmit = jest.fn().mockResolvedValue(true);
+            renderModal({ onClose, onSubmit });
+            fillForm();
+            fireEvent.click(getSaveButton());
+            clickConfirmYes();
+            await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+            expect(screen.getByTestId(NAME_INPUT)).toHaveValue('');
+            expect(getSaveButton()).toBeDisabled();
+        });
+
+        it('keeps modal open and closes confirm when onSubmit resolves false', async () => {
+            const onClose = jest.fn();
+            const onSubmit = jest.fn().mockResolvedValue(false);
+            renderModal({ onClose, onSubmit });
+            fillForm();
+            fireEvent.click(getSaveButton());
+            clickConfirmYes();
+            await waitFor(() =>
+                expect(screen.getAllByTestId('confirm-modal').every((el) => el.getAttribute('data-open') === 'false')).toBe(true),
+            );
+            expect(onClose).not.toHaveBeenCalled();
+            expect(screen.getByTestId('modal-overlay')).toBeInTheDocument();
+        });
+
+        it('disables confirm buttons while submitting', async () => {
+            let resolve!: (v: boolean) => void;
+            const onSubmit = jest.fn().mockReturnValue(new Promise<boolean>((r) => { resolve = r; }));
+            renderModal({ onSubmit });
+            fillForm();
+            fireEvent.click(getSaveButton());
+            const yesBtn = within(getOpenConfirmModal()).getByTestId('confirm-yes');
+            fireEvent.click(yesBtn);
+            expect(yesBtn).toBeDisabled();
+            await act(async () => { resolve(true); });
+        });
+    });
+
+    describe('close behaviour', () => {
+        it('closes directly when form is clean', () => {
+            const onClose = jest.fn();
+            renderModal({ onClose });
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+            expect(onClose).toHaveBeenCalledTimes(1);
+        });
+
+        it('opens close confirmation when name is dirty', () => {
+            const onClose = jest.fn();
+            renderModal({ onClose });
+            typeName('dirty');
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+            expect(onClose).not.toHaveBeenCalled();
+            expect(getOpenConfirmModal()).toBeInTheDocument();
+        });
+
+        it('shows correct title in close confirmation', () => {
+            renderModal();
+            typeName('dirty');
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.CONFIRM_CLOSE_TITLE)).toBeInTheDocument();
+        });
+
+        it('calls onClose and resets form on confirm close', () => {
+            const onClose = jest.fn();
+            renderModal({ onClose });
+            fillForm();
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+            clickConfirmYes();
+            expect(onClose).toHaveBeenCalledTimes(1);
+            expect(screen.getByTestId(NAME_INPUT)).toHaveValue('');
+        });
+
+        it('keeps modal open on cancel close', () => {
+            const onClose = jest.fn();
+            renderModal({ onClose });
+            typeName('dirty');
+            fireEvent.click(screen.getByRole('button', { name: 'Close modal' }));
+            clickConfirmNo();
+            expect(onClose).not.toHaveBeenCalled();
+            expect(screen.getByTestId('modal-overlay')).toBeInTheDocument();
+        });
+    });
+
+    it('normalizes whitespace in name on blur', () => {
+        renderModal();
+        typeName('  foo   bar  ');
+        fireEvent.blur(screen.getByTestId(NAME_INPUT));
+        expect(screen.getByTestId(NAME_INPUT)).toHaveValue('foo bar');
+    });
+});

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.tsx
@@ -1,0 +1,224 @@
+import { useCallback, useMemo, useState } from 'react';
+import cn from 'classnames';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { InputWithCharacterLimit } from '@/components/admin/input-with-character-limit/InputWithCharacterLimit';
+import { Select } from '@/components/common/select/Select';
+import { Modal } from '@/components/common/modal/Modal';
+import { Button } from '@/components/admin/button/Button';
+import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
+import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
+import { getNormalizedInputText } from '@/utils/functions/formatters/text-formatters';
+import { validateFundsExpendituresCategoryName } from '@/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema';
+import styles from './EditFundsExpendituresCategoryModal.module.scss';
+
+interface EditFundsExpendituresCategoryModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    categories: ReportFundsExpendituresCategory[];
+    onSubmit: (categoryId: number, name: string) => Promise<boolean>;
+}
+
+export const EditFundsExpendituresCategoryModal = ({
+    isOpen,
+    onClose,
+    categories,
+    onSubmit,
+}: EditFundsExpendituresCategoryModalProps) => {
+    const [selectedCategoryId, setSelectedCategoryId] = useState<number | undefined>(undefined);
+    const [name, setName] = useState('');
+    const [nameError, setNameError] = useState<string | undefined>(undefined);
+    const [hasNameBeenBlurred, setHasNameBeenBlurred] = useState(false);
+    const [isConfirmSaveOpen, setIsConfirmSaveOpen] = useState(false);
+    const [isCloseConfirmOpen, setIsCloseConfirmOpen] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const selectedCategory = categories.find((c) => c.id === selectedCategoryId);
+
+    const otherCategories = useMemo(
+        () => categories.filter((c) => c.id !== selectedCategoryId),
+        [categories, selectedCategoryId],
+    );
+
+    const isDirty = name.trim().length > 0;
+
+    const isSubmitDisabled = useMemo(
+        () =>
+            !selectedCategoryId ||
+            validateFundsExpendituresCategoryName(name, selectedCategory?.type, otherCategories) !== undefined,
+        [selectedCategoryId, name, selectedCategory?.type, otherCategories],
+    );
+
+    const resetForm = useCallback(() => {
+        setSelectedCategoryId(undefined);
+        setName('');
+        setNameError(undefined);
+        setHasNameBeenBlurred(false);
+        setIsConfirmSaveOpen(false);
+        setIsCloseConfirmOpen(false);
+        setIsSubmitting(false);
+    }, []);
+
+    const handleCategoryChange = useCallback(
+        (id: number) => {
+            setSelectedCategoryId(id);
+            if (hasNameBeenBlurred) {
+                const newSelected = categories.find((c) => c.id === id);
+                const others = categories.filter((c) => c.id !== id);
+                setNameError(validateFundsExpendituresCategoryName(name, newSelected?.type, others));
+            }
+        },
+        [hasNameBeenBlurred, name, categories],
+    );
+
+    const handleNameBlur = useCallback(() => {
+        setHasNameBeenBlurred(true);
+        setName(getNormalizedInputText(name));
+        setNameError(validateFundsExpendituresCategoryName(name, selectedCategory?.type, otherCategories));
+    }, [name, selectedCategory?.type, otherCategories]);
+
+    const handleSaveClick = useCallback(() => {
+        setIsConfirmSaveOpen(true);
+    }, []);
+
+    const handleConfirmSave = useCallback(async () => {
+        if (!selectedCategoryId) return;
+        setIsSubmitting(true);
+        const success = await onSubmit(selectedCategoryId, getNormalizedInputText(name));
+        if (success) {
+            resetForm();
+            onClose();
+        } else {
+            setIsSubmitting(false);
+            setIsConfirmSaveOpen(false);
+        }
+    }, [selectedCategoryId, name, onSubmit, resetForm, onClose]);
+
+    const handleCancelSave = useCallback(() => {
+        setIsConfirmSaveOpen(false);
+    }, []);
+
+    const handleRequestClose = useCallback(() => {
+        if (isDirty) {
+            setIsCloseConfirmOpen(true);
+            return;
+        }
+        resetForm();
+        onClose();
+    }, [isDirty, resetForm, onClose]);
+
+    const handleConfirmClose = useCallback(() => {
+        setIsCloseConfirmOpen(false);
+        resetForm();
+        onClose();
+    }, [resetForm, onClose]);
+
+    const handleCancelClose = useCallback(() => {
+        setIsCloseConfirmOpen(false);
+    }, []);
+
+    return (
+        <>
+            <Modal isOpen={isOpen} onClose={handleRequestClose} className={styles.modal} maxWidth="650px">
+                <Modal.Title>
+                    <div className={styles.header}>
+                        <h2 className={styles.title}>{FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.TITLE}</h2>
+                        <p className={styles.subtitle}>{FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.SUBTITLE}</p>
+                    </div>
+                </Modal.Title>
+
+                <Modal.Content>
+                    <div className={styles.content}>
+                        <div className={styles.panel}>
+                            <div className={styles.form}>
+                                <div className={styles.field}>
+                                    <div className={styles.labelRow}>
+                                        <label className={styles.label}>
+                                            <span className={styles.required}>*</span>
+                                            {FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CATEGORY_LABEL}
+                                        </label>
+                                        {selectedCategory && (
+                                            <span className={styles.type}>
+                                                {selectedCategory.type === 'income'
+                                                    ? FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.INCOME
+                                                    : FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.EXPENSE}
+                                            </span>
+                                        )}
+                                    </div>
+                                    <Select<number | undefined>
+                                        value={selectedCategoryId}
+                                        onValueChange={(val) => handleCategoryChange(val as number)}
+                                        placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CATEGORY_PLACEHOLDER}
+                                        className={styles.selectContainer}
+                                        headClassName={styles.selectHead}
+                                    >
+                                        {categories.map((c) => (
+                                            <Select.Option key={c.id} value={c.id} name={c.name} />
+                                        ))}
+                                    </Select>
+                                </div>
+
+                                <div className={styles.field}>
+                                    <label className={styles.label}>
+                                        <span className={styles.required}>*</span>
+                                        {FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.NAME_LABEL}
+                                    </label>
+                                    <div className={cn({ [styles.inputError]: Boolean(nameError) })}>
+                                        <InputWithCharacterLimit
+                                            id="edit-category-name"
+                                            name="editCategoryName"
+                                            value={name}
+                                            onChange={(e) => setName(e.target.value)}
+                                            onBlur={handleNameBlur}
+                                            maxLength={FUNDS_EXPENDITURES_VALIDATION.categoryNameMax}
+                                            maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
+                                                FUNDS_EXPENDITURES_VALIDATION.categoryNameMax,
+                                            )}
+                                            placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.NAME_PLACEHOLDER}
+                                            showCounter={true}
+                                            hasError={Boolean(nameError)}
+                                            className={styles.input}
+                                        />
+                                    </div>
+                                    <p className={cn(styles.error, { [styles.errorHidden]: !nameError })}>
+                                        {nameError ?? ' '}
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </Modal.Content>
+
+                <Modal.Actions>
+                    <div className={styles.actions}>
+                        <Button
+                            buttonStyle="primary"
+                            onClick={handleSaveClick}
+                            disabled={isSubmitDisabled || isSubmitting}
+                            className={styles.submit}
+                        >
+                            {FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.SUBMIT_BUTTON}
+                        </Button>
+                    </div>
+                </Modal.Actions>
+            </Modal>
+
+            <ConfirmationModal
+                isOpen={isConfirmSaveOpen}
+                title={FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.CONFIRM_SAVE_TITLE}
+                onConfirm={handleConfirmSave}
+                onCancel={handleCancelSave}
+                onClose={handleCancelSave}
+                isButtonsDisabled={isSubmitting}
+            />
+
+            <ConfirmationModal
+                isOpen={isCloseConfirmOpen}
+                title={FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.CONFIRM_CLOSE_TITLE}
+                onConfirm={handleConfirmClose}
+                onCancel={handleCancelClose}
+                onClose={handleCancelClose}
+            />
+        </>
+    );
+};

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.tsx
@@ -57,8 +57,9 @@ export const EditFundsExpendituresCategoryModal = ({
     const isSubmitDisabled = useMemo(
         () =>
             !selectedCategoryId ||
+            name.trim() === selectedCategory?.name.trim() ||
             validateFundsExpendituresCategoryName(name, selectedCategory?.type, otherCategories) !== undefined,
-        [selectedCategoryId, name, selectedCategory?.type, otherCategories],
+        [selectedCategoryId, name, selectedCategory?.name, selectedCategory?.type, otherCategories],
     );
 
     const resetForm = useCallback(() => {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.tsx
@@ -12,6 +12,18 @@ import { getNormalizedInputText } from '@/utils/functions/formatters/text-format
 import { validateFundsExpendituresCategoryName } from '@/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema';
 import styles from './EditFundsExpendituresCategoryModal.module.scss';
 
+const renderInputWithError = (
+    input: React.ReactNode,
+    error?: string,
+    inputErrorClass?: string,
+    errorClass?: string,
+) => (
+    <>
+        <div className={cn({ [inputErrorClass || '']: Boolean(error) })}>{input}</div>
+        <p className={cn(errorClass, { [styles.errorHidden]: !error })}>{error ?? ' '}</p>
+    </>
+);
+
 interface EditFundsExpendituresCategoryModalProps {
     isOpen: boolean;
     onClose: () => void;
@@ -163,7 +175,7 @@ export const EditFundsExpendituresCategoryModal = ({
                                         <span className={styles.required}>*</span>
                                         {FUNDS_EXPENDITURES_TEXT.MODAL.EDIT_CATEGORY.NAME_LABEL}
                                     </label>
-                                    <div className={cn({ [styles.inputError]: Boolean(nameError) })}>
+                                    {renderInputWithError(
                                         <InputWithCharacterLimit
                                             id="edit-category-name"
                                             name="editCategoryName"
@@ -178,11 +190,11 @@ export const EditFundsExpendituresCategoryModal = ({
                                             showCounter={true}
                                             hasError={Boolean(nameError)}
                                             className={styles.input}
-                                        />
-                                    </div>
-                                    <p className={cn(styles.error, { [styles.errorHidden]: !nameError })}>
-                                        {nameError ?? ' '}
-                                    </p>
+                                        />,
+                                        nameError,
+                                        styles.inputError,
+                                        styles.error,
+                                    )}
                                 </div>
                             </div>
                         </div>

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
@@ -24,10 +24,12 @@ export const ReportAnalytics = () => {
     const [fundsExchangeRateDraft, setFundsExchangeRateDraft] = useState<string | null>();
     const [isAddCategoryModalOpen, setIsAddCategoryModalOpen] = useState(false);
     const [isDeleteCategoryModalOpen, setIsDeleteCategoryModalOpen] = useState(false);
+    const [isEditCategoryModalOpen, setIsEditCategoryModalOpen] = useState(false);
 
     const categoryContextMenuOptions: ContextMenuOption[] = useMemo(
         () => [
             { id: 'add-category', name: FUNDS_EXPENDITURES_TEXT.BUTTON.ADD_CATEGORY },
+            { id: 'edit-category', name: FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT_CATEGORY },
             { id: 'delete-category', name: FUNDS_EXPENDITURES_TEXT.BUTTON.DELETE_CATEGORY },
         ],
         [],
@@ -36,6 +38,8 @@ export const ReportAnalytics = () => {
     const handleCategoryContextMenuOption = useCallback((id: string) => {
         if (id === 'add-category') {
             setIsAddCategoryModalOpen(true);
+        } else if (id === 'edit-category') {
+            setIsEditCategoryModalOpen(true);
         } else if (id === 'delete-category') {
             setIsDeleteCategoryModalOpen(true);
         }
@@ -65,6 +69,8 @@ export const ReportAnalytics = () => {
                         onExchangeRateValueChange={setFundsExchangeRateDraft}
                         isAddCategoryModalOpen={isAddCategoryModalOpen}
                         onAddCategoryModalClose={() => setIsAddCategoryModalOpen(false)}
+                        isEditCategoryModalOpen={isEditCategoryModalOpen}
+                        onEditCategoryModalClose={() => setIsEditCategoryModalOpen(false)}
                         isDeleteCategoryModalOpen={isDeleteCategoryModalOpen}
                         onDeleteCategoryModalClose={() => setIsDeleteCategoryModalOpen(false)}
                     />

--- a/src/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema.test.ts
@@ -8,6 +8,7 @@ import {
 
 const REQUIRED = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
 const MIN_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMin);
+const MAX_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMax);
 const DUPLICATE_ERROR = FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.ERROR.NAME_DUPLICATE;
 
 const category = (name: string, type: 'income' | 'expense'): ReportFundsExpendituresCategory => ({
@@ -27,6 +28,11 @@ describe('validateFundsExpendituresCategoryName', () => {
 
     it('returns min length error when name is shorter than minimum', () => {
         expect(validateFundsExpendituresCategoryName('abc', undefined, [])).toBe(MIN_ERROR);
+    });
+
+    it('returns max length error when name exceeds maximum', () => {
+        const longName = 'а'.repeat(FUNDS_EXPENDITURES_VALIDATION.categoryNameMax + 1);
+        expect(validateFundsExpendituresCategoryName(longName, undefined, [])).toBe(MAX_ERROR);
     });
 
     it('returns duplicate error when name matches existing category for same type', () => {

--- a/src/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema.ts
@@ -19,6 +19,8 @@ export const validateFundsExpendituresCategoryName = (
     if (!normalized) return COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
     if (normalized.length < FUNDS_EXPENDITURES_VALIDATION.categoryNameMin)
         return COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMin);
+    if (normalized.length > FUNDS_EXPENDITURES_VALIDATION.categoryNameMax)
+        return COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMax);
     if (type && isNameDuplicate(normalized, type, categories))
         return FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.ERROR.NAME_DUPLICATE;
     return undefined;


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1443
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1444

## Description

This PR adds the ability to rename existing categories in the system.

## How it looks


https://github.com/user-attachments/assets/7bdba5c1-deb6-4207-82f4-8f3dba447496


## Summary of change

Added modal "Редагувати категорію" with category selection and name input

## How to recreate changes

1. Open "Звітність" -> "Звіт та аналітика"-> "Доходи та витрати"
2. Click the options (burger) icon for a category
3. Select "Редагувати"
4. Choose a category (except "Програмні")
5. Enter a new name (observe validation and character counter)
6. Click "Зберегти"
7. Confirm the action in the popup
8. Verify that:
- The category name is updated everywhere in the system
- Changes appear in dropdowns, filters, and records

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [x]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit fund expenditure categories: select a category, rename with validation/normalization, save confirmation, and unsaved-changes protection.

* **UI / Copy**
  * Added modal labels/placeholders, success/retry/failure messages, pluralized record warnings, and an "Edit" button label.

* **Styles**
  * Improved layout and visual styling for category modals, hint text, and action buttons.

* **Tests**
  * Added and updated tests covering edit modal behavior, validation, confirm flows, and delete interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->