### PR TITLE
feat(reports): add program expenditures api client methods and dto types

### DIFF
--- a/src/const/common/api-routes/main-api.ts
+++ b/src/const/common/api-routes/main-api.ts
@@ -97,6 +97,7 @@ export const API_ROUTES = {
             SUMMARY: 'ReportFundsExpendituresRecords/summary',
             CATEGORIES: 'ReportFundsExpendituresCategories',
         },
+        PROGRAM_EXPENDITURES_RECORDS: 'ReportProgramExpendituresRecords',
     },
     PDF_SECTION: {
         BASE: 'PdfSection',

--- a/src/services/api/admin/reports/program-expenses-api.test.ts
+++ b/src/services/api/admin/reports/program-expenses-api.test.ts
@@ -1,4 +1,5 @@
 import { ProgramExpensesProgram, ProgramExpensesRecord } from '@/types/admin/reports';
+import { API_ROUTES } from '@/const/common/api-routes/main-api';
 
 const loadProgramExpensesApi = (
     records: Array<ProgramExpensesRecord & { isPublished: boolean }>,
@@ -148,6 +149,75 @@ describe('ProgramExpensesApi', () => {
                 totalAmountUsd: 0,
             },
             records: [],
+        });
+    });
+
+    describe('ProgramExpensesApi CRUD methods', () => {
+        const mockClient = {
+            get: jest.fn(),
+            post: jest.fn(),
+            put: jest.fn(),
+            delete: jest.fn(),
+        } as any;
+
+        let originalApi: typeof import('./program-expenses-api').ProgramExpensesApi;
+
+        beforeAll(() => {
+            jest.resetModules();
+            jest.dontMock('@/utils/mock-data/admin/reports/program-expenses');
+            originalApi = require('./program-expenses-api').ProgramExpensesApi;
+        });
+
+        afterEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it('getAll should call GET and return data', async () => {
+            const mockData = [{ id: 1, amountUah: 100 }];
+            mockClient.get.mockResolvedValueOnce({ data: mockData });
+
+            const result = await originalApi.getAll(mockClient);
+
+            expect(mockClient.get).toHaveBeenCalledWith(API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS);
+            expect(result).toEqual(mockData);
+        });
+
+        it('post should call POST with correct payload and return data', async () => {
+            const record = { reportingYear: 2025, hippotherapyProgramCategoryId: 1, amountUah: 100, amountUsd: 10 };
+            const mockData = { id: 1, ...record };
+            mockClient.post.mockResolvedValueOnce({ data: mockData });
+
+            const result = await originalApi.post(mockClient, record);
+
+            expect(mockClient.post).toHaveBeenCalledWith(API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS, record);
+            expect(result).toEqual(mockData);
+        });
+
+        it('update should call PUT with correct payload and return data', async () => {
+            const record = { hippotherapyProgramCategoryId: 1, amountUah: 200, amountUsd: 20 };
+            const mockData = { id: 5, reportingYear: 2025, ...record };
+            mockClient.put.mockResolvedValueOnce({ data: mockData });
+
+            const result = await originalApi.update(mockClient, 5, record);
+
+            expect(mockClient.put).toHaveBeenCalledWith(`${API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS}/5`, record);
+            expect(result).toEqual(mockData);
+        });
+
+        it('delete should call DELETE with correct id', async () => {
+            mockClient.delete.mockResolvedValueOnce({});
+
+            await originalApi.delete(mockClient, 10);
+
+            expect(mockClient.delete).toHaveBeenCalledWith(`${API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS}/10`);
+        });
+
+        it('bulkDelete should call POST with correct payload', async () => {
+            mockClient.post.mockResolvedValueOnce({});
+
+            await originalApi.bulkDelete(mockClient, [1, 2, 3]);
+
+            expect(mockClient.post).toHaveBeenCalledWith(`${API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS}/bulk-delete`, [1, 2, 3]);
         });
     });
 });

--- a/src/services/api/admin/reports/program-expenses-api.test.ts
+++ b/src/services/api/admin/reports/program-expenses-api.test.ts
@@ -217,7 +217,10 @@ describe('ProgramExpensesApi', () => {
 
             await originalApi.bulkDelete(mockClient, [1, 2, 3]);
 
-            expect(mockClient.post).toHaveBeenCalledWith(`${API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS}/bulk-delete`, [1, 2, 3]);
+            expect(mockClient.post).toHaveBeenCalledWith(
+                `${API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS}/bulk-delete`,
+                [1, 2, 3],
+            );
         });
     });
 });

--- a/src/services/api/admin/reports/program-expenses-api.ts
+++ b/src/services/api/admin/reports/program-expenses-api.ts
@@ -1,5 +1,14 @@
+import { AxiosInstance } from 'axios';
 import { RequestOptions } from '@/types/common/api';
-import { ProgramExpensesProgram, ProgramExpensesReadOnlyData, ProgramExpensesSummary } from '@/types/admin/reports';
+import {
+    ProgramExpensesProgram,
+    ProgramExpensesReadOnlyData,
+    ProgramExpensesSummary,
+    ReportProgramExpendituresRecordDto,
+    CreateReportProgramExpendituresRecordDto,
+    UpdateReportProgramExpendituresRecordDto,
+} from '@/types/admin/reports';
+import { API_ROUTES } from '@/const/common/api-routes/main-api';
 import {
     MOCK_PROGRAM_EXPENSES_EXCHANGE_RATE,
     MOCK_PROGRAM_EXPENSES_PROGRAMS,
@@ -74,5 +83,43 @@ export const ProgramExpensesApi = {
             summary: PROGRAM_EXPENSES_SUMMARY,
             records: PUBLISHED_PROGRAM_EXPENSES_RECORDS,
         };
+    },
+
+    getAll: async (client: AxiosInstance): Promise<ReportProgramExpendituresRecordDto[]> => {
+        const response = await client.get<ReportProgramExpendituresRecordDto[]>(
+            API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS,
+        );
+        return response.data;
+    },
+
+    post: async (
+        client: AxiosInstance,
+        record: CreateReportProgramExpendituresRecordDto,
+    ): Promise<ReportProgramExpendituresRecordDto> => {
+        const response = await client.post<ReportProgramExpendituresRecordDto>(
+            API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS,
+            record,
+        );
+        return response.data;
+    },
+
+    update: async (
+        client: AxiosInstance,
+        id: number,
+        record: UpdateReportProgramExpendituresRecordDto,
+    ): Promise<ReportProgramExpendituresRecordDto> => {
+        const response = await client.put<ReportProgramExpendituresRecordDto>(
+            `${API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS}/${id}`,
+            record,
+        );
+        return response.data;
+    },
+
+    delete: async (client: AxiosInstance, id: number): Promise<void> => {
+        await client.delete(`${API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS}/${id}`);
+    },
+
+    bulkDelete: async (client: AxiosInstance, ids: number[]): Promise<void> => {
+        await client.post(`${API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS}/bulk-delete`, ids);
     },
 };

--- a/src/types/admin/reports.ts
+++ b/src/types/admin/reports.ts
@@ -196,3 +196,24 @@ export interface ProgramExpensesReadOnlyData {
     summary: ProgramExpensesSummary;
     records: ProgramExpensesRecord[];
 }
+
+export interface ReportProgramExpendituresRecordDto {
+    id: number;
+    reportingYear: number;
+    hippotherapyProgramCategoryId: number;
+    amountUah: number;
+    amountUsd: number;
+}
+
+export interface CreateReportProgramExpendituresRecordDto {
+    reportingYear: number;
+    hippotherapyProgramCategoryId: number;
+    amountUah: number;
+    amountUsd: number;
+}
+
+export interface UpdateReportProgramExpendituresRecordDto {
+    hippotherapyProgramCategoryId: number;
+    amountUah: number;
+    amountUsd: number;
+}


### PR DESCRIPTION
## Github issue

* [Github issue](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2296)

## Description

Add CRUD methods (getAll, post, update, delete, bulkDelete) to ProgramExpensesApi for real backend integration. Add DTO interfaces in reports types. Register PROGRAM_EXPENDITURES_RECORDS route. Restore getReadOnlyData to use mock data.

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [x]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoints for program expenditure records management with support for retrieving, creating, updating, deleting, and bulk deleting records.

* **Tests**
  * Added comprehensive test coverage for program expenditure records CRUD operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ita-social-projects/VictoryCenter-Client/pull/387)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->