### PR TITLE
Feature/issue-2102-2103: [Reports] Implement category translation modal window

### DIFF
--- a/src/components/admin/localization-modal/LocalizationModal.tsx
+++ b/src/components/admin/localization-modal/LocalizationModal.tsx
@@ -16,6 +16,7 @@ interface LocalizationModalProps {
     saveButtonText?: string;
     checkIsDirty?: () => boolean;
     isDirty?: boolean;
+    className?: string;
     children: React.ReactNode;
 }
 
@@ -29,6 +30,7 @@ export const LocalizationModal = ({
     saveButtonText = COMMON_TEXT_ADMIN.BUTTON.SAVE_TRANSLATION,
     checkIsDirty,
     isDirty,
+    className,
     children,
 }: LocalizationModalProps) => {
     const [showCloseConfirm, setShowCloseConfirm] = useState(false);
@@ -52,7 +54,7 @@ export const LocalizationModal = ({
 
     return (
         <>
-            <Modal isOpen={isOpen} onClose={handleRequestClose}>
+            <Modal isOpen={isOpen} onClose={handleRequestClose} className={className}>
                 <Modal.Title>{title}</Modal.Title>
                 <Modal.Content>{children}</Modal.Content>
                 <Modal.Actions>

--- a/src/components/admin/localization-modal/LocalizationModal.tsx
+++ b/src/components/admin/localization-modal/LocalizationModal.tsx
@@ -16,7 +16,6 @@ interface LocalizationModalProps {
     saveButtonText?: string;
     checkIsDirty?: () => boolean;
     isDirty?: boolean;
-    className?: string;
     children: React.ReactNode;
 }
 
@@ -30,7 +29,6 @@ export const LocalizationModal = ({
     saveButtonText = COMMON_TEXT_ADMIN.BUTTON.SAVE_TRANSLATION,
     checkIsDirty,
     isDirty,
-    className,
     children,
 }: LocalizationModalProps) => {
     const [showCloseConfirm, setShowCloseConfirm] = useState(false);
@@ -54,7 +52,7 @@ export const LocalizationModal = ({
 
     return (
         <>
-            <Modal isOpen={isOpen} onClose={handleRequestClose} className={className}>
+            <Modal isOpen={isOpen} onClose={handleRequestClose}>
                 <Modal.Title>{title}</Modal.Title>
                 <Modal.Content>{children}</Modal.Content>
                 <Modal.Actions>

--- a/src/components/admin/translation-controls/TranslationControls.module.scss
+++ b/src/components/admin/translation-controls/TranslationControls.module.scss
@@ -7,7 +7,7 @@
     flex-direction: row;
     justify-content: space-between;
     gap: 10px;
-    margin: 0.5rem 0;
+    margin: 8px 0;
 }
 
 .language-select {

--- a/src/components/admin/translation-controls/TranslationControls.module.scss
+++ b/src/components/admin/translation-controls/TranslationControls.module.scss
@@ -7,7 +7,7 @@
     flex-direction: row;
     justify-content: space-between;
     gap: 10px;
-    margin: 8px 0;
+    margin: 0.5rem 0;
 }
 
 .language-select {

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -167,6 +167,8 @@ export const FUNDS_EXPENDITURES_TEXT = {
         CATEGORY_DELETE_FAILED_RETRY: 'Виникла помилка, спробуйте ще раз',
         CATEGORY_UPDATED_SUCCESSFULLY: 'Категорію оновлено успішно',
         CATEGORY_UPDATE_FAILED_RETRY: 'Виникла помилка, спробуйте ще раз',
+        FAIL_TO_TRANSLATE_CATEGORY: 'Не вдалося зберегти переклад категорії. Спробуйте ще раз',
+        FAIL_TO_UPDATE_CATEGORY_TRANSLATION: 'Не вдалося оновити переклад категорії. Спробуйте ще раз',
     },
     MODAL: {
         SHARED: {
@@ -231,6 +233,13 @@ export const FUNDS_EXPENDITURES_TEXT = {
                 NAME_DUPLICATE: 'Категорія з такою назвою вже існує',
             },
         },
+        TRANSLATE_CATEGORY: {
+            TITLE: 'Переклад категорії',
+            CATEGORY_LABEL: 'Категорія',
+            CATEGORY_PLACEHOLDER: 'Оберіть категорію',
+            NAME_LABEL: 'Назва',
+            NAME_PLACEHOLDER: 'Введіть назву категорії',
+        },
     },
     BUTTON: {
         EDIT: 'Редагувати Доходи та витрати',
@@ -239,6 +248,7 @@ export const FUNDS_EXPENDITURES_TEXT = {
         ADD_CATEGORY: 'Додати категорію',
         DELETE_CATEGORY: 'Видалити',
         EDIT_CATEGORY: 'Редагувати',
+        TRANSLATE_CATEGORY: 'Перекласти',
     },
     FILTER: {
         TYPE_PLACEHOLDER: 'Тип',

--- a/src/const/common/api-routes/main-api.ts
+++ b/src/const/common/api-routes/main-api.ts
@@ -109,6 +109,9 @@ export const API_ROUTES = {
     FAQ_LOCALIZATIONS: {
         BASE: 'FaqQuestionLocalizations',
     },
+    REPORT_FUNDS_EXPENDITURES_CATEGORY_LOCALIZATIONS: {
+        BASE: 'ReportFundsExpendituresCategoryLocalizations',
+    },
     HISTORY: {
         BASE: 'History',
     },

--- a/src/hooks/admin/use-funds-expenditures-record-form/useFundsExpendituresRecordForm.test.ts
+++ b/src/hooks/admin/use-funds-expenditures-record-form/useFundsExpendituresRecordForm.test.ts
@@ -6,9 +6,9 @@ import * as fundsExpendituresSchema from '@/validation/admin/reports-schema/fund
 import { useFundsExpendituresRecordForm } from './useFundsExpendituresRecordForm';
 
 const categories: ReportFundsExpendituresCategory[] = [
-    { id: 3, name: 'C income', type: 'income' },
-    { id: 1, name: 'A income', type: 'income' },
-    { id: 2, name: 'B expense', type: 'expense' },
+    { id: 3, name: 'C income', type: 'income', localizations: [] },
+    { id: 1, name: 'A income', type: 'income', localizations: [] },
+    { id: 2, name: 'B expense', type: 'expense', localizations: [] },
 ];
 
 const records: ReportFundsExpendituresRecord[] = [

--- a/src/hooks/admin/use-translate-reports-category/useTranslateReportsCategory.test.ts
+++ b/src/hooks/admin/use-translate-reports-category/useTranslateReportsCategory.test.ts
@@ -1,0 +1,245 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useTranslateReportsCategory } from './useTranslateReportsCategory';
+import { ReportFundsExpendituresCategoryLocalizationsApi } from '@/services/api/admin/reports/report-funds-expenditures-category-localizations/report-funds-expenditures-category-localizations-api';
+import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/localization/localization-mappers';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { LocalizationLanguage, TranslationStatus } from '@/types/common/language';
+import { ReportFundsExpendituresCategory, ReportFundsExpendituresCategoryLocalization } from '@/types/admin/reports';
+import { ModalMode } from '@/types/admin/common';
+
+jest.mock(
+    '@/services/api/admin/reports/report-funds-expenditures-category-localizations/report-funds-expenditures-category-localizations-api',
+);
+jest.mock('@/utils/functions/mappers/common/localization/localization-mappers');
+jest.mock('../use-admin-client/useAdminClient', () => ({
+    useAdminClient: () => ({ post: jest.fn(), put: jest.fn() }),
+}));
+
+const mockedCreate = ReportFundsExpendituresCategoryLocalizationsApi.create as jest.MockedFunction<
+    typeof ReportFundsExpendituresCategoryLocalizationsApi.create
+>;
+const mockedUpdate = ReportFundsExpendituresCategoryLocalizationsApi.update as jest.MockedFunction<
+    typeof ReportFundsExpendituresCategoryLocalizationsApi.update
+>;
+const mockedMapper = mapLocalizationDtoToModel as jest.MockedFunction<typeof mapLocalizationDtoToModel>;
+
+const categoryMock: ReportFundsExpendituresCategory = {
+    id: 1,
+    name: 'Original category',
+    type: 'income',
+    localizations: [],
+};
+
+const languageMock: LocalizationLanguage = {
+    id: 2,
+    code: 'en',
+    name: 'English',
+};
+
+const formValues = { name: 'Translated category' };
+
+const localizationDtoMock = {
+    entityId: 1,
+    name: 'Translated category',
+    localizationInfoDto: { id: 2, code: 'en' },
+    translationStatus: TranslationStatus.Relevant,
+};
+
+const localizationModelMock: ReportFundsExpendituresCategoryLocalization = {
+    name: 'Translated category',
+    language: { id: 2, code: 'en' },
+    translationStatus: TranslationStatus.Relevant,
+};
+
+describe('useTranslateReportsCategory', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should initialize with default state', () => {
+        const { result } = renderHook(() =>
+            useTranslateReportsCategory({
+                category: categoryMock,
+                language: languageMock,
+                onSuccess: jest.fn(),
+                mode: ModalMode.Add,
+            }),
+        );
+
+        expect(result.current.isSubmitting).toBe(false);
+        expect(result.current.error).toBe('');
+    });
+
+    it('should create translation successfully in add mode', async () => {
+        const onSuccess = jest.fn();
+        mockedCreate.mockResolvedValue(localizationDtoMock as any);
+        mockedMapper.mockReturnValue(localizationModelMock);
+
+        const { result } = renderHook(() =>
+            useTranslateReportsCategory({
+                category: categoryMock,
+                language: languageMock,
+                onSuccess,
+                mode: ModalMode.Add,
+            }),
+        );
+
+        act(() => {
+            result.current.translateCategory(formValues);
+        });
+
+        await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+
+        expect(mockedCreate).toHaveBeenCalledWith(expect.anything(), {
+            entityId: 1,
+            languageId: 2,
+            name: formValues.name,
+        });
+        expect(onSuccess).toHaveBeenCalledWith({
+            ...categoryMock,
+            localizations: [localizationModelMock],
+        });
+        expect(result.current.isSubmitting).toBe(false);
+        expect(result.current.error).toBe('');
+    });
+
+    it('should update translation successfully in edit mode', async () => {
+        const onSuccess = jest.fn();
+        mockedUpdate.mockResolvedValue(localizationDtoMock as any);
+        mockedMapper.mockReturnValue(localizationModelMock);
+
+        const categoryWithLocalization: ReportFundsExpendituresCategory = {
+            ...categoryMock,
+            localizations: [{ ...localizationModelMock, language: languageMock }],
+        };
+
+        const { result } = renderHook(() =>
+            useTranslateReportsCategory({
+                category: categoryWithLocalization,
+                language: languageMock,
+                onSuccess,
+                mode: ModalMode.Edit,
+            }),
+        );
+
+        await act(async () => {
+            await result.current.translateCategory(formValues);
+        });
+
+        expect(mockedUpdate).toHaveBeenCalledWith(expect.anything(), categoryMock.id, languageMock.id, {
+            name: formValues.name,
+        });
+        expect(onSuccess).toHaveBeenCalledWith({
+            ...categoryWithLocalization,
+            localizations: [localizationModelMock],
+        });
+    });
+
+    it('should set error when create fails', async () => {
+        const onSuccess = jest.fn();
+        mockedCreate.mockRejectedValue(new Error('API error'));
+
+        const { result } = renderHook(() =>
+            useTranslateReportsCategory({
+                category: categoryMock,
+                language: languageMock,
+                onSuccess,
+                mode: ModalMode.Add,
+            }),
+        );
+
+        await act(async () => {
+            try {
+                await result.current.translateCategory(formValues);
+            } catch {}
+        });
+
+        await waitFor(() => {
+            expect(result.current.error).toBe(FUNDS_EXPENDITURES_TEXT.MESSAGE.FAIL_TO_TRANSLATE_CATEGORY);
+        });
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(result.current.isSubmitting).toBe(false);
+    });
+
+    it('should set error when update fails in edit mode', async () => {
+        const onSuccess = jest.fn();
+        mockedUpdate.mockRejectedValue(new Error('API error'));
+
+        const { result } = renderHook(() =>
+            useTranslateReportsCategory({
+                category: categoryMock,
+                language: languageMock,
+                onSuccess,
+                mode: ModalMode.Edit,
+            }),
+        );
+
+        await act(async () => {
+            try {
+                await result.current.translateCategory(formValues);
+            } catch {}
+        });
+
+        await waitFor(() => {
+            expect(result.current.error).toBe(FUNDS_EXPENDITURES_TEXT.MESSAGE.FAIL_TO_UPDATE_CATEGORY_TRANSLATION);
+        });
+        expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when category is null', async () => {
+        const onSuccess = jest.fn();
+
+        const { result } = renderHook(() =>
+            useTranslateReportsCategory({
+                category: null,
+                language: languageMock,
+                onSuccess,
+                mode: ModalMode.Add,
+            }),
+        );
+
+        await act(async () => {
+            await result.current.translateCategory(formValues);
+        });
+
+        expect(mockedCreate).not.toHaveBeenCalled();
+        expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when language is null', async () => {
+        const onSuccess = jest.fn();
+
+        const { result } = renderHook(() =>
+            useTranslateReportsCategory({
+                category: categoryMock,
+                language: null,
+                onSuccess,
+                mode: ModalMode.Add,
+            }),
+        );
+
+        await act(async () => {
+            await result.current.translateCategory(formValues);
+        });
+
+        expect(mockedCreate).not.toHaveBeenCalled();
+        expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('should clear error', () => {
+        const { result } = renderHook(() =>
+            useTranslateReportsCategory({
+                category: categoryMock,
+                language: languageMock,
+                onSuccess: jest.fn(),
+                mode: ModalMode.Add,
+            }),
+        );
+
+        act(() => {
+            result.current.clearError();
+        });
+
+        expect(result.current.error).toBe('');
+    });
+});

--- a/src/hooks/admin/use-translate-reports-category/useTranslateReportsCategory.test.ts
+++ b/src/hooks/admin/use-translate-reports-category/useTranslateReportsCategory.test.ts
@@ -149,9 +149,7 @@ describe('useTranslateReportsCategory', () => {
         );
 
         await act(async () => {
-            try {
-                await result.current.translateCategory(formValues);
-            } catch {}
+            await result.current.translateCategory(formValues);
         });
 
         await waitFor(() => {
@@ -175,9 +173,7 @@ describe('useTranslateReportsCategory', () => {
         );
 
         await act(async () => {
-            try {
-                await result.current.translateCategory(formValues);
-            } catch {}
+            await result.current.translateCategory(formValues);
         });
 
         await waitFor(() => {

--- a/src/hooks/admin/use-translate-reports-category/useTranslateReportsCategory.ts
+++ b/src/hooks/admin/use-translate-reports-category/useTranslateReportsCategory.ts
@@ -72,13 +72,12 @@ export const useTranslateReportsCategory = ({
                 };
                 onSuccess(updatedCategory);
             }
-        } catch (err) {
+        } catch {
             setError(
                 isEditMode
                     ? FUNDS_EXPENDITURES_TEXT.MESSAGE.FAIL_TO_UPDATE_CATEGORY_TRANSLATION
                     : FUNDS_EXPENDITURES_TEXT.MESSAGE.FAIL_TO_TRANSLATE_CATEGORY,
             );
-            throw err;
         } finally {
             setIsSubmitting(false);
         }

--- a/src/hooks/admin/use-translate-reports-category/useTranslateReportsCategory.ts
+++ b/src/hooks/admin/use-translate-reports-category/useTranslateReportsCategory.ts
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import { ModalMode } from '@/types/admin/common';
+import { ReportFundsExpendituresCategory, ReportFundsExpendituresCategoryLocalization } from '@/types/admin/reports';
+import { LocalizationLanguage } from '@/types/common/language';
+import { useAdminClient } from '../use-admin-client/useAdminClient';
+import { ReportFundsExpendituresCategoryLocalizationsApi } from '@/services/api/admin/reports/report-funds-expenditures-category-localizations/report-funds-expenditures-category-localizations-api';
+import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/localization/localization-mappers';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { TranslateReportsCategoryFormValues } from '@/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryForm';
+
+interface UseTranslateReportsCategoryParams {
+    category: ReportFundsExpendituresCategory | null;
+    language: LocalizationLanguage | null;
+    onSuccess: (updatedCategory: ReportFundsExpendituresCategory) => void;
+    mode: ModalMode;
+}
+
+export const useTranslateReportsCategory = ({
+    category,
+    language,
+    onSuccess,
+    mode,
+}: UseTranslateReportsCategoryParams) => {
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [error, setError] = useState<string>('');
+
+    const client = useAdminClient();
+    const isEditMode = mode === ModalMode.Edit;
+
+    const translateCategory = async (data: TranslateReportsCategoryFormValues) => {
+        if (!category || !language) return;
+
+        try {
+            setIsSubmitting(true);
+            setError('');
+
+            if (isEditMode) {
+                const updatedDto = await ReportFundsExpendituresCategoryLocalizationsApi.update(
+                    client,
+                    category.id,
+                    language.id,
+                    { name: data.name },
+                );
+
+                const updatedLocalization = mapLocalizationDtoToModel<
+                    typeof updatedDto,
+                    ReportFundsExpendituresCategoryLocalization
+                >(updatedDto);
+
+                const updatedCategory: ReportFundsExpendituresCategory = {
+                    ...category,
+                    localizations: category.localizations.map((loc) =>
+                        loc.language.id === language.id ? updatedLocalization : loc,
+                    ),
+                };
+                onSuccess(updatedCategory);
+            } else {
+                const createdDto = await ReportFundsExpendituresCategoryLocalizationsApi.create(client, {
+                    entityId: category.id,
+                    languageId: language.id,
+                    name: data.name,
+                });
+
+                const createdLocalization = mapLocalizationDtoToModel<
+                    typeof createdDto,
+                    ReportFundsExpendituresCategoryLocalization
+                >(createdDto);
+
+                const updatedCategory: ReportFundsExpendituresCategory = {
+                    ...category,
+                    localizations: [...category.localizations, createdLocalization],
+                };
+                onSuccess(updatedCategory);
+            }
+        } catch (err) {
+            setError(
+                isEditMode
+                    ? FUNDS_EXPENDITURES_TEXT.MESSAGE.FAIL_TO_UPDATE_CATEGORY_TRANSLATION
+                    : FUNDS_EXPENDITURES_TEXT.MESSAGE.FAIL_TO_TRANSLATE_CATEGORY,
+            );
+            throw err;
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const clearError = () => setError('');
+
+    return { translateCategory, isSubmitting, error, clearError };
+};

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
@@ -22,14 +22,14 @@ const MOCK_FUNDS_EXPENDITURES_SETTINGS: ReportFundsExpendituresSettings = {
 };
 
 const MOCK_FUNDS_EXPENDITURES_CATEGORIES: ReportFundsExpendituresCategory[] = [
-    { id: 1, name: 'Грантові кошти', type: 'income' },
-    { id: 2, name: 'Благодійні внески', type: 'income' },
-    { id: 3, name: 'Власні надходження', type: 'income' },
-    { id: 4, name: 'Інші надходження', type: 'income' },
-    { id: 5, name: 'Адміністративні витрати', type: 'expense' },
-    { id: 6, name: 'Програмні витрати', type: 'expense' },
-    { id: 7, name: 'Обладнання', type: 'expense' },
-    { id: 8, name: 'Заробітна плата', type: 'expense' },
+    { id: 1, name: 'Грантові кошти', type: 'income', localizations: [] },
+    { id: 2, name: 'Благодійні внески', type: 'income', localizations: [] },
+    { id: 3, name: 'Власні надходження', type: 'income', localizations: [] },
+    { id: 4, name: 'Інші надходження', type: 'income', localizations: [] },
+    { id: 5, name: 'Адміністративні витрати', type: 'expense', localizations: [] },
+    { id: 6, name: 'Програмні витрати', type: 'expense', localizations: [] },
+    { id: 7, name: 'Обладнання', type: 'expense', localizations: [] },
+    { id: 8, name: 'Заробітна плата', type: 'expense', localizations: [] },
 ];
 
 const MOCK_FUNDS_EXPENDITURES_RECORDS: ReportFundsExpendituresRecord[] = [
@@ -902,9 +902,9 @@ describe('FundsExpenditureSection', () => {
 describe('FundsExpenditureSection bulk delete flow', () => {
     const settingsMock = { id: 1, exchangeRate: '40', disclaimerTitle: 'Disclaimer' };
     const categoriesMock: ReportFundsExpendituresCategory[] = [
-        { id: 1, name: 'A', type: 'income' },
-        { id: 2, name: 'B', type: 'income' },
-        { id: 3, name: PROGRAM_EXPENSES_TEXT.TABLE.TYPE_LABEL, type: 'expense' },
+        { id: 1, name: 'A', type: 'income', localizations: [] },
+        { id: 2, name: 'B', type: 'income', localizations: [] },
+        { id: 3, name: PROGRAM_EXPENSES_TEXT.TABLE.TYPE_LABEL, type: 'expense', localizations: [] },
     ];
     const recordsMock: ReportFundsExpendituresRecord[] = [
         { id: 1, categoryId: 1, type: 'income', reportingYear: '2025', amountUah: '100', amountUsd: '10' },

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -63,6 +63,7 @@ interface FundsExpenditureSectionProps {
     onDeleteCategoryModalClose?: () => void;
     isEditCategoryModalOpen?: boolean;
     onEditCategoryModalClose?: () => void;
+    onCategoriesLoaded?: (categories: ReportFundsExpendituresCategory[]) => void;
 }
 
 export const FundsExpenditureSection = ({
@@ -76,6 +77,7 @@ export const FundsExpenditureSection = ({
     onDeleteCategoryModalClose,
     isEditCategoryModalOpen = false,
     onEditCategoryModalClose,
+    onCategoriesLoaded,
 }: FundsExpenditureSectionProps = {}) => {
     const adminClient = useAdminClient();
     const { addToast } = useToast();
@@ -222,6 +224,10 @@ export const FundsExpenditureSection = ({
     useEffect(() => {
         setRecordsState(allRecords);
     }, [allRecords]);
+
+    useEffect(() => {
+        onCategoriesLoaded?.(categories);
+    }, [categories, onCategoriesLoaded]);
 
     const isPublishEnabled = useMemo(() => {
         const normalized = disclaimerValue.replaceAll(/\s+/g, ' ').trim();

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.test.tsx
@@ -103,7 +103,9 @@ describe('AddFundsExpendituresCategoryModal', () => {
         });
 
         it('shows duplicate error on blur when name matches existing category for same type', () => {
-            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Приватні донори', type: 'income', localizations: [] }];
+            const categories: ReportFundsExpendituresCategory[] = [
+                { id: 1, name: 'Приватні донори', type: 'income', localizations: [] },
+            ];
             renderOpen(jest.fn(), categories);
             fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'income' } });
             fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Донори приватні' } });
@@ -112,7 +114,9 @@ describe('AddFundsExpendituresCategoryModal', () => {
         });
 
         it('does not show duplicate error when type differs from existing category', () => {
-            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Приватні донори', type: 'expense', localizations: [] }];
+            const categories: ReportFundsExpendituresCategory[] = [
+                { id: 1, name: 'Приватні донори', type: 'expense', localizations: [] },
+            ];
             renderOpen(jest.fn(), categories);
             fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'income' } });
             fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Приватні донори' } });
@@ -134,7 +138,9 @@ describe('AddFundsExpendituresCategoryModal', () => {
 
     describe('name re-validation on type change', () => {
         it('shows duplicate error when type changes to one that has the same name', () => {
-            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Category A', type: 'expense', localizations: [] }];
+            const categories: ReportFundsExpendituresCategory[] = [
+                { id: 1, name: 'Category A', type: 'expense', localizations: [] },
+            ];
             renderOpen(jest.fn(), categories);
             fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Category A' } });
             fireEvent.blur(screen.getByTestId(NAME_INPUT));
@@ -145,7 +151,9 @@ describe('AddFundsExpendituresCategoryModal', () => {
         });
 
         it('clears duplicate error when type changes to one without the same name', () => {
-            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Category A', type: 'income', localizations: [] }];
+            const categories: ReportFundsExpendituresCategory[] = [
+                { id: 1, name: 'Category A', type: 'income', localizations: [] },
+            ];
             renderOpen(jest.fn(), categories);
             fillForm('income', 'Category A');
             fireEvent.blur(screen.getByTestId(NAME_INPUT));
@@ -156,7 +164,9 @@ describe('AddFundsExpendituresCategoryModal', () => {
         });
 
         it('does not show name error on type change before name has been blurred', () => {
-            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Category A', type: 'expense', localizations: [] }];
+            const categories: ReportFundsExpendituresCategory[] = [
+                { id: 1, name: 'Category A', type: 'expense', localizations: [] },
+            ];
             renderOpen(jest.fn(), categories);
             fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Category A' } });
 

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.test.tsx
@@ -103,7 +103,7 @@ describe('AddFundsExpendituresCategoryModal', () => {
         });
 
         it('shows duplicate error on blur when name matches existing category for same type', () => {
-            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Приватні донори', type: 'income' }];
+            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Приватні донори', type: 'income', localizations: [] }];
             renderOpen(jest.fn(), categories);
             fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'income' } });
             fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Донори приватні' } });
@@ -112,7 +112,7 @@ describe('AddFundsExpendituresCategoryModal', () => {
         });
 
         it('does not show duplicate error when type differs from existing category', () => {
-            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Приватні донори', type: 'expense' }];
+            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Приватні донори', type: 'expense', localizations: [] }];
             renderOpen(jest.fn(), categories);
             fireEvent.change(screen.getByTestId(TYPE_SELECT), { target: { value: 'income' } });
             fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Приватні донори' } });
@@ -134,7 +134,7 @@ describe('AddFundsExpendituresCategoryModal', () => {
 
     describe('name re-validation on type change', () => {
         it('shows duplicate error when type changes to one that has the same name', () => {
-            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Category A', type: 'expense' }];
+            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Category A', type: 'expense', localizations: [] }];
             renderOpen(jest.fn(), categories);
             fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Category A' } });
             fireEvent.blur(screen.getByTestId(NAME_INPUT));
@@ -145,7 +145,7 @@ describe('AddFundsExpendituresCategoryModal', () => {
         });
 
         it('clears duplicate error when type changes to one without the same name', () => {
-            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Category A', type: 'income' }];
+            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Category A', type: 'income', localizations: [] }];
             renderOpen(jest.fn(), categories);
             fillForm('income', 'Category A');
             fireEvent.blur(screen.getByTestId(NAME_INPUT));
@@ -156,7 +156,7 @@ describe('AddFundsExpendituresCategoryModal', () => {
         });
 
         it('does not show name error on type change before name has been blurred', () => {
-            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Category A', type: 'expense' }];
+            const categories: ReportFundsExpendituresCategory[] = [{ id: 1, name: 'Category A', type: 'expense', localizations: [] }];
             renderOpen(jest.fn(), categories);
             fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Category A' } });
 

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal.test.tsx
@@ -10,8 +10,8 @@ const CANCEL_BUTTON_NAME = COMMON_TEXT_ADMIN.BUTTON.CANCEL;
 const YES_BUTTON = COMMON_TEXT_ADMIN.BUTTON.YES;
 const NO_BUTTON = COMMON_TEXT_ADMIN.BUTTON.NO;
 
-const incomeCategory: ReportFundsExpendituresCategory = { id: 1, name: 'Донори', type: 'income' };
-const expenseCategory: ReportFundsExpendituresCategory = { id: 2, name: 'Оренда', type: 'expense' };
+const incomeCategory: ReportFundsExpendituresCategory = { id: 1, name: 'Донори', type: 'income', localizations: [] };
+const expenseCategory: ReportFundsExpendituresCategory = { id: 2, name: 'Оренда', type: 'expense', localizations: [] };
 
 const incomeRecord: ReportFundsExpendituresRecord = {
     id: 10,

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.test.tsx
@@ -114,7 +114,11 @@ describe('EditFundsExpendituresCategoryModal', () => {
         });
 
         it('is disabled when name duplicates another category of the same type', () => {
-            const categories = [incomeCategory, expenseCategory, { id: 3, name: 'Гранти', type: 'income' as const, localizations: [] }];
+            const categories = [
+                incomeCategory,
+                expenseCategory,
+                { id: 3, name: 'Гранти', type: 'income' as const, localizations: [] },
+            ];
             renderModal({ categories });
             selectCategory(incomeCategory.name);
             typeName('Гранти');
@@ -138,7 +142,11 @@ describe('EditFundsExpendituresCategoryModal', () => {
         });
 
         it('shows duplicate error when name matches another category of the same type', () => {
-            const categories = [incomeCategory, expenseCategory, { id: 3, name: 'Гранти', type: 'income' as const, localizations: [] }];
+            const categories = [
+                incomeCategory,
+                expenseCategory,
+                { id: 3, name: 'Гранти', type: 'income' as const, localizations: [] },
+            ];
             renderModal({ categories });
             selectCategory(incomeCategory.name);
             typeName('Гранти');

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal.test.tsx
@@ -19,8 +19,8 @@ const DUPLICATE_ERROR = FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.ERROR.NAME_DUPLIC
 const YES_BUTTON = COMMON_TEXT_ADMIN.BUTTON.YES;
 const NO_BUTTON = COMMON_TEXT_ADMIN.BUTTON.NO;
 
-const incomeCategory: ReportFundsExpendituresCategory = { id: 1, name: 'Донори', type: 'income' };
-const expenseCategory: ReportFundsExpendituresCategory = { id: 2, name: 'Оренда', type: 'expense' };
+const incomeCategory: ReportFundsExpendituresCategory = { id: 1, name: 'Донори', type: 'income', localizations: [] };
+const expenseCategory: ReportFundsExpendituresCategory = { id: 2, name: 'Оренда', type: 'expense', localizations: [] };
 
 const renderModal = (
     overrides: Partial<{
@@ -114,7 +114,7 @@ describe('EditFundsExpendituresCategoryModal', () => {
         });
 
         it('is disabled when name duplicates another category of the same type', () => {
-            const categories = [incomeCategory, expenseCategory, { id: 3, name: 'Гранти', type: 'income' as const }];
+            const categories = [incomeCategory, expenseCategory, { id: 3, name: 'Гранти', type: 'income' as const, localizations: [] }];
             renderModal({ categories });
             selectCategory(incomeCategory.name);
             typeName('Гранти');
@@ -138,7 +138,7 @@ describe('EditFundsExpendituresCategoryModal', () => {
         });
 
         it('shows duplicate error when name matches another category of the same type', () => {
-            const categories = [incomeCategory, expenseCategory, { id: 3, name: 'Гранти', type: 'income' as const }];
+            const categories = [incomeCategory, expenseCategory, { id: 3, name: 'Гранти', type: 'income' as const, localizations: [] }];
             renderModal({ categories });
             selectCategory(incomeCategory.name);
             typeName('Гранти');

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryForm.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryForm.test.tsx
@@ -1,0 +1,225 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
+import { TranslateReportsCategoryForm } from './TranslateReportsCategoryForm';
+
+jest.mock('@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup', () => ({
+    InputWithCharacterLimitGroup: ({ id, value, onChange, onBlur, disabled, error }: any) => (
+        <>
+            <input data-testid={id} value={value} onChange={onChange} onBlur={onBlur} disabled={disabled ?? false} />
+            {error && <span>{error}</span>}
+        </>
+    ),
+}));
+
+jest.mock('@/components/admin/input-groups/single-select-input-group/SingleSelectInputGroup', () => ({
+    SingleSelectInputGroup: ({ id, options, onChange, disabled, placeholder }: any) => (
+        <select
+            data-testid={id}
+            disabled={disabled ?? false}
+            onChange={(e) => {
+                const opt = options.find((o: any) => String(o.id) === e.target.value) ?? null;
+                onChange(opt);
+            }}
+        >
+            <option value="">{placeholder}</option>
+            {options.map((o: any) => (
+                <option key={o.id} value={o.id}>
+                    {o.name}
+                </option>
+            ))}
+        </select>
+    ),
+}));
+
+const categoriesMock: ReportFundsExpendituresCategory[] = [
+    { id: 1, name: 'Category One', type: 'income', localizations: [] },
+    { id: 2, name: 'Category Two', type: 'expense', localizations: [] },
+];
+
+const CATEGORY_SELECT = 'translate-category-select';
+const NAME_INPUT = 'translate-category-name';
+const REQUIRED_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
+const MIN_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMin);
+const MAX_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMax);
+
+describe('TranslateReportsCategoryForm', () => {
+    it('renders category select and name input', () => {
+        render(<TranslateReportsCategoryForm categories={categoriesMock} onSubmit={jest.fn()} />);
+
+        expect(screen.getByTestId(CATEGORY_SELECT)).toBeInTheDocument();
+        expect(screen.getByTestId(NAME_INPUT)).toBeInTheDocument();
+    });
+
+    it('name input is disabled when no category is selected', () => {
+        render(<TranslateReportsCategoryForm categories={categoriesMock} onSubmit={jest.fn()} />);
+
+        expect(screen.getByTestId(NAME_INPUT)).toBeDisabled();
+    });
+
+    it('name input is enabled after category is selected', () => {
+        render(<TranslateReportsCategoryForm categories={categoriesMock} onSubmit={jest.fn()} />);
+
+        fireEvent.change(screen.getByTestId(CATEGORY_SELECT), { target: { value: '1' } });
+        expect(screen.getByTestId(NAME_INPUT)).not.toBeDisabled();
+    });
+
+    it('calls onCategoryChange when category selection changes', () => {
+        const onCategoryChange = jest.fn();
+        render(
+            <TranslateReportsCategoryForm
+                categories={categoriesMock}
+                onSubmit={jest.fn()}
+                onCategoryChange={onCategoryChange}
+            />,
+        );
+
+        fireEvent.change(screen.getByTestId(CATEGORY_SELECT), { target: { value: '1' } });
+        expect(onCategoryChange).toHaveBeenCalled();
+    });
+
+    describe('name validation', () => {
+        it('shows required error on blur when name is empty', () => {
+            render(<TranslateReportsCategoryForm categories={categoriesMock} onSubmit={jest.fn()} />);
+
+            fireEvent.change(screen.getByTestId(CATEGORY_SELECT), { target: { value: '1' } });
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(REQUIRED_ERROR)).toBeInTheDocument();
+        });
+
+        it('shows min length error on blur when name is too short', () => {
+            render(<TranslateReportsCategoryForm categories={categoriesMock} onSubmit={jest.fn()} />);
+
+            fireEvent.change(screen.getByTestId(CATEGORY_SELECT), { target: { value: '1' } });
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'ab' } });
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(MIN_ERROR)).toBeInTheDocument();
+        });
+
+        it('shows max length error on blur when name is too long', () => {
+            render(<TranslateReportsCategoryForm categories={categoriesMock} onSubmit={jest.fn()} />);
+
+            const longName = 'a'.repeat(FUNDS_EXPENDITURES_VALIDATION.categoryNameMax + 1);
+            fireEvent.change(screen.getByTestId(CATEGORY_SELECT), { target: { value: '1' } });
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: longName } });
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(MAX_ERROR)).toBeInTheDocument();
+        });
+
+        it('clears error when name becomes valid on re-blur', () => {
+            render(<TranslateReportsCategoryForm categories={categoriesMock} onSubmit={jest.fn()} />);
+
+            fireEvent.change(screen.getByTestId(CATEGORY_SELECT), { target: { value: '1' } });
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'ab' } });
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.getByText(MIN_ERROR)).toBeInTheDocument();
+
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Valid name here' } });
+            fireEvent.blur(screen.getByTestId(NAME_INPUT));
+            expect(screen.queryByText(MIN_ERROR)).not.toBeInTheDocument();
+        });
+    });
+
+    describe('onValidationChange', () => {
+        it('reports valid when category selected and name is valid', () => {
+            const onValidationChange = jest.fn();
+            render(
+                <TranslateReportsCategoryForm
+                    categories={categoriesMock}
+                    onSubmit={jest.fn()}
+                    onValidationChange={onValidationChange}
+                />,
+            );
+
+            fireEvent.change(screen.getByTestId(CATEGORY_SELECT), { target: { value: '1' } });
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Valid name here' } });
+
+            expect(onValidationChange).toHaveBeenLastCalledWith(true);
+        });
+
+        it('reports invalid when name is too short', () => {
+            const onValidationChange = jest.fn();
+            render(
+                <TranslateReportsCategoryForm
+                    categories={categoriesMock}
+                    onSubmit={jest.fn()}
+                    onValidationChange={onValidationChange}
+                />,
+            );
+
+            fireEvent.change(screen.getByTestId(CATEGORY_SELECT), { target: { value: '1' } });
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'ab' } });
+
+            expect(onValidationChange).toHaveBeenLastCalledWith(false);
+        });
+    });
+
+    describe('onDirtyChange', () => {
+        it('reports dirty when name is changed from empty default', () => {
+            const onDirtyChange = jest.fn();
+            render(
+                <TranslateReportsCategoryForm
+                    categories={categoriesMock}
+                    onSubmit={jest.fn()}
+                    onDirtyChange={onDirtyChange}
+                />,
+            );
+
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'some text' } });
+            expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+        });
+
+        it('reports not dirty when name matches initialData', () => {
+            const onDirtyChange = jest.fn();
+            render(
+                <TranslateReportsCategoryForm
+                    categories={categoriesMock}
+                    onSubmit={jest.fn()}
+                    initialData={{ name: 'existing name' }}
+                    onDirtyChange={onDirtyChange}
+                />,
+            );
+
+            fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'existing name' } });
+            expect(onDirtyChange).toHaveBeenLastCalledWith(false);
+        });
+    });
+
+    it('pre-fills name input when initialData is provided', () => {
+        render(
+            <TranslateReportsCategoryForm
+                categories={categoriesMock}
+                onSubmit={jest.fn()}
+                initialData={{ name: 'Pre-filled name' }}
+            />,
+        );
+
+        expect(screen.getByTestId(NAME_INPUT)).toHaveValue('Pre-filled name');
+    });
+
+    it('disables inputs when formDisabled is true', () => {
+        render(<TranslateReportsCategoryForm categories={categoriesMock} onSubmit={jest.fn()} formDisabled={true} />);
+
+        expect(screen.getByTestId(CATEGORY_SELECT)).toBeDisabled();
+        expect(screen.getByTestId(NAME_INPUT)).toBeDisabled();
+    });
+
+    it('calls onSubmit with form values when submitted via ref', async () => {
+        const onSubmit = jest.fn();
+        const ref = { current: null as any };
+
+        render(<TranslateReportsCategoryForm ref={ref} categories={categoriesMock} onSubmit={onSubmit} />);
+
+        fireEvent.change(screen.getByTestId(CATEGORY_SELECT), { target: { value: '1' } });
+        fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Valid name here' } });
+
+        await waitFor(() => {
+            if (ref.current?.isValid()) {
+                ref.current.submit();
+            }
+        });
+
+        await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ name: 'Valid name here' }));
+    });
+});

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryForm.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryForm.test.tsx
@@ -164,6 +164,7 @@ describe('TranslateReportsCategoryForm', () => {
                 />,
             );
 
+            fireEvent.change(screen.getByTestId(CATEGORY_SELECT), { target: { value: '1' } });
             fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'some text' } });
             expect(onDirtyChange).toHaveBeenLastCalledWith(true);
         });
@@ -179,6 +180,7 @@ describe('TranslateReportsCategoryForm', () => {
                 />,
             );
 
+            fireEvent.change(screen.getByTestId(CATEGORY_SELECT), { target: { value: '1' } });
             fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'existing name' } });
             expect(onDirtyChange).toHaveBeenLastCalledWith(false);
         });

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryForm.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryForm.test.tsx
@@ -113,8 +113,6 @@ describe('TranslateReportsCategoryForm', () => {
             fireEvent.change(screen.getByTestId(CATEGORY_SELECT), { target: { value: '1' } });
             fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'ab' } });
             fireEvent.blur(screen.getByTestId(NAME_INPUT));
-            expect(screen.getByText(MIN_ERROR)).toBeInTheDocument();
-
             fireEvent.change(screen.getByTestId(NAME_INPUT), { target: { value: 'Valid name here' } });
             fireEvent.blur(screen.getByTestId(NAME_INPUT));
             expect(screen.queryByText(MIN_ERROR)).not.toBeInTheDocument();

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryForm.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryForm.tsx
@@ -1,0 +1,132 @@
+import { forwardRef, useEffect, useState } from 'react';
+import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
+import { SingleSelectInputGroup } from '@/components/admin/input-groups/single-select-input-group/SingleSelectInputGroup';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { useFormManager } from '@/hooks/admin/use-form-manager/useFormManager';
+import { VisibilityStatus } from '@/types/admin/common';
+import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
+import { getNormalizedInputText } from '@/utils/functions/formatters/text-formatters';
+import styles from './TranslateReportsCategoryModal.module.scss';
+
+export interface TranslateReportsCategoryFormValues {
+    name: string;
+}
+
+export interface TranslateReportsCategoryFormErrorState {
+    name: string | undefined;
+    [key: string]: string | undefined;
+}
+
+export interface TranslateReportsCategoryFormRef {
+    submit: (status?: VisibilityStatus) => Promise<void>;
+    isValid: () => boolean;
+    isDirty: () => boolean;
+}
+
+export interface TranslateReportsCategoryFormProps {
+    onSubmit: (data: TranslateReportsCategoryFormValues) => void | Promise<void>;
+    categories: ReportFundsExpendituresCategory[];
+    initialData?: TranslateReportsCategoryFormValues | null;
+    formDisabled?: boolean;
+    onCategoryChange?: (category: ReportFundsExpendituresCategory | null) => void;
+    onValidationChange?: (isValid: boolean) => void;
+    onDirtyChange?: (isDirty: boolean) => void;
+}
+
+const DEFAULT_FORM_STATE: TranslateReportsCategoryFormValues = {
+    name: '',
+};
+
+const validateForm = (formState: TranslateReportsCategoryFormValues): TranslateReportsCategoryFormErrorState => ({
+    name: validateTranslationName(formState.name),
+});
+
+const validateTranslationName = (value: string): string | undefined => {
+    const normalized = getNormalizedInputText(value);
+    if (!normalized) return COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
+    if (normalized.length < FUNDS_EXPENDITURES_VALIDATION.categoryNameMin)
+        return COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMin);
+    if (normalized.length > FUNDS_EXPENDITURES_VALIDATION.categoryNameMax)
+        return COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(FUNDS_EXPENDITURES_VALIDATION.categoryNameMax);
+    return undefined;
+};
+
+export const TranslateReportsCategoryForm = forwardRef<
+    TranslateReportsCategoryFormRef,
+    TranslateReportsCategoryFormProps
+>(
+    (
+        { initialData = null, onSubmit, categories, formDisabled, onCategoryChange, onValidationChange, onDirtyChange },
+        ref,
+    ) => {
+        const { formState, setFormState, errors, setErrors, isSubmitting } = useFormManager<
+            TranslateReportsCategoryFormValues,
+            TranslateReportsCategoryFormErrorState
+        >({
+            defaultFormState: DEFAULT_FORM_STATE,
+            initialData,
+            validateForm,
+            onValidationChange,
+            ref,
+            onSubmit: (data) => onSubmit(data),
+        });
+
+        const [selectedCategory, setSelectedCategory] = useState<ReportFundsExpendituresCategory | null>(null);
+
+        useEffect(() => {
+            const isDirty = JSON.stringify(formState) !== JSON.stringify(initialData ?? DEFAULT_FORM_STATE);
+            onDirtyChange?.(isDirty);
+        }, [formState, initialData, onDirtyChange]);
+
+        const handleCategoryChange = (category: ReportFundsExpendituresCategory | null) => {
+            setSelectedCategory(category);
+            onCategoryChange?.(category);
+        };
+
+        const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+            setFormState((prev) => ({ ...prev, name: e.target.value }));
+        };
+
+        const handleNameBlur = () => {
+            const error = validateTranslationName(formState.name);
+            setErrors((prev) => ({ ...prev, name: error }));
+        };
+
+        return (
+            <form
+                onSubmit={(e) => e.preventDefault()}
+                id="translate-reports-category-form"
+                noValidate
+                className={styles.form}
+            >
+                <SingleSelectInputGroup
+                    label={FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_CATEGORY.CATEGORY_LABEL}
+                    isRequired
+                    options={categories}
+                    getOptionId={(c) => c.id}
+                    getOptionName={(c) => c.name}
+                    disabled={isSubmitting || formDisabled}
+                    onChange={handleCategoryChange}
+                    value={selectedCategory || undefined}
+                    placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_CATEGORY.CATEGORY_PLACEHOLDER}
+                    id="translate-category-select"
+                />
+
+                <InputWithCharacterLimitGroup
+                    label={FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_CATEGORY.NAME_LABEL}
+                    error={errors.name}
+                    isRequired
+                    value={formState.name}
+                    onChange={handleNameChange}
+                    onBlur={handleNameBlur}
+                    disabled={isSubmitting || formDisabled || !selectedCategory}
+                    maxLength={FUNDS_EXPENDITURES_VALIDATION.categoryNameMax}
+                    showCounterBelow
+                    name="name"
+                    id="translate-category-name"
+                />
+            </form>
+        );
+    },
+);

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.module.scss
@@ -1,0 +1,81 @@
+@use '@/assets/sass/variables/colors' as c;
+@use '@/assets/sass/mixins/typography.mixins' as type;
+
+.modal {
+    width: 594px;
+    max-width: 594px;
+    background: c.$grey-50;
+    border-radius: 8px;
+    padding: 40px 30px;
+    box-sizing: border-box;
+
+    :global(.modal-header) {
+        margin-bottom: 0;
+        padding: 0;
+    }
+
+    :global(.modal-header .modal-title-wrapper) {
+        text-align: left;
+    }
+
+    :global(.modal-header-text) {
+        font-family: 'Mulish', sans-serif;
+        font-style: normal;
+        font-weight: 400;
+        font-size: 32px;
+        line-height: 24px;
+        letter-spacing: -0.02em;
+        color: c.$blue-900;
+        text-align: left;
+    }
+
+    :global(.modal-header .close-icon) {
+        padding-right: 0;
+        margin-bottom: 4px;
+    }
+
+    :global(.modal-body) {
+        margin-bottom: 0;
+        padding: 0;
+    }
+
+    :global(.modal-footer) {
+        padding: 0;
+        margin-top: 0;
+        gap: 0;
+        flex-wrap: nowrap;
+        justify-content: center;
+
+        button {
+            width: 100%;
+            height: 40px;
+            font-family: 'Mulish', sans-serif;
+            font-size: 16px;
+            font-weight: 400;
+            line-height: 24px;
+            letter-spacing: -0.02em;
+            border-radius: 8px;
+        }
+    }
+}
+
+.content {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding-top: 10px;
+}
+
+.form {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+    width: 100%;
+}
+
+.error {
+    @include type.small-text-regular;
+    color: c.$error;
+    min-height: 20px;
+    margin: 2px 0 0;
+}

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.module.scss
@@ -24,7 +24,7 @@
         font-weight: 400;
         font-size: 32px;
         line-height: 24px;
-        letter-spacing: -0.02em;
+        letter-spacing: -0.64px;
         color: c.$blue-900;
         text-align: left;
     }
@@ -53,7 +53,7 @@
             font-size: 16px;
             font-weight: 400;
             line-height: 24px;
-            letter-spacing: -0.02em;
+            letter-spacing: -0.64px;
             border-radius: 8px;
         }
     }

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.module.scss
@@ -23,7 +23,7 @@
         font-style: normal;
         font-weight: 400;
         font-size: 32px;
-        line-height: 24px;
+        line-height: 40px;
         letter-spacing: -0.64px;
         color: c.$blue-900;
         text-align: left;

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.test.tsx
@@ -55,37 +55,39 @@ jest.mock('@/components/admin/localization-modal/LocalizationModal', () => ({
         ) : null,
 }));
 
-jest.mock('./TranslateReportsCategoryForm', () => ({
-    TranslateReportsCategoryForm: ({
-        categories,
-        onCategoryChange,
-        onValidationChange,
-        onSubmit,
-        onDirtyChange,
-    }: any) => (
-        <div data-testid="translate-form">
-            <select
-                data-testid="category-select"
-                onChange={(e) => {
-                    const cat = categories.find((c: any) => String(c.id) === e.target.value) ?? null;
-                    onCategoryChange?.(cat);
-                    onValidationChange?.(!!cat);
-                    onDirtyChange?.(!!cat);
-                }}
-            >
-                <option value="">-- select --</option>
-                {categories.map((c: any) => (
-                    <option key={c.id} value={c.id}>
-                        {c.name}
-                    </option>
-                ))}
-            </select>
-            <button data-testid="form-submit" onClick={() => onSubmit({ name: 'Translated name' })}>
-                Submit
-            </button>
-        </div>
-    ),
-}));
+jest.mock('./TranslateReportsCategoryForm', () => {
+    const { forwardRef, useImperativeHandle } = jest.requireActual('react');
+    const TranslateReportsCategoryForm = forwardRef(
+        ({ categories, onCategoryChange, onValidationChange, onSubmit, onDirtyChange }: any, ref: any) => {
+            useImperativeHandle(ref, () => ({
+                isValid: () => true,
+                isDirty: () => true,
+                submit: () => onSubmit({ name: 'Translated name' }),
+            }));
+            return (
+                <div data-testid="translate-form">
+                    <select
+                        data-testid="category-select"
+                        onChange={(e) => {
+                            const cat = categories.find((c: any) => String(c.id) === e.target.value) ?? null;
+                            onCategoryChange?.(cat);
+                            onValidationChange?.(!!cat);
+                            onDirtyChange?.(!!cat);
+                        }}
+                    >
+                        <option value="">-- select --</option>
+                        {categories.map((c: any) => (
+                            <option key={c.id} value={c.id}>
+                                {c.name}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+            );
+        },
+    );
+    return { TranslateReportsCategoryForm };
+});
 
 const languageEn: LocalizationLanguage = { id: 2, code: 'en', name: 'English' };
 const languageUk: LocalizationLanguage = { id: 1, code: 'uk', name: 'Українська' };
@@ -207,7 +209,7 @@ describe('TranslateReportsCategoryModal', () => {
 
         fireEvent.change(screen.getByTestId('category-select'), { target: { value: '1' } });
 
-        fireEvent.click(screen.getByTestId('form-submit'));
+        fireEvent.click(screen.getByTestId('modal-save'));
 
         await waitFor(() => expect(onTranslateCategory).toHaveBeenCalled());
         await waitFor(() => expect(onClose).toHaveBeenCalled());

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.test.tsx
@@ -1,0 +1,220 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
+import { LocalizationLanguage, TranslationStatus } from '@/types/common/language';
+import { TranslateReportsCategoryModal } from './TranslateReportsCategoryModal';
+
+jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
+    useAdminClient: () => ({ post: jest.fn(), put: jest.fn() }),
+}));
+
+jest.mock(
+    '@/services/api/admin/reports/report-funds-expenditures-category-localizations/report-funds-expenditures-category-localizations-api',
+    () => ({
+        ReportFundsExpendituresCategoryLocalizationsApi: {
+            create: jest.fn(),
+            update: jest.fn(),
+        },
+    }),
+);
+
+jest.mock('@/utils/functions/mappers/common/localization/localization-mappers', () => ({
+    mapLocalizationDtoToModel: jest.fn(),
+}));
+
+jest.mock('@/components/admin/translation-controls/TranslationControls', () => ({
+    TranslationControls: ({ languages, selectedLanguage, onLanguageChange }: any) => (
+        <div data-testid="translation-controls">
+            {languages.map((lang: any) => (
+                <button
+                    key={lang.id}
+                    data-testid={`lang-${lang.code}`}
+                    onClick={() => onLanguageChange(lang)}
+                    data-selected={selectedLanguage?.id === lang.id}
+                >
+                    {lang.name}
+                </button>
+            ))}
+        </div>
+    ),
+}));
+
+jest.mock('@/components/admin/localization-modal/LocalizationModal', () => ({
+    LocalizationModal: ({ isOpen, onClose, title, onSave, isSubmitting, isFormValid, isDirty, children }: any) =>
+        isOpen ? (
+            <div data-testid="localization-modal">
+                <div data-testid="modal-title">{title}</div>
+                <button data-testid="modal-close" onClick={onClose}>
+                    Close
+                </button>
+                <button data-testid="modal-save" onClick={onSave} disabled={!isFormValid || isSubmitting || !isDirty}>
+                    Save
+                </button>
+                <div data-testid="modal-content">{children}</div>
+            </div>
+        ) : null,
+}));
+
+jest.mock('./TranslateReportsCategoryForm', () => ({
+    TranslateReportsCategoryForm: ({
+        categories,
+        onCategoryChange,
+        onValidationChange,
+        onSubmit,
+        onDirtyChange,
+    }: any) => (
+        <div data-testid="translate-form">
+            <select
+                data-testid="category-select"
+                onChange={(e) => {
+                    const cat = categories.find((c: any) => String(c.id) === e.target.value) ?? null;
+                    onCategoryChange?.(cat);
+                    onValidationChange?.(!!cat);
+                    onDirtyChange?.(!!cat);
+                }}
+            >
+                <option value="">-- select --</option>
+                {categories.map((c: any) => (
+                    <option key={c.id} value={c.id}>
+                        {c.name}
+                    </option>
+                ))}
+            </select>
+            <button data-testid="form-submit" onClick={() => onSubmit({ name: 'Translated name' })}>
+                Submit
+            </button>
+        </div>
+    ),
+}));
+
+const languageEn: LocalizationLanguage = { id: 2, code: 'en', name: 'English' };
+const languageUk: LocalizationLanguage = { id: 1, code: 'uk', name: 'Українська' };
+
+const categoriesMock: ReportFundsExpendituresCategory[] = [
+    { id: 1, name: 'Category One', type: 'income', localizations: [] },
+    { id: 2, name: 'Category Two', type: 'expense', localizations: [] },
+];
+
+const defaultProps = {
+    isOpen: true,
+    onClose: jest.fn(),
+    categories: categoriesMock,
+    translatedLanguages: [languageEn, languageUk],
+    onTranslateCategory: jest.fn(),
+};
+
+describe('TranslateReportsCategoryModal', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders modal when isOpen is true', () => {
+        render(<TranslateReportsCategoryModal {...defaultProps} />);
+        expect(screen.getByTestId('localization-modal')).toBeInTheDocument();
+    });
+
+    it('does not render when isOpen is false', () => {
+        render(<TranslateReportsCategoryModal {...defaultProps} isOpen={false} />);
+        expect(screen.queryByTestId('localization-modal')).not.toBeInTheDocument();
+    });
+
+    it('renders the fixed modal title', () => {
+        render(<TranslateReportsCategoryModal {...defaultProps} />);
+        expect(screen.getByTestId('modal-title')).toHaveTextContent(
+            FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_CATEGORY.TITLE,
+        );
+    });
+
+    it('renders TranslationControls with provided languages', () => {
+        render(<TranslateReportsCategoryModal {...defaultProps} />);
+        expect(screen.getByTestId('translation-controls')).toBeInTheDocument();
+        expect(screen.getByTestId('lang-en')).toBeInTheDocument();
+        expect(screen.getByTestId('lang-uk')).toBeInTheDocument();
+    });
+
+    it('initializes language to first non-default locale', () => {
+        render(<TranslateReportsCategoryModal {...defaultProps} />);
+        expect(screen.getByTestId('lang-en')).toHaveAttribute('data-selected', 'true');
+    });
+
+    it('calls onClose when close button is clicked', () => {
+        const onClose = jest.fn();
+        render(<TranslateReportsCategoryModal {...defaultProps} onClose={onClose} />);
+
+        fireEvent.click(screen.getByTestId('modal-close'));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders translate form with categories', () => {
+        render(<TranslateReportsCategoryModal {...defaultProps} />);
+        expect(screen.getByTestId('translate-form')).toBeInTheDocument();
+        expect(screen.getByTestId('category-select')).toBeInTheDocument();
+    });
+
+    it('does not render error message by default', () => {
+        render(<TranslateReportsCategoryModal {...defaultProps} />);
+        expect(screen.queryByText(FUNDS_EXPENDITURES_TEXT.MESSAGE.FAIL_TO_TRANSLATE_CATEGORY)).not.toBeInTheDocument();
+    });
+
+    it('resets state when modal is closed and reopened', async () => {
+        const { rerender } = render(<TranslateReportsCategoryModal {...defaultProps} />);
+
+        fireEvent.change(screen.getByTestId('category-select'), { target: { value: '1' } });
+
+        fireEvent.click(screen.getByTestId('modal-close'));
+
+        rerender(<TranslateReportsCategoryModal {...defaultProps} isOpen={false} />);
+        rerender(<TranslateReportsCategoryModal {...defaultProps} isOpen={true} />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('localization-modal')).toBeInTheDocument();
+        });
+    });
+
+    it('calls onTranslateCategory when form is submitted successfully', async () => {
+        const {
+            ReportFundsExpendituresCategoryLocalizationsApi,
+        } = require('@/services/api/admin/reports/report-funds-expenditures-category-localizations/report-funds-expenditures-category-localizations-api');
+        const {
+            mapLocalizationDtoToModel,
+        } = require('@/utils/functions/mappers/common/localization/localization-mappers');
+
+        const dtoMock = {
+            entityId: 1,
+            name: 'Translated name',
+            localizationInfoDto: { id: 2, code: 'en' },
+            translationStatus: TranslationStatus.Relevant,
+        };
+        const modelMock = {
+            name: 'Translated name',
+            language: { id: 2, code: 'en', name: 'English' },
+            translationStatus: TranslationStatus.Relevant,
+        };
+
+        ReportFundsExpendituresCategoryLocalizationsApi.create.mockResolvedValue(dtoMock);
+        mapLocalizationDtoToModel.mockReturnValue(modelMock);
+
+        const onTranslateCategory = jest.fn();
+        const onClose = jest.fn();
+
+        render(
+            <TranslateReportsCategoryModal
+                {...defaultProps}
+                onTranslateCategory={onTranslateCategory}
+                onClose={onClose}
+            />,
+        );
+
+        fireEvent.change(screen.getByTestId('category-select'), { target: { value: '1' } });
+
+        fireEvent.click(screen.getByTestId('form-submit'));
+
+        await waitFor(() => expect(onTranslateCategory).toHaveBeenCalled());
+        await waitFor(() => expect(onClose).toHaveBeenCalled());
+    });
+
+    it('does not initialize language when translatedLanguages is empty', () => {
+        render(<TranslateReportsCategoryModal {...defaultProps} translatedLanguages={[]} />);
+        expect(screen.getByTestId('translation-controls')).toBeInTheDocument();
+    });
+});

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { LocalizationModal } from '@/components/admin/localization-modal/LocalizationModal';
+import { TranslationControls } from '@/components/admin/translation-controls/TranslationControls';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { DEFAULT_LOCALE } from '@/const/common/locales';
+import { useTranslateReportsCategory } from '@/hooks/admin/use-translate-reports-category/useTranslateReportsCategory';
+import { ModalMode } from '@/types/admin/common';
+import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
+import { LocalizationLanguage } from '@/types/common/language';
+import styles from './TranslateReportsCategoryModal.module.scss';
+import {
+    TranslateReportsCategoryForm,
+    TranslateReportsCategoryFormRef,
+    TranslateReportsCategoryFormValues,
+} from './TranslateReportsCategoryForm';
+
+interface TranslateReportsCategoryModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    categories: ReportFundsExpendituresCategory[];
+    translatedLanguages: LocalizationLanguage[];
+    onTranslateCategory: (updatedCategory: ReportFundsExpendituresCategory) => void;
+}
+
+export const TranslateReportsCategoryModal = ({
+    isOpen,
+    onClose,
+    categories,
+    translatedLanguages,
+    onTranslateCategory,
+}: TranslateReportsCategoryModalProps) => {
+    const formRef = useRef<TranslateReportsCategoryFormRef>(null);
+    const [isFormValid, setIsFormValid] = useState(false);
+    const [isDirty, setIsDirty] = useState(false);
+    const [selectedCategory, setSelectedCategory] = useState<ReportFundsExpendituresCategory | null>(null);
+
+    const [language, setLanguage] = useState<LocalizationLanguage | null>(null);
+
+    useEffect(() => {
+        if (!translatedLanguages?.length) return;
+        setLanguage(
+            (prev) => prev ?? translatedLanguages.find((l) => l.code !== DEFAULT_LOCALE) ?? translatedLanguages[0],
+        );
+    }, [translatedLanguages]);
+
+    const existingLocalization = useMemo(() => {
+        if (!selectedCategory?.localizations || !language) return null;
+        return selectedCategory.localizations.find((loc) => loc.language.id === language.id) ?? null;
+    }, [selectedCategory, language]);
+
+    const mode = existingLocalization ? ModalMode.Edit : ModalMode.Add;
+
+    const initialData = useMemo<TranslateReportsCategoryFormValues | null>(() => {
+        if (mode !== ModalMode.Edit || !existingLocalization) return null;
+        return { name: existingLocalization.name };
+    }, [existingLocalization, mode]);
+
+    const { translateCategory, isSubmitting, error, clearError } = useTranslateReportsCategory({
+        category: selectedCategory,
+        language,
+        onSuccess: (updated) => {
+            onTranslateCategory(updated);
+            handleClose();
+        },
+        mode,
+    });
+
+    const handleClose = () => {
+        setSelectedCategory(null);
+        setIsFormValid(false);
+        setIsDirty(false);
+        clearError();
+        onClose();
+    };
+
+    const handleSaveClick = () => {
+        if (!formRef.current?.isValid()) return;
+        formRef.current.submit();
+    };
+
+    const checkIsDirty = () => formRef.current?.isDirty() ?? false;
+
+    const handleFormSubmit = async (data: TranslateReportsCategoryFormValues) => {
+        await translateCategory(data);
+    };
+
+    return (
+        <LocalizationModal
+            isOpen={isOpen}
+            onClose={handleClose}
+            title={FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_CATEGORY.TITLE}
+            onSave={handleSaveClick}
+            isSubmitting={isSubmitting}
+            isFormValid={isFormValid}
+            checkIsDirty={checkIsDirty}
+            isDirty={isDirty}
+            className={styles.modal}
+        >
+            <div className={styles.content}>
+                <TranslationControls
+                    selectedLanguage={language}
+                    isSubmitting={isSubmitting}
+                    languages={translatedLanguages}
+                    onLanguageChange={setLanguage}
+                />
+                {error && <div className={styles.error}>{error}</div>}
+                <TranslateReportsCategoryForm
+                    ref={formRef}
+                    categories={categories}
+                    initialData={initialData}
+                    onCategoryChange={setSelectedCategory}
+                    onValidationChange={setIsFormValid}
+                    onSubmit={handleFormSubmit}
+                    formDisabled={isSubmitting}
+                    onDirtyChange={setIsDirty}
+                />
+            </div>
+        </LocalizationModal>
+    );
+};

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.tsx
@@ -94,7 +94,6 @@ export const TranslateReportsCategoryModal = ({
             isFormValid={isFormValid}
             checkIsDirty={checkIsDirty}
             isDirty={isDirty}
-            className={styles.modal}
         >
             <div className={styles.content}>
                 <TranslationControls

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
@@ -189,11 +189,11 @@ jest.mock('@/components/common/select/Select', () => {
 });
 
 const MOCK_CATEGORIES: ReportFundsExpendituresCategory[] = [
-    { id: 1, name: 'Грантові кошти', type: 'income' },
-    { id: 2, name: 'Благодійні внески', type: 'income' },
-    { id: 3, name: 'Власні надходження', type: 'income' },
-    { id: 4, name: 'Адміністративні витрати', type: 'expense' },
-    { id: 5, name: 'Програмні витрати', type: 'expense' },
+    { id: 1, name: 'Грантові кошти', type: 'income', localizations: [] },
+    { id: 2, name: 'Благодійні внески', type: 'income', localizations: [] },
+    { id: 3, name: 'Власні надходження', type: 'income', localizations: [] },
+    { id: 4, name: 'Адміністративні витрати', type: 'expense', localizations: [] },
+    { id: 5, name: 'Програмні витрати', type: 'expense', localizations: [] },
 ];
 
 const MOCK_RECORDS: EnrichedRecord[] = [

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-toolbar/FundsExpendituresToolbar.test.tsx
@@ -100,8 +100,8 @@ jest.mock('@/components/common/select/Select', () => {
 });
 
 const MOCK_CATEGORIES: ReportFundsExpendituresCategory[] = [
-    { id: 1, name: 'Грантові кошти', type: 'income' },
-    { id: 2, name: 'Благодійні внески', type: 'income' },
+    { id: 1, name: 'Грантові кошти', type: 'income', localizations: [] },
+    { id: 2, name: 'Благодійні внески', type: 'income', localizations: [] },
 ];
 
 describe('FundsExpendituresToolbar', () => {

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
@@ -88,9 +88,7 @@ jest.mock('../funds-expenditures-section/FundsExpendituresSection', () => ({
             <button
                 type="button"
                 data-testid="trigger-categories-loaded"
-                onClick={() =>
-                    onCategoriesLoaded?.([{ id: 1, name: 'Cat', type: 'income', localizations: [] }])
-                }
+                onClick={() => onCategoriesLoaded?.([{ id: 1, name: 'Cat', type: 'income', localizations: [] }])}
             >
                 Load categories
             </button>
@@ -312,9 +310,7 @@ describe('ReportAnalytics', () => {
             render(<ReportAnalytics />);
 
             fireEvent.click(screen.getByTestId('context-menu'));
-            fireEvent.click(
-                screen.getByRole('menuitem', { name: FUNDS_EXPENDITURES_TEXT.BUTTON.TRANSLATE_CATEGORY }),
-            );
+            fireEvent.click(screen.getByRole('menuitem', { name: FUNDS_EXPENDITURES_TEXT.BUTTON.TRANSLATE_CATEGORY }));
 
             expect(screen.getByTestId('translate-category-modal')).toHaveAttribute('data-open', 'true');
         });
@@ -323,9 +319,7 @@ describe('ReportAnalytics', () => {
             render(<ReportAnalytics />);
 
             fireEvent.click(screen.getByTestId('context-menu'));
-            fireEvent.click(
-                screen.getByRole('menuitem', { name: FUNDS_EXPENDITURES_TEXT.BUTTON.TRANSLATE_CATEGORY }),
-            );
+            fireEvent.click(screen.getByRole('menuitem', { name: FUNDS_EXPENDITURES_TEXT.BUTTON.TRANSLATE_CATEGORY }));
             fireEvent.click(screen.getByTestId('translate-modal-close'));
 
             expect(screen.getByTestId('translate-category-modal')).toHaveAttribute('data-open', 'false');

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
@@ -1,6 +1,17 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import { localizationLanguagesDataFetch } from '@/services/api/public/localization/languages/languages-api';
 import { ReportAnalytics } from './ReportAnalytics';
 import { FUNDS_EXPENDITURES_TEXT, REPORTS_TEXT } from '@/const/admin/reports';
+
+jest.mock('@/contexts/admin/toast-context-provider/ToastContextProvider', () => ({
+    useToast: () => ({ addToast: jest.fn() }),
+}));
+
+jest.mock('@/services/api/public/localization/languages/languages-api', () => ({
+    localizationLanguagesDataFetch: jest.fn(),
+}));
+
+const mockLocalizationLanguagesDataFetch = localizationLanguagesDataFetch as jest.Mock;
 
 jest.mock('../pdf-files-section/PdfFilesSection', () => ({
     PdfFilesSection: () => <div data-testid="pdf-files-section">PdfFilesSection</div>,
@@ -56,6 +67,13 @@ jest.mock('../funds-expenditures-section/FundsExpendituresSection', () => ({
     ),
 }));
 
+jest.mock(
+    '../funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal',
+    () => ({
+        TranslateReportsCategoryModal: () => null,
+    }),
+);
+
 jest.mock('../program-expenses-section/ProgramExpensesSection', () => ({
     ProgramExpensesSection: ({ isEditing = false }: { isEditing?: boolean }) => (
         <div data-testid="program-expenses-section" data-editing={String(isEditing)}>
@@ -65,6 +83,10 @@ jest.mock('../program-expenses-section/ProgramExpensesSection', () => ({
 }));
 
 describe('ReportAnalytics', () => {
+    beforeEach(() => {
+        mockLocalizationLanguagesDataFetch.mockResolvedValue([]);
+    });
+
     it('should render the component with correct title', () => {
         render(<ReportAnalytics />);
 

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
@@ -1,11 +1,15 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { localizationLanguagesDataFetch } from '@/services/api/public/localization/languages/languages-api';
+import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextProvider';
 import { ReportAnalytics } from './ReportAnalytics';
 import { FUNDS_EXPENDITURES_TEXT, REPORTS_TEXT } from '@/const/admin/reports';
 
 jest.mock('@/contexts/admin/toast-context-provider/ToastContextProvider', () => ({
-    useToast: () => ({ addToast: jest.fn() }),
+    useToast: jest.fn(),
 }));
+
+const mockAddToast = jest.fn();
+const mockedUseToast = useToast as jest.MockedFunction<typeof useToast>;
 
 jest.mock('@/services/api/public/localization/languages/languages-api', () => ({
     localizationLanguagesDataFetch: jest.fn(),
@@ -138,6 +142,13 @@ jest.mock('../program-expenses-section/ProgramExpensesSection', () => ({
 describe('ReportAnalytics', () => {
     beforeEach(() => {
         mockLocalizationLanguagesDataFetch.mockResolvedValue([]);
+        mockedUseToast.mockReturnValue({
+            addToast: mockAddToast,
+            toasts: [],
+            removeToast: function (id: number): void {
+                throw new Error('Function not implemented.');
+            },
+        });
     });
 
     it('should render the component with correct title', () => {
@@ -340,6 +351,7 @@ describe('ReportAnalytics', () => {
             fireEvent.click(screen.getByTestId('translate-modal-submit'));
 
             expect(screen.getByTestId('translate-modal-categories-count')).toHaveTextContent('1');
+            expect(mockAddToast).toHaveBeenCalled();
         });
     });
 });

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { localizationLanguagesDataFetch } from '@/services/api/public/localization/languages/languages-api';
 import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextProvider';
 import { ReportAnalytics } from './ReportAnalytics';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT, REPORTS_TEXT } from '@/const/admin/reports';
 
 jest.mock('@/contexts/admin/toast-context-provider/ToastContextProvider', () => ({
@@ -142,19 +143,26 @@ jest.mock('../program-expenses-section/ProgramExpensesSection', () => ({
 describe('ReportAnalytics', () => {
     beforeEach(() => {
         mockLocalizationLanguagesDataFetch.mockResolvedValue([]);
-        mockedUseToast.mockReturnValue({
-            addToast: mockAddToast,
-            toasts: [],
-            removeToast: function (id: number): void {
-                throw new Error('Function not implemented.');
-            },
-        });
+        mockedUseToast.mockReturnValue({ addToast: mockAddToast } as any);
     });
 
     it('should render the component with correct title', () => {
         render(<ReportAnalytics />);
 
         expect(screen.getByText(REPORTS_TEXT.REPORT_AND_ANALYTICS.TITLE)).toBeInTheDocument();
+    });
+
+    it('should show error toast when language fetch fails', async () => {
+        mockLocalizationLanguagesDataFetch.mockRejectedValue(new Error('Network error'));
+
+        render(<ReportAnalytics />);
+
+        await waitFor(() => {
+            expect(mockAddToast).toHaveBeenCalledWith(
+                COMMON_TEXT_ADMIN.LOCALIZATION.LANGUAGES.MESSAGE.FAILED_TO_FETCH_LANGUAGES,
+                'error',
+            );
+        });
     });
 
     it('should show first tab as active by default', () => {

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
@@ -25,6 +25,11 @@ jest.mock('../funds-expenditures-section/FundsExpendituresSection', () => ({
         onExchangeRateValueChange,
         isAddCategoryModalOpen,
         onAddCategoryModalClose,
+        isEditCategoryModalOpen,
+        onEditCategoryModalClose,
+        isDeleteCategoryModalOpen,
+        onDeleteCategoryModalClose,
+        onCategoriesLoaded,
     }: {
         initialIsEditing?: boolean;
         draftExchangeRate?: string | null;
@@ -32,12 +37,19 @@ jest.mock('../funds-expenditures-section/FundsExpendituresSection', () => ({
         onExchangeRateValueChange?: (exchangeRate: string | null) => void;
         isAddCategoryModalOpen?: boolean;
         onAddCategoryModalClose?: () => void;
+        isEditCategoryModalOpen?: boolean;
+        onEditCategoryModalClose?: () => void;
+        isDeleteCategoryModalOpen?: boolean;
+        onDeleteCategoryModalClose?: () => void;
+        onCategoriesLoaded?: (cats: any[]) => void;
     }) => (
         <div
             data-testid="funds-expenditure-section"
             data-initial-editing={String(initialIsEditing)}
             data-draft-exchange-rate={draftExchangeRate ?? ''}
             data-category-modal-open={String(isAddCategoryModalOpen ?? false)}
+            data-edit-category-modal-open={String(isEditCategoryModalOpen ?? false)}
+            data-delete-category-modal-open={String(isDeleteCategoryModalOpen ?? false)}
         >
             FundsExpenditureSection
             <button
@@ -63,6 +75,25 @@ jest.mock('../funds-expenditures-section/FundsExpendituresSection', () => ({
             <button type="button" data-testid="close-category-modal" onClick={() => onAddCategoryModalClose?.()}>
                 Close category modal
             </button>
+            <button type="button" data-testid="close-edit-category-modal" onClick={() => onEditCategoryModalClose?.()}>
+                Close edit modal
+            </button>
+            <button
+                type="button"
+                data-testid="close-delete-category-modal"
+                onClick={() => onDeleteCategoryModalClose?.()}
+            >
+                Close delete modal
+            </button>
+            <button
+                type="button"
+                data-testid="trigger-categories-loaded"
+                onClick={() =>
+                    onCategoriesLoaded?.([{ id: 1, name: 'Cat', type: 'income', localizations: [] }])
+                }
+            >
+                Load categories
+            </button>
         </div>
     ),
 }));
@@ -70,7 +101,31 @@ jest.mock('../funds-expenditures-section/FundsExpendituresSection', () => ({
 jest.mock(
     '../funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal',
     () => ({
-        TranslateReportsCategoryModal: () => null,
+        TranslateReportsCategoryModal: ({
+            isOpen,
+            onClose,
+            onTranslateCategory,
+            categories,
+        }: {
+            isOpen?: boolean;
+            onClose?: () => void;
+            onTranslateCategory?: (cat: any) => void;
+            categories?: any[];
+        }) => (
+            <div data-testid="translate-category-modal" data-open={String(isOpen ?? false)}>
+                <button type="button" data-testid="translate-modal-close" onClick={() => onClose?.()}>
+                    Close
+                </button>
+                <button
+                    type="button"
+                    data-testid="translate-modal-submit"
+                    onClick={() => onTranslateCategory?.({ id: 1, name: 'Updated', type: 'income', localizations: [] })}
+                >
+                    Submit
+                </button>
+                <span data-testid="translate-modal-categories-count">{categories?.length ?? 0}</span>
+            </div>
+        ),
     }),
 );
 
@@ -195,6 +250,102 @@ describe('ReportAnalytics', () => {
                 'data-category-modal-open',
                 'false',
             );
+        });
+    });
+
+    describe('edit category modal', () => {
+        it('should open edit category modal when "Редагувати категорію" option is selected', () => {
+            render(<ReportAnalytics />);
+
+            fireEvent.click(screen.getByTestId('context-menu'));
+            fireEvent.click(screen.getByRole('menuitem', { name: FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT_CATEGORY }));
+
+            expect(screen.getByTestId('funds-expenditure-section')).toHaveAttribute(
+                'data-edit-category-modal-open',
+                'true',
+            );
+        });
+
+        it('should close edit category modal when onEditCategoryModalClose is called', () => {
+            render(<ReportAnalytics />);
+
+            fireEvent.click(screen.getByTestId('context-menu'));
+            fireEvent.click(screen.getByRole('menuitem', { name: FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT_CATEGORY }));
+            fireEvent.click(screen.getByTestId('close-edit-category-modal'));
+
+            expect(screen.getByTestId('funds-expenditure-section')).toHaveAttribute(
+                'data-edit-category-modal-open',
+                'false',
+            );
+        });
+    });
+
+    describe('delete category modal', () => {
+        it('should open delete category modal when "Видалити категорію" option is selected', () => {
+            render(<ReportAnalytics />);
+
+            fireEvent.click(screen.getByTestId('context-menu'));
+            fireEvent.click(screen.getByRole('menuitem', { name: FUNDS_EXPENDITURES_TEXT.BUTTON.DELETE_CATEGORY }));
+
+            expect(screen.getByTestId('funds-expenditure-section')).toHaveAttribute(
+                'data-delete-category-modal-open',
+                'true',
+            );
+        });
+
+        it('should close delete category modal when onDeleteCategoryModalClose is called', () => {
+            render(<ReportAnalytics />);
+
+            fireEvent.click(screen.getByTestId('context-menu'));
+            fireEvent.click(screen.getByRole('menuitem', { name: FUNDS_EXPENDITURES_TEXT.BUTTON.DELETE_CATEGORY }));
+            fireEvent.click(screen.getByTestId('close-delete-category-modal'));
+
+            expect(screen.getByTestId('funds-expenditure-section')).toHaveAttribute(
+                'data-delete-category-modal-open',
+                'false',
+            );
+        });
+    });
+
+    describe('translate category modal', () => {
+        it('should open translate category modal when "Перекласти категорію" option is selected', () => {
+            render(<ReportAnalytics />);
+
+            fireEvent.click(screen.getByTestId('context-menu'));
+            fireEvent.click(
+                screen.getByRole('menuitem', { name: FUNDS_EXPENDITURES_TEXT.BUTTON.TRANSLATE_CATEGORY }),
+            );
+
+            expect(screen.getByTestId('translate-category-modal')).toHaveAttribute('data-open', 'true');
+        });
+
+        it('should close translate category modal when onClose is called', () => {
+            render(<ReportAnalytics />);
+
+            fireEvent.click(screen.getByTestId('context-menu'));
+            fireEvent.click(
+                screen.getByRole('menuitem', { name: FUNDS_EXPENDITURES_TEXT.BUTTON.TRANSLATE_CATEGORY }),
+            );
+            fireEvent.click(screen.getByTestId('translate-modal-close'));
+
+            expect(screen.getByTestId('translate-category-modal')).toHaveAttribute('data-open', 'false');
+        });
+
+        it('should pass categories loaded from FundsExpenditureSection to TranslateReportsCategoryModal', () => {
+            render(<ReportAnalytics />);
+
+            fireEvent.click(screen.getByTestId('trigger-categories-loaded'));
+
+            expect(screen.getByTestId('translate-modal-categories-count')).toHaveTextContent('1');
+        });
+
+        it('should update categories and show toast when handleTranslateCategory is called', () => {
+            render(<ReportAnalytics />);
+
+            fireEvent.click(screen.getByTestId('trigger-categories-loaded'));
+            fireEvent.click(screen.getByTestId('translate-modal-submit'));
+
+            expect(screen.getByTestId('translate-modal-categories-count')).toHaveTextContent('1');
         });
     });
 });

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
@@ -39,10 +39,14 @@ export const ReportAnalytics = () => {
     const [categories, setCategories] = useState<ReportFundsExpendituresCategory[]>([]);
 
     useEffect(() => {
-        localizationLanguagesDataFetch().then((langs) => {
-            setTranslationLanguages(langs.filter((l) => l.code !== DEFAULT_LOCALE));
-        });
-    }, []);
+        localizationLanguagesDataFetch()
+            .then((langs) => {
+                setTranslationLanguages(langs.filter((l) => l.code !== DEFAULT_LOCALE));
+            })
+            .catch(() => {
+                addToast(COMMON_TEXT_ADMIN.LOCALIZATION.LANGUAGES.MESSAGE.FAILED_TO_FETCH_LANGUAGES, ToastType.Error);
+            });
+    }, [addToast]);
 
     const categoryContextMenuOptions: ContextMenuOption[] = useMemo(
         () => [

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
@@ -1,9 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { CategoryBar, ContextMenuOption } from '@/components/admin/category-bar/CategoryBar';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT, REPORTS_TEXT } from '@/const/admin/reports';
 import { DEFAULT_LOCALE } from '@/const/common/locales';
+import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextProvider';
 import { localizationLanguagesDataFetch } from '@/services/api/public/localization/languages/languages-api';
 import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
+import { ToastType } from '@/types/admin/toast';
 import { LocalizationLanguage } from '@/types/common/language';
 import styles from './ReportAnalytics.module.scss';
 import './ReportAnalytics.scss';
@@ -24,6 +27,7 @@ const ANALYTICS_TABS: ReportAnalyticsTab[] = [
 ];
 
 export const ReportAnalytics = () => {
+    const { addToast } = useToast();
     const [activeTab, setActiveTab] = useState<ReportAnalyticsTab>(ANALYTICS_TABS[0]);
     const [isFundsEditing, setIsFundsEditing] = useState(false);
     const [fundsExchangeRateDraft, setFundsExchangeRateDraft] = useState<string | null>();
@@ -62,9 +66,13 @@ export const ReportAnalytics = () => {
         }
     }, []);
 
-    const handleTranslateCategory = useCallback((updatedCategory: ReportFundsExpendituresCategory) => {
-        setCategories((prev) => prev.map((c) => (c.id === updatedCategory.id ? updatedCategory : c)));
-    }, []);
+    const handleTranslateCategory = useCallback(
+        (updatedCategory: ReportFundsExpendituresCategory) => {
+            setCategories((prev) => prev.map((c) => (c.id === updatedCategory.id ? updatedCategory : c)));
+            addToast(COMMON_TEXT_ADMIN.MESSAGE.TRANSLATION_SAVED_SUCCESS, ToastType.Success);
+        },
+        [addToast],
+    );
 
     return (
         <div className={styles['report-analytics']}>

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
@@ -1,11 +1,16 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { CategoryBar, ContextMenuOption } from '@/components/admin/category-bar/CategoryBar';
 import { FUNDS_EXPENDITURES_TEXT, REPORTS_TEXT } from '@/const/admin/reports';
+import { DEFAULT_LOCALE } from '@/const/common/locales';
+import { localizationLanguagesDataFetch } from '@/services/api/public/localization/languages/languages-api';
+import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
+import { LocalizationLanguage } from '@/types/common/language';
 import styles from './ReportAnalytics.module.scss';
 import './ReportAnalytics.scss';
 import { PdfFilesSection } from '../pdf-files-section/PdfFilesSection';
 import { FundsExpenditureSection } from '../funds-expenditures-section/FundsExpendituresSection';
 import { ProgramExpensesSection } from '../program-expenses-section/ProgramExpensesSection';
+import { TranslateReportsCategoryModal } from '../funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal';
 
 interface ReportAnalyticsTab {
     id: 'income-expenses' | 'program-expenses' | 'pdf-files';
@@ -25,12 +30,22 @@ export const ReportAnalytics = () => {
     const [isAddCategoryModalOpen, setIsAddCategoryModalOpen] = useState(false);
     const [isDeleteCategoryModalOpen, setIsDeleteCategoryModalOpen] = useState(false);
     const [isEditCategoryModalOpen, setIsEditCategoryModalOpen] = useState(false);
+    const [isTranslateCategoryModalOpen, setIsTranslateCategoryModalOpen] = useState(false);
+    const [translationLanguages, setTranslationLanguages] = useState<LocalizationLanguage[]>([]);
+    const [categories, setCategories] = useState<ReportFundsExpendituresCategory[]>([]);
+
+    useEffect(() => {
+        localizationLanguagesDataFetch().then((langs) => {
+            setTranslationLanguages(langs.filter((l) => l.code !== DEFAULT_LOCALE));
+        });
+    }, []);
 
     const categoryContextMenuOptions: ContextMenuOption[] = useMemo(
         () => [
             { id: 'add-category', name: FUNDS_EXPENDITURES_TEXT.BUTTON.ADD_CATEGORY },
             { id: 'edit-category', name: FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT_CATEGORY },
             { id: 'delete-category', name: FUNDS_EXPENDITURES_TEXT.BUTTON.DELETE_CATEGORY },
+            { id: 'translate-category', name: FUNDS_EXPENDITURES_TEXT.BUTTON.TRANSLATE_CATEGORY },
         ],
         [],
     );
@@ -42,7 +57,13 @@ export const ReportAnalytics = () => {
             setIsEditCategoryModalOpen(true);
         } else if (id === 'delete-category') {
             setIsDeleteCategoryModalOpen(true);
+        } else if (id === 'translate-category') {
+            setIsTranslateCategoryModalOpen(true);
         }
+    }, []);
+
+    const handleTranslateCategory = useCallback((updatedCategory: ReportFundsExpendituresCategory) => {
+        setCategories((prev) => prev.map((c) => (c.id === updatedCategory.id ? updatedCategory : c)));
     }, []);
 
     return (
@@ -73,10 +94,19 @@ export const ReportAnalytics = () => {
                         onEditCategoryModalClose={() => setIsEditCategoryModalOpen(false)}
                         isDeleteCategoryModalOpen={isDeleteCategoryModalOpen}
                         onDeleteCategoryModalClose={() => setIsDeleteCategoryModalOpen(false)}
+                        onCategoriesLoaded={setCategories}
                     />
                 )}
                 {activeTab.id === 'program-expenses' && <ProgramExpensesSection isEditing={isFundsEditing} />}
             </div>
+
+            <TranslateReportsCategoryModal
+                isOpen={isTranslateCategoryModalOpen}
+                onClose={() => setIsTranslateCategoryModalOpen(false)}
+                categories={categories}
+                translatedLanguages={translationLanguages}
+                onTranslateCategory={handleTranslateCategory}
+            />
         </div>
     );
 };

--- a/src/services/api/admin/reports/funds-expenditures-api.test.ts
+++ b/src/services/api/admin/reports/funds-expenditures-api.test.ts
@@ -74,8 +74,8 @@ describe('FundsExpendituresApi', () => {
                 signal: undefined,
             });
             expect(result).toEqual([
-                { id: 1, name: 'Income category', type: 'income' },
-                { id: 2, name: 'Expense category', type: 'expense' },
+                { id: 1, name: 'Income category', type: 'income', localizations: [] },
+                { id: 2, name: 'Expense category', type: 'expense', localizations: [] },
             ]);
         });
     });
@@ -93,7 +93,7 @@ describe('FundsExpendituresApi', () => {
                 name: 'New income',
                 type: 1,
             });
-            expect(result).toEqual({ id: 3, name: 'New income', type: 'income' });
+            expect(result).toEqual({ id: 3, name: 'New income', type: 'income', localizations: [] });
         });
     });
 
@@ -110,7 +110,7 @@ describe('FundsExpendituresApi', () => {
                 name: 'Updated expense',
                 type: 2,
             });
-            expect(result).toEqual({ id: 2, name: 'Updated expense', type: 'expense' });
+            expect(result).toEqual({ id: 2, name: 'Updated expense', type: 'expense', localizations: [] });
         });
     });
 

--- a/src/services/api/admin/reports/report-funds-expenditures-category-localizations/report-funds-expenditures-category-localizations-api.test.ts
+++ b/src/services/api/admin/reports/report-funds-expenditures-category-localizations/report-funds-expenditures-category-localizations-api.test.ts
@@ -1,0 +1,70 @@
+import { ReportFundsExpendituresCategoryLocalizationsApi } from './report-funds-expenditures-category-localizations-api';
+import { API_ROUTES } from '@/const/common/api-routes/main-api';
+import {
+    CreateReportFundsExpendituresCategoryLocalizationDto,
+    ReportFundsExpendituresCategoryLocalizationDto,
+    UpdateReportFundsExpendituresCategoryLocalizationDto,
+} from '@/types/admin/reports';
+import { LocalizationInfo, TranslationStatus } from '@/types/common/language';
+
+const mockLocalizationDto: ReportFundsExpendituresCategoryLocalizationDto = {
+    entityId: 1,
+    name: 'Translated name',
+    localizationInfoDto: {
+        id: 2,
+        code: 'en',
+        name: 'English',
+    } as LocalizationInfo,
+    translationStatus: TranslationStatus.Relevant,
+};
+
+describe('ReportFundsExpendituresCategoryLocalizationsApi', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('create', () => {
+        it('should call client.post with correct url and payload and return response data', async () => {
+            const mockClient = { post: jest.fn().mockResolvedValueOnce({ data: mockLocalizationDto }) };
+
+            const payload: CreateReportFundsExpendituresCategoryLocalizationDto = {
+                entityId: 1,
+                languageId: 2,
+                name: 'Translated name',
+            };
+
+            const result = await ReportFundsExpendituresCategoryLocalizationsApi.create(mockClient as any, payload);
+
+            expect(mockClient.post).toHaveBeenCalledTimes(1);
+            expect(mockClient.post).toHaveBeenCalledWith(
+                API_ROUTES.REPORT_FUNDS_EXPENDITURES_CATEGORY_LOCALIZATIONS.BASE,
+                payload,
+            );
+            expect(result).toEqual(mockLocalizationDto);
+        });
+    });
+
+    describe('update', () => {
+        it('should call client.put with correct url and payload and return response data', async () => {
+            const mockClient = { put: jest.fn().mockResolvedValueOnce({ data: mockLocalizationDto }) };
+
+            const entityId = 1;
+            const languageId = 2;
+            const payload: UpdateReportFundsExpendituresCategoryLocalizationDto = { name: 'Updated name' };
+
+            const result = await ReportFundsExpendituresCategoryLocalizationsApi.update(
+                mockClient as any,
+                entityId,
+                languageId,
+                payload,
+            );
+
+            expect(mockClient.put).toHaveBeenCalledTimes(1);
+            expect(mockClient.put).toHaveBeenCalledWith(
+                `${API_ROUTES.REPORT_FUNDS_EXPENDITURES_CATEGORY_LOCALIZATIONS.BASE}/${entityId}/${languageId}`,
+                payload,
+            );
+            expect(result).toEqual(mockLocalizationDto);
+        });
+    });
+});

--- a/src/services/api/admin/reports/report-funds-expenditures-category-localizations/report-funds-expenditures-category-localizations-api.ts
+++ b/src/services/api/admin/reports/report-funds-expenditures-category-localizations/report-funds-expenditures-category-localizations-api.ts
@@ -1,0 +1,33 @@
+import { API_ROUTES } from '@/const/common/api-routes/main-api';
+import {
+    CreateReportFundsExpendituresCategoryLocalizationDto,
+    ReportFundsExpendituresCategoryLocalizationDto,
+    UpdateReportFundsExpendituresCategoryLocalizationDto,
+} from '@/types/admin/reports';
+import { AxiosInstance } from 'axios';
+
+export const ReportFundsExpendituresCategoryLocalizationsApi = {
+    create: async (
+        client: AxiosInstance,
+        data: CreateReportFundsExpendituresCategoryLocalizationDto,
+    ): Promise<ReportFundsExpendituresCategoryLocalizationDto> => {
+        const response = await client.post<ReportFundsExpendituresCategoryLocalizationDto>(
+            API_ROUTES.REPORT_FUNDS_EXPENDITURES_CATEGORY_LOCALIZATIONS.BASE,
+            data,
+        );
+        return response.data;
+    },
+
+    update: async (
+        client: AxiosInstance,
+        entityId: number,
+        languageId: number,
+        data: UpdateReportFundsExpendituresCategoryLocalizationDto,
+    ): Promise<ReportFundsExpendituresCategoryLocalizationDto> => {
+        const response = await client.put<ReportFundsExpendituresCategoryLocalizationDto>(
+            `${API_ROUTES.REPORT_FUNDS_EXPENDITURES_CATEGORY_LOCALIZATIONS.BASE}/${entityId}/${languageId}`,
+            data,
+        );
+        return response.data;
+    },
+};

--- a/src/types/admin/reports.ts
+++ b/src/types/admin/reports.ts
@@ -1,3 +1,4 @@
+import { EntityLocalization, EntityLocalizationDto, EntityWithLocalizations } from '../common/language';
 import { Image, ImageValues } from '../common/image';
 
 export interface ReportsMediaSettingsCollectedFundsDto {
@@ -146,7 +147,32 @@ export interface ReportFundsExpendituresSettings {
     exchangeRate: string | null;
 }
 
-export interface ReportFundsExpendituresCategory {
+export interface ReportFundsExpendituresCategoryLocalizableFields {
+    name: string;
+}
+
+export interface ReportFundsExpendituresCategoryLocalizationDto
+    extends EntityLocalizationDto,
+        ReportFundsExpendituresCategoryLocalizableFields {
+    entityId: number;
+}
+
+export interface ReportFundsExpendituresCategoryLocalization
+    extends EntityLocalization,
+        ReportFundsExpendituresCategoryLocalizableFields {}
+
+export interface CreateReportFundsExpendituresCategoryLocalizationDto {
+    entityId: number;
+    languageId: number;
+    name: string;
+}
+
+export interface UpdateReportFundsExpendituresCategoryLocalizationDto {
+    name: string;
+}
+
+export interface ReportFundsExpendituresCategory
+    extends EntityWithLocalizations<ReportFundsExpendituresCategoryLocalization> {
     id: number;
     name: string;
     type: FundsExpendituresTransactionType;

--- a/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.test.ts
+++ b/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.test.ts
@@ -224,6 +224,7 @@ describe('reports-mapper', () => {
                 id: 2,
                 name: 'Category',
                 type: 'expense',
+                localizations: [],
             });
         });
 

--- a/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.ts
+++ b/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.ts
@@ -85,6 +85,7 @@ export const mapReportFundsExpendituresCategoryDtoToCategory = (
     id: dto.id,
     name: dto.name,
     type: mapFundsExpendituresTypeDtoToTransactionType(dto.type),
+    localizations: [],
 });
 
 export const mapReportFundsExpendituresCategoryToCreateDto = (

--- a/src/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema.test.ts
@@ -15,6 +15,7 @@ const category = (name: string, type: 'income' | 'expense'): ReportFundsExpendit
     id: 1,
     name,
     type,
+    localizations: [],
 });
 
 describe('validateFundsExpendituresCategoryName', () => {


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2102
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2103
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2104
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2106

## Description

This PR implements the "Додати переклад" modal window for category translation functionality in reports.


## How it looks


https://github.com/user-attachments/assets/0d0d40b0-dc60-4e84-978a-3d19e5ea203d


## Summary of change

- Added category translation modal component
- Added translation form validation
- Added language select with default English option
- Added categories select integration
- Implemented modal open/close behavior
- Added disabled state handling for submit button
- Applied styles and hover states according to Figma mock-ups

## How to recreate changes

1. Open "Доходи та витрати" tab
2. Open category actions menu
3. Click on "Перекласти"
4. Verify that:
- translation modal opens
- all fields are empty
 - "Зберегти переклад" button is disabled
 - language dropdown contains only "Англійська"
 - category dropdown contains all existing categories
5. Fill required fields
6. Verify that save button becomes enabled


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [x]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Category translation modal and form with language selection and create/edit flows
  * API support for category localization and hook to submit translations
  * "Translate category" added to category context menu

* **Improvements**
  * Categories now carry localization data; UI updates propagate translated categories
  * New validation, error messages, and clearer submit/error states

* **Tests**
  * Extensive tests added for translation flows, form, modal, API, and mappings

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ita-social-projects/VictoryCenter-Client/pull/389)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->