### PR TITLE
Feature/issue-2116-2117: [Reports] Add edit and save functionality for dislaimer translations

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -243,6 +243,8 @@ export const FUNDS_EXPENDITURES_TEXT = {
         TRANSLATE_DISCLAIMER: {
             TITLE: 'Додати переклад',
             DESCRIPTION_LABEL: 'Опис',
+            FAIL_TO_TRANSLATE: 'Не вдалося зберегти переклад дісклеймера. Спробуйте ще раз',
+            FAIL_TO_UPDATE_TRANSLATION: 'Не вдалося оновити переклад дісклеймера. Спробуйте ще раз',
         },
     },
     BUTTON: {

--- a/src/const/common/api-routes/main-api.ts
+++ b/src/const/common/api-routes/main-api.ts
@@ -112,6 +112,9 @@ export const API_ROUTES = {
     REPORT_FUNDS_EXPENDITURES_CATEGORY_LOCALIZATIONS: {
         BASE: 'ReportFundsExpendituresCategoryLocalizations',
     },
+    REPORT_FUNDS_EXPENDITURES_SETTINGS_LOCALIZATIONS: {
+        BASE: 'ReportFundsExpendituresSettingsLocalizations',
+    },
     HISTORY: {
         BASE: 'History',
     },

--- a/src/hooks/admin/use-translate-disclaimer/useTranslateDisclaimer.test.ts
+++ b/src/hooks/admin/use-translate-disclaimer/useTranslateDisclaimer.test.ts
@@ -1,0 +1,229 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useTranslateDisclaimer } from './useTranslateDisclaimer';
+import { ReportFundsExpendituresSettingsLocalizationsApi } from '@/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api';
+import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/localization/localization-mappers';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { LocalizationLanguage, TranslationStatus } from '@/types/common/language';
+import { ReportFundsExpendituresSettings, ReportFundsExpendituresSettingsLocalization } from '@/types/admin/reports';
+import { ModalMode } from '@/types/admin/common';
+
+jest.mock(
+    '@/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api',
+);
+jest.mock('@/utils/functions/mappers/common/localization/localization-mappers');
+jest.mock('../use-admin-client/useAdminClient', () => ({
+    useAdminClient: () => ({ post: jest.fn(), put: jest.fn() }),
+}));
+
+const mockedCreate = ReportFundsExpendituresSettingsLocalizationsApi.create as jest.MockedFunction<
+    typeof ReportFundsExpendituresSettingsLocalizationsApi.create
+>;
+const mockedUpdate = ReportFundsExpendituresSettingsLocalizationsApi.update as jest.MockedFunction<
+    typeof ReportFundsExpendituresSettingsLocalizationsApi.update
+>;
+const mockedMapper = mapLocalizationDtoToModel as jest.MockedFunction<typeof mapLocalizationDtoToModel>;
+
+const settingsMock: ReportFundsExpendituresSettings = {
+    id: 1,
+    disclaimerTitle: 'Original disclaimer',
+    exchangeRate: null,
+};
+
+const languageMock: LocalizationLanguage = {
+    id: 2,
+    code: 'en',
+    name: 'English',
+};
+
+const formValues = { description: 'Translated disclaimer' };
+
+const localizationDtoMock = {
+    entityId: 1,
+    disclaimerTitle: 'Translated disclaimer',
+    localizationInfoDto: { id: 2, code: 'en' },
+    translationStatus: TranslationStatus.Relevant,
+};
+
+const localizationModelMock: ReportFundsExpendituresSettingsLocalization = {
+    disclaimerTitle: 'Translated disclaimer',
+    language: { id: 2, code: 'en' },
+    translationStatus: TranslationStatus.Relevant,
+};
+
+describe('useTranslateDisclaimer', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should initialize with default state', () => {
+        const { result } = renderHook(() =>
+            useTranslateDisclaimer({
+                settings: settingsMock,
+                language: languageMock,
+                onSuccess: jest.fn(),
+                mode: ModalMode.Add,
+            }),
+        );
+
+        expect(result.current.isSubmitting).toBe(false);
+        expect(result.current.error).toBe('');
+    });
+
+    it('should create translation successfully in add mode', async () => {
+        const onSuccess = jest.fn();
+        mockedCreate.mockResolvedValue(localizationDtoMock as any);
+        mockedMapper.mockReturnValue(localizationModelMock);
+
+        const { result } = renderHook(() =>
+            useTranslateDisclaimer({
+                settings: settingsMock,
+                language: languageMock,
+                onSuccess,
+                mode: ModalMode.Add,
+            }),
+        );
+
+        await act(async () => {
+            await result.current.translateDisclaimer(formValues);
+        });
+
+        expect(mockedCreate).toHaveBeenCalledWith(expect.anything(), {
+            entityId: settingsMock.id,
+            languageId: languageMock.id,
+            disclaimerTitle: formValues.description,
+        });
+        expect(onSuccess).toHaveBeenCalledWith(localizationModelMock);
+        expect(result.current.isSubmitting).toBe(false);
+        expect(result.current.error).toBe('');
+    });
+
+    it('should update translation successfully in edit mode', async () => {
+        const onSuccess = jest.fn();
+        mockedUpdate.mockResolvedValue(localizationDtoMock as any);
+        mockedMapper.mockReturnValue(localizationModelMock);
+
+        const { result } = renderHook(() =>
+            useTranslateDisclaimer({
+                settings: settingsMock,
+                language: languageMock,
+                onSuccess,
+                mode: ModalMode.Edit,
+            }),
+        );
+
+        await act(async () => {
+            await result.current.translateDisclaimer(formValues);
+        });
+
+        expect(mockedUpdate).toHaveBeenCalledWith(expect.anything(), settingsMock.id, languageMock.id, {
+            disclaimerTitle: formValues.description,
+        });
+        expect(onSuccess).toHaveBeenCalledWith(localizationModelMock);
+    });
+
+    it('should set error when create fails', async () => {
+        const onSuccess = jest.fn();
+        mockedCreate.mockRejectedValue(new Error('API error'));
+
+        const { result } = renderHook(() =>
+            useTranslateDisclaimer({
+                settings: settingsMock,
+                language: languageMock,
+                onSuccess,
+                mode: ModalMode.Add,
+            }),
+        );
+
+        await act(async () => {
+            await result.current.translateDisclaimer(formValues);
+        });
+
+        await waitFor(() => {
+            expect(result.current.error).toBe(FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_DISCLAIMER.FAIL_TO_TRANSLATE);
+        });
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(result.current.isSubmitting).toBe(false);
+    });
+
+    it('should set error when update fails in edit mode', async () => {
+        const onSuccess = jest.fn();
+        mockedUpdate.mockRejectedValue(new Error('API error'));
+
+        const { result } = renderHook(() =>
+            useTranslateDisclaimer({
+                settings: settingsMock,
+                language: languageMock,
+                onSuccess,
+                mode: ModalMode.Edit,
+            }),
+        );
+
+        await act(async () => {
+            await result.current.translateDisclaimer(formValues);
+        });
+
+        await waitFor(() => {
+            expect(result.current.error).toBe(
+                FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_DISCLAIMER.FAIL_TO_UPDATE_TRANSLATION,
+            );
+        });
+        expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when settings is null', async () => {
+        const onSuccess = jest.fn();
+
+        const { result } = renderHook(() =>
+            useTranslateDisclaimer({
+                settings: null,
+                language: languageMock,
+                onSuccess,
+                mode: ModalMode.Add,
+            }),
+        );
+
+        await act(async () => {
+            await result.current.translateDisclaimer(formValues);
+        });
+
+        expect(mockedCreate).not.toHaveBeenCalled();
+        expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when language is null', async () => {
+        const onSuccess = jest.fn();
+
+        const { result } = renderHook(() =>
+            useTranslateDisclaimer({
+                settings: settingsMock,
+                language: null,
+                onSuccess,
+                mode: ModalMode.Add,
+            }),
+        );
+
+        await act(async () => {
+            await result.current.translateDisclaimer(formValues);
+        });
+
+        expect(mockedCreate).not.toHaveBeenCalled();
+        expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('should clear error', () => {
+        const { result } = renderHook(() =>
+            useTranslateDisclaimer({
+                settings: settingsMock,
+                language: languageMock,
+                onSuccess: jest.fn(),
+                mode: ModalMode.Add,
+            }),
+        );
+
+        act(() => {
+            result.current.clearError();
+        });
+
+        expect(result.current.error).toBe('');
+    });
+});

--- a/src/hooks/admin/use-translate-disclaimer/useTranslateDisclaimer.ts
+++ b/src/hooks/admin/use-translate-disclaimer/useTranslateDisclaimer.ts
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { ModalMode } from '@/types/admin/common';
+import { ReportFundsExpendituresSettings, ReportFundsExpendituresSettingsLocalization } from '@/types/admin/reports';
+import { LocalizationLanguage } from '@/types/common/language';
+import { useAdminClient } from '../use-admin-client/useAdminClient';
+import { ReportFundsExpendituresSettingsLocalizationsApi } from '@/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api';
+import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/localization/localization-mappers';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { TranslateDisclaimerFormValues } from '@/pages/admin/reports/components/funds-expenditures-section/components/common/translate-disclaimer-modal/TranslateDisclaimerForm';
+
+interface UseTranslateDisclaimerParams {
+    settings: ReportFundsExpendituresSettings | null;
+    language: LocalizationLanguage | null;
+    onSuccess: (localization: ReportFundsExpendituresSettingsLocalization) => void;
+    mode: ModalMode;
+}
+
+export const useTranslateDisclaimer = ({ settings, language, onSuccess, mode }: UseTranslateDisclaimerParams) => {
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [error, setError] = useState<string>('');
+
+    const client = useAdminClient();
+    const isEditMode = mode === ModalMode.Edit;
+
+    const translateDisclaimer = async (data: TranslateDisclaimerFormValues) => {
+        if (!settings || !language) return;
+
+        try {
+            setIsSubmitting(true);
+            setError('');
+
+            if (isEditMode) {
+                const updatedDto = await ReportFundsExpendituresSettingsLocalizationsApi.update(
+                    client,
+                    settings.id,
+                    language.id,
+                    { disclaimerTitle: data.description },
+                );
+                onSuccess(
+                    mapLocalizationDtoToModel<typeof updatedDto, ReportFundsExpendituresSettingsLocalization>(
+                        updatedDto,
+                    ),
+                );
+            } else {
+                const createdDto = await ReportFundsExpendituresSettingsLocalizationsApi.create(client, {
+                    entityId: settings.id,
+                    languageId: language.id,
+                    disclaimerTitle: data.description,
+                });
+                onSuccess(
+                    mapLocalizationDtoToModel<typeof createdDto, ReportFundsExpendituresSettingsLocalization>(
+                        createdDto,
+                    ),
+                );
+            }
+        } catch {
+            setError(
+                isEditMode
+                    ? FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_DISCLAIMER.FAIL_TO_UPDATE_TRANSLATION
+                    : FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_DISCLAIMER.FAIL_TO_TRANSLATE,
+            );
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const clearError = () => setError('');
+
+    return { translateDisclaimer, isSubmitting, error, clearError };
+};

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -20,6 +20,7 @@ import {
     ReportFundsExpendituresCategory,
     ReportFundsExpendituresRecord,
     ReportFundsExpendituresSettings,
+    ReportFundsExpendituresSettingsLocalization,
 } from '@/types/admin/reports';
 import { LocalizationLanguage } from '@/types/common/language';
 import { useDataFetch } from '@/hooks/common/use-data-fetch/useDataFetch';
@@ -99,6 +100,8 @@ export const FundsExpenditureSection = ({
     const [activeRecordModalType, setActiveRecordModalType] = useState<FundsExpendituresTransactionType | null>(null);
 
     const [isTranslateDisclaimerModalOpen, setIsTranslateDisclaimerModalOpen] = useState(false);
+    const [disclaimerLocalization, setDisclaimerLocalization] =
+        useState<ReportFundsExpendituresSettingsLocalization | null>(null);
 
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
     const [recordToDelete, setRecordToDelete] = useState<ReportFundsExpendituresRecord | null>(null);
@@ -696,7 +699,14 @@ export const FundsExpenditureSection = ({
             <TranslateDisclaimerModal
                 isOpen={isTranslateDisclaimerModalOpen}
                 onClose={() => setIsTranslateDisclaimerModalOpen(false)}
+                settings={settings}
                 translationLanguages={translationLanguages}
+                existingLocalization={disclaimerLocalization}
+                onTranslateSuccess={(localization) => {
+                    setDisclaimerLocalization(localization);
+                    setIsTranslateDisclaimerModalOpen(false);
+                    addToast(COMMON_TEXT_ADMIN.MESSAGE.TRANSLATION_SAVED_SUCCESS, ToastType.Success);
+                }}
             />
         </div>
     );

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-disclaimer-modal/TranslateDisclaimerModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-disclaimer-modal/TranslateDisclaimerModal.test.tsx
@@ -3,6 +3,24 @@ import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
 import { LocalizationLanguage } from '@/types/common/language';
 import { TranslateDisclaimerModal } from './TranslateDisclaimerModal';
 
+jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
+    useAdminClient: () => ({ post: jest.fn(), put: jest.fn() }),
+}));
+
+jest.mock(
+    '@/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api',
+    () => ({
+        ReportFundsExpendituresSettingsLocalizationsApi: {
+            create: jest.fn(),
+            update: jest.fn(),
+        },
+    }),
+);
+
+jest.mock('@/utils/functions/mappers/common/localization/localization-mappers', () => ({
+    mapLocalizationDtoToModel: jest.fn(),
+}));
+
 jest.mock('@/components/admin/translation-controls/TranslationControls', () => ({
     TranslationControls: ({ languages, selectedLanguage, onLanguageChange }: any) => (
         <div data-testid="translation-controls">
@@ -11,7 +29,7 @@ jest.mock('@/components/admin/translation-controls/TranslationControls', () => (
                     key={lang.id}
                     data-testid={`lang-${lang.code}`}
                     onClick={() => onLanguageChange(lang)}
-                    data-selected={selectedLanguage?.id === lang.id}
+                    data-selected={String(selectedLanguage?.id === lang.id)}
                 >
                     {lang.name}
                 </button>
@@ -71,6 +89,9 @@ const defaultProps = {
     isOpen: true,
     onClose: jest.fn(),
     translationLanguages: [languageEn],
+    settings: null,
+    existingLocalization: null,
+    onTranslateSuccess: jest.fn(),
 };
 
 describe('TranslateDisclaimerModal', () => {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-disclaimer-modal/TranslateDisclaimerModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-disclaimer-modal/TranslateDisclaimerModal.tsx
@@ -1,7 +1,12 @@
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect, useMemo } from 'react';
 import { LocalizationModal } from '@/components/admin/localization-modal/LocalizationModal';
 import { TranslationControls } from '@/components/admin/translation-controls/TranslationControls';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { DEFAULT_LOCALE } from '@/const/common/locales';
+import { useTranslateDisclaimer } from '@/hooks/admin/use-translate-disclaimer/useTranslateDisclaimer';
+import { ModalMode } from '@/types/admin/common';
+import { ReportFundsExpendituresSettings, ReportFundsExpendituresSettingsLocalization } from '@/types/admin/reports';
 import { LocalizationLanguage } from '@/types/common/language';
 import styles from './TranslateDisclaimerModal.module.scss';
 import {
@@ -13,20 +18,53 @@ import {
 interface TranslateDisclaimerModalProps {
     isOpen: boolean;
     onClose: () => void;
+    settings: ReportFundsExpendituresSettings | null;
     translationLanguages: LocalizationLanguage[];
+    existingLocalization: ReportFundsExpendituresSettingsLocalization | null;
+    onTranslateSuccess: (localization: ReportFundsExpendituresSettingsLocalization) => void;
 }
 
-export const TranslateDisclaimerModal = ({ isOpen, onClose, translationLanguages }: TranslateDisclaimerModalProps) => {
+export const TranslateDisclaimerModal = ({
+    isOpen,
+    onClose,
+    settings,
+    translationLanguages,
+    existingLocalization,
+    onTranslateSuccess,
+}: TranslateDisclaimerModalProps) => {
     const formRef = useRef<TranslateDisclaimerFormRef>(null);
     const [isFormValid, setIsFormValid] = useState(false);
     const [isDirty, setIsDirty] = useState(false);
-    const [selectedLanguage, setSelectedLanguage] = useState<LocalizationLanguage | null>(
-        translationLanguages[0] ?? null,
-    );
+    const [selectedLanguage, setSelectedLanguage] = useState<LocalizationLanguage | null>(null);
+
+    useEffect(() => {
+        if (!translationLanguages?.length) return;
+        setSelectedLanguage(
+            (prev) => prev ?? translationLanguages.find((l) => l.code !== DEFAULT_LOCALE) ?? translationLanguages[0],
+        );
+    }, [translationLanguages]);
+
+    const mode = existingLocalization ? ModalMode.Edit : ModalMode.Add;
+
+    const initialData = useMemo<TranslateDisclaimerFormValues | null>(() => {
+        if (mode !== ModalMode.Edit || !existingLocalization) return null;
+        return { description: existingLocalization.disclaimerTitle };
+    }, [existingLocalization, mode]);
+
+    const { translateDisclaimer, isSubmitting, error, clearError } = useTranslateDisclaimer({
+        settings,
+        language: selectedLanguage,
+        onSuccess: (localization) => {
+            onTranslateSuccess(localization);
+            handleClose();
+        },
+        mode,
+    });
 
     const handleClose = () => {
         setIsFormValid(false);
         setIsDirty(false);
+        clearError();
         onClose();
     };
 
@@ -37,15 +75,21 @@ export const TranslateDisclaimerModal = ({ isOpen, onClose, translationLanguages
 
     const checkIsDirty = () => formRef.current?.isDirty() ?? false;
 
-    const handleFormSubmit = async (_data: TranslateDisclaimerFormValues) => {};
+    const handleFormSubmit = async (data: TranslateDisclaimerFormValues) => {
+        await translateDisclaimer(data);
+    };
 
     return (
         <LocalizationModal
             isOpen={isOpen}
             onClose={handleClose}
-            title={FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_DISCLAIMER.TITLE}
+            title={
+                mode === ModalMode.Edit
+                    ? COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.UPDATE_TRANSLATION
+                    : FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_DISCLAIMER.TITLE
+            }
             onSave={handleSaveClick}
-            isSubmitting={false}
+            isSubmitting={isSubmitting}
             isFormValid={isFormValid}
             checkIsDirty={checkIsDirty}
             isDirty={isDirty}
@@ -53,16 +97,17 @@ export const TranslateDisclaimerModal = ({ isOpen, onClose, translationLanguages
             <div className={styles.content}>
                 <TranslationControls
                     selectedLanguage={selectedLanguage}
-                    isSubmitting={false}
+                    isSubmitting={isSubmitting}
                     languages={translationLanguages}
                     onLanguageChange={setSelectedLanguage}
                 />
+                {error && <div className={styles.error}>{error}</div>}
                 <TranslateDisclaimerForm
                     ref={formRef}
-                    initialData={null}
+                    initialData={initialData}
                     onValidationChange={setIsFormValid}
                     onSubmit={handleFormSubmit}
-                    formDisabled={false}
+                    formDisabled={isSubmitting}
                     onDirtyChange={setIsDirty}
                 />
             </div>

--- a/src/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api.test.ts
+++ b/src/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api.test.ts
@@ -10,7 +10,7 @@ import { TranslationStatus } from '@/types/common/language';
 const mockLocalizationDto: ReportFundsExpendituresSettingsLocalizationDto = {
     entityId: 1,
     disclaimerTitle: 'Translated disclaimer',
-    localizationInfoDto: { id: 2, code: 'en', name: 'English' },
+    localizationInfoDto: { id: 2, code: 'en' },
     translationStatus: TranslationStatus.Relevant,
 };
 

--- a/src/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api.test.ts
+++ b/src/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api.test.ts
@@ -1,0 +1,68 @@
+import { ReportFundsExpendituresSettingsLocalizationsApi } from './report-funds-expenditures-settings-localizations-api';
+import { API_ROUTES } from '@/const/common/api-routes/main-api';
+import {
+    CreateReportFundsExpendituresSettingsLocalizationDto,
+    ReportFundsExpendituresSettingsLocalizationDto,
+    UpdateReportFundsExpendituresSettingsLocalizationDto,
+} from '@/types/admin/reports';
+import { TranslationStatus } from '@/types/common/language';
+
+const mockLocalizationDto: ReportFundsExpendituresSettingsLocalizationDto = {
+    entityId: 1,
+    disclaimerTitle: 'Translated disclaimer',
+    localizationInfoDto: { id: 2, code: 'en', name: 'English' },
+    translationStatus: TranslationStatus.Relevant,
+};
+
+describe('ReportFundsExpendituresSettingsLocalizationsApi', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('create', () => {
+        it('should call client.post with correct url and payload and return response data', async () => {
+            const mockClient = { post: jest.fn().mockResolvedValueOnce({ data: mockLocalizationDto }) };
+
+            const payload: CreateReportFundsExpendituresSettingsLocalizationDto = {
+                entityId: 1,
+                languageId: 2,
+                disclaimerTitle: 'Translated disclaimer',
+            };
+
+            const result = await ReportFundsExpendituresSettingsLocalizationsApi.create(mockClient as any, payload);
+
+            expect(mockClient.post).toHaveBeenCalledTimes(1);
+            expect(mockClient.post).toHaveBeenCalledWith(
+                API_ROUTES.REPORT_FUNDS_EXPENDITURES_SETTINGS_LOCALIZATIONS.BASE,
+                payload,
+            );
+            expect(result).toEqual(mockLocalizationDto);
+        });
+    });
+
+    describe('update', () => {
+        it('should call client.put with correct url and payload and return response data', async () => {
+            const mockClient = { put: jest.fn().mockResolvedValueOnce({ data: mockLocalizationDto }) };
+
+            const entityId = 1;
+            const languageId = 2;
+            const payload: UpdateReportFundsExpendituresSettingsLocalizationDto = {
+                disclaimerTitle: 'Updated disclaimer',
+            };
+
+            const result = await ReportFundsExpendituresSettingsLocalizationsApi.update(
+                mockClient as any,
+                entityId,
+                languageId,
+                payload,
+            );
+
+            expect(mockClient.put).toHaveBeenCalledTimes(1);
+            expect(mockClient.put).toHaveBeenCalledWith(
+                `${API_ROUTES.REPORT_FUNDS_EXPENDITURES_SETTINGS_LOCALIZATIONS.BASE}/${entityId}/${languageId}`,
+                payload,
+            );
+            expect(result).toEqual(mockLocalizationDto);
+        });
+    });
+});

--- a/src/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api.ts
+++ b/src/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api.ts
@@ -1,0 +1,33 @@
+import { API_ROUTES } from '@/const/common/api-routes/main-api';
+import {
+    CreateReportFundsExpendituresSettingsLocalizationDto,
+    ReportFundsExpendituresSettingsLocalizationDto,
+    UpdateReportFundsExpendituresSettingsLocalizationDto,
+} from '@/types/admin/reports';
+import { AxiosInstance } from 'axios';
+
+export const ReportFundsExpendituresSettingsLocalizationsApi = {
+    create: async (
+        client: AxiosInstance,
+        data: CreateReportFundsExpendituresSettingsLocalizationDto,
+    ): Promise<ReportFundsExpendituresSettingsLocalizationDto> => {
+        const response = await client.post<ReportFundsExpendituresSettingsLocalizationDto>(
+            API_ROUTES.REPORT_FUNDS_EXPENDITURES_SETTINGS_LOCALIZATIONS.BASE,
+            data,
+        );
+        return response.data;
+    },
+
+    update: async (
+        client: AxiosInstance,
+        entityId: number,
+        languageId: number,
+        data: UpdateReportFundsExpendituresSettingsLocalizationDto,
+    ): Promise<ReportFundsExpendituresSettingsLocalizationDto> => {
+        const response = await client.put<ReportFundsExpendituresSettingsLocalizationDto>(
+            `${API_ROUTES.REPORT_FUNDS_EXPENDITURES_SETTINGS_LOCALIZATIONS.BASE}/${entityId}/${languageId}`,
+            data,
+        );
+        return response.data;
+    },
+};

--- a/src/types/admin/reports.ts
+++ b/src/types/admin/reports.ts
@@ -177,6 +177,30 @@ export interface UpdateReportFundsExpendituresCategoryLocalizationDto {
     name: string;
 }
 
+export interface ReportFundsExpendituresSettingsLocalizableFields {
+    disclaimerTitle: string;
+}
+
+export interface ReportFundsExpendituresSettingsLocalizationDto
+    extends EntityLocalizationDto,
+        ReportFundsExpendituresSettingsLocalizableFields {
+    entityId: number;
+}
+
+export interface ReportFundsExpendituresSettingsLocalization
+    extends EntityLocalization,
+        ReportFundsExpendituresSettingsLocalizableFields {}
+
+export interface CreateReportFundsExpendituresSettingsLocalizationDto {
+    entityId: number;
+    languageId: number;
+    disclaimerTitle: string;
+}
+
+export interface UpdateReportFundsExpendituresSettingsLocalizationDto {
+    disclaimerTitle: string;
+}
+
 export interface ReportFundsExpendituresCategory
     extends EntityWithLocalizations<ReportFundsExpendituresCategoryLocalization> {
     id: number;


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2116
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2117

## Description

This PR implements functionality for editing and saving disclaimer translations in the admin panel.

## How it looks

https://github.com/user-attachments/assets/7c5e90cd-fb3c-412b-9daa-ddcf3a7f24bf

## Summary of change

Added ability to edit existing disclaimer translations
Implemented modal window "Редагувати переклад"
Enabled/disabled "Зберегти переклад" button based on validation state

## How to recreate changes

1. Open the "Доходи та витрати" tab
2. Navigate to the disclaimer management section
3. Click the Translate icon for an existing disclaimer
4. Verify that:
- the modal "Редагувати переклад" opens
- fields are populated with existing translation data
- live character counters are displayed
5. Edit the translation fields
6. Verify:
- validation works correctly
- cleanup icons appear when fields are not empty
- additional characters cannot be entered after reaching the limit
7. Click "Зберегти переклад"
8. Verify that:
- modal closes successfully
- snackbar "Переклад збережено успішно" appears for 3 seconds
- updated translation is displayed on the public English Reports page

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [x]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now translate fund expenditure report disclaimers into multiple languages.
  * Added ability to create and edit disclaimer translations with language-specific support.
  * Enhanced modal functionality to display appropriate success notifications when translations are saved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ita-social-projects/VictoryCenter-Client/pull/403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->