### PR TITLE
feature/issue-2269: [Reporst] Add error handling for failed bulk deletion

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -243,6 +243,7 @@ export const FUNDS_EXPENDITURES_TEXT = {
         DELETE_BUTTON: 'Видалити вибрані',
         DELETE_CONFIRM_TITLE: 'Видалити обрані записи?',
         DELETE_SUCCESS: 'Записи видалені успішно',
+        DELETE_FAILED: 'Помилка при видаленні записів. Спробуйте ще раз.',
     },
 };
 

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -369,7 +369,8 @@ export const FundsExpenditureSection = ({
             refetchSummary();
             addToast(FUNDS_EXPENDITURES_TEXT.BULK.DELETE_SUCCESS, ToastType.Success);
         } catch {
-            addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.RECORD_DELETE_FAILED_RETRY, ToastType.Error);
+            setIsBulkDeleteModalOpen(false);
+            addToast(FUNDS_EXPENDITURES_TEXT.BULK.DELETE_FAILED, ToastType.Error, 5000);
         } finally {
             setIsBulkDeleting(false);
         }


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2269

## Description

This PR adds user notification for unsuccessful bulk deletion in the "Доходи та витрати" tab.

## How it looks


https://github.com/user-attachments/assets/25217c8b-6c23-4ddf-b496-515343afb293


## Summary of change

- Implemented error handling for failed bulk deletion
- Ensured atomic behavior (no partial deletion)
- Preserved checkbox selection state after failure
- Added snackbar message:
 "Помилка при видаленні записів. Спробуйте ще раз." (auto-dismiss after 5 seconds)
- Prevented recalculation of totals on failure

## How to recreate changes

1. Open "Доходи та витрати" tab
2. Select multiple records using checkboxes
3. Trigger bulk deletion
4. Simulate or cause a failed request

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and messaging when bulk deletion of records encounters failures, providing users with clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->