### PR TITLE
Feature/issues-2478-2479: [Main] Display content presented in the 'Partners' block

### DIFF
--- a/src/const/admin/main-page.ts
+++ b/src/const/admin/main-page.ts
@@ -18,6 +18,20 @@ export const MAIN_PAGE_TEXT = {
             TITLE_LABEL: COMMON_TEXT_ADMIN.TYPE.TITLE,
             DESCRIPTION_LABEL: COMMON_TEXT_ADMIN.TYPE.DESCRIPTION,
         },
+        STATISTICS: {
+            TITLE_UA_LABEL: 'Заголовок (UA)',
+            TITLE_EN_LABEL: 'Заголовок (ENG)',
+            PREVIEW_TITLE: 'PREVIEW МЕТРИК',
+            METRICS_TITLE: 'МЕТРИКИ',
+            LANG: {
+                UKR: 'UKR',
+                ENG: 'ENG',
+            },
+        },
+        PARTNERS: {
+            TITLE_LABEL: COMMON_TEXT_ADMIN.TYPE.TITLE,
+            DESCRIPTION_LABEL: COMMON_TEXT_ADMIN.TYPE.DESCRIPTION,
+        },
     },
 
     BUTTONS: {

--- a/src/const/admin/main-page.ts
+++ b/src/const/admin/main-page.ts
@@ -18,6 +18,10 @@ export const MAIN_PAGE_TEXT = {
             TITLE_LABEL: COMMON_TEXT_ADMIN.TYPE.TITLE,
             DESCRIPTION_LABEL: COMMON_TEXT_ADMIN.TYPE.DESCRIPTION,
         },
+        PARTNERS: {
+            TITLE_LABEL: COMMON_TEXT_ADMIN.TYPE.TITLE,
+            DESCRIPTION_LABEL: COMMON_TEXT_ADMIN.TYPE.DESCRIPTION,
+        },
     },
 
     BUTTONS: {
@@ -46,6 +50,21 @@ export const MAIN_PAGE_VALIDATION = {
     },
 
     aboutUsBlock: {
+        title: {
+            min: 10,
+            max: 50,
+            getMinError: () => COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(10),
+            getMaxError: () => COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(50),
+        },
+        description: {
+            min: 10,
+            max: 1000,
+            getMinError: () => COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(10),
+            getMaxError: () => COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(1000),
+        },
+    },
+
+    partnersBlock: {
         title: {
             min: 10,
             max: 50,

--- a/src/pages/admin/main/components/about-us-block/AboutUsBlockForm.test.tsx
+++ b/src/pages/admin/main/components/about-us-block/AboutUsBlockForm.test.tsx
@@ -1,27 +1,8 @@
-import React from 'react';
+import { MainPage } from '@/types/admin/main-page';
+import '@/utils/test-mocks/setup-form-mocks';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { AboutUsBlockForm } from './AboutUsBlockForm';
-import { MainPage } from '@/types/admin/main-page';
-
-jest.mock('@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup', () => ({
-    __esModule: true,
-    InputWithCharacterLimitGroup: require('@/utils/test-mocks/main-page-mocks').MockInputWithCharacterLimitGroup,
-}));
-
-jest.mock(
-    '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup',
-    () => ({
-        __esModule: true,
-        TextAreaWithCharacterLimitGroup: require('@/utils/test-mocks/main-page-mocks')
-            .MockTextAreaWithCharacterLimitGroup,
-    }),
-);
-
-jest.mock('@/components/admin/button/Button', () => ({
-    __esModule: true,
-    Button: require('@/utils/test-mocks/main-page-mocks').MockSubmitButton,
-}));
 
 const mockInitialData: MainPage = {
     id: 1,

--- a/src/pages/admin/main/components/main-page-content/MainPageContent.test.tsx
+++ b/src/pages/admin/main/components/main-page-content/MainPageContent.test.tsx
@@ -15,6 +15,11 @@ jest.mock('../about-us-block/AboutUsBlockForm', () => ({
     AboutUsBlockForm: () => <div data-testid="about-us-block-form">About Us Form</div>,
 }));
 
+jest.mock('../partners-block/PartnersBlockForm', () => ({
+    __esModule: true,
+    PartnersBlockForm: () => <div data-testid="partners-block-form">Partners Form</div>,
+}));
+
 jest.mock('@/components/admin/category-bar/CategoryBar', () => ({
     __esModule: true,
     CategoryBar: require('@/utils/test-mocks/main-page-mocks').MockMainPageCategoryBar,
@@ -110,6 +115,7 @@ describe('MainPageContent', () => {
         });
 
         fireEvent.click(screen.getByTestId('tab-btn-partners'));
-        expect(getByExactText(`Блок "${MAIN_PAGE_TEXT.TABS.PARTNERS}" в розробці`)).toBeInTheDocument();
+        expect(screen.getByTestId('partners-block-form')).toBeInTheDocument();
+        expect(screen.queryByTestId('title-block-form')).not.toBeInTheDocument();
     });
 });

--- a/src/pages/admin/main/components/main-page-content/MainPageContent.tsx
+++ b/src/pages/admin/main/components/main-page-content/MainPageContent.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect } from 'react';
 import { CategoryBar } from '@/components/admin/category-bar/CategoryBar';
 import { PageLoader } from '@/components/common/page-loader/PageLoader';
-import { TitleBlockForm } from '../title-block/TitleBlockForm';
-import { AboutUsBlockForm } from '../about-us-block/AboutUsBlockForm';
 import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
 import { MainPage } from '@/types/admin/main-page';
 import { MOCK_MAIN_PAGE_DATA } from '@/utils/mock-data/admin/main-page/main-page';
+import { AboutUsBlockForm } from '../about-us-block/AboutUsBlockForm';
+import { PartnersBlockForm } from '../partners-block/PartnersBlockForm';
+import { TitleBlockForm } from '../title-block/TitleBlockForm';
 import styles from './MainPageContent.module.scss';
 
 type TabType = 'title' | 'about' | 'statistics' | 'donations' | 'partners';
@@ -79,7 +80,7 @@ export const MainPageContent = () => {
                 {activeTab === 'about' && <AboutUsBlockForm initialData={data} />}
                 {activeTab === 'statistics' && <div>Блок "{MAIN_PAGE_TEXT.TABS.STATISTICS}" в розробці</div>}
                 {activeTab === 'donations' && <div>Блок "{MAIN_PAGE_TEXT.TABS.DONATIONS}" в розробці</div>}
-                {activeTab === 'partners' && <div>Блок "{MAIN_PAGE_TEXT.TABS.PARTNERS}" в розробці</div>}
+                {activeTab === 'partners' && <PartnersBlockForm initialData={data} />}
             </div>
         </div>
     );

--- a/src/pages/admin/main/components/main-page-content/MainPageContent.tsx
+++ b/src/pages/admin/main/components/main-page-content/MainPageContent.tsx
@@ -1,14 +1,12 @@
 import { useState, useEffect } from 'react';
 import { CategoryBar } from '@/components/admin/category-bar/CategoryBar';
 import { PageLoader } from '@/components/common/page-loader/PageLoader';
-import { TitleBlockForm } from '../title-block/TitleBlockForm';
-import { AboutUsBlockForm } from '../about-us-block/AboutUsBlockForm';
-import { StatisticsBlockForm } from '../statistics-block/StatisticsBlockForm';
 import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
 import { MainPage } from '@/types/admin/main-page';
 import { MOCK_MAIN_PAGE_DATA } from '@/utils/mock-data/admin/main-page/main-page';
 import { AboutUsBlockForm } from '../about-us-block/AboutUsBlockForm';
 import { PartnersBlockForm } from '../partners-block/PartnersBlockForm';
+import { StatisticsBlockForm } from '../statistics-block/StatisticsBlockForm';
 import { TitleBlockForm } from '../title-block/TitleBlockForm';
 import styles from './MainPageContent.module.scss';
 

--- a/src/pages/admin/main/components/partners-block/PartnersBlockForm.module.scss
+++ b/src/pages/admin/main/components/partners-block/PartnersBlockForm.module.scss
@@ -1,0 +1,38 @@
+@use '@/assets/sass/variables/colors' as c;
+
+.form {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+}
+
+.content {
+    display: flex;
+    flex-direction: row;
+    gap: 40px;
+    margin-bottom: 40px;
+    width: 100%;
+}
+
+.column {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.textarea-custom textarea {
+    min-height: 349px;
+    resize: none;
+}
+
+.actions {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+}
+
+.publish-button {
+    width: 608px;
+    max-width: 100%;
+}

--- a/src/pages/admin/main/components/partners-block/PartnersBlockForm.test.tsx
+++ b/src/pages/admin/main/components/partners-block/PartnersBlockForm.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { PartnersBlockForm } from './PartnersBlockForm';
+import { MainPage } from '@/types/admin/main-page';
+
+jest.mock('@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup', () => ({
+    __esModule: true,
+    InputWithCharacterLimitGroup: require('@/utils/test-mocks/main-page-mocks').MockInputWithCharacterLimitGroup,
+}));
+
+jest.mock(
+    '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup',
+    () => ({
+        __esModule: true,
+        TextAreaWithCharacterLimitGroup: require('@/utils/test-mocks/main-page-mocks')
+            .MockTextAreaWithCharacterLimitGroup,
+    }),
+);
+
+jest.mock('@/components/admin/button/Button', () => ({
+    __esModule: true,
+    Button: require('@/utils/test-mocks/main-page-mocks').MockSubmitButton,
+}));
+
+const mockInitialData: MainPage = {
+    id: 1,
+    title: 'Титульний заголовок',
+    description: 'Титульний опис',
+    image: null,
+    mainAboutUs: null,
+    mainPartners: {
+        id: 1,
+        title: 'Наші надійні партнери',
+        description: 'Опис партнерів нашого фонду',
+    },
+};
+
+describe('PartnersBlockForm', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders with empty default values when initialData is null', () => {
+        render(<PartnersBlockForm initialData={null} />);
+
+        const titleInput = screen.getByTestId('partners-block-title') as HTMLInputElement;
+        const descriptionInput = screen.getByTestId('partners-block-description') as HTMLTextAreaElement;
+
+        expect(titleInput.value).toBe('');
+        expect(descriptionInput.value).toBe('');
+        expect(screen.getByTestId('submit-btn')).toBeDisabled();
+    });
+
+    it('renders with empty default values when initialData.mainPartners is null', () => {
+        render(<PartnersBlockForm initialData={{ ...mockInitialData, mainPartners: null }} />);
+
+        const titleInput = screen.getByTestId('partners-block-title') as HTMLInputElement;
+
+        expect(titleInput.value).toBe('');
+        expect(screen.getByTestId('submit-btn')).toBeDisabled();
+    });
+
+    it('populates fields correctly from initialData.mainPartners', async () => {
+        render(<PartnersBlockForm initialData={mockInitialData} />);
+
+        const titleInput = screen.getByTestId('partners-block-title') as HTMLInputElement;
+        const descriptionInput = screen.getByTestId('partners-block-description') as HTMLTextAreaElement;
+
+        await waitFor(() => {
+            expect(titleInput.value).toBe('Наші надійні партнери');
+            expect(descriptionInput.value).toBe('Опис партнерів нашого фонду');
+        });
+
+        expect(screen.getByTestId('submit-btn')).toBeDisabled();
+    });
+
+    it('enables submit button when form becomes dirty and is valid', async () => {
+        render(<PartnersBlockForm initialData={mockInitialData} />);
+
+        const titleInput = screen.getByTestId('partners-block-title');
+        fireEvent.change(titleInput, { target: { value: 'Новий заголовок Партнерів' } });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('submit-btn')).not.toBeDisabled();
+        });
+    });
+
+    it('disables submit button when a required field is cleared', async () => {
+        render(<PartnersBlockForm initialData={mockInitialData} />);
+
+        const descriptionInput = screen.getByTestId('partners-block-description');
+
+        fireEvent.change(descriptionInput, { target: { value: '   ' } });
+        fireEvent.blur(descriptionInput);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('submit-btn')).toBeDisabled();
+        });
+    });
+
+    it('allows submitting the form without throwing errors', async () => {
+        render(<PartnersBlockForm initialData={mockInitialData} />);
+
+        const descriptionInput = screen.getByTestId('partners-block-description');
+        fireEvent.change(descriptionInput, { target: { value: 'Оновлений текст про наших нових партнерів' } });
+
+        const submitBtn = screen.getByTestId('submit-btn');
+        await waitFor(() => expect(submitBtn).not.toBeDisabled());
+
+        expect(() => fireEvent.click(submitBtn)).not.toThrow();
+    });
+});

--- a/src/pages/admin/main/components/partners-block/PartnersBlockForm.test.tsx
+++ b/src/pages/admin/main/components/partners-block/PartnersBlockForm.test.tsx
@@ -10,6 +10,7 @@ const mockInitialData: MainPage = {
     description: 'Титульний опис',
     image: null,
     mainAboutUs: null,
+    impactStatistics: null,
     mainPartners: {
         id: 1,
         title: 'Наші надійні партнери',

--- a/src/pages/admin/main/components/partners-block/PartnersBlockForm.test.tsx
+++ b/src/pages/admin/main/components/partners-block/PartnersBlockForm.test.tsx
@@ -1,27 +1,8 @@
-import React from 'react';
+import { MainPage } from '@/types/admin/main-page';
+import '@/utils/test-mocks/setup-form-mocks';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { PartnersBlockForm } from './PartnersBlockForm';
-import { MainPage } from '@/types/admin/main-page';
-
-jest.mock('@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup', () => ({
-    __esModule: true,
-    InputWithCharacterLimitGroup: require('@/utils/test-mocks/main-page-mocks').MockInputWithCharacterLimitGroup,
-}));
-
-jest.mock(
-    '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup',
-    () => ({
-        __esModule: true,
-        TextAreaWithCharacterLimitGroup: require('@/utils/test-mocks/main-page-mocks')
-            .MockTextAreaWithCharacterLimitGroup,
-    }),
-);
-
-jest.mock('@/components/admin/button/Button', () => ({
-    __esModule: true,
-    Button: require('@/utils/test-mocks/main-page-mocks').MockSubmitButton,
-}));
 
 const mockInitialData: MainPage = {
     id: 1,

--- a/src/pages/admin/main/components/partners-block/PartnersBlockForm.tsx
+++ b/src/pages/admin/main/components/partners-block/PartnersBlockForm.tsx
@@ -1,0 +1,97 @@
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useEffect } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { Button } from '@/components/admin/button/Button';
+import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
+import { TextAreaWithCharacterLimitGroup } from '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup';
+import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
+import { MainPage, PARTNERS_BLOCK_FORM_DEFAULTS, PartnersBlockFormValues } from '@/types/admin/main-page';
+import { PartnersBlockValidationSchema } from '@/validation/admin/main-page-schema/main-page-schema';
+import styles from './PartnersBlockForm.module.scss';
+
+interface PartnersBlockFormProps {
+    initialData: MainPage | null;
+}
+
+export const PartnersBlockForm = ({ initialData }: PartnersBlockFormProps) => {
+    const {
+        control,
+        handleSubmit,
+        reset,
+        formState: { isDirty, isValid, errors },
+    } = useForm<PartnersBlockFormValues>({
+        mode: 'onChange',
+        resolver: yupResolver(PartnersBlockValidationSchema),
+        defaultValues: PARTNERS_BLOCK_FORM_DEFAULTS,
+    });
+
+    useEffect(() => {
+        reset({
+            title: initialData?.mainPartners?.title || '',
+            description: initialData?.mainPartners?.description || '',
+        });
+    }, [initialData, reset]);
+
+    const onSubmit = () => {
+        // API integration is intentionally deferred for the display-only phase.
+    };
+
+    return (
+        <form className={styles.form} onSubmit={handleSubmit(onSubmit)}>
+            <div className={styles.content}>
+                <div className={styles.column}>
+                    <Controller
+                        name="title"
+                        control={control}
+                        render={({ field: { onChange, value, onBlur, name } }) => (
+                            <InputWithCharacterLimitGroup
+                                id="partners-block-title"
+                                name={name}
+                                label={MAIN_PAGE_TEXT.BLOCKS.PARTNERS.TITLE_LABEL}
+                                value={value}
+                                onChange={onChange}
+                                onBlur={onBlur}
+                                error={errors.title?.message}
+                                maxLength={MAIN_PAGE_VALIDATION.partnersBlock.title.max}
+                                isRequired={true}
+                            />
+                        )}
+                    />
+                </div>
+
+                <div className={styles.column}>
+                    <Controller
+                        name="description"
+                        control={control}
+                        render={({ field: { onChange, value, onBlur, name } }) => (
+                            <TextAreaWithCharacterLimitGroup
+                                id="partners-block-description"
+                                name={name}
+                                label={MAIN_PAGE_TEXT.BLOCKS.PARTNERS.DESCRIPTION_LABEL}
+                                value={value}
+                                onChange={onChange}
+                                onBlur={onBlur}
+                                error={errors.description?.message}
+                                maxLength={MAIN_PAGE_VALIDATION.partnersBlock.description.max}
+                                isRequired={true}
+                                rows={14}
+                                className={styles['textarea-custom']}
+                            />
+                        )}
+                    />
+                </div>
+            </div>
+
+            <div className={styles.actions}>
+                <Button
+                    type="submit"
+                    buttonStyle="primary"
+                    disabled={!isDirty || !isValid}
+                    className={styles['publish-button']}
+                >
+                    {MAIN_PAGE_TEXT.BUTTONS.PUBLISH}
+                </Button>
+            </div>
+        </form>
+    );
+};

--- a/src/pages/admin/main/components/title-block/TitleBlockForm.test.tsx
+++ b/src/pages/admin/main/components/title-block/TitleBlockForm.test.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
+import { MainPage } from '@/types/admin/main-page';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { TitleBlockForm } from './TitleBlockForm';
-import { MainPage } from '@/types/admin/main-page';
 
 jest.mock('@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup', () => ({
     __esModule: true,

--- a/src/types/admin/main-page.ts
+++ b/src/types/admin/main-page.ts
@@ -6,10 +6,18 @@ export interface MainAboutUs {
     description: string;
 }
 
+export interface MainPartnersLocalization {
+    id?: number;
+    languageCode?: string;
+    title: string;
+    description: string;
+}
+
 export interface MainPartners {
     id: number;
     title: string;
     description: string;
+    localizations?: MainPartnersLocalization[];
 }
 
 export interface MainPage {
@@ -19,6 +27,16 @@ export interface MainPage {
     image: Image | ImageValues | null;
     mainAboutUs: MainAboutUs | null;
     mainPartners: MainPartners | null;
+}
+
+export interface CreateMainPartnersDto {
+    title: string;
+    description: string;
+}
+
+export interface UpdateMainPartnersDto {
+    title: string;
+    description: string;
 }
 
 export interface TitleBlockFormValues {
@@ -39,6 +57,16 @@ export interface AboutUsBlockFormValues {
 }
 
 export const ABOUT_US_BLOCK_FORM_DEFAULTS: AboutUsBlockFormValues = {
+    title: '',
+    description: '',
+};
+
+export interface PartnersBlockFormValues {
+    title: string;
+    description: string;
+}
+
+export const PARTNERS_BLOCK_FORM_DEFAULTS: PartnersBlockFormValues = {
     title: '',
     description: '',
 };

--- a/src/utils/test-mocks/setup-form-mocks.ts
+++ b/src/utils/test-mocks/setup-form-mocks.ts
@@ -1,0 +1,18 @@
+jest.mock('@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup', () => ({
+    __esModule: true,
+    InputWithCharacterLimitGroup: require('@/utils/test-mocks/main-page-mocks').MockInputWithCharacterLimitGroup,
+}));
+
+jest.mock(
+    '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup',
+    () => ({
+        __esModule: true,
+        TextAreaWithCharacterLimitGroup: require('@/utils/test-mocks/main-page-mocks')
+            .MockTextAreaWithCharacterLimitGroup,
+    }),
+);
+
+jest.mock('@/components/admin/button/Button', () => ({
+    __esModule: true,
+    Button: require('@/utils/test-mocks/main-page-mocks').MockSubmitButton,
+}));

--- a/src/validation/admin/main-page-schema/main-page-schema.test.ts
+++ b/src/validation/admin/main-page-schema/main-page-schema.test.ts
@@ -90,7 +90,9 @@ describe('MAIN_PAGE_VALIDATION_FUNCTIONS', () => {
         });
 
         it('treats spaces as empty and returns required error', () => {
-            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validatePartnersTitle('   ')).toBe(MAIN_PAGE_VALIDATION.common.REQUIRED);
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validatePartnersTitle('   ')).toBe(
+                MAIN_PAGE_VALIDATION.common.REQUIRED,
+            );
         });
 
         it('returns min error for title shorter than 10 chars', () => {

--- a/src/validation/admin/main-page-schema/main-page-schema.test.ts
+++ b/src/validation/admin/main-page-schema/main-page-schema.test.ts
@@ -79,4 +79,64 @@ describe('MAIN_PAGE_VALIDATION_FUNCTIONS', () => {
             expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validateImage(mockImage as any)).toBeUndefined();
         });
     });
+
+    describe('validatePartnersTitle', () => {
+        it('returns undefined for a valid title (between 10 and 50 chars)', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validatePartnersTitle('Надійні партнери фонду')).toBeUndefined();
+        });
+
+        it('returns required error for an empty title', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validatePartnersTitle('')).toBe(MAIN_PAGE_VALIDATION.common.REQUIRED);
+        });
+
+        it('treats spaces as empty and returns required error', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validatePartnersTitle('   ')).toBe(MAIN_PAGE_VALIDATION.common.REQUIRED);
+        });
+
+        it('returns min error for title shorter than 10 chars', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validatePartnersTitle('Коротко')).toBe(
+                MAIN_PAGE_VALIDATION.partnersBlock.title.getMinError(),
+            );
+        });
+
+        it('returns max error for title longer than 50 chars', () => {
+            const longTitle = 'a'.repeat(MAIN_PAGE_VALIDATION.partnersBlock.title.max + 1);
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validatePartnersTitle(longTitle)).toBe(
+                MAIN_PAGE_VALIDATION.partnersBlock.title.getMaxError(),
+            );
+        });
+    });
+
+    describe('validatePartnersDescription', () => {
+        it('returns undefined for a valid description', () => {
+            expect(
+                MAIN_PAGE_VALIDATION_FUNCTIONS.validatePartnersDescription('Детальний опис для блоку наших партнерів.'),
+            ).toBeUndefined();
+        });
+
+        it('returns required error for an empty description', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validatePartnersDescription('')).toBe(
+                MAIN_PAGE_VALIDATION.common.REQUIRED,
+            );
+        });
+
+        it('treats spaces as empty and returns required error', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validatePartnersDescription('      ')).toBe(
+                MAIN_PAGE_VALIDATION.common.REQUIRED,
+            );
+        });
+
+        it('returns min error for description shorter than 10 chars', () => {
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validatePartnersDescription('Замало')).toBe(
+                MAIN_PAGE_VALIDATION.partnersBlock.description.getMinError(),
+            );
+        });
+
+        it('returns max error for description longer than 1000 chars', () => {
+            const longDescription = 'a'.repeat(MAIN_PAGE_VALIDATION.partnersBlock.description.max + 1);
+            expect(MAIN_PAGE_VALIDATION_FUNCTIONS.validatePartnersDescription(longDescription)).toBe(
+                MAIN_PAGE_VALIDATION.partnersBlock.description.getMaxError(),
+            );
+        });
+    });
 });

--- a/src/validation/admin/main-page-schema/main-page-schema.ts
+++ b/src/validation/admin/main-page-schema/main-page-schema.ts
@@ -1,8 +1,13 @@
-import * as Yup from 'yup';
 import { MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
-import { AboutUsBlockFormValues, TitleBlockFormValues, PartnersBlockFormValues, StatisticsBlockFormValues } from '@/types/admin/main-page';
+import {
+    AboutUsBlockFormValues,
+    PartnersBlockFormValues,
+    StatisticsBlockFormValues,
+    TitleBlockFormValues,
+} from '@/types/admin/main-page';
 import { Image, ImageValues } from '@/types/common/image';
 import { getNormalizedInputText } from '@/utils/functions/formatters/text-formatters';
+import * as Yup from 'yup';
 
 const buildStringValidation = (config: {
     min: number;

--- a/src/validation/admin/main-page-schema/main-page-schema.ts
+++ b/src/validation/admin/main-page-schema/main-page-schema.ts
@@ -1,6 +1,6 @@
 import * as Yup from 'yup';
 import { MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
-import { AboutUsBlockFormValues, TitleBlockFormValues } from '@/types/admin/main-page';
+import { AboutUsBlockFormValues, TitleBlockFormValues, PartnersBlockFormValues } from '@/types/admin/main-page';
 import { Image, ImageValues } from '@/types/common/image';
 import { getNormalizedInputText } from '@/utils/functions/formatters/text-formatters';
 
@@ -35,6 +35,11 @@ export const AboutUsBlockValidationSchema: Yup.ObjectSchema<AboutUsBlockFormValu
     description: buildStringValidation(MAIN_PAGE_VALIDATION.aboutUsBlock.description),
 });
 
+export const PartnersBlockValidationSchema: Yup.ObjectSchema<PartnersBlockFormValues> = Yup.object({
+    title: buildStringValidation(MAIN_PAGE_VALIDATION.partnersBlock.title),
+    description: buildStringValidation(MAIN_PAGE_VALIDATION.partnersBlock.description),
+});
+
 export const MAIN_PAGE_VALIDATION_FUNCTIONS = {
     validateTitle: (value: string): string | undefined => {
         try {
@@ -57,6 +62,24 @@ export const MAIN_PAGE_VALIDATION_FUNCTIONS = {
     validateImage: (value: Image | ImageValues | null): string | undefined => {
         try {
             TitleBlockValidationSchema.validateSyncAt('image', { image: value });
+            return undefined;
+        } catch (error: any) {
+            return error.message;
+        }
+    },
+
+    validatePartnersTitle: (value: string): string | undefined => {
+        try {
+            PartnersBlockValidationSchema.validateSyncAt('title', { title: value });
+            return undefined;
+        } catch (error: any) {
+            return error.message;
+        }
+    },
+
+    validatePartnersDescription: (value: string): string | undefined => {
+        try {
+            PartnersBlockValidationSchema.validateSyncAt('description', { description: value });
             return undefined;
         } catch (error: any) {
             return error.message;


### PR DESCRIPTION
## Github tickets

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2478
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2479

## Description

This PR implements the 'Партнери' (Partners) tab in the Admin panel for the Main Page content management. It allows administrators to view, edit, and validate the textual content (Title and Description) of the Partners block to ensure it is kept up-to-date and follows the required constraints.

#### ⚠️Notes 
- The flow still uses mock data (no API integration yet).
- The Publish button is intentionally non-functional (display-only); it becomes enabled only when all validations pass.

https://github.com/user-attachments/assets/6c353e5d-5458-45f0-9ea3-49e652b3d343

## Summary of change

- **Types & DTOs**: Added `MainPartners` interfaces and DTOs mapping to the backend architecture.
- Validation: Implemented` PartnersBlockValidationSchema` using Yup, enforcing string boundaries (Title: 10-50 chars, Description: 10-1000 chars), required states, and applying the Space Management approach via text formatters.
- **UI Components**: Created `PartnersBlockForm` component utilizing react-hook-form and custom input groups with character limiters.
- **Testing**: Added comprehensive unit tests for validation schemas, the form component behavior (disabling/enabling buttons, dirty states), and updated the main content tests.
- **Refactoring:** Extracted duplicated Jest mocks into a shared `setup-form-mocks.ts` file to resolve SonarQube code duplication warnings across form tests.

## How to recreate changes

1. Go to Admin -> Main Page (/admin-panel/main) -> Partners tab.
2. In the "Партнери" tab, try entering less than 10 characters in the 'Заголовок' or 'Опис' fields - verify the "Не менше 10 символів" error appears on blur.
3. Try entering more than 1000 characters in the 'Опис' field - verify the input prevents further typing.
4. Verify that the "Опублікувати" button remains disabled until the form is both modified (isDirty) and valid (isValid).

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test coverage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Partners section to the admin main page with editable Title (10–50 chars) and Description (10–1,000 chars); publish enabled only when changes are valid.
* **Style**
  * New form styling for the Partners block for improved layout and responsive publish button.
* **Tests**
  * Added/updated tests to cover Partners form behavior and validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ita-social-projects/VictoryCenter-Client/pull/385)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->