### PR TITLE
[Fix/issue-2386] Fixed a bug with saving order changes.

### DIFF
--- a/src/pages/admin/programs/components/program-form/ProgramForm.tsx
+++ b/src/pages/admin/programs/components/program-form/ProgramForm.tsx
@@ -341,7 +341,7 @@ export const ProgramForm = forwardRef<ProgramFormRef, ProgramFormProps>(
                 setFormState((prev) => {
                     const updatedSections = [...prev.sections];
                     [updatedSections[idx - 1], updatedSections[idx]] = [updatedSections[idx], updatedSections[idx - 1]];
-                    return { ...prev, sections: updatedSections };
+                    return { ...prev, sections: updatedSections.map((s, i) => ({ ...s, order: i })) };
                 });
 
                 setSectionStates((prev) => {
@@ -368,7 +368,7 @@ export const ProgramForm = forwardRef<ProgramFormRef, ProgramFormProps>(
                 setFormState((prev) => {
                     const updatedSections = [...prev.sections];
                     [updatedSections[idx + 1], updatedSections[idx]] = [updatedSections[idx], updatedSections[idx + 1]];
-                    return { ...prev, sections: updatedSections };
+                    return { ...prev, sections: updatedSections.map((s, i) => ({ ...s, order: i })) };
                 });
 
                 setSectionStates((prev) => {


### PR DESCRIPTION
## JIRA or Github ticker

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2386)

## Description

Fix section reorder not being saved in program profile edit modal.

## Summary of change

In handleMoveUpSection and handleMoveDownSection added 
remapping of .order field to match new array index after swap

## How to recreate changes

1. Open any program profile in admin panel
2. Move any section up or down using order control buttons
3. Click "Опублікувати" or "Зберегти як чернетку"
4. Reopen the program — section order is now saved correctly

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed section reordering to properly maintain order indices when moving sections up or down in the program form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->