### PR TITLE
Fix/issue-2474: [Single Program][UI] Auto-focus on new block does not ensure full visibility in viewport

### DIFF
--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.test.tsx
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.test.tsx
@@ -1,15 +1,15 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { render, screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import { ProgramSectionForm } from './ProgramSectionForm';
-import type { ProgramSectionFormProps } from './ProgramSectionForm';
-import type { CreateHippotherapyProgramSectionDto } from '@/types/common/program-sections';
-import { SectionTemplate, SectionMode } from '@/types/common/sections';
-import { ContentType } from '@/types/common/section-contents';
-import { SECTIONS_TEXT } from '@/const/admin/sections';
-import { renderProgramSection } from '@/utils/functions/render-program-section';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { SECTIONS_TEXT } from '@/const/admin/sections';
+import type { CreateHippotherapyProgramSectionDto } from '@/types/common/program-sections';
+import { ContentType } from '@/types/common/section-contents';
+import { SectionMode, SectionTemplate } from '@/types/common/sections';
+import { renderProgramSection } from '@/utils/functions/render-program-section';
+import type { ProgramSectionFormProps } from './ProgramSectionForm';
+import { ProgramSectionForm } from './ProgramSectionForm';
 
 jest.mock('@/utils/functions/render-program-section', () => ({
     renderProgramSection: jest.fn(() => <div data-testid="editable-section" />),
@@ -131,10 +131,13 @@ const getContentByGroupAndType = (s: CreateHippotherapyProgramSectionDto, groupI
 const createFocusableTextarea = (id: string) => {
     const el = document.createElement('textarea');
     el.id = id;
-    const focusMock = jest.fn();
-    (el as any).focus = focusMock;
+    const focusMock = jest.fn<void, [FocusOptions?]>();
+    el.focus = focusMock as unknown as typeof el.focus;
+
+    const scrollIntoViewMock = jest.fn<void, [ScrollIntoViewOptions?]>();
+    el.scrollIntoView = scrollIntoViewMock as unknown as typeof el.scrollIntoView;
     document.body.appendChild(el);
-    return { el, focusMock };
+    return { el, focusMock, scrollIntoViewMock };
 };
 
 describe('ProgramSectionForm', () => {
@@ -250,7 +253,11 @@ describe('ProgramSectionForm', () => {
         });
 
         const onCancel = jest.fn();
-        const { handlers } = renderWithHandlers({ section, isNewSection: false, onCancel });
+        const { handlers } = renderWithHandlers({
+            section,
+            isNewSection: false,
+            onCancel,
+        });
 
         const editButton = screen.getByLabelText('Edit section');
         fireEvent.click(editButton);
@@ -642,7 +649,7 @@ describe('ProgramSectionForm', () => {
 
             const maxOrder = Math.max(...section.contents.map((c: any) => c.order));
             const nextIndex = 2;
-            const { focusMock } = createFocusableTextarea(`pair-description-${nextIndex}`);
+            const { focusMock, scrollIntoViewMock } = createFocusableTextarea(`pair-description-${nextIndex}`);
 
             act(() => {
                 handlers.onAddPair();
@@ -683,7 +690,15 @@ describe('ProgramSectionForm', () => {
             expect((getContentByGroupAndType(updated, 1, ContentType.Description) as any)?.description).toBe('D2');
             expect((getContentByGroupAndType(updated, 1, ContentType.Author) as any)?.author).toBe('A2');
 
+            expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+            expect(scrollIntoViewMock).toHaveBeenCalledWith({
+                behavior: 'smooth',
+                block: 'nearest',
+                inline: 'center',
+            });
+
             expect(focusMock).toHaveBeenCalledTimes(1);
+            expect(focusMock).toHaveBeenCalledWith({ preventScroll: true });
 
             jest.useRealTimers();
         });
@@ -830,7 +845,10 @@ describe('ProgramSectionForm', () => {
         });
 
         it('calls onSave and transitions back to View mode when a valid dirty section is saved', () => {
-            const { handlers } = renderWithHandlers({ isNewSection: true, isSectionValid: true });
+            const { handlers } = renderWithHandlers({
+                isNewSection: true,
+                isSectionValid: true,
+            });
 
             act(() => {
                 handlers.onTitleChange('Updated title');

--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
@@ -369,10 +369,6 @@ export const ProgramSectionForm = ({
 
         setTimeout(() => {
             const element = document.getElementById(`pair-description-${nextGroupIndex}`) as HTMLTextAreaElement | null;
-            // When adding a new pair inside the horizontal carousel, focusing the textarea
-            // does not always scroll the card fully into view (notably around the 4th card
-            // when overflow/navigation first appears). Explicitly scroll the focused element
-            // into view horizontally, then focus without triggering an additional scroll.
             element?.scrollIntoView({
                 behavior: 'smooth',
                 block: 'nearest',

--- a/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
+++ b/src/pages/admin/programs/components/program-section-form/ProgramSectionForm.tsx
@@ -1,26 +1,26 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
     createSectionFormActionsClassNames,
     SectionFormActions,
 } from '@/components/admin/section-form-actions/SectionFormActions';
-import { ImageValues } from '@/types/common/image';
-import { renderProgramSection } from '@/utils/functions/render-program-section';
-import styles from './ProgramSectionForm.module.scss';
-import { FaqSectionQuestionDto, CreateHippotherapyProgramSectionDto } from '@/types/common/program-sections';
-import { SectionTemplate, SectionMode } from '@/types/common/sections';
+import type { ImageValues } from '@/types/common/image';
+import type { CreateHippotherapyProgramSectionDto, FaqSectionQuestionDto } from '@/types/common/program-sections';
 import { ContentType } from '@/types/common/section-contents';
+import { SectionMode, SectionTemplate } from '@/types/common/sections';
+import { getDescriptionAuthorPairsByGroup } from '@/utils/functions/mappers/public/program/get-grouped-program-section-content-pairs';
+import {
+    ensureTitleContentAndOnePair,
+    getContentByType,
+    getDescriptionsInOrder,
+    getFaqPairs,
+} from '@/utils/functions/program-section-content/programSectionContent';
+import { renderProgramSection } from '@/utils/functions/render-program-section';
 import {
     getSectionTemplateMaxGroupCount,
     normalizeGroupedContentsGroupIndexes,
 } from '@/utils/functions/section-template-validation/sectionTemplateValidation';
 import { PROGRAM_SECTION_VALIDATION_FUNCTIONS } from '@/validation/admin/program-schema/program-schema';
-import { getDescriptionAuthorPairsByGroup } from '@/utils/functions/mappers/public/program/get-grouped-program-section-content-pairs';
-import {
-    getContentByType,
-    getDescriptionsInOrder,
-    getFaqPairs,
-    ensureTitleContentAndOnePair,
-} from '@/utils/functions/program-section-content/programSectionContent';
+import styles from './ProgramSectionForm.module.scss';
 
 const sectionFormActionsClassNames = createSectionFormActionsClassNames(styles);
 
@@ -369,7 +369,16 @@ export const ProgramSectionForm = ({
 
         setTimeout(() => {
             const element = document.getElementById(`pair-description-${nextGroupIndex}`) as HTMLTextAreaElement | null;
-            element?.focus();
+            // When adding a new pair inside the horizontal carousel, focusing the textarea
+            // does not always scroll the card fully into view (notably around the 4th card
+            // when overflow/navigation first appears). Explicitly scroll the focused element
+            // into view horizontally, then focus without triggering an additional scroll.
+            element?.scrollIntoView({
+                behavior: 'smooth',
+                block: 'nearest',
+                inline: 'center',
+            });
+            element?.focus({ preventScroll: true });
         }, 0);
     }, [emitSectionChange]);
 
@@ -616,7 +625,10 @@ export const ProgramSectionForm = ({
         };
 
         if (onRequestSaveSection && isDirty) {
-            onRequestSaveSection({ onConfirm: applySave, onDecline: handleDeclineSave });
+            onRequestSaveSection({
+                onConfirm: applySave,
+                onDecline: handleDeclineSave,
+            });
             return;
         }
 


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2474

## Description

Fixes an edge case where adding the 4th block correctly moved focus to the new input, but did not scroll the block fully into the visible area. The fix makes scrolling deterministic for every newly added block by triggering an explicit “scroll into view” at the right DOM timing before applying focus.

### Note
Some code changes are done 'cause of formatter was ran.
Changes were tested on Zen Browser (Firefox-based)

## How it looks

https://github.com/user-attachments/assets/5e5be86a-e0b4-4f3e-869d-15b1c6b0f1ba

## Summary of change

- Ensured newly added blocks are explicitly scrolled into view (including the 4th block case) before focus is applied.
- Preserved existing behavior for other blocks (1st–3rd, 5th+).
- Updated the related unit test to cover the scroll + focus sequence.

## How to recreate changes

1. Open the admin page for creating or editing a single Program. (`/admin-panel/programs`/
2. Go to a section/template that supports adding blocks dynamically.
3. Fill valid values in all required fields for existing blocks.
4. Click “Add block” until you add the 4th block.
5. Verify the newly added block is automatically scrolled fully into view and its input is focused (no manual navigation/arrow click needed).
6. Repeat for the 5th block to confirm behavior remains correct.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test coverage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved textarea scrolling and focus behavior when adding new pairs to program section forms. The newly created textarea now smoothly scrolls into view before receiving focus, providing a more seamless user experience in carousel template workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->