### PR TITLE
Feature/issue-2107: [Reports] Implement category translation editing functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ See **[MCP_SETUP.md](MCP_SETUP.md)** for detailed setup instructions for both Cl
 
 #### Step 2
 
-- **HACK AWAY!** 🔨🔨🔨
+- **HACK AWAY!** 🔨🔨🔨 
 
 #### Step 3
 

--- a/src/assets/sass/mixins/_typography.mixins.scss
+++ b/src/assets/sass/mixins/_typography.mixins.scss
@@ -49,6 +49,10 @@
     @include _text(t.$fw-bold, t.$h3-size, t.$h3-height, t.$h3-spacing, uppercase);
 }
 
+@mixin h4-regular {
+    @include _text(t.$fw-regular, t.$h4-size, t.$h4-height, t.$h4-spacing);
+}
+
 @mixin h4-semibold {
     @include _text(t.$fw-semibold, t.$h4-size, t.$h4-height, t.$h4-spacing);
 }

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -240,6 +240,12 @@ export const FUNDS_EXPENDITURES_TEXT = {
             NAME_LABEL: 'Назва',
             NAME_PLACEHOLDER: 'Введіть назву категорії',
         },
+        TRANSLATE_DISCLAIMER: {
+            TITLE: 'Додати переклад',
+            DESCRIPTION_LABEL: 'Опис',
+            FAIL_TO_TRANSLATE: 'Не вдалося зберегти переклад дісклеймера. Спробуйте ще раз',
+            FAIL_TO_UPDATE_TRANSLATION: 'Не вдалося оновити переклад дісклеймера. Спробуйте ще раз',
+        },
     },
     BUTTON: {
         EDIT: 'Редагувати Доходи та витрати',

--- a/src/const/common/api-routes/main-api.ts
+++ b/src/const/common/api-routes/main-api.ts
@@ -112,6 +112,9 @@ export const API_ROUTES = {
     REPORT_FUNDS_EXPENDITURES_CATEGORY_LOCALIZATIONS: {
         BASE: 'ReportFundsExpendituresCategoryLocalizations',
     },
+    REPORT_FUNDS_EXPENDITURES_SETTINGS_LOCALIZATIONS: {
+        BASE: 'ReportFundsExpendituresSettingsLocalizations',
+    },
     HISTORY: {
         BASE: 'History',
     },

--- a/src/hooks/admin/use-translate-disclaimer/useTranslateDisclaimer.test.ts
+++ b/src/hooks/admin/use-translate-disclaimer/useTranslateDisclaimer.test.ts
@@ -1,0 +1,229 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useTranslateDisclaimer } from './useTranslateDisclaimer';
+import { ReportFundsExpendituresSettingsLocalizationsApi } from '@/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api';
+import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/localization/localization-mappers';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { LocalizationLanguage, TranslationStatus } from '@/types/common/language';
+import { ReportFundsExpendituresSettings, ReportFundsExpendituresSettingsLocalization } from '@/types/admin/reports';
+import { ModalMode } from '@/types/admin/common';
+
+jest.mock(
+    '@/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api',
+);
+jest.mock('@/utils/functions/mappers/common/localization/localization-mappers');
+jest.mock('../use-admin-client/useAdminClient', () => ({
+    useAdminClient: () => ({ post: jest.fn(), put: jest.fn() }),
+}));
+
+const mockedCreate = ReportFundsExpendituresSettingsLocalizationsApi.create as jest.MockedFunction<
+    typeof ReportFundsExpendituresSettingsLocalizationsApi.create
+>;
+const mockedUpdate = ReportFundsExpendituresSettingsLocalizationsApi.update as jest.MockedFunction<
+    typeof ReportFundsExpendituresSettingsLocalizationsApi.update
+>;
+const mockedMapper = mapLocalizationDtoToModel as jest.MockedFunction<typeof mapLocalizationDtoToModel>;
+
+const settingsMock: ReportFundsExpendituresSettings = {
+    id: 1,
+    disclaimerTitle: 'Original disclaimer',
+    exchangeRate: null,
+};
+
+const languageMock: LocalizationLanguage = {
+    id: 2,
+    code: 'en',
+    name: 'English',
+};
+
+const formValues = { description: 'Translated disclaimer' };
+
+const localizationDtoMock = {
+    entityId: 1,
+    disclaimerTitle: 'Translated disclaimer',
+    localizationInfoDto: { id: 2, code: 'en' },
+    translationStatus: TranslationStatus.Relevant,
+};
+
+const localizationModelMock: ReportFundsExpendituresSettingsLocalization = {
+    disclaimerTitle: 'Translated disclaimer',
+    language: { id: 2, code: 'en' },
+    translationStatus: TranslationStatus.Relevant,
+};
+
+describe('useTranslateDisclaimer', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should initialize with default state', () => {
+        const { result } = renderHook(() =>
+            useTranslateDisclaimer({
+                settings: settingsMock,
+                language: languageMock,
+                onSuccess: jest.fn(),
+                mode: ModalMode.Add,
+            }),
+        );
+
+        expect(result.current.isSubmitting).toBe(false);
+        expect(result.current.error).toBe('');
+    });
+
+    it('should create translation successfully in add mode', async () => {
+        const onSuccess = jest.fn();
+        mockedCreate.mockResolvedValue(localizationDtoMock as any);
+        mockedMapper.mockReturnValue(localizationModelMock);
+
+        const { result } = renderHook(() =>
+            useTranslateDisclaimer({
+                settings: settingsMock,
+                language: languageMock,
+                onSuccess,
+                mode: ModalMode.Add,
+            }),
+        );
+
+        await act(async () => {
+            await result.current.translateDisclaimer(formValues);
+        });
+
+        expect(mockedCreate).toHaveBeenCalledWith(expect.anything(), {
+            entityId: settingsMock.id,
+            languageId: languageMock.id,
+            disclaimerTitle: formValues.description,
+        });
+        expect(onSuccess).toHaveBeenCalledWith(localizationModelMock);
+        expect(result.current.isSubmitting).toBe(false);
+        expect(result.current.error).toBe('');
+    });
+
+    it('should update translation successfully in edit mode', async () => {
+        const onSuccess = jest.fn();
+        mockedUpdate.mockResolvedValue(localizationDtoMock as any);
+        mockedMapper.mockReturnValue(localizationModelMock);
+
+        const { result } = renderHook(() =>
+            useTranslateDisclaimer({
+                settings: settingsMock,
+                language: languageMock,
+                onSuccess,
+                mode: ModalMode.Edit,
+            }),
+        );
+
+        await act(async () => {
+            await result.current.translateDisclaimer(formValues);
+        });
+
+        expect(mockedUpdate).toHaveBeenCalledWith(expect.anything(), settingsMock.id, languageMock.id, {
+            disclaimerTitle: formValues.description,
+        });
+        expect(onSuccess).toHaveBeenCalledWith(localizationModelMock);
+    });
+
+    it('should set error when create fails', async () => {
+        const onSuccess = jest.fn();
+        mockedCreate.mockRejectedValue(new Error('API error'));
+
+        const { result } = renderHook(() =>
+            useTranslateDisclaimer({
+                settings: settingsMock,
+                language: languageMock,
+                onSuccess,
+                mode: ModalMode.Add,
+            }),
+        );
+
+        await act(async () => {
+            await result.current.translateDisclaimer(formValues);
+        });
+
+        await waitFor(() => {
+            expect(result.current.error).toBe(FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_DISCLAIMER.FAIL_TO_TRANSLATE);
+        });
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(result.current.isSubmitting).toBe(false);
+    });
+
+    it('should set error when update fails in edit mode', async () => {
+        const onSuccess = jest.fn();
+        mockedUpdate.mockRejectedValue(new Error('API error'));
+
+        const { result } = renderHook(() =>
+            useTranslateDisclaimer({
+                settings: settingsMock,
+                language: languageMock,
+                onSuccess,
+                mode: ModalMode.Edit,
+            }),
+        );
+
+        await act(async () => {
+            await result.current.translateDisclaimer(formValues);
+        });
+
+        await waitFor(() => {
+            expect(result.current.error).toBe(
+                FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_DISCLAIMER.FAIL_TO_UPDATE_TRANSLATION,
+            );
+        });
+        expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when settings is null', async () => {
+        const onSuccess = jest.fn();
+
+        const { result } = renderHook(() =>
+            useTranslateDisclaimer({
+                settings: null,
+                language: languageMock,
+                onSuccess,
+                mode: ModalMode.Add,
+            }),
+        );
+
+        await act(async () => {
+            await result.current.translateDisclaimer(formValues);
+        });
+
+        expect(mockedCreate).not.toHaveBeenCalled();
+        expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when language is null', async () => {
+        const onSuccess = jest.fn();
+
+        const { result } = renderHook(() =>
+            useTranslateDisclaimer({
+                settings: settingsMock,
+                language: null,
+                onSuccess,
+                mode: ModalMode.Add,
+            }),
+        );
+
+        await act(async () => {
+            await result.current.translateDisclaimer(formValues);
+        });
+
+        expect(mockedCreate).not.toHaveBeenCalled();
+        expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('should clear error', () => {
+        const { result } = renderHook(() =>
+            useTranslateDisclaimer({
+                settings: settingsMock,
+                language: languageMock,
+                onSuccess: jest.fn(),
+                mode: ModalMode.Add,
+            }),
+        );
+
+        act(() => {
+            result.current.clearError();
+        });
+
+        expect(result.current.error).toBe('');
+    });
+});

--- a/src/hooks/admin/use-translate-disclaimer/useTranslateDisclaimer.ts
+++ b/src/hooks/admin/use-translate-disclaimer/useTranslateDisclaimer.ts
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { ModalMode } from '@/types/admin/common';
+import { ReportFundsExpendituresSettings, ReportFundsExpendituresSettingsLocalization } from '@/types/admin/reports';
+import { LocalizationLanguage } from '@/types/common/language';
+import { useAdminClient } from '../use-admin-client/useAdminClient';
+import { ReportFundsExpendituresSettingsLocalizationsApi } from '@/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api';
+import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/localization/localization-mappers';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { TranslateDisclaimerFormValues } from '@/pages/admin/reports/components/funds-expenditures-section/components/common/translate-disclaimer-modal/TranslateDisclaimerForm';
+
+interface UseTranslateDisclaimerParams {
+    settings: ReportFundsExpendituresSettings | null;
+    language: LocalizationLanguage | null;
+    onSuccess: (localization: ReportFundsExpendituresSettingsLocalization) => void;
+    mode: ModalMode;
+}
+
+export const useTranslateDisclaimer = ({ settings, language, onSuccess, mode }: UseTranslateDisclaimerParams) => {
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [error, setError] = useState<string>('');
+
+    const client = useAdminClient();
+    const isEditMode = mode === ModalMode.Edit;
+
+    const translateDisclaimer = async (data: TranslateDisclaimerFormValues) => {
+        if (!settings || !language) return;
+
+        try {
+            setIsSubmitting(true);
+            setError('');
+
+            if (isEditMode) {
+                const updatedDto = await ReportFundsExpendituresSettingsLocalizationsApi.update(
+                    client,
+                    settings.id,
+                    language.id,
+                    { disclaimerTitle: data.description },
+                );
+                onSuccess(
+                    mapLocalizationDtoToModel<typeof updatedDto, ReportFundsExpendituresSettingsLocalization>(
+                        updatedDto,
+                    ),
+                );
+            } else {
+                const createdDto = await ReportFundsExpendituresSettingsLocalizationsApi.create(client, {
+                    entityId: settings.id,
+                    languageId: language.id,
+                    disclaimerTitle: data.description,
+                });
+                onSuccess(
+                    mapLocalizationDtoToModel<typeof createdDto, ReportFundsExpendituresSettingsLocalization>(
+                        createdDto,
+                    ),
+                );
+            }
+        } catch {
+            setError(
+                isEditMode
+                    ? FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_DISCLAIMER.FAIL_TO_UPDATE_TRANSLATION
+                    : FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_DISCLAIMER.FAIL_TO_TRANSLATE,
+            );
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const clearError = () => setError('');
+
+    return { translateDisclaimer, isSubmitting, error, clearError };
+};

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.module.scss
@@ -26,11 +26,38 @@
     gap: 20px;
 }
 
+.disclaimer-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
 .disclaimer-label {
     @include type.subtitle-1-medium;
     font-weight: 700;
     line-height: 24px;
     color: c.$grey-900;
+}
+
+.translate-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    color: c.$blue-500;
+
+    svg {
+        width: 24px;
+        height: 24px;
+    }
+
+    &:hover {
+        color: c.$blue-700;
+    }
 }
 
 .disclaimer-text-area {

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -20,7 +20,9 @@ import {
     ReportFundsExpendituresCategory,
     ReportFundsExpendituresRecord,
     ReportFundsExpendituresSettings,
+    ReportFundsExpendituresSettingsLocalization,
 } from '@/types/admin/reports';
+import { LocalizationLanguage } from '@/types/common/language';
 import { useDataFetch } from '@/hooks/common/use-data-fetch/useDataFetch';
 import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
 import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextProvider';
@@ -39,6 +41,7 @@ import { AddFundsExpendituresCategoryModal } from './components/common/add-funds
 import { DeleteRecordModal } from './components/common/delete-record-modal/DeleteRecordModal';
 import { DeleteFundsExpendituresCategoryModal } from './components/common/delete-funds-expenditures-category-modal/DeleteFundsExpendituresCategoryModal';
 import { EditFundsExpendituresCategoryModal } from './components/common/edit-funds-expenditures-category-modal/EditFundsExpendituresCategoryModal';
+import { TranslateDisclaimerModal } from './components/common/translate-disclaimer-modal/TranslateDisclaimerModal';
 import styles from './FundsExpendituresSection.module.scss';
 
 const enrichRecords = (
@@ -64,6 +67,7 @@ interface FundsExpenditureSectionProps {
     isEditCategoryModalOpen?: boolean;
     onEditCategoryModalClose?: () => void;
     onCategoriesLoaded?: (categories: ReportFundsExpendituresCategory[]) => void;
+    translationLanguages?: LocalizationLanguage[];
 }
 
 export const FundsExpenditureSection = ({
@@ -78,6 +82,7 @@ export const FundsExpenditureSection = ({
     isEditCategoryModalOpen = false,
     onEditCategoryModalClose,
     onCategoriesLoaded,
+    translationLanguages = [],
 }: FundsExpenditureSectionProps = {}) => {
     const adminClient = useAdminClient();
     const { addToast } = useToast();
@@ -93,6 +98,10 @@ export const FundsExpenditureSection = ({
     const [recordsState, setRecordsState] = useState<ReportFundsExpendituresRecord[]>([]);
     const [isRowEditMode, setIsRowEditMode] = useState(false);
     const [activeRecordModalType, setActiveRecordModalType] = useState<FundsExpendituresTransactionType | null>(null);
+
+    const [isTranslateDisclaimerModalOpen, setIsTranslateDisclaimerModalOpen] = useState(false);
+    const [disclaimerLocalization, setDisclaimerLocalization] =
+        useState<ReportFundsExpendituresSettingsLocalization | null>(null);
 
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
     const [recordToDelete, setRecordToDelete] = useState<ReportFundsExpendituresRecord | null>(null);
@@ -505,6 +514,7 @@ export const FundsExpenditureSection = ({
     }
 
     const EditIcon = ACTION_ICONS.edit.default;
+    const TranslateIcon = ACTION_ICONS.translate.default;
 
     return (
         <div className={styles.section}>
@@ -538,7 +548,19 @@ export const FundsExpenditureSection = ({
             ) : (
                 settings?.disclaimerTitle && (
                     <div className={styles.disclaimer}>
-                        <span className={styles['disclaimer-label']}>{FUNDS_EXPENDITURES_TEXT.DISCLAIMER_LABEL}</span>
+                        <div className={styles['disclaimer-header']}>
+                            <span className={styles['disclaimer-label']}>
+                                {FUNDS_EXPENDITURES_TEXT.DISCLAIMER_LABEL}
+                            </span>
+                            <button
+                                type="button"
+                                className={styles['translate-btn']}
+                                onClick={() => setIsTranslateDisclaimerModalOpen(true)}
+                                aria-label="Перекласти дісклеймер"
+                            >
+                                <TranslateIcon />
+                            </button>
+                        </div>
                         <div className={styles['disclaimer-text-area']}>
                             <p className={styles['disclaimer-text']}>{settings.disclaimerTitle}</p>
                         </div>
@@ -672,6 +694,19 @@ export const FundsExpenditureSection = ({
                 onConfirm={handleConfirmBulkDelete}
                 onCancel={handleBulkDeleteCancel}
                 onClose={handleBulkDeleteCancel}
+            />
+
+            <TranslateDisclaimerModal
+                isOpen={isTranslateDisclaimerModalOpen}
+                onClose={() => setIsTranslateDisclaimerModalOpen(false)}
+                settings={settings}
+                translationLanguages={translationLanguages}
+                existingLocalization={disclaimerLocalization}
+                onTranslateSuccess={(localization) => {
+                    setDisclaimerLocalization(localization);
+                    setIsTranslateDisclaimerModalOpen(false);
+                    addToast(COMMON_TEXT_ADMIN.MESSAGE.TRANSLATION_SAVED_SUCCESS, ToastType.Success);
+                }}
             />
         </div>
     );

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-disclaimer-modal/TranslateDisclaimerForm.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-disclaimer-modal/TranslateDisclaimerForm.test.tsx
@@ -1,0 +1,238 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { TranslateDisclaimerForm } from './TranslateDisclaimerForm';
+
+jest.mock(
+    '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup',
+    () => ({
+        TextAreaWithCharacterLimitGroup: ({ id, value, onChange, onBlur, disabled, error }: any) => (
+            <>
+                <textarea
+                    data-testid={id}
+                    value={value}
+                    onChange={onChange}
+                    onBlur={onBlur}
+                    disabled={disabled ?? false}
+                />
+                {error && <span data-testid={`${id}-error`}>{error}</span>}
+            </>
+        ),
+    }),
+);
+
+const DESCRIPTION_INPUT = 'translate-disclaimer-description';
+const REQUIRED_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
+const MIN_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.disclaimer.min);
+const MAX_ERROR = COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(FUNDS_EXPENDITURES_VALIDATION.disclaimer.max);
+
+describe('TranslateDisclaimerForm', () => {
+    it('renders description textarea', () => {
+        render(<TranslateDisclaimerForm onSubmit={jest.fn()} />);
+
+        expect(screen.getByTestId(DESCRIPTION_INPUT)).toBeInTheDocument();
+    });
+
+    it('renders with empty value by default', () => {
+        render(<TranslateDisclaimerForm onSubmit={jest.fn()} />);
+
+        expect(screen.getByTestId(DESCRIPTION_INPUT)).toHaveValue('');
+    });
+
+    it('pre-fills description when initialData is provided', () => {
+        render(
+            <TranslateDisclaimerForm onSubmit={jest.fn()} initialData={{ description: 'Pre-filled description' }} />,
+        );
+
+        expect(screen.getByTestId(DESCRIPTION_INPUT)).toHaveValue('Pre-filled description');
+    });
+
+    it('disables textarea when formDisabled is true', () => {
+        render(<TranslateDisclaimerForm onSubmit={jest.fn()} formDisabled={true} />);
+
+        expect(screen.getByTestId(DESCRIPTION_INPUT)).toBeDisabled();
+    });
+
+    it('textarea is enabled by default', () => {
+        render(<TranslateDisclaimerForm onSubmit={jest.fn()} />);
+
+        expect(screen.getByTestId(DESCRIPTION_INPUT)).not.toBeDisabled();
+    });
+
+    it('normalizes consecutive spaces on change', () => {
+        render(<TranslateDisclaimerForm onSubmit={jest.fn()} />);
+
+        fireEvent.change(screen.getByTestId(DESCRIPTION_INPUT), { target: { value: 'hello  world' } });
+
+        expect(screen.getByTestId(DESCRIPTION_INPUT)).toHaveValue('hello world');
+    });
+
+    it('trims and normalizes text on blur', () => {
+        render(<TranslateDisclaimerForm onSubmit={jest.fn()} />);
+
+        fireEvent.change(screen.getByTestId(DESCRIPTION_INPUT), { target: { value: '  hello   world  ' } });
+        fireEvent.blur(screen.getByTestId(DESCRIPTION_INPUT));
+
+        expect(screen.getByTestId(DESCRIPTION_INPUT)).toHaveValue('hello world');
+    });
+
+    describe('validation', () => {
+        it('shows required error on blur when description is empty', () => {
+            render(<TranslateDisclaimerForm onSubmit={jest.fn()} />);
+
+            fireEvent.blur(screen.getByTestId(DESCRIPTION_INPUT));
+
+            expect(screen.getByTestId(`${DESCRIPTION_INPUT}-error`)).toHaveTextContent(REQUIRED_ERROR);
+        });
+
+        it('shows required error on blur when description is only whitespace', () => {
+            render(<TranslateDisclaimerForm onSubmit={jest.fn()} />);
+
+            fireEvent.change(screen.getByTestId(DESCRIPTION_INPUT), { target: { value: '   ' } });
+            fireEvent.blur(screen.getByTestId(DESCRIPTION_INPUT));
+
+            expect(screen.getByTestId(`${DESCRIPTION_INPUT}-error`)).toHaveTextContent(REQUIRED_ERROR);
+        });
+
+        it('shows min length error on blur when description is too short', () => {
+            render(<TranslateDisclaimerForm onSubmit={jest.fn()} />);
+
+            fireEvent.change(screen.getByTestId(DESCRIPTION_INPUT), { target: { value: 'a' } });
+            fireEvent.blur(screen.getByTestId(DESCRIPTION_INPUT));
+
+            expect(screen.getByTestId(`${DESCRIPTION_INPUT}-error`)).toHaveTextContent(MIN_ERROR);
+        });
+
+        it('shows max length error on blur when description is too long', () => {
+            render(<TranslateDisclaimerForm onSubmit={jest.fn()} />);
+
+            const longText = 'a'.repeat(FUNDS_EXPENDITURES_VALIDATION.disclaimer.max + 1);
+            fireEvent.change(screen.getByTestId(DESCRIPTION_INPUT), { target: { value: longText } });
+            fireEvent.blur(screen.getByTestId(DESCRIPTION_INPUT));
+
+            expect(screen.getByTestId(`${DESCRIPTION_INPUT}-error`)).toHaveTextContent(MAX_ERROR);
+        });
+
+        it('clears error when description becomes valid on re-blur', () => {
+            render(<TranslateDisclaimerForm onSubmit={jest.fn()} />);
+
+            fireEvent.change(screen.getByTestId(DESCRIPTION_INPUT), { target: { value: 'a' } });
+            fireEvent.blur(screen.getByTestId(DESCRIPTION_INPUT));
+            expect(screen.getByTestId(`${DESCRIPTION_INPUT}-error`)).toBeInTheDocument();
+
+            fireEvent.change(screen.getByTestId(DESCRIPTION_INPUT), { target: { value: 'Valid description text' } });
+            fireEvent.blur(screen.getByTestId(DESCRIPTION_INPUT));
+            expect(screen.queryByTestId(`${DESCRIPTION_INPUT}-error`)).not.toBeInTheDocument();
+        });
+
+        it('does not show error before blur', () => {
+            render(<TranslateDisclaimerForm onSubmit={jest.fn()} />);
+
+            expect(screen.queryByTestId(`${DESCRIPTION_INPUT}-error`)).not.toBeInTheDocument();
+        });
+    });
+
+    describe('onValidationChange', () => {
+        it('reports valid when description is valid', () => {
+            const onValidationChange = jest.fn();
+            render(<TranslateDisclaimerForm onSubmit={jest.fn()} onValidationChange={onValidationChange} />);
+
+            fireEvent.change(screen.getByTestId(DESCRIPTION_INPUT), {
+                target: { value: 'Valid description text' },
+            });
+
+            expect(onValidationChange).toHaveBeenLastCalledWith(true);
+        });
+
+        it('reports invalid when description is empty', () => {
+            const onValidationChange = jest.fn();
+            render(<TranslateDisclaimerForm onSubmit={jest.fn()} onValidationChange={onValidationChange} />);
+
+            expect(onValidationChange).toHaveBeenLastCalledWith(false);
+        });
+
+        it('reports invalid when description is too short', () => {
+            const onValidationChange = jest.fn();
+            render(<TranslateDisclaimerForm onSubmit={jest.fn()} onValidationChange={onValidationChange} />);
+
+            fireEvent.change(screen.getByTestId(DESCRIPTION_INPUT), { target: { value: 'a' } });
+
+            expect(onValidationChange).toHaveBeenLastCalledWith(false);
+        });
+
+        it('reports invalid when description exceeds max length', () => {
+            const onValidationChange = jest.fn();
+            render(<TranslateDisclaimerForm onSubmit={jest.fn()} onValidationChange={onValidationChange} />);
+
+            const longText = 'a'.repeat(FUNDS_EXPENDITURES_VALIDATION.disclaimer.max + 1);
+            fireEvent.change(screen.getByTestId(DESCRIPTION_INPUT), { target: { value: longText } });
+
+            expect(onValidationChange).toHaveBeenLastCalledWith(false);
+        });
+    });
+
+    describe('onDirtyChange', () => {
+        it('reports dirty when description is changed from empty default', () => {
+            const onDirtyChange = jest.fn();
+            render(<TranslateDisclaimerForm onSubmit={jest.fn()} onDirtyChange={onDirtyChange} />);
+
+            fireEvent.change(screen.getByTestId(DESCRIPTION_INPUT), { target: { value: 'some text' } });
+
+            expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+        });
+
+        it('reports not dirty when description matches initialData', () => {
+            const onDirtyChange = jest.fn();
+            render(
+                <TranslateDisclaimerForm
+                    onSubmit={jest.fn()}
+                    initialData={{ description: 'existing text' }}
+                    onDirtyChange={onDirtyChange}
+                />,
+            );
+
+            fireEvent.change(screen.getByTestId(DESCRIPTION_INPUT), { target: { value: 'existing text' } });
+
+            expect(onDirtyChange).toHaveBeenLastCalledWith(false);
+        });
+
+        it('reports not dirty on initial render with no initialData', () => {
+            const onDirtyChange = jest.fn();
+            render(<TranslateDisclaimerForm onSubmit={jest.fn()} onDirtyChange={onDirtyChange} />);
+
+            expect(onDirtyChange).toHaveBeenLastCalledWith(false);
+        });
+    });
+
+    it('calls onSubmit with form values when submitted via ref', async () => {
+        const onSubmit = jest.fn();
+        const ref = { current: null as any };
+
+        render(<TranslateDisclaimerForm ref={ref} onSubmit={onSubmit} />);
+
+        fireEvent.change(screen.getByTestId(DESCRIPTION_INPUT), {
+            target: { value: 'Valid description text' },
+        });
+
+        await waitFor(() => {
+            if (ref.current?.isValid()) {
+                ref.current.submit();
+            }
+        });
+
+        await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ description: 'Valid description text' }));
+    });
+
+    it('does not call onSubmit when description is invalid', async () => {
+        const onSubmit = jest.fn();
+        const ref = { current: null as any };
+
+        render(<TranslateDisclaimerForm ref={ref} onSubmit={onSubmit} />);
+
+        await waitFor(() => {
+            ref.current?.submit();
+        });
+
+        await waitFor(() => expect(onSubmit).not.toHaveBeenCalled());
+    });
+});

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-disclaimer-modal/TranslateDisclaimerForm.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-disclaimer-modal/TranslateDisclaimerForm.tsx
@@ -1,0 +1,110 @@
+import { forwardRef, useEffect } from 'react';
+import { TextAreaWithCharacterLimitGroup } from '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup';
+import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { useFormManager } from '@/hooks/admin/use-form-manager/useFormManager';
+import { VisibilityStatus } from '@/types/admin/common';
+import { getNormalizedInputText } from '@/utils/functions/formatters/text-formatters';
+import styles from './TranslateDisclaimerModal.module.scss';
+
+export interface TranslateDisclaimerFormValues {
+    description: string;
+}
+
+export interface TranslateDisclaimerFormErrorState {
+    description: string | undefined;
+    [key: string]: string | undefined;
+}
+
+export interface TranslateDisclaimerFormRef {
+    submit: (status?: VisibilityStatus) => Promise<void>;
+    isValid: () => boolean;
+    isDirty: () => boolean;
+}
+
+export interface TranslateDisclaimerFormProps {
+    onSubmit: (data: TranslateDisclaimerFormValues) => void | Promise<void>;
+    initialData?: TranslateDisclaimerFormValues | null;
+    formDisabled?: boolean;
+    onValidationChange?: (isValid: boolean) => void;
+    onDirtyChange?: (isDirty: boolean) => void;
+}
+
+const DEFAULT_FORM_STATE: TranslateDisclaimerFormValues = {
+    description: '',
+};
+
+const validateDescription = (value: string): string | undefined => {
+    const normalized = getNormalizedInputText(value);
+    if (!normalized) return COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED;
+    if (normalized.length < FUNDS_EXPENDITURES_VALIDATION.disclaimer.min)
+        return COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(FUNDS_EXPENDITURES_VALIDATION.disclaimer.min);
+    if (normalized.length > FUNDS_EXPENDITURES_VALIDATION.disclaimer.max)
+        return COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(FUNDS_EXPENDITURES_VALIDATION.disclaimer.max);
+    return undefined;
+};
+
+const validateForm = (
+    formState: TranslateDisclaimerFormValues,
+    _isPublishing?: boolean,
+): TranslateDisclaimerFormErrorState => ({
+    description: validateDescription(formState.description),
+});
+
+export const TranslateDisclaimerForm = forwardRef<TranslateDisclaimerFormRef, TranslateDisclaimerFormProps>(
+    ({ initialData = null, onSubmit, formDisabled, onValidationChange, onDirtyChange }, ref) => {
+        const { formState, setFormState, errors, setErrors, isSubmitting } = useFormManager<
+            TranslateDisclaimerFormValues,
+            TranslateDisclaimerFormErrorState
+        >({
+            defaultFormState: DEFAULT_FORM_STATE,
+            initialData,
+            validateForm,
+            onValidationChange,
+            ref,
+            onSubmit: (data, _status) => onSubmit(data),
+        });
+
+        useEffect(() => {
+            const isDirty = JSON.stringify(formState) !== JSON.stringify(initialData ?? DEFAULT_FORM_STATE);
+            onDirtyChange?.(isDirty);
+        }, [formState, initialData, onDirtyChange]);
+
+        const handleDescriptionChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+            const normalized = e.target.value.replaceAll(/ {2,}/g, ' ');
+            setFormState((prev) => ({ ...prev, description: normalized }));
+        };
+
+        const handleDescriptionBlur = () => {
+            const trimmed = formState.description.replaceAll(/\s+/g, ' ').trim();
+            setFormState((prev) => ({ ...prev, description: trimmed }));
+            setErrors((prev) => ({ ...prev, description: validateDescription(trimmed) }));
+        };
+
+        return (
+            <form
+                onSubmit={(e) => e.preventDefault()}
+                id="translate-disclaimer-form"
+                noValidate
+                className={styles.form}
+            >
+                <TextAreaWithCharacterLimitGroup
+                    id="translate-disclaimer-description"
+                    name="description"
+                    label={FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_DISCLAIMER.DESCRIPTION_LABEL}
+                    value={formState.description}
+                    onChange={handleDescriptionChange}
+                    onBlur={handleDescriptionBlur}
+                    maxLength={FUNDS_EXPENDITURES_VALIDATION.disclaimer.max}
+                    maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
+                        FUNDS_EXPENDITURES_VALIDATION.disclaimer.max,
+                    )}
+                    error={errors.description}
+                    rows={4}
+                    isRequired
+                    disabled={isSubmitting || formDisabled}
+                />
+            </form>
+        );
+    },
+);

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-disclaimer-modal/TranslateDisclaimerModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-disclaimer-modal/TranslateDisclaimerModal.module.scss
@@ -1,0 +1,72 @@
+@use '@/assets/sass/variables/colors' as c;
+@use '@/assets/sass/mixins/typography.mixins' as type;
+
+.modal {
+    width: 594px;
+    max-width: 594px;
+    background: c.$grey-50;
+    border-radius: 8px;
+    padding: 40px 30px;
+    box-sizing: border-box;
+
+    :global(.modal-header) {
+        margin-bottom: 0;
+        padding: 0;
+    }
+
+    :global(.modal-header .modal-title-wrapper) {
+        text-align: left;
+    }
+
+    :global(.modal-header-text) {
+        @include type.h4-regular;
+        color: c.$blue-900;
+        text-align: left;
+    }
+
+    :global(.modal-header .close-icon) {
+        padding-right: 0;
+        margin-bottom: 4px;
+    }
+
+    :global(.modal-body) {
+        margin-bottom: 0;
+        padding: 0;
+    }
+
+    :global(.modal-footer) {
+        padding: 0;
+        margin-top: 0;
+        gap: 0;
+        flex-wrap: nowrap;
+        justify-content: center;
+
+        button {
+            @include type.body-2-regular;
+            width: 100%;
+            height: 40px;
+            border-radius: 8px;
+        }
+    }
+}
+
+.content {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding-top: 10px;
+}
+
+.form {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+    width: 100%;
+}
+
+.error {
+    @include type.small-text-regular;
+    color: c.$error;
+    min-height: 20px;
+    margin: 2px 0 0;
+}

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-disclaimer-modal/TranslateDisclaimerModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-disclaimer-modal/TranslateDisclaimerModal.test.tsx
@@ -1,0 +1,201 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { LocalizationLanguage } from '@/types/common/language';
+import { TranslateDisclaimerModal } from './TranslateDisclaimerModal';
+
+jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
+    useAdminClient: () => ({ post: jest.fn(), put: jest.fn() }),
+}));
+
+jest.mock(
+    '@/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api',
+    () => ({
+        ReportFundsExpendituresSettingsLocalizationsApi: {
+            create: jest.fn(),
+            update: jest.fn(),
+        },
+    }),
+);
+
+jest.mock('@/utils/functions/mappers/common/localization/localization-mappers', () => ({
+    mapLocalizationDtoToModel: jest.fn(),
+}));
+
+jest.mock('@/components/admin/translation-controls/TranslationControls', () => ({
+    TranslationControls: ({ languages, selectedLanguage, onLanguageChange }: any) => (
+        <div data-testid="translation-controls">
+            {languages.map((lang: any) => (
+                <button
+                    key={lang.id}
+                    data-testid={`lang-${lang.code}`}
+                    onClick={() => onLanguageChange(lang)}
+                    data-selected={String(selectedLanguage?.id === lang.id)}
+                >
+                    {lang.name}
+                </button>
+            ))}
+        </div>
+    ),
+}));
+
+jest.mock('@/components/admin/localization-modal/LocalizationModal', () => ({
+    LocalizationModal: ({ isOpen, onClose, title, onSave, isSubmitting, isFormValid, isDirty, children }: any) =>
+        isOpen ? (
+            <div data-testid="localization-modal">
+                <div data-testid="modal-title">{title}</div>
+                <button data-testid="modal-close" onClick={onClose}>
+                    Close
+                </button>
+                <button data-testid="modal-save" onClick={onSave} disabled={!isFormValid || isSubmitting || !isDirty}>
+                    Save
+                </button>
+                <div data-testid="modal-content">{children}</div>
+            </div>
+        ) : null,
+}));
+
+jest.mock('./TranslateDisclaimerForm', () => {
+    const { forwardRef, useImperativeHandle } = jest.requireActual('react');
+    const TranslateDisclaimerForm = forwardRef(
+        ({ onValidationChange, onSubmit, onDirtyChange, formDisabled }: any, ref: any) => {
+            useImperativeHandle(ref, () => ({
+                isValid: () => true,
+                isDirty: () => true,
+                submit: () => onSubmit({ description: 'Test description text' }),
+            }));
+            return (
+                <div data-testid="translate-disclaimer-form">
+                    <button
+                        data-testid="make-valid"
+                        onClick={() => {
+                            onValidationChange?.(true);
+                            onDirtyChange?.(true);
+                        }}
+                    >
+                        Make valid
+                    </button>
+                    <span data-testid="form-disabled">{String(formDisabled)}</span>
+                </div>
+            );
+        },
+    );
+    return { TranslateDisclaimerForm };
+});
+
+const languageEn: LocalizationLanguage = { id: 2, code: 'en', name: 'Англійська' };
+const languageUk: LocalizationLanguage = { id: 1, code: 'uk', name: 'Українська' };
+
+const defaultProps = {
+    isOpen: true,
+    onClose: jest.fn(),
+    translationLanguages: [languageEn],
+    settings: null,
+    existingLocalization: null,
+    onTranslateSuccess: jest.fn(),
+};
+
+describe('TranslateDisclaimerModal', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders modal when isOpen is true', () => {
+        render(<TranslateDisclaimerModal {...defaultProps} />);
+
+        expect(screen.getByTestId('localization-modal')).toBeInTheDocument();
+    });
+
+    it('does not render when isOpen is false', () => {
+        render(<TranslateDisclaimerModal {...defaultProps} isOpen={false} />);
+
+        expect(screen.queryByTestId('localization-modal')).not.toBeInTheDocument();
+    });
+
+    it('renders add-mode title', () => {
+        render(<TranslateDisclaimerModal {...defaultProps} />);
+
+        expect(screen.getByTestId('modal-title')).toHaveTextContent(
+            FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_DISCLAIMER.TITLE,
+        );
+    });
+
+    it('renders TranslationControls with provided languages', () => {
+        render(<TranslateDisclaimerModal {...defaultProps} translationLanguages={[languageEn, languageUk]} />);
+
+        expect(screen.getByTestId('translation-controls')).toBeInTheDocument();
+        expect(screen.getByTestId('lang-en')).toBeInTheDocument();
+        expect(screen.getByTestId('lang-uk')).toBeInTheDocument();
+    });
+
+    it('initializes selected language to first in the list', () => {
+        render(<TranslateDisclaimerModal {...defaultProps} translationLanguages={[languageEn, languageUk]} />);
+
+        expect(screen.getByTestId('lang-en')).toHaveAttribute('data-selected', 'true');
+        expect(screen.getByTestId('lang-uk')).toHaveAttribute('data-selected', 'false');
+    });
+
+    it('renders TranslationControls with no languages when list is empty', () => {
+        render(<TranslateDisclaimerModal {...defaultProps} translationLanguages={[]} />);
+
+        expect(screen.getByTestId('translation-controls')).toBeInTheDocument();
+    });
+
+    it('renders the disclaimer form', () => {
+        render(<TranslateDisclaimerModal {...defaultProps} />);
+
+        expect(screen.getByTestId('translate-disclaimer-form')).toBeInTheDocument();
+    });
+
+    it('calls onClose when close button is clicked', () => {
+        const onClose = jest.fn();
+        render(<TranslateDisclaimerModal {...defaultProps} onClose={onClose} />);
+
+        fireEvent.click(screen.getByTestId('modal-close'));
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('save button is disabled when form is not valid', () => {
+        render(<TranslateDisclaimerModal {...defaultProps} />);
+
+        expect(screen.getByTestId('modal-save')).toBeDisabled();
+    });
+
+    it('save button is enabled after form becomes valid and dirty', () => {
+        render(<TranslateDisclaimerModal {...defaultProps} />);
+
+        fireEvent.click(screen.getByTestId('make-valid'));
+
+        expect(screen.getByTestId('modal-save')).not.toBeDisabled();
+    });
+
+    it('resets form validity state when modal is closed and reopened', () => {
+        const { rerender } = render(<TranslateDisclaimerModal {...defaultProps} />);
+
+        fireEvent.click(screen.getByTestId('make-valid'));
+        expect(screen.getByTestId('modal-save')).not.toBeDisabled();
+
+        fireEvent.click(screen.getByTestId('modal-close'));
+        rerender(<TranslateDisclaimerModal {...defaultProps} isOpen={false} />);
+        rerender(<TranslateDisclaimerModal {...defaultProps} isOpen={true} />);
+
+        expect(screen.getByTestId('modal-save')).toBeDisabled();
+    });
+
+    it('updates selected language when language button is clicked', () => {
+        render(<TranslateDisclaimerModal {...defaultProps} translationLanguages={[languageEn, languageUk]} />);
+
+        expect(screen.getByTestId('lang-en')).toHaveAttribute('data-selected', 'true');
+
+        fireEvent.click(screen.getByTestId('lang-uk'));
+
+        expect(screen.getByTestId('lang-uk')).toHaveAttribute('data-selected', 'true');
+        expect(screen.getByTestId('lang-en')).toHaveAttribute('data-selected', 'false');
+    });
+
+    it('passes formDisabled=false to the form', () => {
+        render(<TranslateDisclaimerModal {...defaultProps} />);
+
+        expect(screen.getByTestId('form-disabled')).toHaveTextContent('false');
+    });
+});

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-disclaimer-modal/TranslateDisclaimerModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-disclaimer-modal/TranslateDisclaimerModal.tsx
@@ -1,0 +1,116 @@
+import { useRef, useState, useEffect, useMemo } from 'react';
+import { LocalizationModal } from '@/components/admin/localization-modal/LocalizationModal';
+import { TranslationControls } from '@/components/admin/translation-controls/TranslationControls';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { DEFAULT_LOCALE } from '@/const/common/locales';
+import { useTranslateDisclaimer } from '@/hooks/admin/use-translate-disclaimer/useTranslateDisclaimer';
+import { ModalMode } from '@/types/admin/common';
+import { ReportFundsExpendituresSettings, ReportFundsExpendituresSettingsLocalization } from '@/types/admin/reports';
+import { LocalizationLanguage } from '@/types/common/language';
+import styles from './TranslateDisclaimerModal.module.scss';
+import {
+    TranslateDisclaimerForm,
+    TranslateDisclaimerFormRef,
+    TranslateDisclaimerFormValues,
+} from './TranslateDisclaimerForm';
+
+interface TranslateDisclaimerModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    settings: ReportFundsExpendituresSettings | null;
+    translationLanguages: LocalizationLanguage[];
+    existingLocalization: ReportFundsExpendituresSettingsLocalization | null;
+    onTranslateSuccess: (localization: ReportFundsExpendituresSettingsLocalization) => void;
+}
+
+export const TranslateDisclaimerModal = ({
+    isOpen,
+    onClose,
+    settings,
+    translationLanguages,
+    existingLocalization,
+    onTranslateSuccess,
+}: TranslateDisclaimerModalProps) => {
+    const formRef = useRef<TranslateDisclaimerFormRef>(null);
+    const [isFormValid, setIsFormValid] = useState(false);
+    const [isDirty, setIsDirty] = useState(false);
+    const [selectedLanguage, setSelectedLanguage] = useState<LocalizationLanguage | null>(null);
+
+    useEffect(() => {
+        if (!translationLanguages?.length) return;
+        setSelectedLanguage(
+            (prev) => prev ?? translationLanguages.find((l) => l.code !== DEFAULT_LOCALE) ?? translationLanguages[0],
+        );
+    }, [translationLanguages]);
+
+    const mode = existingLocalization ? ModalMode.Edit : ModalMode.Add;
+
+    const initialData = useMemo<TranslateDisclaimerFormValues | null>(() => {
+        if (mode !== ModalMode.Edit || !existingLocalization) return null;
+        return { description: existingLocalization.disclaimerTitle };
+    }, [existingLocalization, mode]);
+
+    const { translateDisclaimer, isSubmitting, error, clearError } = useTranslateDisclaimer({
+        settings,
+        language: selectedLanguage,
+        onSuccess: (localization) => {
+            onTranslateSuccess(localization);
+            handleClose();
+        },
+        mode,
+    });
+
+    const handleClose = () => {
+        setIsFormValid(false);
+        setIsDirty(false);
+        clearError();
+        onClose();
+    };
+
+    const handleSaveClick = () => {
+        if (!formRef.current?.isValid()) return;
+        formRef.current.submit();
+    };
+
+    const checkIsDirty = () => formRef.current?.isDirty() ?? false;
+
+    const handleFormSubmit = async (data: TranslateDisclaimerFormValues) => {
+        await translateDisclaimer(data);
+    };
+
+    return (
+        <LocalizationModal
+            isOpen={isOpen}
+            onClose={handleClose}
+            title={
+                mode === ModalMode.Edit
+                    ? COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.UPDATE_TRANSLATION
+                    : FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_DISCLAIMER.TITLE
+            }
+            onSave={handleSaveClick}
+            isSubmitting={isSubmitting}
+            isFormValid={isFormValid}
+            checkIsDirty={checkIsDirty}
+            isDirty={isDirty}
+        >
+            <div className={styles.content}>
+                <TranslationControls
+                    selectedLanguage={selectedLanguage}
+                    isSubmitting={isSubmitting}
+                    languages={translationLanguages}
+                    onLanguageChange={setSelectedLanguage}
+                />
+                {error && <div className={styles.error}>{error}</div>}
+                <TranslateDisclaimerForm
+                    ref={formRef}
+                    initialData={initialData}
+                    onValidationChange={setIsFormValid}
+                    onSubmit={handleFormSubmit}
+                    formDisabled={isSubmitting}
+                    onDirtyChange={setIsDirty}
+                />
+            </div>
+        </LocalizationModal>
+    );
+};

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryForm.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryForm.tsx
@@ -81,6 +81,8 @@ export const TranslateReportsCategoryForm = forwardRef<
 
         const handleCategoryChange = (category: ReportFundsExpendituresCategory | null) => {
             setSelectedCategory(category);
+            setFormState(DEFAULT_FORM_STATE);
+            setErrors({} as TranslateReportsCategoryFormErrorState);
             onCategoryChange?.(category);
         };
 

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.module.scss
@@ -19,12 +19,7 @@
     }
 
     :global(.modal-header-text) {
-        font-family: 'Mulish', sans-serif;
-        font-style: normal;
-        font-weight: 400;
-        font-size: 32px;
-        line-height: 40px;
-        letter-spacing: -0.64px;
+        @include type.h4-regular;
         color: c.$blue-900;
         text-align: left;
     }
@@ -47,13 +42,9 @@
         justify-content: center;
 
         button {
+            @include type.body-2-regular;
             width: 100%;
             height: 40px;
-            font-family: 'Mulish', sans-serif;
-            font-size: 16px;
-            font-weight: 400;
-            line-height: 24px;
-            letter-spacing: -0.64px;
             border-radius: 8px;
         }
     }

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.test.tsx
@@ -26,34 +26,30 @@ jest.mock('@/utils/functions/mappers/common/localization/localization-mappers', 
 jest.mock('@/components/admin/translation-controls/TranslationControls', () => ({
     TranslationControls: ({ languages, selectedLanguage, onLanguageChange }: any) => (
         <div data-testid="translation-controls">
-            {languages.map((lang: any) => (
+            {(languages ?? []).map((lang: any) => (
                 <button
                     key={lang.id}
                     data-testid={`lang-${lang.code}`}
-                    onClick={() => onLanguageChange(lang)}
-                    data-selected={selectedLanguage?.id === lang.id}
-                >
-                    {lang.name}
-                </button>
+                    data-selected={String(selectedLanguage?.id === lang.id)}
+                    onClick={() => onLanguageChange?.(lang)}
+                />
             ))}
         </div>
     ),
 }));
 
 jest.mock('@/components/admin/localization-modal/LocalizationModal', () => ({
-    LocalizationModal: ({ isOpen, onClose, title, onSave, isSubmitting, isFormValid, isDirty, children }: any) =>
-        isOpen ? (
+    LocalizationModal: ({ isOpen, onClose, onSave, title, children }: any) => {
+        if (!isOpen) return null;
+        return (
             <div data-testid="localization-modal">
                 <div data-testid="modal-title">{title}</div>
-                <button data-testid="modal-close" onClick={onClose}>
-                    Close
-                </button>
-                <button data-testid="modal-save" onClick={onSave} disabled={!isFormValid || isSubmitting || !isDirty}>
-                    Save
-                </button>
-                <div data-testid="modal-content">{children}</div>
+                <div>{children}</div>
+                <button data-testid="modal-close" onClick={onClose} />
+                <button data-testid="modal-save" onClick={onSave} />
             </div>
-        ) : null,
+        );
+    },
 }));
 
 jest.mock('./TranslateReportsCategoryForm', () => {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
 import { ReportFundsExpendituresCategory } from '@/types/admin/reports';
 import { LocalizationLanguage, TranslationStatus } from '@/types/common/language';
@@ -97,6 +98,15 @@ const categoriesMock: ReportFundsExpendituresCategory[] = [
     { id: 2, name: 'Category Two', type: 'expense', localizations: [] },
 ];
 
+const categoryWithEnTranslation: ReportFundsExpendituresCategory = {
+    id: 3,
+    name: 'Category Three',
+    type: 'income',
+    localizations: [
+        { language: { id: 2, code: 'en' }, translationStatus: TranslationStatus.Relevant, name: 'Translated Three' },
+    ],
+};
+
 const defaultProps = {
     isOpen: true,
     onClose: jest.fn(),
@@ -120,10 +130,20 @@ describe('TranslateReportsCategoryModal', () => {
         expect(screen.queryByTestId('localization-modal')).not.toBeInTheDocument();
     });
 
-    it('renders the fixed modal title', () => {
+    it('shows add-mode title when selected category has no translation for selected language', () => {
         render(<TranslateReportsCategoryModal {...defaultProps} />);
         expect(screen.getByTestId('modal-title')).toHaveTextContent(
             FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_CATEGORY.TITLE,
+        );
+    });
+
+    it('shows edit-mode title when selected category has an existing translation for selected language', () => {
+        render(<TranslateReportsCategoryModal {...defaultProps} categories={[categoryWithEnTranslation]} />);
+
+        fireEvent.change(screen.getByTestId('category-select'), { target: { value: '3' } });
+
+        expect(screen.getByTestId('modal-title')).toHaveTextContent(
+            COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.UPDATE_TRANSLATION,
         );
     });
 

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-reports-category-modal/TranslateReportsCategoryModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { LocalizationModal } from '@/components/admin/localization-modal/LocalizationModal';
 import { TranslationControls } from '@/components/admin/translation-controls/TranslationControls';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
 import { DEFAULT_LOCALE } from '@/const/common/locales';
 import { useTranslateReportsCategory } from '@/hooks/admin/use-translate-reports-category/useTranslateReportsCategory';
@@ -88,7 +89,11 @@ export const TranslateReportsCategoryModal = ({
         <LocalizationModal
             isOpen={isOpen}
             onClose={handleClose}
-            title={FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_CATEGORY.TITLE}
+            title={
+                mode === ModalMode.Edit
+                    ? COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.UPDATE_TRANSLATION
+                    : FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_CATEGORY.TITLE
+            }
             onSave={handleSaveClick}
             isSubmitting={isSubmitting}
             isFormValid={isFormValid}

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
@@ -107,6 +107,7 @@ export const ReportAnalytics = () => {
                         isDeleteCategoryModalOpen={isDeleteCategoryModalOpen}
                         onDeleteCategoryModalClose={() => setIsDeleteCategoryModalOpen(false)}
                         onCategoriesLoaded={setCategories}
+                        translationLanguages={translationLanguages}
                     />
                 )}
                 {activeTab.id === 'program-expenses' && <ProgramExpensesSection isEditing={isFundsEditing} />}

--- a/src/services/api/admin/reports/funds-expenditures-api.test.ts
+++ b/src/services/api/admin/reports/funds-expenditures-api.test.ts
@@ -63,8 +63,8 @@ describe('FundsExpendituresApi', () => {
         it('should request categories and map enum dto', async () => {
             mockClient.get.mockResolvedValueOnce({
                 data: [
-                    { id: 1, name: 'Income category', type: 1 },
-                    { id: 2, name: 'Expense category', type: 2 },
+                    { id: 1, name: 'Income category', type: 1, localizations: [] },
+                    { id: 2, name: 'Expense category', type: 2, localizations: [] },
                 ],
             });
 
@@ -82,7 +82,7 @@ describe('FundsExpendituresApi', () => {
 
     describe('createCategory', () => {
         it('should post category and map response', async () => {
-            mockClient.post.mockResolvedValueOnce({ data: { id: 3, name: 'New income', type: 1 } });
+            mockClient.post.mockResolvedValueOnce({ data: { id: 3, name: 'New income', type: 1, localizations: [] } });
 
             const result = await FundsExpendituresApi.createCategory(mockClient, {
                 name: 'New income',
@@ -99,7 +99,7 @@ describe('FundsExpendituresApi', () => {
 
     describe('updateCategory', () => {
         it('should put category and map response', async () => {
-            mockClient.put.mockResolvedValueOnce({ data: { id: 2, name: 'Updated expense', type: 2 } });
+            mockClient.put.mockResolvedValueOnce({ data: { id: 2, name: 'Updated expense', type: 2, localizations: [] } });
 
             const result = await FundsExpendituresApi.updateCategory(mockClient, 2, {
                 name: 'Updated expense',

--- a/src/services/api/admin/reports/funds-expenditures-api.test.ts
+++ b/src/services/api/admin/reports/funds-expenditures-api.test.ts
@@ -99,7 +99,9 @@ describe('FundsExpendituresApi', () => {
 
     describe('updateCategory', () => {
         it('should put category and map response', async () => {
-            mockClient.put.mockResolvedValueOnce({ data: { id: 2, name: 'Updated expense', type: 2, localizations: [] } });
+            mockClient.put.mockResolvedValueOnce({
+                data: { id: 2, name: 'Updated expense', type: 2, localizations: [] },
+            });
 
             const result = await FundsExpendituresApi.updateCategory(mockClient, 2, {
                 name: 'Updated expense',

--- a/src/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api.test.ts
+++ b/src/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api.test.ts
@@ -1,0 +1,68 @@
+import { ReportFundsExpendituresSettingsLocalizationsApi } from './report-funds-expenditures-settings-localizations-api';
+import { API_ROUTES } from '@/const/common/api-routes/main-api';
+import {
+    CreateReportFundsExpendituresSettingsLocalizationDto,
+    ReportFundsExpendituresSettingsLocalizationDto,
+    UpdateReportFundsExpendituresSettingsLocalizationDto,
+} from '@/types/admin/reports';
+import { TranslationStatus } from '@/types/common/language';
+
+const mockLocalizationDto: ReportFundsExpendituresSettingsLocalizationDto = {
+    entityId: 1,
+    disclaimerTitle: 'Translated disclaimer',
+    localizationInfoDto: { id: 2, code: 'en' },
+    translationStatus: TranslationStatus.Relevant,
+};
+
+describe('ReportFundsExpendituresSettingsLocalizationsApi', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('create', () => {
+        it('should call client.post with correct url and payload and return response data', async () => {
+            const mockClient = { post: jest.fn().mockResolvedValueOnce({ data: mockLocalizationDto }) };
+
+            const payload: CreateReportFundsExpendituresSettingsLocalizationDto = {
+                entityId: 1,
+                languageId: 2,
+                disclaimerTitle: 'Translated disclaimer',
+            };
+
+            const result = await ReportFundsExpendituresSettingsLocalizationsApi.create(mockClient as any, payload);
+
+            expect(mockClient.post).toHaveBeenCalledTimes(1);
+            expect(mockClient.post).toHaveBeenCalledWith(
+                API_ROUTES.REPORT_FUNDS_EXPENDITURES_SETTINGS_LOCALIZATIONS.BASE,
+                payload,
+            );
+            expect(result).toEqual(mockLocalizationDto);
+        });
+    });
+
+    describe('update', () => {
+        it('should call client.put with correct url and payload and return response data', async () => {
+            const mockClient = { put: jest.fn().mockResolvedValueOnce({ data: mockLocalizationDto }) };
+
+            const entityId = 1;
+            const languageId = 2;
+            const payload: UpdateReportFundsExpendituresSettingsLocalizationDto = {
+                disclaimerTitle: 'Updated disclaimer',
+            };
+
+            const result = await ReportFundsExpendituresSettingsLocalizationsApi.update(
+                mockClient as any,
+                entityId,
+                languageId,
+                payload,
+            );
+
+            expect(mockClient.put).toHaveBeenCalledTimes(1);
+            expect(mockClient.put).toHaveBeenCalledWith(
+                `${API_ROUTES.REPORT_FUNDS_EXPENDITURES_SETTINGS_LOCALIZATIONS.BASE}/${entityId}/${languageId}`,
+                payload,
+            );
+            expect(result).toEqual(mockLocalizationDto);
+        });
+    });
+});

--- a/src/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api.ts
+++ b/src/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api.ts
@@ -1,0 +1,33 @@
+import { API_ROUTES } from '@/const/common/api-routes/main-api';
+import {
+    CreateReportFundsExpendituresSettingsLocalizationDto,
+    ReportFundsExpendituresSettingsLocalizationDto,
+    UpdateReportFundsExpendituresSettingsLocalizationDto,
+} from '@/types/admin/reports';
+import { AxiosInstance } from 'axios';
+
+export const ReportFundsExpendituresSettingsLocalizationsApi = {
+    create: async (
+        client: AxiosInstance,
+        data: CreateReportFundsExpendituresSettingsLocalizationDto,
+    ): Promise<ReportFundsExpendituresSettingsLocalizationDto> => {
+        const response = await client.post<ReportFundsExpendituresSettingsLocalizationDto>(
+            API_ROUTES.REPORT_FUNDS_EXPENDITURES_SETTINGS_LOCALIZATIONS.BASE,
+            data,
+        );
+        return response.data;
+    },
+
+    update: async (
+        client: AxiosInstance,
+        entityId: number,
+        languageId: number,
+        data: UpdateReportFundsExpendituresSettingsLocalizationDto,
+    ): Promise<ReportFundsExpendituresSettingsLocalizationDto> => {
+        const response = await client.put<ReportFundsExpendituresSettingsLocalizationDto>(
+            `${API_ROUTES.REPORT_FUNDS_EXPENDITURES_SETTINGS_LOCALIZATIONS.BASE}/${entityId}/${languageId}`,
+            data,
+        );
+        return response.data;
+    },
+};

--- a/src/types/admin/reports.ts
+++ b/src/types/admin/reports.ts
@@ -1,4 +1,9 @@
-import { EntityLocalization, EntityLocalizationDto, EntityWithLocalizations } from '../common/language';
+import {
+    EntityLocalization,
+    EntityLocalizationDto,
+    EntityWithDtoLocalizations,
+    EntityWithLocalizations,
+} from '../common/language';
 import { Image, ImageValues } from '../common/image';
 
 export interface ReportsMediaSettingsCollectedFundsDto {
@@ -91,7 +96,8 @@ export interface UpdateReportFundsExpendituresSettingsDto {
     exchangeRate: number;
 }
 
-export interface ReportFundsExpendituresCategoryDto {
+export interface ReportFundsExpendituresCategoryDto
+    extends EntityWithDtoLocalizations<ReportFundsExpendituresCategoryLocalizationDto> {
     id: number;
     name: string;
     type: ReportFundsExpendituresTypeDto;

--- a/src/types/admin/reports.ts
+++ b/src/types/admin/reports.ts
@@ -177,6 +177,30 @@ export interface UpdateReportFundsExpendituresCategoryLocalizationDto {
     name: string;
 }
 
+export interface ReportFundsExpendituresSettingsLocalizableFields {
+    disclaimerTitle: string;
+}
+
+export interface ReportFundsExpendituresSettingsLocalizationDto
+    extends EntityLocalizationDto,
+        ReportFundsExpendituresSettingsLocalizableFields {
+    entityId: number;
+}
+
+export interface ReportFundsExpendituresSettingsLocalization
+    extends EntityLocalization,
+        ReportFundsExpendituresSettingsLocalizableFields {}
+
+export interface CreateReportFundsExpendituresSettingsLocalizationDto {
+    entityId: number;
+    languageId: number;
+    disclaimerTitle: string;
+}
+
+export interface UpdateReportFundsExpendituresSettingsLocalizationDto {
+    disclaimerTitle: string;
+}
+
 export interface ReportFundsExpendituresCategory
     extends EntityWithLocalizations<ReportFundsExpendituresCategoryLocalization> {
     id: number;

--- a/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.test.ts
+++ b/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.test.ts
@@ -213,11 +213,12 @@ describe('reports-mapper', () => {
             });
         });
 
-        it('should map category dto to category', () => {
+        it('should map category dto to category with empty localizations', () => {
             const dto: ReportFundsExpendituresCategoryDto = {
                 id: 2,
                 name: 'Category',
                 type: 2,
+                localizations: [],
             };
 
             expect(mapReportFundsExpendituresCategoryDtoToCategory(dto)).toEqual({
@@ -225,6 +226,36 @@ describe('reports-mapper', () => {
                 name: 'Category',
                 type: 'expense',
                 localizations: [],
+            });
+        });
+
+        it('should map category dto to category with localizations', () => {
+            const dto: ReportFundsExpendituresCategoryDto = {
+                id: 2,
+                name: 'Category',
+                type: 2,
+                localizations: [
+                    {
+                        entityId: 2,
+                        localizationInfoDto: { id: 1, code: 'en' },
+                        translationStatus: 1,
+                        name: 'Category EN',
+                    },
+                ],
+            };
+
+            expect(mapReportFundsExpendituresCategoryDtoToCategory(dto)).toEqual({
+                id: 2,
+                name: 'Category',
+                type: 'expense',
+                localizations: [
+                    {
+                        entityId: 2,
+                        language: { id: 1, code: 'en' },
+                        translationStatus: 1,
+                        name: 'Category EN',
+                    },
+                ],
             });
         });
 

--- a/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.ts
+++ b/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.ts
@@ -5,6 +5,7 @@ import {
     FundsExpendituresTransactionType,
     ReportFundsExpendituresCategory,
     ReportFundsExpendituresCategoryDto,
+    ReportFundsExpendituresCategoryLocalization,
     ReportFundsExpendituresRecord,
     ReportFundsExpendituresRecordDto,
     ReportFundsExpendituresSettings,
@@ -22,6 +23,7 @@ import {
     UpdateReportFundsExpendituresSettingsDto,
 } from '@/types/admin/reports';
 
+import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/localization/localization-mappers';
 import { formatNumberDecimalComma } from '@/utils/functions/formatters/format-number';
 
 export const mapReportsMediaSettingsDtoToMediaSettings = (dto: ReportsMediaSettingsDto): ReportsMediaSettings => ({
@@ -85,7 +87,9 @@ export const mapReportFundsExpendituresCategoryDtoToCategory = (
     id: dto.id,
     name: dto.name,
     type: mapFundsExpendituresTypeDtoToTransactionType(dto.type),
-    localizations: [],
+    localizations: dto.localizations.map((loc) =>
+        mapLocalizationDtoToModel<typeof loc, ReportFundsExpendituresCategoryLocalization>(loc),
+    ),
 });
 
 export const mapReportFundsExpendituresCategoryToCreateDto = (


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2107

## Description

This PR implements category translation editing functionality in the translation modal window.

## How it looks


https://github.com/user-attachments/assets/7c65ac36-69e9-4a2d-8dda-72258f09e5fb


## Summary of change

Added translation edit mode support
Updated modal title dynamically based on translation existence

## How to recreate changes

1. Open "Доходи та витрати" tab
2. Open category actions menu
3. Click on "Перекласти"
4. Select a category that already has translation
5. Verify that:
- modal title changes to "Редагувати переклад"
- "Назва" field is populated with existing translation
- character counter is displayed
6. Edit translation value
7. Verify:
- character counter updates dynamically
- additional characters cannot be entered after limit is reached
- clean-up icon appears for non-empty field
- validation works correctly
8. Verify that "Зберегти переклад" button becomes active after valid input

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [x]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Translation modal in admin reports now shows context-aware titles for add vs. edit mode and preserves existing translations.

* **Refactor**
  * Typography unified with shared design-system mixins; added a reusable H4 typography mixin.

* **Bug Fixes**
  * Category form clears name and errors when changing selection to avoid stale input.

* **Tests**
  * Expanded tests for localization mapping, API responses, and add/edit modal behavior.

* **Documentation**
  * "Contributing → Git flow" emphasizes the "HACK AWAY! 🔨🔨🔨" line.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ita-social-projects/VictoryCenter-Client/pull/390?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->