### PR TITLE
Feature/issue-1881: Validate Add Program Expense modal inputs

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -308,6 +308,9 @@ export const PROGRAM_EXPENSES_TEXT = {
             PROGRAM_NO_AVAILABLE: 'Немає доступних програм',
         },
     },
+    VALIDATION: {
+        PROGRAM_UNIQUE: 'Така категорія вже додана, Оберіть іншу категорію',
+    },
     FILTER: {
         PROGRAMS_PLACEHOLDER: 'Програми',
         ALL_OPTION: 'Всі',

--- a/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.test.ts
+++ b/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.test.ts
@@ -1,0 +1,148 @@
+import { act, renderHook } from '@testing-library/react';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+import { ProgramExpensesProgram, ProgramExpensesRecord } from '@/types/admin/reports';
+import { useProgramExpenseRecordForm } from './useProgramExpenseRecordForm';
+
+const programs: ProgramExpensesProgram[] = [
+    { id: 2, name: 'Program B' },
+    { id: 1, name: 'Program A' },
+];
+
+const records: ProgramExpensesRecord[] = [
+    {
+        id: 1,
+        programId: 1,
+        programName: 'Program A',
+        type: 'expense',
+        reportingYear: '2025',
+        amountUah: '100',
+        amountUsd: '10',
+    },
+];
+
+const createHookParams = (
+    overrides: Partial<Parameters<typeof useProgramExpenseRecordForm>[0]> = {},
+): Parameters<typeof useProgramExpenseRecordForm>[0] => ({
+    isOpen: true,
+    programs,
+    records,
+    ...overrides,
+});
+
+const renderUseProgramExpenseForm = (overrides: Partial<Parameters<typeof useProgramExpenseRecordForm>[0]> = {}) =>
+    renderHook(() => useProgramExpenseRecordForm(createHookParams(overrides)));
+
+describe('useProgramExpenseRecordForm', () => {
+    it('sorts programs by name', () => {
+        const { result } = renderUseProgramExpenseForm();
+
+        expect(result.current.programOptions.map((program) => program.name)).toEqual(['Program A', 'Program B']);
+    });
+
+    it('validates required select fields on blur', () => {
+        const { result } = renderUseProgramExpenseForm();
+
+        act(() => {
+            result.current.handleReportingYearBlur();
+            result.current.handleProgramBlur();
+        });
+
+        expect(result.current.formState.errors.reportingYear).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED);
+        expect(result.current.formState.errors.programId).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED);
+    });
+
+    it('validates duplicate program category and blocks submit', () => {
+        const { result } = renderUseProgramExpenseForm();
+
+        act(() => {
+            result.current.handleReportingYearChange('2026');
+            result.current.handleProgramChange(1);
+            result.current.handleAmountChange('amountUah', '100');
+            result.current.handleAmountChange('amountUsd', '10');
+        });
+
+        expect(result.current.formState.errors.programId).toBe(PROGRAM_EXPENSES_TEXT.VALIDATION.PROGRAM_UNIQUE);
+        expect(result.current.isSubmitDisabled).toBe(true);
+    });
+
+    it('enables submit when all validations pass', () => {
+        const { result } = renderUseProgramExpenseForm();
+
+        act(() => {
+            result.current.handleReportingYearChange('2026');
+            result.current.handleProgramChange(2);
+            result.current.handleAmountChange('amountUah', '100');
+            result.current.handleAmountChange('amountUsd', '10');
+        });
+
+        expect(result.current.isSubmitDisabled).toBe(false);
+    });
+
+    it('validates amount fields on change and blur', () => {
+        const { result } = renderUseProgramExpenseForm();
+
+        act(() => {
+            result.current.handleAmountChange('amountUah', '1234567890');
+            result.current.handleAmountChange('amountUsd', '0');
+        });
+
+        expect(result.current.formState.errors.amountUah).toBe(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DIGITS);
+        expect(result.current.formState.errors.amountUsd).toBeUndefined();
+
+        act(() => {
+            result.current.handleAmountBlur('amountUsd');
+        });
+
+        expect(result.current.formState.errors.amountUsd).toBe(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_ZERO);
+    });
+
+    it('resets values when modal closes', () => {
+        const { result, rerender } = renderHook(
+            ({ isOpen }) =>
+                useProgramExpenseRecordForm({
+                    isOpen,
+                    programs,
+                    records,
+                }),
+            { initialProps: { isOpen: true } },
+        );
+
+        act(() => {
+            result.current.handleReportingYearChange('2026');
+            result.current.handleProgramChange(2);
+            result.current.handleAmountChange('amountUah', '100');
+        });
+
+        expect(result.current.isDirty).toBe(true);
+
+        rerender({ isOpen: false });
+
+        expect(result.current.formState.reportingYear).toBeUndefined();
+        expect(result.current.formState.programId).toBeUndefined();
+        expect(result.current.formState.amountUah).toBe('');
+        expect(result.current.isDirty).toBe(false);
+    });
+
+    it('clears selected program when it is no longer available', () => {
+        const { result, rerender } = renderHook(
+            ({ nextPrograms }) =>
+                useProgramExpenseRecordForm({
+                    isOpen: true,
+                    programs: nextPrograms,
+                    records,
+                }),
+            { initialProps: { nextPrograms: programs } },
+        );
+
+        act(() => {
+            result.current.handleProgramChange(2);
+        });
+
+        expect(result.current.formState.programId).toBe(2);
+
+        rerender({ nextPrograms: programs.filter((program) => program.id !== 2) });
+
+        expect(result.current.formState.programId).toBeUndefined();
+    });
+});

--- a/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.ts
+++ b/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.ts
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ProgramExpensesProgram, ProgramExpensesRecord } from '@/types/admin/reports';
+import {
+    normalizeProgramExpenseAmountInput,
+    validateProgramExpenseAmount,
+    validateProgramExpenseProgram,
+    validateProgramExpenseReportingYear,
+} from '@/validation/admin/reports-schema/program-expenses-record-schema/program-expenses-record-schema';
+
+interface ProgramExpenseFormState {
+    reportingYear: string | undefined;
+    programId: number | undefined;
+    amountUah: string;
+    amountUsd: string;
+    errors: {
+        reportingYear?: string;
+        programId?: string;
+        amountUah?: string;
+        amountUsd?: string;
+    };
+}
+
+interface UseProgramExpenseRecordFormParams {
+    isOpen: boolean;
+    programs: ProgramExpensesProgram[];
+    records: ProgramExpensesRecord[];
+}
+
+const INITIAL_STATE: ProgramExpenseFormState = {
+    reportingYear: undefined,
+    programId: undefined,
+    amountUah: '',
+    amountUsd: '',
+    errors: {},
+};
+
+export const useProgramExpenseRecordForm = ({ isOpen, programs, records }: UseProgramExpenseRecordFormParams) => {
+    const [formState, setFormState] = useState<ProgramExpenseFormState>(INITIAL_STATE);
+
+    const programOptions = useMemo(
+        () =>
+            [...programs].sort((firstProgram, secondProgram) =>
+                firstProgram.name.localeCompare(secondProgram.name, 'uk'),
+            ),
+        [programs],
+    );
+
+    const isProgramSelectDisabled = programOptions.length === 0;
+
+    const getProgramError = useCallback(
+        (programId: number | undefined, trigger: 'change' | 'blur'): string | undefined =>
+            validateProgramExpenseProgram({
+                recordId: 0,
+                programId,
+                records,
+                trigger,
+            }),
+        [records],
+    );
+
+    useEffect(() => {
+        if (!isOpen) {
+            setFormState(INITIAL_STATE);
+            return;
+        }
+
+        const selectedProgramExists =
+            formState.programId === undefined || programOptions.some((program) => program.id === formState.programId);
+
+        if (isProgramSelectDisabled || !selectedProgramExists) {
+            setFormState((previousState) => ({
+                ...previousState,
+                programId: undefined,
+                errors: {
+                    ...previousState.errors,
+                    programId: undefined,
+                },
+            }));
+        }
+    }, [formState.programId, isOpen, isProgramSelectDisabled, programOptions]);
+
+    const handleAmountChange = useCallback((field: 'amountUah' | 'amountUsd', value: string) => {
+        const normalizedValue = normalizeProgramExpenseAmountInput(value);
+
+        setFormState((previousState) => ({
+            ...previousState,
+            [field]: normalizedValue,
+            errors: {
+                ...previousState.errors,
+                [field]: validateProgramExpenseAmount(normalizedValue, 'change'),
+            },
+        }));
+    }, []);
+
+    const handleAmountBlur = useCallback((field: 'amountUah' | 'amountUsd') => {
+        setFormState((previousState) => {
+            const normalizedValue = normalizeProgramExpenseAmountInput(previousState[field], true);
+
+            return {
+                ...previousState,
+                [field]: normalizedValue,
+                errors: {
+                    ...previousState.errors,
+                    [field]: validateProgramExpenseAmount(normalizedValue, 'blur'),
+                },
+            };
+        });
+    }, []);
+
+    const handleReportingYearChange = useCallback((reportingYear: string | undefined) => {
+        setFormState((previousState) => ({
+            ...previousState,
+            reportingYear,
+            errors: {
+                ...previousState.errors,
+                reportingYear: validateProgramExpenseReportingYear(reportingYear, 'change'),
+            },
+        }));
+    }, []);
+
+    const handleReportingYearBlur = useCallback(() => {
+        setFormState((previousState) => ({
+            ...previousState,
+            errors: {
+                ...previousState.errors,
+                reportingYear: validateProgramExpenseReportingYear(previousState.reportingYear, 'blur'),
+            },
+        }));
+    }, []);
+
+    const handleProgramChange = useCallback(
+        (programId: number | undefined) => {
+            setFormState((previousState) => ({
+                ...previousState,
+                programId,
+                errors: {
+                    ...previousState.errors,
+                    programId: getProgramError(programId, 'change'),
+                },
+            }));
+        },
+        [getProgramError],
+    );
+
+    const handleProgramBlur = useCallback(() => {
+        setFormState((previousState) => ({
+            ...previousState,
+            errors: {
+                ...previousState.errors,
+                programId: getProgramError(previousState.programId, 'blur'),
+            },
+        }));
+    }, [getProgramError]);
+
+    const isDirty =
+        Boolean(formState.reportingYear) ||
+        Boolean(formState.programId) ||
+        formState.amountUah.trim() !== '' ||
+        formState.amountUsd.trim() !== '';
+
+    const isSubmitDisabled =
+        Boolean(validateProgramExpenseReportingYear(formState.reportingYear, 'save')) ||
+        Boolean(getProgramError(formState.programId, 'blur')) ||
+        Boolean(validateProgramExpenseAmount(formState.amountUah, 'save')) ||
+        Boolean(validateProgramExpenseAmount(formState.amountUsd, 'save'));
+
+    return {
+        formState,
+        programOptions,
+        isProgramSelectDisabled,
+        isDirty,
+        isSubmitDisabled,
+        handleReportingYearChange,
+        handleReportingYearBlur,
+        handleProgramChange,
+        handleProgramBlur,
+        handleAmountChange,
+        handleAmountBlur,
+    };
+};

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
@@ -111,6 +111,7 @@ export const ProgramExpensesSection = ({ isEditing = false }: ProgramExpensesSec
             <AddProgramExpenseRecordModal
                 isOpen={isAddProgramExpenseModalOpen}
                 programs={data.programs}
+                records={data.records}
                 exchangeRate={exchangeRate}
                 onClose={handleCloseAddProgramExpenseModal}
             />

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.module.scss
@@ -132,12 +132,29 @@
         background: c.$white;
         filter: drop-shadow(0 1px 2px rgba(c.$bluish-black, 0.05));
     }
+
+    :global(.char-limit-input--error) {
+        border-color: c.$error;
+    }
 }
 
 .label {
     @include type.body-2-regular;
 
+    display: inline-flex;
+    gap: 2px;
     color: c.$grey-900;
+}
+
+.required {
+    color: c.$error;
+}
+
+.error {
+    @include type.small-text-regular;
+
+    margin: 0;
+    color: c.$error;
 }
 
 .input {

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.module.scss
@@ -126,15 +126,10 @@
     :global(.char-limit-input) {
         width: 100%;
         height: 50px;
-        border: 1px solid c.$grey-700;
         border-radius: 8px;
         padding: 10px 17px 10px 10px;
         background: c.$white;
         filter: drop-shadow(0 1px 2px rgba(c.$bluish-black, 0.05));
-    }
-
-    :global(.char-limit-input--error) {
-        border-color: c.$error;
     }
 }
 

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.test.tsx
@@ -51,11 +51,13 @@ jest.mock('@/components/admin/input-with-character-limit/InputWithCharacterLimit
         id,
         value,
         onChange,
+        onBlur,
     }: {
         id: string;
         value: string;
         onChange: (event: ChangeEvent<HTMLInputElement>) => void;
-    }) => <input data-testid={id} value={value} onChange={onChange} />,
+        onBlur?: () => void;
+    }) => <input data-testid={id} value={value} onChange={onChange} onBlur={onBlur} />,
 }));
 
 jest.mock('@/utils/functions/get-reporting-year-options/get-reporting-year-options', () => ({
@@ -67,9 +69,28 @@ const PROGRAMS = [
     { id: 1, name: 'Program A' },
 ];
 
+const RECORDS = [
+    {
+        id: 1,
+        programId: 1,
+        programName: 'Program A',
+        type: 'expense' as const,
+        reportingYear: '2025',
+        amountUah: '100',
+        amountUsd: '10',
+    },
+];
+
 const renderModal = (props: Partial<ComponentProps<typeof AddProgramExpenseRecordModal>> = {}) =>
     render(
-        <AddProgramExpenseRecordModal isOpen programs={PROGRAMS} exchangeRate="42.15" onClose={jest.fn()} {...props} />,
+        <AddProgramExpenseRecordModal
+            isOpen
+            programs={PROGRAMS}
+            records={RECORDS}
+            exchangeRate="42.15"
+            onClose={jest.fn()}
+            {...props}
+        />,
     );
 
 const getSelectToggle = (displayValue: string): HTMLButtonElement => {
@@ -111,21 +132,25 @@ describe('AddProgramExpenseRecordModal', () => {
         expect(screen.queryByText(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER)).not.toBeInTheDocument();
     });
 
-    it('normalizes program expense amount inputs', () => {
+    it('validates program expense amount inputs on change and blur', () => {
         renderModal();
 
         const amountUahInput = screen.getByTestId('add-program-expense-amount-uah');
         const amountUsdInput = screen.getByTestId('add-program-expense-amount-usd');
 
-        fireEvent.change(amountUahInput, { target: { value: '123 456 789 0' } });
-        fireEvent.change(amountUsdInput, { target: { value: '12.345abc' } });
+        fireEvent.change(amountUahInput, { target: { value: '1234567890' } });
+        fireEvent.change(amountUsdInput, { target: { value: 'abc' } });
 
-        expect(amountUahInput).toHaveValue('123456789');
-        expect(amountUsdInput).toHaveValue('12,34');
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DIGITS)).toBeInTheDocument();
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER)).toBeInTheDocument();
 
-        fireEvent.change(amountUsdInput, { target: { value: ',50' } });
+        fireEvent.change(amountUsdInput, { target: { value: '0' } });
 
-        expect(amountUsdInput).toHaveValue('');
+        expect(screen.queryByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_ZERO)).not.toBeInTheDocument();
+
+        fireEvent.blur(amountUsdInput);
+
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_ZERO)).toBeInTheDocument();
     });
 
     it('updates selected program value', () => {
@@ -134,6 +159,38 @@ describe('AddProgramExpenseRecordModal', () => {
         selectOption(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER, 'Program A');
 
         expect(getSelectToggle('Program A')).toBeInTheDocument();
+    });
+
+    it('shows required errors on blur for empty selects', () => {
+        renderModal();
+
+        fireEvent.blur(getSelectToggle(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER));
+        fireEvent.blur(getSelectToggle(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER));
+
+        expect(screen.getAllByText(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED)).toHaveLength(2);
+    });
+
+    it('shows duplicate program category error and keeps submit disabled', () => {
+        renderModal();
+
+        selectOption(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER, '2026');
+        selectOption(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER, 'Program A');
+        fireEvent.change(screen.getByTestId('add-program-expense-amount-uah'), { target: { value: '100' } });
+        fireEvent.change(screen.getByTestId('add-program-expense-amount-usd'), { target: { value: '10' } });
+
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.VALIDATION.PROGRAM_UNIQUE)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.MODAL.ADD.SUBMIT_BUTTON })).toBeDisabled();
+    });
+
+    it('enables submit when all validation rules pass', () => {
+        renderModal();
+
+        selectOption(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER, '2026');
+        selectOption(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER, 'Program B');
+        fireEvent.change(screen.getByTestId('add-program-expense-amount-uah'), { target: { value: '100' } });
+        fireEvent.change(screen.getByTestId('add-program-expense-amount-usd'), { target: { value: '10' } });
+
+        expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.MODAL.ADD.SUBMIT_BUTTON })).toBeEnabled();
     });
 
     it('closes immediately when the form is clean', () => {
@@ -170,7 +227,13 @@ describe('AddProgramExpenseRecordModal', () => {
 
     it('resets form state and close confirmation when modal closes', () => {
         const { rerender } = render(
-            <AddProgramExpenseRecordModal isOpen programs={PROGRAMS} exchangeRate={null} onClose={jest.fn()} />,
+            <AddProgramExpenseRecordModal
+                isOpen
+                programs={PROGRAMS}
+                records={RECORDS}
+                exchangeRate={null}
+                onClose={jest.fn()}
+            />,
         );
 
         const amountUahInput = screen.getByTestId('add-program-expense-amount-uah');
@@ -181,9 +244,23 @@ describe('AddProgramExpenseRecordModal', () => {
         expect(screen.getByTestId('close-confirmation')).toBeInTheDocument();
 
         rerender(
-            <AddProgramExpenseRecordModal isOpen={false} programs={PROGRAMS} exchangeRate={null} onClose={jest.fn()} />,
+            <AddProgramExpenseRecordModal
+                isOpen={false}
+                programs={PROGRAMS}
+                records={RECORDS}
+                exchangeRate={null}
+                onClose={jest.fn()}
+            />,
         );
-        rerender(<AddProgramExpenseRecordModal isOpen programs={PROGRAMS} exchangeRate={null} onClose={jest.fn()} />);
+        rerender(
+            <AddProgramExpenseRecordModal
+                isOpen
+                programs={PROGRAMS}
+                records={RECORDS}
+                exchangeRate={null}
+                onClose={jest.fn()}
+            />,
+        );
 
         expect(screen.getByTestId('add-program-expense-amount-uah')).toHaveValue('');
         expect(screen.queryByTestId('close-confirmation')).not.toBeInTheDocument();

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.test.tsx
@@ -148,9 +148,22 @@ describe('AddProgramExpenseRecordModal', () => {
 
         expect(screen.queryByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_ZERO)).not.toBeInTheDocument();
 
+        fireEvent.change(amountUahInput, { target: { value: '0' } });
+        fireEvent.blur(amountUahInput);
         fireEvent.blur(amountUsdInput);
 
-        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_ZERO)).toBeInTheDocument();
+        expect(screen.getAllByText(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_ZERO)).toHaveLength(2);
+    });
+
+    it('normalizes UAH amount on blur', () => {
+        renderModal();
+
+        const amountUahInput = screen.getByTestId('add-program-expense-amount-uah');
+
+        fireEvent.change(amountUahInput, { target: { value: ' 100.50 ' } });
+        fireEvent.blur(amountUahInput);
+
+        expect(amountUahInput).toHaveValue('100,50');
     });
 
     it('updates selected program value', () => {
@@ -168,6 +181,18 @@ describe('AddProgramExpenseRecordModal', () => {
         fireEvent.blur(getSelectToggle(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER));
 
         expect(screen.getAllByText(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED)).toHaveLength(2);
+    });
+
+    it('does not validate selects when focus stays inside the select field', () => {
+        renderModal();
+
+        const reportingYearToggle = getSelectToggle(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER);
+        const programToggle = getSelectToggle(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER);
+
+        fireEvent.blur(reportingYearToggle, { relatedTarget: reportingYearToggle });
+        fireEvent.blur(programToggle, { relatedTarget: programToggle });
+
+        expect(screen.queryByText(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED)).not.toBeInTheDocument();
     });
 
     it('shows duplicate program category error and keeps submit disabled', () => {

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.tsx
@@ -1,4 +1,4 @@
-import { FocusEvent, useEffect, useMemo, useRef } from 'react';
+import { ChangeEvent, FocusEvent, ReactNode, useEffect, useMemo, useRef } from 'react';
 import { Button } from '@/components/admin/button/Button';
 import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
 import { InputWithCharacterLimit } from '@/components/admin/input-with-character-limit/InputWithCharacterLimit';
@@ -21,6 +21,88 @@ interface AddProgramExpenseRecordModalProps {
 }
 
 const PROGRAM_EXPENSE_AMOUNT_MAX_LENGTH = 12;
+
+interface RequiredFieldLabelProps {
+    children: ReactNode;
+}
+
+const RequiredFieldLabel = ({ children }: RequiredFieldLabelProps) => (
+    <label className={styles.label}>
+        <span className={styles.required}>*</span>
+        {children}
+    </label>
+);
+
+interface FieldErrorProps {
+    message?: string;
+}
+
+const FieldError = ({ message }: FieldErrorProps) => (message ? <p className={styles.error}>{message}</p> : null);
+
+interface SelectFieldProps {
+    label: string;
+    error?: string;
+    onBlurCapture: (event: FocusEvent<HTMLDivElement>) => void;
+    children: ReactNode;
+}
+
+const SelectField = ({ label, error, onBlurCapture, children }: SelectFieldProps) => (
+    <div className={styles.field} onBlurCapture={onBlurCapture}>
+        <RequiredFieldLabel>{label}</RequiredFieldLabel>
+        {children}
+        <FieldError message={error} />
+    </div>
+);
+
+interface ExchangeRateChipProps {
+    exchangeRate: string | null;
+}
+
+const ExchangeRateChip = ({ exchangeRate }: ExchangeRateChipProps) => (
+    <div className={styles['exchange-rate-chip']}>
+        <span className={styles['exchange-rate-chip-label']}>{FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL}</span>
+        <input
+            type="text"
+            value={exchangeRate ?? ''}
+            disabled
+            className={styles['exchange-rate-value']}
+            aria-label={FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL}
+        />
+    </div>
+);
+
+interface AmountFieldProps {
+    id: string;
+    name: 'amountUah' | 'amountUsd';
+    label: string;
+    value: string;
+    error?: string;
+    headerAddon?: ReactNode;
+    onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+    onBlur: () => void;
+}
+
+const AmountField = ({ id, name, label, value, error, headerAddon, onChange, onBlur }: AmountFieldProps) => (
+    <div className={styles.field}>
+        <div className={headerAddon ? styles['amount-usd-header'] : undefined}>
+            <RequiredFieldLabel>{label}</RequiredFieldLabel>
+            {headerAddon}
+        </div>
+        <InputWithCharacterLimit
+            id={id}
+            name={name}
+            type="text"
+            value={value}
+            onChange={onChange}
+            onBlur={onBlur}
+            maxLength={PROGRAM_EXPENSE_AMOUNT_MAX_LENGTH}
+            showCounter={false}
+            className={styles.input}
+            hasError={Boolean(error)}
+        />
+        <FieldError message={error} />
+    </div>
+);
 
 export const AddProgramExpenseRecordModal = ({
     isOpen,
@@ -90,11 +172,11 @@ export const AddProgramExpenseRecordModal = ({
                 <Modal.Content>
                     <div className={styles.panel}>
                         <div className={styles.form}>
-                            <div className={styles.field} onBlurCapture={handleReportingYearFieldBlur}>
-                                <label className={styles.label}>
-                                    <span className={styles.required}>*</span>
-                                    {FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_LABEL}
-                                </label>
+                            <SelectField
+                                label={FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_LABEL}
+                                error={formState.errors.reportingYear}
+                                onBlurCapture={handleReportingYearFieldBlur}
+                            >
                                 <Select<string>
                                     value={formState.reportingYear}
                                     onValueChange={handleReportingYearChange}
@@ -107,16 +189,13 @@ export const AddProgramExpenseRecordModal = ({
                                         <Select.Option key={year} value={year} name={year} />
                                     ))}
                                 </Select>
-                                {formState.errors.reportingYear && (
-                                    <p className={styles.error}>{formState.errors.reportingYear}</p>
-                                )}
-                            </div>
+                            </SelectField>
 
-                            <div className={styles.field} onBlurCapture={handleProgramFieldBlur}>
-                                <label className={styles.label}>
-                                    <span className={styles.required}>*</span>
-                                    {PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_LABEL}
-                                </label>
+                            <SelectField
+                                label={PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_LABEL}
+                                error={formState.errors.programId}
+                                onBlurCapture={handleProgramFieldBlur}
+                            >
                                 {isProgramSelectDisabled ? (
                                     <div className={styles['disabled-select-placeholder']}>
                                         {PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_NO_AVAILABLE}
@@ -135,68 +214,28 @@ export const AddProgramExpenseRecordModal = ({
                                         ))}
                                     </Select>
                                 )}
-                                {formState.errors.programId && (
-                                    <p className={styles.error}>{formState.errors.programId}</p>
-                                )}
-                            </div>
+                            </SelectField>
 
-                            <div className={styles.field}>
-                                <label className={styles.label}>
-                                    <span className={styles.required}>*</span>
-                                    {FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.AMOUNT_UAH_LABEL}
-                                </label>
-                                <InputWithCharacterLimit
-                                    id="add-program-expense-amount-uah"
-                                    name="amountUah"
-                                    type="text"
-                                    value={formState.amountUah}
-                                    onChange={(event) => handleAmountChange('amountUah', event.target.value)}
-                                    onBlur={() => handleAmountBlur('amountUah')}
-                                    maxLength={PROGRAM_EXPENSE_AMOUNT_MAX_LENGTH}
-                                    showCounter={false}
-                                    className={styles.input}
-                                    hasError={Boolean(formState.errors.amountUah)}
-                                />
-                                {formState.errors.amountUah && (
-                                    <p className={styles.error}>{formState.errors.amountUah}</p>
-                                )}
-                            </div>
+                            <AmountField
+                                id="add-program-expense-amount-uah"
+                                name="amountUah"
+                                label={FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.AMOUNT_UAH_LABEL}
+                                value={formState.amountUah}
+                                error={formState.errors.amountUah}
+                                onChange={(event) => handleAmountChange('amountUah', event.target.value)}
+                                onBlur={() => handleAmountBlur('amountUah')}
+                            />
 
-                            <div className={styles.field}>
-                                <div className={styles['amount-usd-header']}>
-                                    <label className={styles.label}>
-                                        <span className={styles.required}>*</span>
-                                        {FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.AMOUNT_USD_LABEL}
-                                    </label>
-                                    <div className={styles['exchange-rate-chip']}>
-                                        <span className={styles['exchange-rate-chip-label']}>
-                                            {FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL}
-                                        </span>
-                                        <input
-                                            type="text"
-                                            value={exchangeRate ?? ''}
-                                            disabled
-                                            className={styles['exchange-rate-value']}
-                                            aria-label={FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL}
-                                        />
-                                    </div>
-                                </div>
-                                <InputWithCharacterLimit
-                                    id="add-program-expense-amount-usd"
-                                    name="amountUsd"
-                                    type="text"
-                                    value={formState.amountUsd}
-                                    onChange={(event) => handleAmountChange('amountUsd', event.target.value)}
-                                    onBlur={() => handleAmountBlur('amountUsd')}
-                                    maxLength={PROGRAM_EXPENSE_AMOUNT_MAX_LENGTH}
-                                    showCounter={false}
-                                    className={styles.input}
-                                    hasError={Boolean(formState.errors.amountUsd)}
-                                />
-                                {formState.errors.amountUsd && (
-                                    <p className={styles.error}>{formState.errors.amountUsd}</p>
-                                )}
-                            </div>
+                            <AmountField
+                                id="add-program-expense-amount-usd"
+                                name="amountUsd"
+                                label={FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.AMOUNT_USD_LABEL}
+                                value={formState.amountUsd}
+                                error={formState.errors.amountUsd}
+                                headerAddon={<ExchangeRateChip exchangeRate={exchangeRate} />}
+                                onChange={(event) => handleAmountChange('amountUsd', event.target.value)}
+                                onBlur={() => handleAmountBlur('amountUsd')}
+                            />
                         </div>
 
                         <div className={styles.actions}>

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { FocusEvent, useEffect, useMemo, useRef } from 'react';
 import { Button } from '@/components/admin/button/Button';
 import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
 import { InputWithCharacterLimit } from '@/components/admin/input-with-character-limit/InputWithCharacterLimit';
@@ -7,77 +7,48 @@ import { Modal } from '@/components/common/modal/Modal';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
 import { useDirtyModalCloseConfirmation } from '@/hooks/admin/use-dirty-modal-close-confirmation/useDirtyModalCloseConfirmation';
-import { ProgramExpensesProgram } from '@/types/admin/reports';
+import { useProgramExpenseRecordForm } from '@/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm';
+import { ProgramExpensesProgram, ProgramExpensesRecord } from '@/types/admin/reports';
 import { getReportingYearOptions } from '@/utils/functions/get-reporting-year-options/get-reporting-year-options';
 import styles from './AddProgramExpenseRecordModal.module.scss';
 
 interface AddProgramExpenseRecordModalProps {
     isOpen: boolean;
     programs: ProgramExpensesProgram[];
+    records: ProgramExpensesRecord[];
     exchangeRate: string | null;
     onClose: () => void;
 }
 
-interface ProgramExpenseFormState {
-    reportingYear: string | undefined;
-    programId: number | undefined;
-    amountUah: string;
-    amountUsd: string;
-}
-
-const INITIAL_FORM_STATE: ProgramExpenseFormState = {
-    reportingYear: undefined,
-    programId: undefined,
-    amountUah: '',
-    amountUsd: '',
-};
-
 const PROGRAM_EXPENSE_AMOUNT_MAX_LENGTH = 12;
-
-const normalizeProgramExpenseAmountInput = (value: string): string => {
-    const withCommaSeparator = value.replaceAll('.', ',').replaceAll(/\s/g, '');
-    const firstCommaIndex = withCommaSeparator.indexOf(',');
-    const integerSource = firstCommaIndex === -1 ? withCommaSeparator : withCommaSeparator.slice(0, firstCommaIndex);
-    const integerPart = integerSource.replaceAll(/\D/g, '').slice(0, 9);
-
-    if (firstCommaIndex === -1) {
-        return integerPart;
-    }
-
-    if (!integerPart) {
-        return '';
-    }
-
-    const decimalPart = withCommaSeparator
-        .slice(firstCommaIndex + 1)
-        .replaceAll(/\D/g, '')
-        .slice(0, 2);
-
-    return `${integerPart},${decimalPart}`;
-};
 
 export const AddProgramExpenseRecordModal = ({
     isOpen,
     programs,
+    records,
     exchangeRate,
     onClose,
 }: AddProgramExpenseRecordModalProps) => {
     const yearOptions = useMemo(() => getReportingYearOptions(), []);
-    const programOptions = useMemo(
-        () =>
-            [...programs].sort((firstProgram, secondProgram) =>
-                firstProgram.name.localeCompare(secondProgram.name, 'uk'),
-            ),
-        [programs],
-    );
-
-    const [formState, setFormState] = useState<ProgramExpenseFormState>(INITIAL_FORM_STATE);
-
-    const isDirty =
-        Boolean(formState.reportingYear) ||
-        Boolean(formState.programId) ||
-        formState.amountUah.trim() !== '' ||
-        formState.amountUsd.trim() !== '';
+    const reportingYearSelectRef = useRef<HTMLDivElement | null>(null);
+    const programSelectRef = useRef<HTMLDivElement | null>(null);
+    const {
+        formState,
+        programOptions,
+        isProgramSelectDisabled,
+        isDirty,
+        isSubmitDisabled,
+        handleReportingYearChange,
+        handleReportingYearBlur,
+        handleProgramChange,
+        handleProgramBlur,
+        handleAmountChange,
+        handleAmountBlur,
+    } = useProgramExpenseRecordForm({
+        isOpen,
+        programs,
+        records,
+    });
 
     const { isCloseConfirmOpen, handleRequestClose, handleConfirmClose, handleCancelClose } =
         useDirtyModalCloseConfirmation({
@@ -87,18 +58,24 @@ export const AddProgramExpenseRecordModal = ({
 
     useEffect(() => {
         if (!isOpen) {
-            setFormState(INITIAL_FORM_STATE);
             handleCancelClose();
         }
     }, [handleCancelClose, isOpen]);
 
-    const handleAmountChange = (field: 'amountUah' | 'amountUsd', value: string) => {
-        const normalizedValue = normalizeProgramExpenseAmountInput(value);
+    const handleReportingYearFieldBlur = (event: FocusEvent<HTMLDivElement>) => {
+        if (reportingYearSelectRef.current?.contains(event.relatedTarget as Node | null)) {
+            return;
+        }
 
-        setFormState((previousState) => ({
-            ...previousState,
-            [field]: normalizedValue,
-        }));
+        handleReportingYearBlur();
+    };
+
+    const handleProgramFieldBlur = (event: FocusEvent<HTMLDivElement>) => {
+        if (programSelectRef.current?.contains(event.relatedTarget as Node | null)) {
+            return;
+        }
+
+        handleProgramBlur();
     };
 
     return (
@@ -113,18 +90,15 @@ export const AddProgramExpenseRecordModal = ({
                 <Modal.Content>
                     <div className={styles.panel}>
                         <div className={styles.form}>
-                            <div className={styles.field}>
+                            <div className={styles.field} onBlurCapture={handleReportingYearFieldBlur}>
                                 <label className={styles.label}>
+                                    <span className={styles.required}>*</span>
                                     {FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_LABEL}
                                 </label>
                                 <Select<string>
                                     value={formState.reportingYear}
-                                    onValueChange={(reportingYear) =>
-                                        setFormState((previousState) => ({
-                                            ...previousState,
-                                            reportingYear,
-                                        }))
-                                    }
+                                    onValueChange={handleReportingYearChange}
+                                    selectContainerRef={reportingYearSelectRef}
                                     placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER}
                                     className={styles.select}
                                     optionClassName={styles['select-option']}
@@ -133,23 +107,25 @@ export const AddProgramExpenseRecordModal = ({
                                         <Select.Option key={year} value={year} name={year} />
                                     ))}
                                 </Select>
+                                {formState.errors.reportingYear && (
+                                    <p className={styles.error}>{formState.errors.reportingYear}</p>
+                                )}
                             </div>
 
-                            <div className={styles.field}>
-                                <label className={styles.label}>{PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_LABEL}</label>
-                                {programOptions.length === 0 ? (
+                            <div className={styles.field} onBlurCapture={handleProgramFieldBlur}>
+                                <label className={styles.label}>
+                                    <span className={styles.required}>*</span>
+                                    {PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_LABEL}
+                                </label>
+                                {isProgramSelectDisabled ? (
                                     <div className={styles['disabled-select-placeholder']}>
                                         {PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_NO_AVAILABLE}
                                     </div>
                                 ) : (
                                     <Select<number>
                                         value={formState.programId}
-                                        onValueChange={(programId) =>
-                                            setFormState((previousState) => ({
-                                                ...previousState,
-                                                programId,
-                                            }))
-                                        }
+                                        onValueChange={handleProgramChange}
+                                        selectContainerRef={programSelectRef}
                                         placeholder={PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER}
                                         className={styles.select}
                                         optionClassName={styles['select-option']}
@@ -159,10 +135,14 @@ export const AddProgramExpenseRecordModal = ({
                                         ))}
                                     </Select>
                                 )}
+                                {formState.errors.programId && (
+                                    <p className={styles.error}>{formState.errors.programId}</p>
+                                )}
                             </div>
 
                             <div className={styles.field}>
                                 <label className={styles.label}>
+                                    <span className={styles.required}>*</span>
                                     {FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.AMOUNT_UAH_LABEL}
                                 </label>
                                 <InputWithCharacterLimit
@@ -171,15 +151,21 @@ export const AddProgramExpenseRecordModal = ({
                                     type="text"
                                     value={formState.amountUah}
                                     onChange={(event) => handleAmountChange('amountUah', event.target.value)}
+                                    onBlur={() => handleAmountBlur('amountUah')}
                                     maxLength={PROGRAM_EXPENSE_AMOUNT_MAX_LENGTH}
                                     showCounter={false}
                                     className={styles.input}
+                                    hasError={Boolean(formState.errors.amountUah)}
                                 />
+                                {formState.errors.amountUah && (
+                                    <p className={styles.error}>{formState.errors.amountUah}</p>
+                                )}
                             </div>
 
                             <div className={styles.field}>
                                 <div className={styles['amount-usd-header']}>
                                     <label className={styles.label}>
+                                        <span className={styles.required}>*</span>
                                         {FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.AMOUNT_USD_LABEL}
                                     </label>
                                     <div className={styles['exchange-rate-chip']}>
@@ -201,15 +187,20 @@ export const AddProgramExpenseRecordModal = ({
                                     type="text"
                                     value={formState.amountUsd}
                                     onChange={(event) => handleAmountChange('amountUsd', event.target.value)}
+                                    onBlur={() => handleAmountBlur('amountUsd')}
                                     maxLength={PROGRAM_EXPENSE_AMOUNT_MAX_LENGTH}
                                     showCounter={false}
                                     className={styles.input}
+                                    hasError={Boolean(formState.errors.amountUsd)}
                                 />
+                                {formState.errors.amountUsd && (
+                                    <p className={styles.error}>{formState.errors.amountUsd}</p>
+                                )}
                             </div>
                         </div>
 
                         <div className={styles.actions}>
-                            <Button buttonStyle="primary" disabled className={styles.submit}>
+                            <Button buttonStyle="primary" disabled={isSubmitDisabled} className={styles.submit}>
                                 {PROGRAM_EXPENSES_TEXT.MODAL.ADD.SUBMIT_BUTTON}
                             </Button>
                             <Button buttonStyle="secondary" onClick={handleRequestClose} className={styles.cancel}>

--- a/src/validation/admin/reports-schema/program-expenses-record-schema/program-expenses-record-schema.test.ts
+++ b/src/validation/admin/reports-schema/program-expenses-record-schema/program-expenses-record-schema.test.ts
@@ -36,11 +36,13 @@ describe('PROGRAM_EXPENSES_RECORD_VALIDATION_FUNCTIONS', () => {
             FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DIGITS,
         );
         expect(validateProgramExpenseAmount('0', 'save')).toBe(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_ZERO);
+        expect(validateProgramExpenseAmount('1200')).toBeUndefined();
         expect(validateProgramExpenseAmount('1200,50', 'save')).toBeUndefined();
     });
 
     it('reuses reporting year required validation', () => {
         expect(validateProgramExpenseReportingYear(undefined, 'change')).toBeUndefined();
+        expect(validateProgramExpenseReportingYear(undefined)).toBeUndefined();
         expect(validateProgramExpenseReportingYear(undefined, 'blur')).toBe(
             COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED,
         );
@@ -48,6 +50,13 @@ describe('PROGRAM_EXPENSES_RECORD_VALIDATION_FUNCTIONS', () => {
     });
 
     it('validates required program category on blur', () => {
+        expect(
+            validateProgramExpenseProgram({
+                recordId: 0,
+                programId: undefined,
+                records,
+            }),
+        ).toBeUndefined();
         expect(
             validateProgramExpenseProgram({
                 recordId: 0,

--- a/src/validation/admin/reports-schema/program-expenses-record-schema/program-expenses-record-schema.test.ts
+++ b/src/validation/admin/reports-schema/program-expenses-record-schema/program-expenses-record-schema.test.ts
@@ -1,0 +1,87 @@
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+import { ProgramExpensesRecord } from '@/types/admin/reports';
+import {
+    normalizeProgramExpenseAmountInput,
+    validateProgramExpenseAmount,
+    validateProgramExpenseProgram,
+    validateProgramExpenseReportingYear,
+} from './program-expenses-record-schema';
+
+describe('PROGRAM_EXPENSES_RECORD_VALIDATION_FUNCTIONS', () => {
+    const records: ProgramExpensesRecord[] = [
+        {
+            id: 1,
+            programId: 1,
+            programName: 'Program A',
+            type: 'expense',
+            reportingYear: '2025',
+            amountUah: '100',
+            amountUsd: '10',
+        },
+        {
+            id: 2,
+            programId: 2,
+            programName: 'Program B',
+            type: 'expense',
+            reportingYear: '2024',
+            amountUah: '200',
+            amountUsd: '20',
+        },
+    ];
+
+    it('reuses funds amount normalization and validation rules', () => {
+        expect(normalizeProgramExpenseAmountInput('1200.567')).toBe('1200,56');
+        expect(validateProgramExpenseAmount('1234567890', 'change')).toBe(
+            FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DIGITS,
+        );
+        expect(validateProgramExpenseAmount('0', 'save')).toBe(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_ZERO);
+        expect(validateProgramExpenseAmount('1200,50', 'save')).toBeUndefined();
+    });
+
+    it('reuses reporting year required validation', () => {
+        expect(validateProgramExpenseReportingYear(undefined, 'change')).toBeUndefined();
+        expect(validateProgramExpenseReportingYear(undefined, 'blur')).toBe(
+            COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED,
+        );
+        expect(validateProgramExpenseReportingYear('2026', 'save')).toBeUndefined();
+    });
+
+    it('validates required program category on blur', () => {
+        expect(
+            validateProgramExpenseProgram({
+                recordId: 0,
+                programId: undefined,
+                records,
+                trigger: 'blur',
+            }),
+        ).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED);
+    });
+
+    it('validates duplicate program category', () => {
+        expect(
+            validateProgramExpenseProgram({
+                recordId: 0,
+                programId: 1,
+                records,
+            }),
+        ).toBe(PROGRAM_EXPENSES_TEXT.VALIDATION.PROGRAM_UNIQUE);
+    });
+
+    it('passes unique program category and ignores current record', () => {
+        expect(
+            validateProgramExpenseProgram({
+                recordId: 1,
+                programId: 1,
+                records,
+            }),
+        ).toBeUndefined();
+        expect(
+            validateProgramExpenseProgram({
+                recordId: 0,
+                programId: 3,
+                records,
+            }),
+        ).toBeUndefined();
+    });
+});

--- a/src/validation/admin/reports-schema/program-expenses-record-schema/program-expenses-record-schema.ts
+++ b/src/validation/admin/reports-schema/program-expenses-record-schema/program-expenses-record-schema.ts
@@ -1,0 +1,46 @@
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+import { ProgramExpensesRecord } from '@/types/admin/reports';
+import {
+    FundsExpendituresAmountValidationTrigger,
+    FundsExpendituresReportingYearValidationTrigger,
+    normalizeFundsExpendituresAmountInput,
+    validateFundsExpendituresAmount,
+    validateFundsExpendituresReportingYear,
+} from '@/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema';
+
+export type ProgramExpenseProgramValidationTrigger = 'change' | 'blur';
+
+interface ValidateProgramExpenseProgramParams {
+    recordId: number;
+    programId: number | undefined;
+    records: ProgramExpensesRecord[];
+    trigger?: ProgramExpenseProgramValidationTrigger;
+}
+
+export const normalizeProgramExpenseAmountInput = normalizeFundsExpendituresAmountInput;
+
+export const validateProgramExpenseAmount = (
+    value: string,
+    trigger: FundsExpendituresAmountValidationTrigger = 'change',
+): string | undefined => validateFundsExpendituresAmount(value, trigger);
+
+export const validateProgramExpenseReportingYear = (
+    value: string | undefined,
+    trigger: FundsExpendituresReportingYearValidationTrigger = 'change',
+): string | undefined => validateFundsExpendituresReportingYear(value, trigger);
+
+export const validateProgramExpenseProgram = ({
+    recordId,
+    programId,
+    records,
+    trigger = 'change',
+}: ValidateProgramExpenseProgramParams): string | undefined => {
+    if (programId === undefined) {
+        return trigger === 'blur' ? COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED : undefined;
+    }
+
+    const hasDuplicate = records.some((item) => item.id !== recordId && item.programId === programId);
+
+    return hasDuplicate ? PROGRAM_EXPENSES_TEXT.VALIDATION.PROGRAM_UNIQUE : undefined;
+};


### PR DESCRIPTION
## GitHub ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1881

## Description

Added inline validation for the Add Program Expense modal, including required reporting year, required program category, duplicate program category check, and amount validation for UAH/USD fields. The Add Expense button now becomes enabled only when all fields are valid.

## How it looks

<img width="801" height="795" alt="image" src="https://github.com/user-attachments/assets/ed36b3b1-af0b-4790-bef7-aeb8524e3f69" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved program expense modal form handling and added reporting-year/program fields with inline validation
  * Submit is now enabled/disabled based on validation state; program list sorting and selection behavior improved

* **Bug Fixes**
  * Duplicate program/category selection now shows a validation message and prevents submit

* **Style**
  * Updated input and error styling for form fields

* **Tests**
  * Added comprehensive tests covering form behavior, validations, normalization, and modal reset

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ita-social-projects/VictoryCenter-Client/pull/393)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->