### PR TITLE
Fix/issue-2466: [Single Program][FAQ Template] Incorrect character counter limit in 'Заголовок' field displays 50 instead of 60 characters.

### DIFF
--- a/src/const/admin/sections.ts
+++ b/src/const/admin/sections.ts
@@ -372,7 +372,7 @@ export const SECTION_TEMPLATE_VALIDATION = {
             [ContentType.FaqQuestion]: { min: 1, max: 10 },
         },
         lengths: {
-            [ContentType.Title]: { min: 5, max: 50 },
+            [ContentType.Title]: { min: 5, max: 60 },
         },
     },
 } as const;


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2466

## Description

Fix incorrect max character limit shown/enforced for the FAQ template “Заголовок” field. The UI counter and validation were capped at 50 due to a wrong per-template rule; this updates the FAQ template title limit to 60 so admins can enter the intended length.

## How it looks
How it was:
<img width="1903" alt="image" src="https://github.com/user-attachments/assets/d61b09df-5f25-4b67-ad97-31a097a5a56b" />

How it now:
<img width="674" alt="image" src="https://github.com/user-attachments/assets/9514b328-5949-4017-9159-1b6ecd2c66bb" />

## Summary of change

Updated FAQ template validation config for `SectionTemplate.SingleTitleQuestionAnswerPairs` so `ContentType.Title.max` is 60 instead of 50

## How to recreate changes

1. Open Admin Panel -> Programs -> Add/Edit Program (`/admin-panel/programs`)
2. Add or edit a section using the FAQ template and focus the “Заголовок” field.
3. Observe the character counter now shows a /60 max.
4. Type 61+ characters: you shouldn't be allowed to type more than 60.


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the maximum length allowed for section template titles from 50 to 60 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->