### PR TITLE
Feature/issue 2507 [Reports] Program expenses - Connect frontend to backend (read only view)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ yarn-error.log*
 .vs/
 *.css
 *.map
+
+swagger.json

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
@@ -4,6 +4,7 @@ import { ProgramExpensesSection } from './ProgramExpensesSection';
 import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
 import { ProgramExpensesReadOnlyData } from '@/types/admin/reports';
 import { ProgramExpensesApi } from '@/services/api/admin/reports/program-expenses-api';
+import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
 
 const MOCK_PROGRAM_EXPENSES_DATA: ProgramExpensesReadOnlyData = {
     exchangeRate: '41.25',
@@ -62,6 +63,10 @@ jest.mock('@/services/api/admin/reports/program-expenses-api', () => ({
     ProgramExpensesApi: {
         getReadOnlyData: (...args: unknown[]) => mockGetReadOnlyData(...args),
     },
+}));
+
+jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
+    useAdminClient: () => 'mock-client',
 }));
 
 let mockUseDataFetchResult = {
@@ -283,7 +288,7 @@ describe('ProgramExpensesSection', () => {
         expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE })).toBeDisabled();
     });
 
-    it('should pass fetch handler that calls ProgramExpensesApi.getReadOnlyData', async () => {
+    it('should pass fetch handler that calls ProgramExpensesApi.getReadOnlyData with client', async () => {
         mockGetReadOnlyData.mockResolvedValue(MOCK_PROGRAM_EXPENSES_DATA);
 
         render(<ProgramExpensesSection />);
@@ -295,9 +300,9 @@ describe('ProgramExpensesSection', () => {
         await useDataFetchProps.fetchHandler();
         await useDataFetchProps.fetchHandler({ test: true });
 
-        expect(mockGetReadOnlyData).toHaveBeenCalledWith({});
+        expect(mockGetReadOnlyData).toHaveBeenCalledWith('mock-client', {});
         expect(ProgramExpensesApi.getReadOnlyData).toBeDefined();
-        expect(mockGetReadOnlyData).toHaveBeenCalledWith({ test: true });
+        expect(mockGetReadOnlyData).toHaveBeenCalledWith('mock-client', { test: true });
     });
 
     it('should render edit mode controls when edit mode is active', () => {

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { InlineLoader } from '@/components/common/inline-loader/InlineLoader';
 import { useDataFetch } from '@/hooks/common/use-data-fetch/useDataFetch';
+import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
 import { ProgramExpensesApi } from '@/services/api/admin/reports/program-expenses-api';
 import { ProgramExpensesReadOnlyData } from '@/types/admin/reports';
 import { ProgramExpensesToolbar } from './components/program-expenses-toolbar/ProgramExpensesToolbar';
@@ -26,10 +27,14 @@ interface ProgramExpensesSectionProps {
 }
 
 export const ProgramExpensesSection = ({ isEditing = false }: ProgramExpensesSectionProps) => {
+    const adminClient = useAdminClient();
     const [selectedProgramIds, setSelectedProgramIds] = useState<number[]>([]);
     const [isAddProgramExpenseModalOpen, setIsAddProgramExpenseModalOpen] = useState(false);
 
-    const fetchReadOnlyData = useCallback((options = {}) => ProgramExpensesApi.getReadOnlyData(options), []);
+    const fetchReadOnlyData = useCallback(
+        (options = {}) => ProgramExpensesApi.getReadOnlyData(adminClient, options),
+        [adminClient],
+    );
 
     const { data, isLoading } = useDataFetch<ProgramExpensesReadOnlyData>({
         initialData: INITIAL_PROGRAM_EXPENSES_DATA,

--- a/src/services/api/admin/reports/program-expenses-api.test.ts
+++ b/src/services/api/admin/reports/program-expenses-api.test.ts
@@ -1,182 +1,182 @@
-import { ProgramExpensesProgram, ProgramExpensesRecord } from '@/types/admin/reports';
+import { ProgramExpensesReadOnlyData } from '@/types/admin/reports';
 import { API_ROUTES } from '@/const/common/api-routes/main-api';
+import { ProgramExpensesApi } from './program-expenses-api';
 
-const loadProgramExpensesApi = (
-    records: Array<ProgramExpensesRecord & { isPublished: boolean }>,
-    programs: ProgramExpensesProgram[] = [],
-    exchangeRate = '42.15',
-) => {
-    jest.resetModules();
-    jest.doMock('@/utils/mock-data/admin/reports/program-expenses', () => ({
-        MOCK_PROGRAM_EXPENSES_EXCHANGE_RATE: exchangeRate,
-        MOCK_PROGRAM_EXPENSES_PROGRAMS: programs,
-        MOCK_PROGRAM_EXPENSES_RECORDS: records,
-    }));
-
-    let api: typeof import('./program-expenses-api').ProgramExpensesApi;
-
-    jest.isolateModules(() => {
-        api = require('./program-expenses-api').ProgramExpensesApi;
-    });
-
-    return api!;
-};
+const mockClient = {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+} as any;
 
 describe('ProgramExpensesApi', () => {
     afterEach(() => {
-        jest.resetModules();
-        jest.dontMock('@/utils/mock-data/admin/reports/program-expenses');
+        jest.clearAllMocks();
     });
 
-    it('should return published records with computed programs and summary', async () => {
-        const api = loadProgramExpensesApi(
-            [
+    describe('getReadOnlyData', () => {
+        it('should fetch records, categories and settings and map to read-only data', async () => {
+            mockClient.get.mockImplementation((url: string) => {
+                if (url === API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS) {
+                    return Promise.resolve({
+                        data: [
+                            {
+                                id: 1,
+                                reportingYear: 2025,
+                                hippotherapyProgramCategoryId: 10,
+                                amountUah: 1500,
+                                amountUsd: 1000,
+                            },
+                            {
+                                id: 2,
+                                reportingYear: 2025,
+                                hippotherapyProgramCategoryId: 20,
+                                amountUah: 250,
+                                amountUsd: 100.5,
+                            },
+                            {
+                                id: 3,
+                                reportingYear: 2024,
+                                hippotherapyProgramCategoryId: 10,
+                                amountUah: 2000,
+                                amountUsd: 800,
+                            },
+                        ],
+                    });
+                }
+                if (url === API_ROUTES.PROGRAMCATEGORY.BASE) {
+                    return Promise.resolve({
+                        data: [
+                            { id: 10, name: 'Program A', programsCount: 2 },
+                            { id: 20, name: 'Program B', programsCount: 1 },
+                        ],
+                    });
+                }
+                if (url === API_ROUTES.REPORTS.FUNDS_EXPENDITURES.SETTINGS) {
+                    return Promise.resolve({ data: { exchangeRate: 42.15 } });
+                }
+                return Promise.reject(new Error(`Unexpected URL: ${url}`));
+            });
+
+            const result = await ProgramExpensesApi.getReadOnlyData(mockClient);
+
+            expect(result.exchangeRate).toBe('42,15');
+            expect(result.records).toEqual([
                 {
                     id: 1,
-                    programId: 2,
-                    programName: 'Program B',
-                    type: 'expense',
-                    reportingYear: '2025',
-                    amountUah: '1 500',
-                    amountUsd: '1000',
-                    isPublished: true,
-                },
-                {
-                    id: 2,
-                    programId: 1,
+                    programId: 10,
                     programName: 'Program A',
                     type: 'expense',
                     reportingYear: '2025',
+                    amountUah: '1500',
+                    amountUsd: '1000',
+                },
+                {
+                    id: 2,
+                    programId: 20,
+                    programName: 'Program B',
+                    type: 'expense',
+                    reportingYear: '2025',
                     amountUah: '250',
-                    amountUsd: '100.5',
-                    isPublished: true,
+                    amountUsd: '100,5',
                 },
                 {
                     id: 3,
-                    programId: 1,
+                    programId: 10,
                     programName: 'Program A',
                     type: 'expense',
                     reportingYear: '2024',
                     amountUah: '2000',
                     amountUsd: '800',
-                    isPublished: true,
                 },
-                {
-                    id: 4,
-                    programId: 3,
-                    programName: 'Program C',
-                    type: 'expense',
-                    reportingYear: '2025',
-                    amountUah: '999',
-                    amountUsd: '999',
-                    isPublished: false,
-                },
-            ],
-            [
-                { id: 1, name: 'Program A from categories' },
-                { id: 4, name: 'Program D' },
-            ],
-        );
+            ]);
+            expect(result.programs).toEqual([
+                { id: 10, name: 'Program A' },
+                { id: 20, name: 'Program B' },
+            ]);
+            expect(result.summary).toEqual({
+                totalAmountUah: 3750,
+                totalAmountUsd: 1900.5,
+            });
+        });
 
-        const result = await api.getReadOnlyData();
+        it('should return null exchange rate when settings value is null', async () => {
+            mockClient.get.mockImplementation((url: string) => {
+                if (url === API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS) {
+                    return Promise.resolve({ data: [] });
+                }
+                if (url === API_ROUTES.PROGRAMCATEGORY.BASE) {
+                    return Promise.resolve({ data: [] });
+                }
+                if (url === API_ROUTES.REPORTS.FUNDS_EXPENDITURES.SETTINGS) {
+                    return Promise.resolve({ data: { exchangeRate: null } });
+                }
+                return Promise.reject(new Error(`Unexpected URL: ${url}`));
+            });
 
-        expect(result.exchangeRate).toBe('42.15');
-        expect(result.records).toEqual([
-            {
-                id: 2,
-                programId: 1,
-                programName: 'Program A',
-                type: 'expense',
-                reportingYear: '2025',
-                amountUah: '250',
-                amountUsd: '100.5',
-            },
-            {
-                id: 1,
-                programId: 2,
-                programName: 'Program B',
-                type: 'expense',
-                reportingYear: '2025',
-                amountUah: '1 500',
-                amountUsd: '1000',
-            },
-            {
-                id: 3,
-                programId: 1,
-                programName: 'Program A',
-                type: 'expense',
-                reportingYear: '2024',
-                amountUah: '2000',
-                amountUsd: '800',
-            },
-        ]);
-        expect(result.programs).toEqual([
-            { id: 1, name: 'Program A from categories' },
-            { id: 2, name: 'Program B' },
-            { id: 4, name: 'Program D' },
-        ]);
-        expect(result.summary).toEqual({
-            totalAmountUah: 3750,
-            totalAmountUsd: 1900.5,
+            const result = await ProgramExpensesApi.getReadOnlyData(mockClient);
+
+            expect(result).toEqual({
+                exchangeRate: null,
+                programs: [],
+                summary: { totalAmountUah: 0, totalAmountUsd: 0 },
+                records: [],
+            });
+        });
+
+        it('should pass cancellation signal to all requests', async () => {
+            mockClient.get.mockResolvedValue({ data: [] });
+            mockClient.get.mockImplementation((url: string) => {
+                if (url === API_ROUTES.REPORTS.FUNDS_EXPENDITURES.SETTINGS) {
+                    return Promise.resolve({ data: { exchangeRate: null } });
+                }
+                return Promise.resolve({ data: [] });
+            });
+
+            const signal = new AbortController().signal;
+            await ProgramExpensesApi.getReadOnlyData(mockClient, { cancellationSignal: signal });
+
+            expect(mockClient.get).toHaveBeenCalledWith(API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS, { signal });
+            expect(mockClient.get).toHaveBeenCalledWith(API_ROUTES.PROGRAMCATEGORY.BASE, { signal });
+            expect(mockClient.get).toHaveBeenCalledWith(API_ROUTES.REPORTS.FUNDS_EXPENDITURES.SETTINGS, { signal });
+        });
+
+        it('should fall back to category id string when category not found in map', async () => {
+            mockClient.get.mockImplementation((url: string) => {
+                if (url === API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS) {
+                    return Promise.resolve({
+                        data: [
+                            {
+                                id: 1,
+                                reportingYear: 2025,
+                                hippotherapyProgramCategoryId: 99,
+                                amountUah: 100,
+                                amountUsd: 10,
+                            },
+                        ],
+                    });
+                }
+                if (url === API_ROUTES.PROGRAMCATEGORY.BASE) {
+                    return Promise.resolve({ data: [] });
+                }
+                if (url === API_ROUTES.REPORTS.FUNDS_EXPENDITURES.SETTINGS) {
+                    return Promise.resolve({ data: { exchangeRate: null } });
+                }
+                return Promise.reject(new Error(`Unexpected URL: ${url}`));
+            });
+
+            const result = await ProgramExpensesApi.getReadOnlyData(mockClient);
+
+            expect(result.records[0].programName).toBe('99');
         });
     });
 
-    it('should return configured programs and zero summary when no records are published', async () => {
-        const api = loadProgramExpensesApi(
-            [
-                {
-                    id: 10,
-                    programId: 5,
-                    programName: 'Hidden Program',
-                    type: 'expense',
-                    reportingYear: '2025',
-                    amountUah: '100',
-                    amountUsd: '10',
-                    isPublished: false,
-                },
-            ],
-            [{ id: 6, name: 'Configured Program' }],
-            '39.00',
-        );
-
-        const result = await api.getReadOnlyData();
-
-        expect(result).toEqual({
-            exchangeRate: '39.00',
-            programs: [{ id: 6, name: 'Configured Program' }],
-            summary: {
-                totalAmountUah: 0,
-                totalAmountUsd: 0,
-            },
-            records: [],
-        });
-    });
-
-    describe('ProgramExpensesApi CRUD methods', () => {
-        const mockClient = {
-            get: jest.fn(),
-            post: jest.fn(),
-            put: jest.fn(),
-            delete: jest.fn(),
-        } as any;
-
-        let originalApi: typeof import('./program-expenses-api').ProgramExpensesApi;
-
-        beforeAll(() => {
-            jest.resetModules();
-            jest.dontMock('@/utils/mock-data/admin/reports/program-expenses');
-            originalApi = require('./program-expenses-api').ProgramExpensesApi;
-        });
-
-        afterEach(() => {
-            jest.clearAllMocks();
-        });
-
+    describe('CRUD methods', () => {
         it('getAll should call GET and return data', async () => {
             const mockData = [{ id: 1, amountUah: 100 }];
             mockClient.get.mockResolvedValueOnce({ data: mockData });
 
-            const result = await originalApi.getAll(mockClient);
+            const result = await ProgramExpensesApi.getAll(mockClient);
 
             expect(mockClient.get).toHaveBeenCalledWith(API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS);
             expect(result).toEqual(mockData);
@@ -187,7 +187,7 @@ describe('ProgramExpensesApi', () => {
             const mockData = { id: 1, ...record };
             mockClient.post.mockResolvedValueOnce({ data: mockData });
 
-            const result = await originalApi.post(mockClient, record);
+            const result = await ProgramExpensesApi.post(mockClient, record);
 
             expect(mockClient.post).toHaveBeenCalledWith(API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS, record);
             expect(result).toEqual(mockData);
@@ -198,7 +198,7 @@ describe('ProgramExpensesApi', () => {
             const mockData = { id: 5, reportingYear: 2025, ...record };
             mockClient.put.mockResolvedValueOnce({ data: mockData });
 
-            const result = await originalApi.update(mockClient, 5, record);
+            const result = await ProgramExpensesApi.update(mockClient, 5, record);
 
             expect(mockClient.put).toHaveBeenCalledWith(`${API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS}/5`, record);
             expect(result).toEqual(mockData);
@@ -207,7 +207,7 @@ describe('ProgramExpensesApi', () => {
         it('delete should call DELETE with correct id', async () => {
             mockClient.delete.mockResolvedValueOnce({});
 
-            await originalApi.delete(mockClient, 10);
+            await ProgramExpensesApi.delete(mockClient, 10);
 
             expect(mockClient.delete).toHaveBeenCalledWith(`${API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS}/10`);
         });
@@ -215,7 +215,7 @@ describe('ProgramExpensesApi', () => {
         it('bulkDelete should call POST with correct payload', async () => {
             mockClient.post.mockResolvedValueOnce({});
 
-            await originalApi.bulkDelete(mockClient, [1, 2, 3]);
+            await ProgramExpensesApi.bulkDelete(mockClient, [1, 2, 3]);
 
             expect(mockClient.post).toHaveBeenCalledWith(
                 `${API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS}/bulk-delete`,

--- a/src/services/api/admin/reports/program-expenses-api.test.ts
+++ b/src/services/api/admin/reports/program-expenses-api.test.ts
@@ -41,6 +41,13 @@ describe('ProgramExpensesApi', () => {
                                 amountUah: 2000,
                                 amountUsd: 800,
                             },
+                            {
+                                id: 4,
+                                reportingYear: 2024,
+                                hippotherapyProgramCategoryId: 20,
+                                amountUah: 0,
+                                amountUsd: 0,
+                            },
                         ],
                     });
                 }
@@ -88,6 +95,15 @@ describe('ProgramExpensesApi', () => {
                     reportingYear: '2024',
                     amountUah: '2000',
                     amountUsd: '800',
+                },
+                {
+                    id: 4,
+                    programId: 20,
+                    programName: 'Program B',
+                    type: 'expense',
+                    reportingYear: '2024',
+                    amountUah: '0',
+                    amountUsd: '0',
                 },
             ]);
             expect(result.programs).toEqual([

--- a/src/services/api/admin/reports/program-expenses-api.ts
+++ b/src/services/api/admin/reports/program-expenses-api.ts
@@ -8,81 +8,72 @@ import {
     CreateReportProgramExpendituresRecordDto,
     UpdateReportProgramExpendituresRecordDto,
 } from '@/types/admin/reports';
+import { ProgramCategory } from '@/types/admin/programs';
 import { API_ROUTES } from '@/const/common/api-routes/main-api';
-import {
-    MOCK_PROGRAM_EXPENSES_EXCHANGE_RATE,
-    MOCK_PROGRAM_EXPENSES_PROGRAMS,
-    MOCK_PROGRAM_EXPENSES_RECORDS,
-} from '@/utils/mock-data/admin/reports/program-expenses';
-import { parseAmount } from '@/utils/functions/parse-amount/parse-amount';
+import { formatNumberDecimalComma } from '@/utils/functions/formatters/format-number';
 
-const getPublishedProgramExpensesRecords = () =>
-    MOCK_PROGRAM_EXPENSES_RECORDS.filter((record) => record.isPublished).sort((firstRecord, secondRecord) => {
-        const yearDifference =
-            Number.parseInt(secondRecord.reportingYear, 10) - Number.parseInt(firstRecord.reportingYear, 10);
+const mapDtoToReadOnlyData = (
+    records: ReportProgramExpendituresRecordDto[],
+    categories: ProgramCategory[],
+    exchangeRate: string | null,
+): ProgramExpensesReadOnlyData => {
+    const categoryMap = new Map<number, string>(categories.map((c) => [c.id, c.name]));
 
-        if (yearDifference !== 0) {
-            return yearDifference;
-        }
-
-        return firstRecord.programName.localeCompare(secondRecord.programName, 'uk');
-    });
-
-const getRecordPrograms = (): ProgramExpensesProgram[] => {
-    const uniqueProgramsMap = new Map<number, ProgramExpensesProgram>();
-
-    getPublishedProgramExpensesRecords().forEach((record) => {
-        uniqueProgramsMap.set(record.programId, {
-            id: record.programId,
-            name: record.programName,
+    const mappedRecords = records
+        .map((record) => ({
+            id: record.id,
+            programId: record.hippotherapyProgramCategoryId,
+            programName:
+                categoryMap.get(record.hippotherapyProgramCategoryId) ?? String(record.hippotherapyProgramCategoryId),
+            type: 'expense' as const,
+            reportingYear: String(record.reportingYear),
+            amountUah: formatNumberDecimalComma(record.amountUah),
+            amountUsd: formatNumberDecimalComma(record.amountUsd),
+        }))
+        .sort((a, b) => {
+            const yearDiff = Number(b.reportingYear) - Number(a.reportingYear);
+            if (yearDiff !== 0) return yearDiff;
+            return a.programName.localeCompare(b.programName, 'uk');
         });
-    });
 
-    return Array.from(uniqueProgramsMap.values());
-};
-
-const mergePrograms = (programs: ProgramExpensesProgram[]): ProgramExpensesProgram[] => {
     const uniqueProgramsMap = new Map<number, ProgramExpensesProgram>();
-
-    programs.forEach((program) => {
-        uniqueProgramsMap.set(program.id, program);
+    mappedRecords.forEach((record) => {
+        uniqueProgramsMap.set(record.programId, { id: record.programId, name: record.programName });
     });
 
-    return Array.from(uniqueProgramsMap.values()).sort((firstProgram, secondProgram) =>
-        firstProgram.name.localeCompare(secondProgram.name, 'uk'),
-    );
-};
+    const programs = Array.from(uniqueProgramsMap.values()).sort((a, b) => a.name.localeCompare(b.name, 'uk'));
 
-const getPrograms = (): ProgramExpensesProgram[] =>
-    mergePrograms([...getRecordPrograms(), ...MOCK_PROGRAM_EXPENSES_PROGRAMS]);
-
-const getSummary = (): ProgramExpensesSummary => {
-    return getPublishedProgramExpensesRecords().reduce<ProgramExpensesSummary>(
-        (summary, record) => ({
-            totalAmountUah: summary.totalAmountUah + parseAmount(record.amountUah),
-            totalAmountUsd: summary.totalAmountUsd + parseAmount(record.amountUsd),
+    const summary = mappedRecords.reduce<ProgramExpensesSummary>(
+        (acc, record) => ({
+            totalAmountUah: acc.totalAmountUah + (Number(record.amountUah.replace(',', '.')) || 0),
+            totalAmountUsd: acc.totalAmountUsd + (Number(record.amountUsd.replace(',', '.')) || 0),
         }),
-        {
-            totalAmountUah: 0,
-            totalAmountUsd: 0,
-        },
+        { totalAmountUah: 0, totalAmountUsd: 0 },
     );
+
+    return { exchangeRate, programs, summary, records: mappedRecords };
 };
-
-const PUBLISHED_PROGRAM_EXPENSES_RECORDS = getPublishedProgramExpensesRecords().map(
-    ({ isPublished: _isPublished, ...record }) => record,
-);
-
-const PROGRAM_EXPENSES_SUMMARY = getSummary();
 
 export const ProgramExpensesApi = {
-    getReadOnlyData: async (_options: RequestOptions = {}): Promise<ProgramExpensesReadOnlyData> => {
-        return {
-            exchangeRate: MOCK_PROGRAM_EXPENSES_EXCHANGE_RATE,
-            programs: getPrograms(),
-            summary: PROGRAM_EXPENSES_SUMMARY,
-            records: PUBLISHED_PROGRAM_EXPENSES_RECORDS,
-        };
+    getReadOnlyData: async (
+        client: AxiosInstance,
+        options: RequestOptions = {},
+    ): Promise<ProgramExpensesReadOnlyData> => {
+        const [recordsResponse, categoriesResponse, settingsResponse] = await Promise.all([
+            client.get<ReportProgramExpendituresRecordDto[]>(API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS, {
+                signal: options.cancellationSignal,
+            }),
+            client.get<ProgramCategory[]>(API_ROUTES.PROGRAMCATEGORY.BASE, {
+                signal: options.cancellationSignal,
+            }),
+            client.get<{ exchangeRate: number | null }>(API_ROUTES.REPORTS.FUNDS_EXPENDITURES.SETTINGS, {
+                signal: options.cancellationSignal,
+            }),
+        ]);
+
+        const exchangeRate = formatNumberDecimalComma(settingsResponse.data.exchangeRate) || null;
+
+        return mapDtoToReadOnlyData(recordsResponse.data, categoriesResponse.data, exchangeRate);
     },
 
     getAll: async (client: AxiosInstance): Promise<ReportProgramExpendituresRecordDto[]> => {


### PR DESCRIPTION
## Github issue

* [Github issue](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2507)

## Description

Wire program expenses read only ui to the real backend api instead of using mocks.

## CHECK LIST
- [x]  New tests was added or existing was modified
- [x]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Program expense reports now retrieve accurate data through the live API instead of using test fixtures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ita-social-projects/VictoryCenter-Client/pull/392)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->