### PR TITLE
Feature/issue 2365 - [Main] Open inline edit panel for standard metric

### DIFF
--- a/src/const/admin/main-page.ts
+++ b/src/const/admin/main-page.ts
@@ -35,7 +35,7 @@ export const MAIN_PAGE_TEXT = {
             VALUE_LABEL: 'Значення',
             PREFIX_LABEL: 'Префікс',
             CANCEL_MODAL_TITLE: 'Відмінити зміни?',
-            PREFIX_NONE: 'None',
+            PREFIX_NONE: 'Без префікса',
         },
         PARTNERS: {
             TITLE_LABEL: COMMON_TEXT_ADMIN.TYPE.TITLE,

--- a/src/const/admin/main-page.ts
+++ b/src/const/admin/main-page.ts
@@ -28,6 +28,15 @@ export const MAIN_PAGE_TEXT = {
                 ENG: 'ENG',
             },
         },
+        EDIT_PANEL: {
+            TITLE: 'Редагування',
+            UKR_NAME_LABEL: 'UKR Назва',
+            ENG_NAME_LABEL: 'ENG Назва',
+            VALUE_LABEL: 'Значення',
+            PREFIX_LABEL: 'Префікс',
+            CANCEL_MODAL_TITLE: 'Відмінити зміни?',
+            PREFIX_NONE: 'None',
+        },
         PARTNERS: {
             TITLE_LABEL: COMMON_TEXT_ADMIN.TYPE.TITLE,
             DESCRIPTION_LABEL: COMMON_TEXT_ADMIN.TYPE.DESCRIPTION,
@@ -36,6 +45,8 @@ export const MAIN_PAGE_TEXT = {
 
     BUTTONS: {
         PUBLISH: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED,
+        CANCEL: COMMON_TEXT_ADMIN.BUTTON.CANCEL,
+        SAVE: COMMON_TEXT_ADMIN.BUTTON.SAVE,
     },
 
     ERRORS: {

--- a/src/const/admin/main-page.ts
+++ b/src/const/admin/main-page.ts
@@ -114,4 +114,13 @@ export const MAIN_PAGE_VALIDATION = {
             getMaxError: () => COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(100),
         },
     },
+
+    editPanel: {
+        name: {
+            min: 2,
+            max: 20,
+            getMinError: () => COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(2),
+            getMaxError: () => COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(20),
+        },
+    },
 } as const;

--- a/src/pages/admin/main/components/main-page-content/MainPageContent.tsx
+++ b/src/pages/admin/main/components/main-page-content/MainPageContent.tsx
@@ -139,6 +139,7 @@ export const MainPageContent = () => {
             savedValuesRef.current = nextValues;
 
             methods.reset(nextValues);
+            setCurrentMetrics([]);
 
             addToast('Зміни успішно опубліковано', ToastType.Success, 3000);
         } catch (error) {

--- a/src/pages/admin/main/components/main-page-content/MainPageContent.tsx
+++ b/src/pages/admin/main/components/main-page-content/MainPageContent.tsx
@@ -11,7 +11,7 @@ import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextPr
 import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
 import { ImageApi } from '@/services/api/admin/image/image-api';
 import { MainPageApi } from '@/services/api/admin/main-page/main-page-api';
-import { MAIN_PAGE_FORM_DEFAULTS, MainPage, MainPageFormValues } from '@/types/admin/main-page';
+import { MAIN_PAGE_FORM_DEFAULTS, MainPage, MainPageFormValues, Metric } from '@/types/admin/main-page';
 import { ToastType } from '@/types/admin/toast';
 import { ImageValues } from '@/types/common/image';
 import {
@@ -53,6 +53,8 @@ export const MainPageContent = () => {
     const [isPublishModalOpen, setIsPublishModalOpen] = useState(false);
     const [isPublishing, setIsPublishing] = useState(false);
     const [pendingPublishData, setPendingPublishData] = useState<MainPageFormValues | null>(null);
+
+    const [currentMetrics, setCurrentMetrics] = useState<Metric[]>([]);
 
     const savedValuesRef = useRef<MainPageFormValues>(MAIN_PAGE_FORM_DEFAULTS);
 
@@ -123,7 +125,12 @@ export const MainPageContent = () => {
                 dataToPublish.statisticsImage = uploaded;
             }
 
-            const patch = mapFormValuesToMainPagePatch(dataToPublish, originalData, languages);
+            const patch = mapFormValuesToMainPagePatch(
+                dataToPublish,
+                originalData,
+                languages,
+                currentMetrics.length ? currentMetrics : undefined,
+            );
 
             const { page, languages: updatedLanguages } = await MainPageApi.publish(client, patch, languages);
 
@@ -190,6 +197,7 @@ export const MainPageContent = () => {
                                 initialData={originalData}
                                 isPublishDisabled={isPublishDisabled}
                                 onPublish={onPublish}
+                                onMetricsChange={setCurrentMetrics}
                             />
                         )}
                         {activeTab === 'donations' && <div>Блок "{MAIN_PAGE_TEXT.TABS.DONATIONS}" в розробці</div>}

--- a/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.test.tsx
@@ -6,6 +6,10 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { FormProvider, useForm, useFormContext } from 'react-hook-form';
 import { StatisticsBlockForm } from './StatisticsBlockForm';
 
+jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
+    useAdminClient: jest.fn(() => ({})),
+}));
+
 jest.mock('@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup', () => ({
     __esModule: true,
     InputWithCharacterLimitGroup: require('@/utils/test-mocks/main-page-mocks').MockInputWithCharacterLimitGroup,
@@ -70,13 +74,25 @@ jest.mock('./components/statistics-metrics-list/StatisticsMetricsList', () => ({
                     }
                     type="button"
                 />
+
+                <button
+                    data-testid="trigger-sort-test"
+                    onClick={() =>
+                        onMetricUpdate?.([
+                            {
+                                ...metrics[0],
+                                localizations: [
+                                    { languageId: 2, name: 'EN' },
+                                    { languageId: 1, name: 'UA' },
+                                ],
+                            },
+                        ])
+                    }
+                    type="button"
+                />
             </div>
         );
     },
-}));
-
-jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
-    useAdminClient: jest.fn(() => ({})),
 }));
 
 const mockAddToast = jest.fn();
@@ -173,8 +189,8 @@ const FormWrapper = ({
 describe('StatisticsBlockForm', () => {
     const mockOnPublish = jest.fn();
 
-    const renderComponent = (props: Partial<React.ComponentProps<typeof StatisticsBlockForm>> = {}) => {
-        return render(
+    const renderComponent = (props: any = {}) =>
+        render(
             <FormWrapper>
                 <StatisticsBlockForm
                     initialData={mockInitialData}
@@ -184,11 +200,9 @@ describe('StatisticsBlockForm', () => {
                 />
             </FormWrapper>,
         );
-    };
 
     beforeEach(() => {
         jest.clearAllMocks();
-        mockAddToast.mockClear();
     });
 
     it('renders and pre-fills titles from form context', async () => {
@@ -383,5 +397,224 @@ describe('StatisticsBlockForm', () => {
             const options = lastCall?.[2];
             expect(options?.shouldDirty).toBe(false);
         });
+    });
+
+    it('handles metrics with missing fields when comparing updates', async () => {
+        const setValueSpy = jest.fn();
+        const initialData: MainPage = {
+            ...mockInitialData,
+            impactStatistics: {
+                ...mockInitialData.impactStatistics!,
+                metrics: [
+                    {
+                        id: undefined,
+                        name: undefined,
+                        value: 7,
+                        type: MetricType.Partners,
+                        prefix: undefined,
+                        isHidden: false,
+                        priority: 1,
+                        localizations: [{ languageId: undefined, name: undefined } as any],
+                    } as any,
+                ],
+            },
+        };
+
+        render(
+            <FormWrapper onSetValue={setValueSpy}>
+                <StatisticsBlockForm initialData={initialData} isPublishDisabled={false} onPublish={mockOnPublish} />
+            </FormWrapper>,
+        );
+
+        fireEvent.click(screen.getByTestId('update-first-to-percent'));
+
+        await waitFor(() => {
+            expect(setValueSpy).toHaveBeenCalledWith(
+                'metrics',
+                expect.any(Array),
+                expect.objectContaining({ shouldDirty: true }),
+            );
+        });
+    });
+
+    it('handles missing impactStatistics or metrics gracefully', async () => {
+        const dataWithoutMetrics: MainPage = {
+            ...mockInitialData,
+            impactStatistics: {
+                ...mockInitialData.impactStatistics!,
+                metrics: undefined as any,
+            },
+        };
+
+        renderComponent({ initialData: dataWithoutMetrics });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('statistics-preview')).toHaveAttribute('data-metrics', '0');
+        });
+    });
+
+    it('handles null initialData gracefully', async () => {
+        renderComponent({ initialData: null as any });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('statistics-preview')).toHaveAttribute('data-metrics', '0');
+        });
+    });
+
+    it('handles missing impactStatistics gracefully', async () => {
+        const dataWithoutStatistics: MainPage = {
+            ...mockInitialData,
+            impactStatistics: undefined as any,
+        };
+
+        renderComponent({ initialData: dataWithoutStatistics });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('statistics-preview')).toHaveAttribute('data-metrics', '0');
+        });
+    });
+
+    it('calls onMetricsChange when metrics are updated', async () => {
+        const onMetricsChange = jest.fn();
+
+        renderComponent({ onMetricsChange });
+
+        fireEvent.click(screen.getByTestId('update-first-to-percent'));
+
+        await waitFor(() => {
+            expect(onMetricsChange).toHaveBeenCalledWith(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: 101,
+                        prefix: MetricPrefix.Percent,
+                    }),
+                ]),
+            );
+        });
+    });
+
+    it('handles metrics with empty localizations arrays', async () => {
+        const dataWithEmptyLocalizations: MainPage = {
+            ...mockInitialData,
+            impactStatistics: {
+                ...mockInitialData.impactStatistics!,
+                metrics: [
+                    {
+                        ...mockInitialData.impactStatistics!.metrics[0],
+                        localizations: [],
+                    },
+                    {
+                        ...mockInitialData.impactStatistics!.metrics[1],
+                        localizations: [],
+                    },
+                ],
+            },
+        };
+
+        renderComponent({ initialData: dataWithEmptyLocalizations });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('statistics-preview')).toHaveAttribute('data-metrics', '2');
+        });
+    });
+
+    it('reverts hidden state correctly when toggle fails for already hidden metric', async () => {
+        const { MainPageApi } = require('@/services/api/admin/main-page/main-page-api');
+        MainPageApi.updateMetricVisibility.mockRejectedValueOnce(new Error('fail'));
+
+        const dataWithHiddenMetric: MainPage = {
+            ...mockInitialData,
+            impactStatistics: {
+                ...mockInitialData.impactStatistics!,
+                metrics: [
+                    { ...mockInitialData.impactStatistics!.metrics[0], isHidden: true },
+                    mockInitialData.impactStatistics!.metrics[1],
+                ],
+            },
+        };
+
+        renderComponent({ initialData: dataWithHiddenMetric });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('statistics-preview')).toHaveAttribute('data-hidden', '101');
+        });
+
+        fireEvent.click(screen.getByTestId('toggle-first-metric'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('statistics-preview')).toHaveAttribute('data-hidden', '101');
+            expect(mockAddToast).toHaveBeenCalledWith(
+                MAIN_PAGE_TEXT.ERRORS.TOGGLE_VISIBILITY_FAILED,
+                ToastType.Error,
+                3000,
+            );
+        });
+    });
+
+    it('handles initialization with empty metrics list', async () => {
+        const emptyMetricsData = {
+            ...mockInitialData,
+            impactStatistics: { ...mockInitialData.impactStatistics!, metrics: [] },
+        };
+        renderComponent({ initialData: emptyMetricsData });
+        await waitFor(() => {
+            expect(screen.getByTestId('statistics-preview')).toHaveAttribute('data-metrics', '0');
+        });
+    });
+
+    it('handles initialization when metrics exist but array is empty', async () => {
+        const dataWithEmptyMetrics: MainPage = {
+            ...mockInitialData,
+            impactStatistics: { ...mockInitialData.impactStatistics!, metrics: [] },
+        };
+        renderComponent({ initialData: dataWithEmptyMetrics });
+        await waitFor(() => {
+            expect(screen.getByTestId('statistics-preview')).toBeInTheDocument();
+        });
+    });
+
+    it('should trigger sort logic in toComparableMetrics via localizations', async () => {
+        renderComponent();
+
+        fireEvent.click(screen.getByTestId('trigger-sort-test'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('metrics-list')).toBeInTheDocument();
+        });
+    });
+
+    it('covers branch: impactStatistics exists but metrics is undefined', () => {
+        const dataWithMissingMetrics = {
+            ...mockInitialData,
+            impactStatistics: { ...mockInitialData.impactStatistics!, metrics: undefined as any },
+        };
+        renderComponent({ initialData: dataWithMissingMetrics });
+        expect(screen.getByTestId('statistics-preview')).toBeInTheDocument();
+    });
+
+    it('covers branch: localizations is undefined and languageId is missing', () => {
+        const dataWithMissingLocs: MainPage = {
+            ...mockInitialData,
+            impactStatistics: {
+                ...mockInitialData.impactStatistics!,
+                metrics: [
+                    {
+                        id: 999,
+                        name: 'Test',
+                        value: 10,
+                        type: MetricType.Partners,
+                        prefix: MetricPrefix.Plus,
+                        isHidden: false,
+                        priority: 1,
+                        localizations: undefined as any,
+                    },
+                ],
+            },
+        };
+        renderComponent({ initialData: dataWithMissingLocs });
+
+        fireEvent.click(screen.getByTestId('trigger-sort-test'));
+
+        expect(screen.getByTestId('statistics-preview')).toBeInTheDocument();
     });
 });

--- a/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.test.tsx
@@ -1,7 +1,9 @@
+import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
 import { MainPage, MainPageFormValues, MetricPrefix, MetricType } from '@/types/admin/main-page';
+import { ToastType } from '@/types/admin/toast';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { FormProvider, useForm } from 'react-hook-form';
+import { FormProvider, useForm, useFormContext } from 'react-hook-form';
 import { StatisticsBlockForm } from './StatisticsBlockForm';
 
 jest.mock('@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup', () => ({
@@ -21,34 +23,66 @@ jest.mock('@/pages/admin/main/components/common/image-upload-form/ImageUploadFor
 
 jest.mock('./components/statistics-preview/StatisticsPreview', () => ({
     StatisticsPreview: ({ metrics, hiddenMetricIds }: any) => (
-        <div data-testid="statistics-preview" data-metrics={metrics.length} data-hidden={hiddenMetricIds.join(',')} />
+        <div
+            data-testid="statistics-preview"
+            data-metrics={metrics.length}
+            data-hidden={hiddenMetricIds.join(',')}
+            data-prefixes={metrics.map((metric: any) => metric.prefix).join(',')}
+        />
     ),
 }));
 
 jest.mock('./components/statistics-metrics-list/StatisticsMetricsList', () => ({
-    StatisticsMetricsList: ({ metrics, onToggleVisibility, onReorder }: any) => (
-        <div data-testid="metrics-list">
-            <button
-                data-testid="toggle-first-metric"
-                onClick={() => onToggleVisibility(metrics[0]?.id ?? 0)}
-                type="button"
-            />
-            <button
-                data-testid="toggle-second-metric"
-                onClick={() => onToggleVisibility(metrics[1]?.id ?? 0)}
-                type="button"
-            />
-            <button data-testid="reorder-metrics" onClick={() => onReorder([])} type="button" />
-        </div>
-    ),
+    StatisticsMetricsList: ({ metrics, onToggleVisibility, onReorder, onMetricUpdate }: any) => {
+        const { MetricPrefix } = require('@/types/admin/main-page');
+        return (
+            <div data-testid="metrics-list">
+                <button
+                    data-testid="toggle-first-metric"
+                    onClick={() => onToggleVisibility(metrics[0]?.id ?? 0)}
+                    type="button"
+                />
+                <button
+                    data-testid="toggle-second-metric"
+                    onClick={() => onToggleVisibility(metrics[1]?.id ?? 0)}
+                    type="button"
+                />
+                <button data-testid="reorder-metrics" onClick={() => onReorder([])} type="button" />
+                <button
+                    data-testid="update-first-to-percent"
+                    onClick={() =>
+                        onMetricUpdate?.(
+                            metrics.map((metric: any, index: number) =>
+                                index === 0 ? { ...metric, prefix: MetricPrefix.Percent } : metric,
+                            ),
+                        )
+                    }
+                    type="button"
+                />
+                <button
+                    data-testid="update-first-to-plus"
+                    onClick={() =>
+                        onMetricUpdate?.(
+                            metrics.map((metric: any, index: number) =>
+                                index === 0 ? { ...metric, prefix: MetricPrefix.Plus } : metric,
+                            ),
+                        )
+                    }
+                    type="button"
+                />
+            </div>
+        );
+    },
 }));
 
 jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
     useAdminClient: jest.fn(() => ({})),
 }));
 
+const mockAddToast = jest.fn();
+
 jest.mock('@/contexts/admin/toast-context-provider/ToastContextProvider', () => ({
-    useToast: () => ({ addToast: jest.fn() }),
+    useToast: () => ({ addToast: mockAddToast }),
 }));
 
 jest.mock('@/services/api/admin/main-page/main-page-api', () => ({
@@ -99,18 +133,41 @@ const mockInitialData: MainPage = {
 const FormWrapper = ({
     children,
     defaultValues,
+    onSetValue,
 }: {
     children: React.ReactNode;
     defaultValues?: Partial<MainPageFormValues>;
+    onSetValue?: jest.Mock;
 }) => {
     const methods = useForm<MainPageFormValues>({
         defaultValues: {
             statisticsTitleUa: '',
             statisticsTitleEn: '',
+            metrics: [],
             ...defaultValues,
         } as MainPageFormValues,
     });
-    return <FormProvider {...methods}>{children}</FormProvider>;
+
+    const setValueSpy = (...args: Parameters<typeof methods.setValue>) => {
+        onSetValue?.(...args);
+        return methods.setValue(...args);
+    };
+
+    const formMethods = {
+        ...methods,
+        setValue: setValueSpy,
+    };
+    const DirtyIndicator = () => {
+        const { formState } = useFormContext<MainPageFormValues>();
+        return <div data-testid="dirty-flag" data-dirty={formState.isDirty ? 'true' : 'false'} />;
+    };
+
+    return (
+        <FormProvider {...formMethods}>
+            <DirtyIndicator />
+            {children}
+        </FormProvider>
+    );
 };
 
 describe('StatisticsBlockForm', () => {
@@ -131,6 +188,7 @@ describe('StatisticsBlockForm', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        mockAddToast.mockClear();
     });
 
     it('renders and pre-fills titles from form context', async () => {
@@ -206,5 +264,124 @@ describe('StatisticsBlockForm', () => {
         expect(screen.getByTestId('submit-btn')).toBeDisabled();
         fireEvent.click(screen.getByTestId('clear-image-error'));
         expect(screen.getByTestId('submit-btn')).not.toBeDisabled();
+    });
+
+    it('does not toggle visibility when only one metric is visible', async () => {
+        const { MainPageApi } = require('@/services/api/admin/main-page/main-page-api');
+        const singleMetricData: MainPage = {
+            ...mockInitialData,
+            impactStatistics: {
+                ...mockInitialData.impactStatistics!,
+                metrics: [mockInitialData.impactStatistics!.metrics[0]],
+            },
+        };
+
+        renderComponent({ initialData: singleMetricData });
+
+        fireEvent.click(screen.getByTestId('toggle-first-metric'));
+
+        await waitFor(() => {
+            expect(MainPageApi.updateMetricVisibility).not.toHaveBeenCalled();
+        });
+    });
+
+    it('reverts hidden state and shows toast when toggle visibility fails', async () => {
+        const { MainPageApi } = require('@/services/api/admin/main-page/main-page-api');
+        MainPageApi.updateMetricVisibility.mockRejectedValueOnce(new Error('fail'));
+
+        renderComponent();
+
+        fireEvent.click(screen.getByTestId('toggle-first-metric'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('statistics-preview')).toHaveAttribute('data-hidden', '');
+            expect(mockAddToast).toHaveBeenCalledWith(
+                MAIN_PAGE_TEXT.ERRORS.TOGGLE_VISIBILITY_FAILED,
+                ToastType.Error,
+                3000,
+            );
+        });
+    });
+
+    it('normalizes backend prefixes before rendering preview', async () => {
+        const rawPrefixData: MainPage = {
+            ...mockInitialData,
+            impactStatistics: {
+                ...mockInitialData.impactStatistics!,
+                metrics: [
+                    { ...mockInitialData.impactStatistics!.metrics[0], prefix: 1 as any },
+                    { ...mockInitialData.impactStatistics!.metrics[1], prefix: 2 as any },
+                ],
+            },
+        };
+
+        renderComponent({ initialData: rawPrefixData });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('statistics-preview')).toHaveAttribute('data-prefixes', 'Plus,Percent');
+        });
+    });
+
+    it('skips reorder when statistic id is missing', async () => {
+        const { MainPageApi } = require('@/services/api/admin/main-page/main-page-api');
+        const missingIdData: MainPage = {
+            ...mockInitialData,
+            impactStatistics: {
+                ...mockInitialData.impactStatistics!,
+                id: undefined,
+            },
+        };
+
+        renderComponent({ initialData: missingIdData });
+
+        fireEvent.click(screen.getByTestId('reorder-metrics'));
+
+        await waitFor(() => {
+            expect(MainPageApi.reorderMetrics).not.toHaveBeenCalled();
+        });
+    });
+
+    it('reverts metrics when reorder fails', async () => {
+        const { MainPageApi } = require('@/services/api/admin/main-page/main-page-api');
+        MainPageApi.reorderMetrics.mockRejectedValueOnce(new Error('fail'));
+
+        renderComponent();
+
+        fireEvent.click(screen.getByTestId('reorder-metrics'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('statistics-preview')).toHaveAttribute('data-metrics', '2');
+            expect(mockAddToast).toHaveBeenCalledWith(MAIN_PAGE_TEXT.ERRORS.REORDER_FAILED, ToastType.Error, 3000);
+        });
+    });
+
+    it('does not keep form dirty when prefix is reverted to initial value', async () => {
+        const setValueSpy = jest.fn();
+        render(
+            <FormWrapper
+                defaultValues={{ metrics: mockInitialData.impactStatistics?.metrics ?? [] }}
+                onSetValue={setValueSpy}
+            >
+                <StatisticsBlockForm
+                    initialData={mockInitialData}
+                    isPublishDisabled={false}
+                    onPublish={mockOnPublish}
+                />
+            </FormWrapper>,
+        );
+
+        fireEvent.click(screen.getByTestId('update-first-to-percent'));
+
+        await waitFor(() => {
+            expect(setValueSpy).toHaveBeenCalled();
+        });
+
+        fireEvent.click(screen.getByTestId('update-first-to-plus'));
+
+        await waitFor(() => {
+            const lastCall = setValueSpy.mock.calls[setValueSpy.mock.calls.length - 1];
+            const options = lastCall?.[2];
+            expect(options?.shouldDirty).toBe(false);
+        });
     });
 });

--- a/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.test.tsx
@@ -317,14 +317,14 @@ describe('StatisticsBlockForm', () => {
         });
     });
 
-    it('normalizes backend prefixes before rendering preview', async () => {
+    it('passes prefix values correctly to preview', async () => {
         const rawPrefixData: MainPage = {
             ...mockInitialData,
             impactStatistics: {
                 ...mockInitialData.impactStatistics!,
                 metrics: [
-                    { ...mockInitialData.impactStatistics!.metrics[0], prefix: 1 as any },
-                    { ...mockInitialData.impactStatistics!.metrics[1], prefix: 2 as any },
+                    { ...mockInitialData.impactStatistics!.metrics[0], prefix: MetricPrefix.Plus },
+                    { ...mockInitialData.impactStatistics!.metrics[1], prefix: MetricPrefix.Percent },
                 ],
             },
         };
@@ -332,7 +332,7 @@ describe('StatisticsBlockForm', () => {
         renderComponent({ initialData: rawPrefixData });
 
         await waitFor(() => {
-            expect(screen.getByTestId('statistics-preview')).toHaveAttribute('data-prefixes', 'Plus,Percent');
+            expect(screen.getByTestId('statistics-preview')).toHaveAttribute('data-prefixes', '1,2');
         });
     });
 

--- a/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
+++ b/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
@@ -36,9 +36,15 @@ interface StatisticsBlockFormProps {
     initialData: MainPage | null;
     isPublishDisabled: boolean;
     onPublish: () => void;
+    onMetricsChange?: (metrics: Metric[]) => void;
 }
 
-export const StatisticsBlockForm = ({ initialData, isPublishDisabled, onPublish }: StatisticsBlockFormProps) => {
+export const StatisticsBlockForm = ({
+    initialData,
+    isPublishDisabled,
+    onPublish,
+    onMetricsChange,
+}: StatisticsBlockFormProps) => {
     const client = useAdminClient();
     const { addToast } = useToast();
 
@@ -102,10 +108,12 @@ export const StatisticsBlockForm = ({ initialData, isPublishDisabled, onPublish 
 
     const handleMetricUpdate = (updatedMetrics: Metric[]) => {
         setMetrics(updatedMetrics);
+        onMetricsChange?.(updatedMetrics);
 
-        setValue('metrics' as keyof MainPageFormValues, updatedMetrics as any, {
+        setValue('metrics', updatedMetrics, {
             shouldDirty: true,
             shouldTouch: true,
+            shouldValidate: true,
         });
     };
 

--- a/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
+++ b/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
@@ -9,7 +9,11 @@ import { ImageUploadForm } from '@/pages/admin/main/components/common/image-uplo
 import { MainPageApi } from '@/services/api/admin/main-page/main-page-api';
 import { MainPage, MainPageFormValues, Metric } from '@/types/admin/main-page';
 import { ToastType } from '@/types/admin/toast';
-import { useEffect, useState } from 'react';
+import {
+    mapMetricsWithResolvedPrefix,
+    resolvePrefix,
+} from '@/utils/functions/mappers/admin/main-page/main-page-mappers';
+import { useEffect, useRef, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { StatisticsMetricsList } from './components/statistics-metrics-list/StatisticsMetricsList';
 import { StatisticsPreview } from './components/statistics-preview/StatisticsPreview';
@@ -53,6 +57,7 @@ export const StatisticsBlockForm = ({
 
     const [metrics, setMetrics] = useState<Metric[]>([]);
     const [hiddenMetricIds, setHiddenMetricIds] = useState<number[]>([]);
+    const initialMetricsRef = useRef<Metric[]>([]);
 
     const {
         control,
@@ -60,14 +65,42 @@ export const StatisticsBlockForm = ({
         formState: { errors },
     } = useFormContext<MainPageFormValues>();
 
+    const toComparableMetrics = (items: Metric[]) =>
+        items.map((metric) => ({
+            id: metric.id ?? null,
+            value: metric.value,
+            name: metric.name ?? '',
+            type: metric.type,
+            prefix: resolvePrefix(metric.prefix),
+            isHidden: metric.isHidden,
+            priority: metric.priority,
+            localizations: (metric.localizations ?? [])
+                .map((loc) => ({
+                    languageId: loc.languageId ?? null,
+                    name: (loc.name ?? '').trim(),
+                }))
+                .sort((a, b) => (a.languageId ?? 0) - (b.languageId ?? 0)),
+        }));
+
+    const areMetricsEqual = (left: Metric[], right: Metric[]) =>
+        JSON.stringify(toComparableMetrics(left)) === JSON.stringify(toComparableMetrics(right));
+
     useEffect(() => {
         if (initialData?.impactStatistics?.metrics) {
-            setMetrics(initialData.impactStatistics.metrics);
+            const normalizedMetrics = mapMetricsWithResolvedPrefix(initialData.impactStatistics.metrics);
 
-            const hiddenIds = initialData.impactStatistics.metrics.filter((m) => m.isHidden).map((m) => m.id as number);
+            setMetrics(normalizedMetrics);
+            initialMetricsRef.current = normalizedMetrics;
+            setValue('metrics', normalizedMetrics, {
+                shouldDirty: false,
+                shouldTouch: false,
+                shouldValidate: false,
+            });
+
+            const hiddenIds = normalizedMetrics.filter((m) => m.isHidden).map((m) => m.id as number);
             setHiddenMetricIds(hiddenIds);
         }
-    }, [initialData]);
+    }, [initialData, setValue]);
 
     const handleToggleVisibility = async (id: number) => {
         const isCurrentlyHidden = hiddenMetricIds.includes(id);
@@ -88,7 +121,8 @@ export const StatisticsBlockForm = ({
     };
 
     const handleReorderMetrics = async (items: Metric[]) => {
-        setMetrics(items);
+        const normalizedMetrics = mapMetricsWithResolvedPrefix(items);
+        setMetrics(normalizedMetrics);
 
         const statisticId = initialData?.impactStatistics?.id;
 
@@ -101,17 +135,21 @@ export const StatisticsBlockForm = ({
         } catch (error) {
             addToast(MAIN_PAGE_TEXT.ERRORS.REORDER_FAILED, ToastType.Error, 3000);
             if (initialData?.impactStatistics?.metrics) {
-                setMetrics(initialData.impactStatistics.metrics);
+                const normalizedMetrics = mapMetricsWithResolvedPrefix(initialData.impactStatistics.metrics);
+                setMetrics(normalizedMetrics);
             }
         }
     };
 
     const handleMetricUpdate = (updatedMetrics: Metric[]) => {
-        setMetrics(updatedMetrics);
-        onMetricsChange?.(updatedMetrics);
+        const normalizedMetrics = mapMetricsWithResolvedPrefix(updatedMetrics);
+        const hasChanges = !areMetricsEqual(normalizedMetrics, initialMetricsRef.current);
 
-        setValue('metrics', updatedMetrics, {
-            shouldDirty: true,
+        setMetrics(normalizedMetrics);
+        onMetricsChange?.(normalizedMetrics);
+
+        setValue('metrics', normalizedMetrics, {
+            shouldDirty: hasChanges,
             shouldTouch: true,
             shouldValidate: true,
         });

--- a/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
+++ b/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
@@ -50,6 +50,7 @@ export const StatisticsBlockForm = ({ initialData, isPublishDisabled, onPublish 
 
     const {
         control,
+        setValue,
         formState: { errors },
     } = useFormContext<MainPageFormValues>();
 
@@ -99,18 +100,29 @@ export const StatisticsBlockForm = ({ initialData, isPublishDisabled, onPublish 
         }
     };
 
+    const handleMetricUpdate = (updatedMetrics: Metric[]) => {
+        setMetrics(updatedMetrics);
+
+        setValue('metrics' as keyof MainPageFormValues, updatedMetrics as any, {
+            shouldDirty: true,
+            shouldTouch: true,
+        });
+    };
+
     return (
         <div className={styles.form}>
             <div className={styles.content}>
-                <ImageUploadForm
-                    control={control as any}
-                    errors={errors}
-                    imageError={imageError}
-                    setImageError={setImageError}
-                    imageConfig={IMAGE_CONFIG}
-                    variant="whoWeAre"
-                    name="statisticsImage"
-                />
+                <div className={styles['image-section']}>
+                    <ImageUploadForm
+                        control={control as any}
+                        errors={errors}
+                        imageError={imageError}
+                        setImageError={setImageError}
+                        imageConfig={IMAGE_CONFIG}
+                        variant="whoWeAre"
+                        name="statisticsImage"
+                    />
+                </div>
 
                 <div className={styles['right-section']}>
                     <StatisticsPreview
@@ -163,6 +175,7 @@ export const StatisticsBlockForm = ({ initialData, isPublishDisabled, onPublish 
                         hiddenMetricIds={hiddenMetricIds}
                         onToggleVisibility={handleToggleVisibility}
                         onReorder={handleReorderMetrics}
+                        onMetricUpdate={handleMetricUpdate}
                     />
                 </div>
             </div>

--- a/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
+++ b/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
@@ -9,10 +9,6 @@ import { ImageUploadForm } from '@/pages/admin/main/components/common/image-uplo
 import { MainPageApi } from '@/services/api/admin/main-page/main-page-api';
 import { MainPage, MainPageFormValues, Metric } from '@/types/admin/main-page';
 import { ToastType } from '@/types/admin/toast';
-import {
-    mapMetricsWithResolvedPrefix,
-    resolvePrefix,
-} from '@/utils/functions/mappers/admin/main-page/main-page-mappers';
 import { useEffect, useRef, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { StatisticsMetricsList } from './components/statistics-metrics-list/StatisticsMetricsList';
@@ -71,7 +67,7 @@ export const StatisticsBlockForm = ({
             value: metric.value,
             name: metric.name ?? '',
             type: metric.type,
-            prefix: resolvePrefix(metric.prefix),
+            prefix: metric.prefix,
             isHidden: metric.isHidden,
             priority: metric.priority,
             localizations: (metric.localizations ?? [])
@@ -87,17 +83,17 @@ export const StatisticsBlockForm = ({
 
     useEffect(() => {
         if (initialData?.impactStatistics?.metrics) {
-            const normalizedMetrics = mapMetricsWithResolvedPrefix(initialData.impactStatistics.metrics);
+            const apiMetrics = initialData.impactStatistics.metrics;
 
-            setMetrics(normalizedMetrics);
-            initialMetricsRef.current = normalizedMetrics;
-            setValue('metrics', normalizedMetrics, {
+            setMetrics(apiMetrics);
+            initialMetricsRef.current = apiMetrics;
+            setValue('metrics', apiMetrics, {
                 shouldDirty: false,
                 shouldTouch: false,
                 shouldValidate: false,
             });
 
-            const hiddenIds = normalizedMetrics.filter((m) => m.isHidden).map((m) => m.id as number);
+            const hiddenIds = apiMetrics.filter((m) => m.isHidden).map((m) => m.id as number);
             setHiddenMetricIds(hiddenIds);
         }
     }, [initialData, setValue]);
@@ -121,11 +117,9 @@ export const StatisticsBlockForm = ({
     };
 
     const handleReorderMetrics = async (items: Metric[]) => {
-        const normalizedMetrics = mapMetricsWithResolvedPrefix(items);
-        setMetrics(normalizedMetrics);
+        setMetrics(items);
 
         const statisticId = initialData?.impactStatistics?.id;
-
         if (!statisticId) return;
 
         const orderedIds = items.map((item) => item.id as number).filter(Boolean);
@@ -135,20 +129,18 @@ export const StatisticsBlockForm = ({
         } catch (error) {
             addToast(MAIN_PAGE_TEXT.ERRORS.REORDER_FAILED, ToastType.Error, 3000);
             if (initialData?.impactStatistics?.metrics) {
-                const normalizedMetrics = mapMetricsWithResolvedPrefix(initialData.impactStatistics.metrics);
-                setMetrics(normalizedMetrics);
+                setMetrics(initialData.impactStatistics.metrics);
             }
         }
     };
 
     const handleMetricUpdate = (updatedMetrics: Metric[]) => {
-        const normalizedMetrics = mapMetricsWithResolvedPrefix(updatedMetrics);
-        const hasChanges = !areMetricsEqual(normalizedMetrics, initialMetricsRef.current);
+        const hasChanges = !areMetricsEqual(updatedMetrics, initialMetricsRef.current);
 
-        setMetrics(normalizedMetrics);
-        onMetricsChange?.(normalizedMetrics);
+        setMetrics(updatedMetrics);
+        onMetricsChange?.(updatedMetrics);
 
-        setValue('metrics', normalizedMetrics, {
+        setValue('metrics', updatedMetrics, {
             shouldDirty: hasChanges,
             shouldTouch: true,
             shouldValidate: true,

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.module.scss
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.module.scss
@@ -1,0 +1,47 @@
+@use '@/assets/sass/variables/colors' as c;
+
+.panel {
+    background-color: c.$grey-150;
+    border-radius: 8px;
+    padding: 16px;
+    margin-bottom: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.header {
+    font-size: 14px;
+    font-weight: 500;
+    color: c.$grey-800;
+}
+
+.formGrid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 16px;
+
+    @media (max-width: 1800px) {
+        grid-template-columns: 1fr;
+    }
+}
+
+.prefixGroup {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.prefixLabel {
+    font-size: 14px;
+    color: c.$donate-tooltip-color;
+}
+
+.actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    margin-top: 8px;
+}

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.test.tsx
@@ -1,0 +1,58 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
+import { Metric, MetricPrefix, MetricType } from '@/types/admin/main-page';
+
+import { RaisedMetricEditPanel } from './RaisedMetricEditPanel';
+
+jest.mock('@/components/admin/button/Button', () => ({
+    __esModule: true,
+    Button: ({ children, disabled, onClick }: any) => (
+        <button type="button" disabled={disabled} onClick={onClick}>
+            {children}
+        </button>
+    ),
+}));
+
+const createMetric = (overrides: Partial<Metric> = {}): Metric => ({
+    id: 3,
+    name: 'Залучених коштів',
+    value: 1000000,
+    type: MetricType.Raised,
+    prefix: MetricPrefix.None,
+    isHidden: false,
+    priority: 3,
+    localizations: [],
+    ...overrides,
+});
+
+describe('RaisedMetricEditPanel', () => {
+    it('renders the panel with header and placeholder message', () => {
+        const metric = createMetric();
+        render(<RaisedMetricEditPanel metric={metric} onCancel={jest.fn()} />);
+
+        expect(screen.getByText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.TITLE)).toBeInTheDocument();
+        expect(screen.getByText(`Редагування метрики "${metric.name}" наразі недоступне.`)).toBeInTheDocument();
+    });
+
+    it('renders active Cancel button and disabled Save button', () => {
+        render(<RaisedMetricEditPanel metric={createMetric()} onCancel={jest.fn()} />);
+
+        const cancelButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.CANCEL });
+        const saveButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.SAVE });
+
+        expect(cancelButton).not.toBeDisabled();
+        expect(saveButton).toBeDisabled();
+    });
+
+    it('calls onCancel when Cancel button is clicked', () => {
+        const onCancelMock = jest.fn();
+        render(<RaisedMetricEditPanel metric={createMetric()} onCancel={onCancelMock} />);
+
+        const cancelButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.CANCEL });
+        fireEvent.click(cancelButton);
+
+        expect(onCancelMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.tsx
@@ -1,0 +1,31 @@
+import { Button } from '@/components/admin/button/Button';
+import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
+import { Metric } from '@/types/admin/main-page';
+
+import styles from './RaisedMetricEditPanel.module.scss';
+
+interface RaisedMetricEditPanelProps {
+    metric: Metric;
+    onCancel: () => void;
+}
+
+export const RaisedMetricEditPanel = ({ metric, onCancel }: RaisedMetricEditPanelProps) => {
+    return (
+        <div className={styles.panel}>
+            <div className={styles.header}>{MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.TITLE}</div>
+
+            <div style={{ padding: '24px 0', color: '#666', fontSize: '14px' }}>
+                Редагування метрики "{metric.name}" наразі недоступне.
+            </div>
+
+            <div className={styles.actions}>
+                <Button buttonStyle="secondary" onClick={onCancel}>
+                    {MAIN_PAGE_TEXT.BUTTONS.CANCEL}
+                </Button>
+                <Button buttonStyle="primary" disabled>
+                    {MAIN_PAGE_TEXT.BUTTONS.SAVE}
+                </Button>
+            </div>
+        </div>
+    );
+};

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.module.scss
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.module.scss
@@ -1,0 +1,47 @@
+@use '@/assets/sass/variables/colors' as c;
+
+.panel {
+    background-color: c.$grey-150;
+    border-radius: 8px;
+    padding: 16px;
+    margin-bottom: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.header {
+    font-size: 14px;
+    font-weight: 500;
+    color: c.$grey-800;
+}
+
+.formGrid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 16px;
+
+    @media (max-width: 1800px) {
+        grid-template-columns: 1fr;
+    }
+}
+
+.prefixGroup {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.prefixLabel {
+    font-size: 14px;
+    color: c.$donate-tooltip-color;
+}
+
+.actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    margin-top: 8px;
+}

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.test.tsx
@@ -1,0 +1,205 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
+import { Metric, MetricPrefix, MetricType } from '@/types/admin/main-page';
+
+import { StatisticsMetricEditPanel } from './StatisticsMetricEditPanel';
+
+jest.mock('@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup', () => ({
+    __esModule: true,
+    InputWithCharacterLimitGroup: ({ id, value, onChange, onBlur }: any) => (
+        <input data-testid={id} value={value ?? ''} onChange={onChange} onBlur={onBlur} />
+    ),
+}));
+
+jest.mock('@/components/admin/button/Button', () => ({
+    __esModule: true,
+    Button: ({ children, buttonStyle: _buttonStyle, ...props }: any) => (
+        <button type="button" {...props}>
+            {children}
+        </button>
+    ),
+}));
+
+jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
+    __esModule: true,
+    ConfirmationModal: ({ isOpen, onConfirm, onCancel, onClose, title }: any) =>
+        isOpen ? (
+            <div data-testid="confirm-modal">
+                <div>{title}</div>
+                <button type="button" data-testid="confirm-action" onClick={onConfirm}>
+                    Confirm
+                </button>
+                <button type="button" data-testid="cancel-action" onClick={onCancel}>
+                    Cancel
+                </button>
+                <button type="button" data-testid="close-action" onClick={onClose}>
+                    Close
+                </button>
+            </div>
+        ) : null,
+}));
+
+jest.mock('@/components/admin/multi-select-input/MultiSelectInput', () => ({
+    __esModule: true,
+    MultiSelectInput: ({ id, options, value, onChange }: any) => (
+        <div data-testid={id} data-selected={value?.[0]?.id ?? ''}>
+            {options.map((option: any) => (
+                <button
+                    key={option.id}
+                    type="button"
+                    data-testid={`${id}-${option.id}`}
+                    onClick={() => onChange([option])}
+                >
+                    {option.name}
+                </button>
+            ))}
+        </div>
+    ),
+}));
+
+const createMetric = (overrides: Partial<Metric> = {}): Metric => ({
+    id: 1,
+    name: 'Назва UA',
+    value: 1200,
+    type: MetricType.Partners,
+    prefix: MetricPrefix.Plus,
+    isHidden: false,
+    priority: 1,
+    localizations: [{ languageId: 1, name: 'Назва UA' } as any, { languageId: 2, name: 'Name EN' } as any],
+    ...overrides,
+});
+
+describe('StatisticsMetricEditPanel', () => {
+    it('renders default values and resolved prefix', () => {
+        render(<StatisticsMetricEditPanel metric={createMetric()} onSave={jest.fn()} onCancel={jest.fn()} />);
+
+        expect(screen.getByTestId('metric-ua-1')).toHaveValue('Назва UA');
+        expect(screen.getByTestId('metric-en-1')).toHaveValue('Name EN');
+        expect(screen.getByTestId('metric-val-1')).toHaveValue('1 200');
+        expect(screen.getByTestId('metric-prefix-1')).toHaveAttribute('data-selected', 'Plus');
+    });
+
+    it('submits trimmed values and parsed number', async () => {
+        const onSave = jest.fn();
+        render(<StatisticsMetricEditPanel metric={createMetric()} onSave={onSave} onCancel={jest.fn()} />);
+
+        fireEvent.change(screen.getByTestId('metric-ua-1'), { target: { value: '  Нова UA  ' } });
+        fireEvent.change(screen.getByTestId('metric-en-1'), { target: { value: '  New EN  ' } });
+        fireEvent.change(screen.getByTestId('metric-val-1'), { target: { value: '2 345' } });
+        fireEvent.click(screen.getByTestId('metric-prefix-1-Percent'));
+
+        const saveButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.SAVE });
+        await waitFor(() => expect(saveButton).not.toBeDisabled());
+        fireEvent.click(saveButton);
+
+        await waitFor(() => {
+            expect(onSave).toHaveBeenCalledTimes(1);
+        });
+
+        const updatedMetric = onSave.mock.calls[0][0];
+        expect(updatedMetric.name).toBe('Нова UA');
+        expect(updatedMetric.value).toBe(2345);
+        expect(updatedMetric.prefix).toBe(MetricPrefix.Percent);
+        expect(updatedMetric.localizations).toEqual([
+            { languageId: 1, name: 'Нова UA' },
+            { languageId: 2, name: 'New EN' },
+        ]);
+    });
+
+    it('uses fallback defaults when name and localizations are missing', () => {
+        render(
+            <StatisticsMetricEditPanel
+                metric={createMetric({ name: '', localizations: undefined, prefix: 2 as any })}
+                onSave={jest.fn()}
+                onCancel={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByTestId('metric-ua-1')).toHaveValue('');
+        expect(screen.getByTestId('metric-en-1')).toHaveValue('');
+        expect(screen.getByTestId('metric-prefix-1')).toHaveAttribute('data-selected', 'Percent');
+    });
+
+    it('preserves non-target localizations when saving', async () => {
+        const onSave = jest.fn();
+        const metric = createMetric({
+            localizations: [
+                { languageId: 1, name: 'Назва UA' } as any,
+                { languageId: 3, name: 'Third Language' } as any,
+            ],
+        });
+
+        render(<StatisticsMetricEditPanel metric={metric} onSave={onSave} onCancel={jest.fn()} />);
+
+        fireEvent.change(screen.getByTestId('metric-ua-1'), { target: { value: 'Нова UA' } });
+        fireEvent.change(screen.getByTestId('metric-en-1'), { target: { value: 'Name EN' } });
+        fireEvent.blur(screen.getByTestId('metric-ua-1'));
+        fireEvent.blur(screen.getByTestId('metric-en-1'));
+        fireEvent.blur(screen.getByTestId('metric-val-1'));
+
+        const saveButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.SAVE });
+        await waitFor(() => expect(saveButton).not.toBeDisabled());
+        fireEvent.click(saveButton);
+
+        await waitFor(() => {
+            expect(onSave).toHaveBeenCalledTimes(1);
+        });
+
+        const updatedMetric = onSave.mock.calls[0][0];
+        expect(updatedMetric.localizations).toEqual([
+            { languageId: 1, name: 'Нова UA' },
+            { languageId: 3, name: 'Third Language' },
+        ]);
+    });
+
+    it('opens cancel modal when form is dirty and confirms cancel', async () => {
+        const onCancel = jest.fn();
+        render(<StatisticsMetricEditPanel metric={createMetric()} onSave={jest.fn()} onCancel={onCancel} />);
+
+        fireEvent.change(screen.getByTestId('metric-ua-1'), { target: { value: 'Зміна' } });
+
+        fireEvent.click(screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.CANCEL }));
+
+        expect(await screen.findByTestId('confirm-modal')).toBeInTheDocument();
+        fireEvent.click(screen.getByTestId('confirm-action'));
+
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('closes cancel modal without triggering onCancel', async () => {
+        const onCancel = jest.fn();
+        render(<StatisticsMetricEditPanel metric={createMetric()} onSave={jest.fn()} onCancel={onCancel} />);
+
+        fireEvent.change(screen.getByTestId('metric-ua-1'), { target: { value: 'Зміна' } });
+        fireEvent.click(screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.CANCEL }));
+
+        expect(await screen.findByTestId('confirm-modal')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('cancel-action'));
+        await waitFor(() => {
+            expect(screen.queryByTestId('confirm-modal')).not.toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.CANCEL }));
+        expect(await screen.findByTestId('confirm-modal')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('close-action'));
+        await waitFor(() => {
+            expect(screen.queryByTestId('confirm-modal')).not.toBeInTheDocument();
+        });
+
+        expect(onCancel).not.toHaveBeenCalled();
+    });
+
+    it('cancels immediately when form is not dirty', () => {
+        const onCancel = jest.fn();
+        render(<StatisticsMetricEditPanel metric={createMetric()} onSave={jest.fn()} onCancel={onCancel} />);
+
+        fireEvent.click(screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.CANCEL }));
+
+        expect(onCancel).toHaveBeenCalledTimes(1);
+        expect(screen.queryByTestId('confirm-modal')).not.toBeInTheDocument();
+    });
+});

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.test.tsx
@@ -43,16 +43,16 @@ jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
 
 jest.mock('@/components/admin/multi-select-input/MultiSelectInput', () => ({
     __esModule: true,
-    MultiSelectInput: ({ id, options, value, onChange }: any) => (
+    MultiSelectInput: ({ id, options, value, onChange, getOptionId, getOptionName }: any) => (
         <div data-testid={id} data-selected={value?.[0]?.id ?? ''}>
             {options.map((option: any) => (
                 <button
-                    key={option.id}
+                    key={getOptionId(option)}
                     type="button"
-                    data-testid={`${id}-${option.id}`}
+                    data-testid={`${id}-${getOptionId(option)}`}
                     onClick={() => onChange([option])}
                 >
-                    {option.name}
+                    {getOptionName(option)}
                 </button>
             ))}
         </div>
@@ -154,6 +154,28 @@ describe('StatisticsMetricEditPanel', () => {
         ]);
     });
 
+    it('keeps prefix when selecting the same option', async () => {
+        const onSave = jest.fn();
+        render(<StatisticsMetricEditPanel metric={createMetric()} onSave={onSave} onCancel={jest.fn()} />);
+
+        fireEvent.click(screen.getByTestId('metric-prefix-1-Plus'));
+        fireEvent.change(screen.getByTestId('metric-ua-1'), { target: { value: 'Оновлена UA' } });
+        fireEvent.blur(screen.getByTestId('metric-ua-1'));
+        fireEvent.blur(screen.getByTestId('metric-en-1'));
+        fireEvent.blur(screen.getByTestId('metric-val-1'));
+
+        const saveButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.SAVE });
+        await waitFor(() => expect(saveButton).not.toBeDisabled());
+        fireEvent.click(saveButton);
+
+        await waitFor(() => {
+            expect(onSave).toHaveBeenCalledTimes(1);
+        });
+
+        const updatedMetric = onSave.mock.calls[0][0];
+        expect(updatedMetric.prefix).toBe(MetricPrefix.Plus);
+    });
+
     it('opens cancel modal when form is dirty and confirms cancel', async () => {
         const onCancel = jest.fn();
         render(<StatisticsMetricEditPanel metric={createMetric()} onSave={jest.fn()} onCancel={onCancel} />);
@@ -201,5 +223,49 @@ describe('StatisticsMetricEditPanel', () => {
 
         expect(onCancel).toHaveBeenCalledTimes(1);
         expect(screen.queryByTestId('confirm-modal')).not.toBeInTheDocument();
+    });
+
+    it('handles saving when localizations are undefined', async () => {
+        const onSave = jest.fn();
+        const metric = createMetric({ localizations: undefined as any });
+
+        render(<StatisticsMetricEditPanel metric={metric} onSave={onSave} onCancel={jest.fn()} />);
+
+        fireEvent.change(screen.getByTestId('metric-ua-1'), { target: { value: 'UA Update' } });
+        fireEvent.change(screen.getByTestId('metric-en-1'), { target: { value: 'EN Update' } });
+        fireEvent.blur(screen.getByTestId('metric-ua-1'));
+        fireEvent.blur(screen.getByTestId('metric-en-1'));
+
+        const saveButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.SAVE });
+        await waitFor(() => expect(saveButton).not.toBeDisabled());
+        fireEvent.click(saveButton);
+
+        await waitFor(() => {
+            const updatedMetric = onSave.mock.calls[0][0];
+            expect(updatedMetric.localizations).toEqual([]);
+        });
+    });
+
+    it('uses default prefix option when provided prefix is invalid', () => {
+        render(
+            <StatisticsMetricEditPanel
+                metric={createMetric({ prefix: 999 as any })}
+                onSave={jest.fn()}
+                onCancel={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByTestId('metric-prefix-1')).toHaveAttribute('data-selected', 'None');
+    });
+
+    it('handles prefix selection fallbacks in onChange', async () => {
+        render(<StatisticsMetricEditPanel metric={createMetric()} onSave={jest.fn()} onCancel={jest.fn()} />);
+
+        const noneOption = screen.getByTestId('metric-prefix-1-None');
+        fireEvent.click(noneOption);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('metric-prefix-1')).toBeInTheDocument();
+        });
     });
 });

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.test.tsx
@@ -72,6 +72,23 @@ const createMetric = (overrides: Partial<Metric> = {}): Metric => ({
 });
 
 describe('StatisticsMetricEditPanel', () => {
+    // Хелпер для усунення дублювання логіки сабміту в тестах
+    const submitForm = async (onSaveMock: jest.Mock) => {
+        fireEvent.blur(screen.getByTestId('metric-ua-1'));
+        fireEvent.blur(screen.getByTestId('metric-en-1'));
+        fireEvent.blur(screen.getByTestId('metric-val-1'));
+
+        const saveButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.SAVE });
+        await waitFor(() => expect(saveButton).not.toBeDisabled());
+        fireEvent.click(saveButton);
+
+        await waitFor(() => {
+            expect(onSaveMock).toHaveBeenCalledTimes(1);
+        });
+
+        return onSaveMock.mock.calls[0][0];
+    };
+
     it('renders default values and resolved prefix', () => {
         render(<StatisticsMetricEditPanel metric={createMetric()} onSave={jest.fn()} onCancel={jest.fn()} />);
 
@@ -90,15 +107,8 @@ describe('StatisticsMetricEditPanel', () => {
         fireEvent.change(screen.getByTestId('metric-val-1'), { target: { value: '2 345' } });
         fireEvent.click(screen.getByTestId(`metric-prefix-1-${MetricPrefix.Percent}`));
 
-        const saveButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.SAVE });
-        await waitFor(() => expect(saveButton).not.toBeDisabled());
-        fireEvent.click(saveButton);
+        const updatedMetric = await submitForm(onSave);
 
-        await waitFor(() => {
-            expect(onSave).toHaveBeenCalledTimes(1);
-        });
-
-        const updatedMetric = onSave.mock.calls[0][0];
         expect(updatedMetric.name).toBe('Нова UA');
         expect(updatedMetric.value).toBe(2345);
         expect(updatedMetric.prefix).toBe(MetricPrefix.Percent);
@@ -135,19 +145,9 @@ describe('StatisticsMetricEditPanel', () => {
 
         fireEvent.change(screen.getByTestId('metric-ua-1'), { target: { value: 'Нова UA' } });
         fireEvent.change(screen.getByTestId('metric-en-1'), { target: { value: 'Name EN' } });
-        fireEvent.blur(screen.getByTestId('metric-ua-1'));
-        fireEvent.blur(screen.getByTestId('metric-en-1'));
-        fireEvent.blur(screen.getByTestId('metric-val-1'));
 
-        const saveButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.SAVE });
-        await waitFor(() => expect(saveButton).not.toBeDisabled());
-        fireEvent.click(saveButton);
+        const updatedMetric = await submitForm(onSave);
 
-        await waitFor(() => {
-            expect(onSave).toHaveBeenCalledTimes(1);
-        });
-
-        const updatedMetric = onSave.mock.calls[0][0];
         expect(updatedMetric.localizations).toEqual([
             { languageId: 1, name: 'Нова UA' },
             { languageId: 3, name: 'Third Language' },
@@ -160,19 +160,9 @@ describe('StatisticsMetricEditPanel', () => {
 
         fireEvent.click(screen.getByTestId(`metric-prefix-1-${MetricPrefix.Plus}`));
         fireEvent.change(screen.getByTestId('metric-ua-1'), { target: { value: 'Оновлена UA' } });
-        fireEvent.blur(screen.getByTestId('metric-ua-1'));
-        fireEvent.blur(screen.getByTestId('metric-en-1'));
-        fireEvent.blur(screen.getByTestId('metric-val-1'));
 
-        const saveButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.SAVE });
-        await waitFor(() => expect(saveButton).not.toBeDisabled());
-        fireEvent.click(saveButton);
+        const updatedMetric = await submitForm(onSave);
 
-        await waitFor(() => {
-            expect(onSave).toHaveBeenCalledTimes(1);
-        });
-
-        const updatedMetric = onSave.mock.calls[0][0];
         expect(updatedMetric.prefix).toBe(MetricPrefix.Plus);
     });
 
@@ -233,17 +223,9 @@ describe('StatisticsMetricEditPanel', () => {
 
         fireEvent.change(screen.getByTestId('metric-ua-1'), { target: { value: 'UA Update' } });
         fireEvent.change(screen.getByTestId('metric-en-1'), { target: { value: 'EN Update' } });
-        fireEvent.blur(screen.getByTestId('metric-ua-1'));
-        fireEvent.blur(screen.getByTestId('metric-en-1'));
 
-        const saveButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.SAVE });
-        await waitFor(() => expect(saveButton).not.toBeDisabled());
-        fireEvent.click(saveButton);
-
-        await waitFor(() => {
-            const updatedMetric = onSave.mock.calls[0][0];
-            expect(updatedMetric.localizations).toEqual([]);
-        });
+        const updatedMetric = await submitForm(onSave);
+        expect(updatedMetric.localizations).toEqual([]);
     });
 
     it('uses default prefix option when provided prefix is invalid', () => {

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.test.tsx
@@ -78,7 +78,7 @@ describe('StatisticsMetricEditPanel', () => {
         expect(screen.getByTestId('metric-ua-1')).toHaveValue('Назва UA');
         expect(screen.getByTestId('metric-en-1')).toHaveValue('Name EN');
         expect(screen.getByTestId('metric-val-1')).toHaveValue('1 200');
-        expect(screen.getByTestId('metric-prefix-1')).toHaveAttribute('data-selected', 'Plus');
+        expect(screen.getByTestId('metric-prefix-1')).toHaveAttribute('data-selected', String(MetricPrefix.Plus));
     });
 
     it('submits trimmed values and parsed number', async () => {
@@ -88,7 +88,7 @@ describe('StatisticsMetricEditPanel', () => {
         fireEvent.change(screen.getByTestId('metric-ua-1'), { target: { value: '  Нова UA  ' } });
         fireEvent.change(screen.getByTestId('metric-en-1'), { target: { value: '  New EN  ' } });
         fireEvent.change(screen.getByTestId('metric-val-1'), { target: { value: '2 345' } });
-        fireEvent.click(screen.getByTestId('metric-prefix-1-Percent'));
+        fireEvent.click(screen.getByTestId(`metric-prefix-1-${MetricPrefix.Percent}`));
 
         const saveButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.SAVE });
         await waitFor(() => expect(saveButton).not.toBeDisabled());
@@ -111,7 +111,7 @@ describe('StatisticsMetricEditPanel', () => {
     it('uses fallback defaults when name and localizations are missing', () => {
         render(
             <StatisticsMetricEditPanel
-                metric={createMetric({ name: '', localizations: undefined, prefix: 2 as any })}
+                metric={createMetric({ name: '', localizations: undefined, prefix: MetricPrefix.Percent })}
                 onSave={jest.fn()}
                 onCancel={jest.fn()}
             />,
@@ -119,7 +119,7 @@ describe('StatisticsMetricEditPanel', () => {
 
         expect(screen.getByTestId('metric-ua-1')).toHaveValue('');
         expect(screen.getByTestId('metric-en-1')).toHaveValue('');
-        expect(screen.getByTestId('metric-prefix-1')).toHaveAttribute('data-selected', 'Percent');
+        expect(screen.getByTestId('metric-prefix-1')).toHaveAttribute('data-selected', String(MetricPrefix.Percent));
     });
 
     it('preserves non-target localizations when saving', async () => {
@@ -158,7 +158,7 @@ describe('StatisticsMetricEditPanel', () => {
         const onSave = jest.fn();
         render(<StatisticsMetricEditPanel metric={createMetric()} onSave={onSave} onCancel={jest.fn()} />);
 
-        fireEvent.click(screen.getByTestId('metric-prefix-1-Plus'));
+        fireEvent.click(screen.getByTestId(`metric-prefix-1-${MetricPrefix.Plus}`));
         fireEvent.change(screen.getByTestId('metric-ua-1'), { target: { value: 'Оновлена UA' } });
         fireEvent.blur(screen.getByTestId('metric-ua-1'));
         fireEvent.blur(screen.getByTestId('metric-en-1'));
@@ -255,13 +255,13 @@ describe('StatisticsMetricEditPanel', () => {
             />,
         );
 
-        expect(screen.getByTestId('metric-prefix-1')).toHaveAttribute('data-selected', 'None');
+        expect(screen.getByTestId('metric-prefix-1')).toHaveAttribute('data-selected', String(MetricPrefix.None));
     });
 
     it('handles prefix selection fallbacks in onChange', async () => {
         render(<StatisticsMetricEditPanel metric={createMetric()} onSave={jest.fn()} onCancel={jest.fn()} />);
 
-        const noneOption = screen.getByTestId('metric-prefix-1-None');
+        const noneOption = screen.getByTestId(`metric-prefix-1-${MetricPrefix.None}`);
         fireEvent.click(noneOption);
 
         await waitFor(() => {

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
@@ -3,6 +3,7 @@ import { ConfirmationModal } from '@/components/admin/confirmation-modal/Confirm
 import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
 import { MultiSelectInput } from '@/components/admin/multi-select-input/MultiSelectInput';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
 import { Metric, MetricPrefix } from '@/types/admin/main-page';
 import { useState } from 'react';
 import styles from './StatisticsMetricEditPanel.module.scss';
@@ -14,7 +15,7 @@ interface StatisticsMetricEditPanelProps {
 }
 
 const PREFIX_OPTIONS = [
-    { id: MetricPrefix.None, name: 'None' },
+    { id: MetricPrefix.None, name: MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.PREFIX_NONE },
     { id: MetricPrefix.Plus, name: '+' },
     { id: MetricPrefix.Percent, name: '%' },
 ];
@@ -85,12 +86,12 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
 
     return (
         <div className={styles.panel}>
-            <div className={styles.header}>Редагування</div>
+            <div className={styles.header}>{MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.TITLE}</div>
             <div className={styles.formGrid}>
                 <InputWithCharacterLimitGroup
                     id={`metric-ua-${metric.id}`}
                     name="nameUa"
-                    label="UKR Назва"
+                    label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UKR_NAME_LABEL}
                     value={nameUa}
                     onChange={(e) => setNameUa(e.target.value)}
                     maxLength={20}
@@ -99,7 +100,7 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
                 <InputWithCharacterLimitGroup
                     id={`metric-en-${metric.id}`}
                     name="nameEn"
-                    label="ENG Назва"
+                    label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.ENG_NAME_LABEL}
                     value={nameEn}
                     onChange={(e) => setNameEn(e.target.value)}
                     maxLength={20}
@@ -108,14 +109,14 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
                 <InputWithCharacterLimitGroup
                     id={`metric-val-${metric.id}`}
                     name="value"
-                    label="Значення"
+                    label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.VALUE_LABEL}
                     value={value}
                     onChange={handleValueChange}
                     maxLength={15}
                     isRequired
                 />
                 <div className={styles.prefixGroup}>
-                    <label className={styles.prefixLabel}>Префікс</label>
+                    <label className={styles.prefixLabel}>{MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.PREFIX_LABEL}</label>
                     <MultiSelectInput
                         id={`metric-prefix-${metric.id}`}
                         options={PREFIX_OPTIONS}
@@ -130,17 +131,17 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
             </div>
             <div className={styles.actions}>
                 <Button buttonStyle="secondary" onClick={handleCancelClick}>
-                    Відмінити
+                    {MAIN_PAGE_TEXT.BUTTONS.CANCEL}
                 </Button>
                 <Button buttonStyle="primary" onClick={handleSave} disabled={isSaveDisabled}>
-                    Зберегти
+                    {MAIN_PAGE_TEXT.BUTTONS.SAVE}
                 </Button>
             </div>
 
             <ConfirmationModal
                 isOpen={isCancelModalOpen}
                 onClose={() => setIsCancelModalOpen(false)}
-                title="Відмінити зміни?"
+                title={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.CANCEL_MODAL_TITLE}
                 onConfirm={handleConfirmCancel}
                 onCancel={() => setIsCancelModalOpen(false)}
                 confirmText={COMMON_TEXT_ADMIN.BUTTON.YES}

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
@@ -1,0 +1,151 @@
+import { Button } from '@/components/admin/button/Button';
+import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
+import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
+import { MultiSelectInput } from '@/components/admin/multi-select-input/MultiSelectInput';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { Metric, MetricPrefix } from '@/types/admin/main-page';
+import { useState } from 'react';
+import styles from './StatisticsMetricEditPanel.module.scss';
+
+interface StatisticsMetricEditPanelProps {
+    metric: Metric;
+    onSave: (updatedMetric: Metric) => void;
+    onCancel: () => void;
+}
+
+const PREFIX_OPTIONS = [
+    { id: MetricPrefix.None, name: 'None' },
+    { id: MetricPrefix.Plus, name: '+' },
+    { id: MetricPrefix.Percent, name: '%' },
+];
+
+const formatThousands = (value: string | number): string => {
+    const raw = String(value).replace(/\D/g, '');
+    return raw.replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
+};
+
+const parseThousands = (value: string): number => {
+    return parseInt(value.replace(/\s/g, ''), 10) || 0;
+};
+
+export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: StatisticsMetricEditPanelProps) => {
+    const initUa = metric.localizations?.find((l) => l.languageId === 1)?.name || '';
+    const initEn = metric.localizations?.find((l) => l.languageId === 2)?.name || '';
+    const initValue = formatThousands(metric.value);
+    const initPrefix = PREFIX_OPTIONS.find((p) => p.id === metric.prefix) || PREFIX_OPTIONS[0];
+
+    const [nameUa, setNameUa] = useState(initUa);
+    const [nameEn, setNameEn] = useState(initEn);
+    const [value, setValue] = useState(initValue);
+    const [prefix, setPrefix] = useState([initPrefix]);
+    const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
+
+    const isChanged = nameUa !== initUa || nameEn !== initEn || value !== initValue || prefix[0].id !== initPrefix.id;
+
+    const isValid = nameUa.trim().length >= 2 && nameEn.trim().length >= 2 && parseThousands(value) > 0;
+    const isSaveDisabled = !isChanged || !isValid;
+
+    const handleValueChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const formatted = formatThousands(e.target.value);
+        setValue(formatted);
+    };
+
+    const handleCancelClick = () => {
+        if (isChanged) {
+            setIsCancelModalOpen(true);
+        } else {
+            onCancel();
+        }
+    };
+
+    const handleConfirmCancel = () => {
+        setIsCancelModalOpen(false);
+        onCancel();
+    };
+
+    const handleSave = () => {
+        if (isSaveDisabled) return;
+
+        const updatedLocalizations =
+            metric.localizations?.map((loc) => {
+                if (loc.languageId === 1) return { ...loc, name: nameUa.trim() };
+                if (loc.languageId === 2) return { ...loc, name: nameEn.trim() };
+                return loc;
+            }) || [];
+
+        const updatedMetric: Metric = {
+            ...metric,
+            value: parseThousands(value),
+            prefix: prefix[0].id as MetricPrefix,
+            localizations: updatedLocalizations,
+        };
+
+        onSave(updatedMetric);
+    };
+
+    return (
+        <div className={styles.panel}>
+            <div className={styles.header}>Редагування</div>
+            <div className={styles.formGrid}>
+                <InputWithCharacterLimitGroup
+                    id={`metric-ua-${metric.id}`}
+                    name="nameUa"
+                    label="UKR Назва"
+                    value={nameUa}
+                    onChange={(e) => setNameUa(e.target.value)}
+                    maxLength={20}
+                    isRequired
+                />
+                <InputWithCharacterLimitGroup
+                    id={`metric-en-${metric.id}`}
+                    name="nameEn"
+                    label="ENG Назва"
+                    value={nameEn}
+                    onChange={(e) => setNameEn(e.target.value)}
+                    maxLength={20}
+                    isRequired
+                />
+                <InputWithCharacterLimitGroup
+                    id={`metric-val-${metric.id}`}
+                    name="value"
+                    label="Значення"
+                    value={value}
+                    onChange={handleValueChange}
+                    maxLength={15}
+                    isRequired
+                />
+                <div className={styles.prefixGroup}>
+                    <label className={styles.prefixLabel}>Префікс</label>
+                    <MultiSelectInput
+                        id={`metric-prefix-${metric.id}`}
+                        options={PREFIX_OPTIONS}
+                        value={prefix}
+                        getOptionId={(opt) => opt.id}
+                        getOptionName={(opt) => opt.name}
+                        onChange={(selected) =>
+                            setPrefix(selected.length ? [selected[selected.length - 1]] : [PREFIX_OPTIONS[0]])
+                        }
+                    />
+                </div>
+            </div>
+            <div className={styles.actions}>
+                <Button buttonStyle="secondary" onClick={handleCancelClick}>
+                    Відмінити
+                </Button>
+                <Button buttonStyle="primary" onClick={handleSave} disabled={isSaveDisabled}>
+                    Зберегти
+                </Button>
+            </div>
+
+            <ConfirmationModal
+                isOpen={isCancelModalOpen}
+                onClose={() => setIsCancelModalOpen(false)}
+                title="Відмінити зміни?"
+                onConfirm={handleConfirmCancel}
+                onCancel={() => setIsCancelModalOpen(false)}
+                confirmText={COMMON_TEXT_ADMIN.BUTTON.YES}
+                cancelText={COMMON_TEXT_ADMIN.BUTTON.NO}
+            />
+        </div>
+    );
+};

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
@@ -9,6 +9,7 @@ import { MultiSelectInput } from '@/components/admin/multi-select-input/MultiSel
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
 import { Metric, MetricPrefix } from '@/types/admin/main-page';
+import { resolvePrefix } from '@/utils/functions/mappers/admin/main-page/main-page-mappers';
 import {
     MetricFormValues,
     metricEditSchema,
@@ -39,10 +40,10 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
         mode: 'onBlur',
         resolver: yupResolver(metricEditSchema),
         defaultValues: {
-            nameUa: metric.localizations?.find((l) => l.languageId === 1)?.name || '',
+            nameUa: metric.name || '',
             nameEn: metric.localizations?.find((l) => l.languageId === 2)?.name || '',
             value: String(metric.value).replace(/\B(?=(\d{3})+(?!\d))/g, ' '),
-            prefix: metric.prefix || MetricPrefix.None,
+            prefix: resolvePrefix(metric.prefix),
         },
     });
 
@@ -56,6 +57,7 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
 
         const updatedMetric: Metric = {
             ...metric,
+            name: data.nameUa.trim(),
             value: parseInt(data.value.replace(/\s/g, ''), 10),
             prefix: data.prefix,
             localizations: updatedLocalizations,
@@ -134,10 +136,13 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
                             <MultiSelectInput
                                 id={`metric-prefix-${metric.id}`}
                                 options={PREFIX_OPTIONS}
-                                value={[PREFIX_OPTIONS.find((p) => p.id === value) || PREFIX_OPTIONS[0]]}
+                                value={[PREFIX_OPTIONS.find((p) => p.id === value) ?? PREFIX_OPTIONS[0]]}
                                 getOptionId={(opt) => opt.id}
                                 getOptionName={(opt) => opt.name}
-                                onChange={(selected) => onChange(selected[0]?.id || MetricPrefix.None)}
+                                onChange={(selected) => {
+                                    const next = selected.find((opt) => opt.id !== value);
+                                    onChange(next?.id ?? value ?? MetricPrefix.None);
+                                }}
                             />
                         )}
                     />

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
@@ -9,7 +9,7 @@ import { MultiSelectInput } from '@/components/admin/multi-select-input/MultiSel
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
 import { Metric, MetricPrefix } from '@/types/admin/main-page';
-import { formatWithSpaces, formatNumberInput } from '@/utils/functions/formatters/format-number';
+import { formatNumberInput, formatWithSpaces } from '@/utils/functions/formatters/format-number';
 import {
     MetricFormValues,
     metricEditSchema,
@@ -42,7 +42,7 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
         defaultValues: {
             nameUa: metric.name || '',
             nameEn: metric.localizations?.find((l) => l.languageId === 2)?.name || '',
-            value: formatWithSpaces(metric.value),
+            value: formatWithSpaces(metric.value ?? 0),
             prefix: metric.prefix ?? MetricPrefix.None,
         },
     });

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
@@ -9,7 +9,6 @@ import { MultiSelectInput } from '@/components/admin/multi-select-input/MultiSel
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
 import { Metric, MetricPrefix } from '@/types/admin/main-page';
-import { resolvePrefix } from '@/utils/functions/mappers/admin/main-page/main-page-mappers';
 import {
     MetricFormValues,
     metricEditSchema,
@@ -43,7 +42,7 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
             nameUa: metric.name || '',
             nameEn: metric.localizations?.find((l) => l.languageId === 2)?.name || '',
             value: String(metric.value).replace(/\B(?=(\d{3})+(?!\d))/g, ' '),
-            prefix: resolvePrefix(metric.prefix),
+            prefix: metric.prefix ?? MetricPrefix.None,
         },
     });
 

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
@@ -9,6 +9,7 @@ import { MultiSelectInput } from '@/components/admin/multi-select-input/MultiSel
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
 import { Metric, MetricPrefix } from '@/types/admin/main-page';
+import { formatWithSpaces, formatNumberInput } from '@/utils/functions/formatters/format-number';
 import {
     MetricFormValues,
     metricEditSchema,
@@ -41,7 +42,7 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
         defaultValues: {
             nameUa: metric.name || '',
             nameEn: metric.localizations?.find((l) => l.languageId === 2)?.name || '',
-            value: String(metric.value).replace(/\B(?=(\d{3})+(?!\d))/g, ' '),
+            value: formatWithSpaces(metric.value),
             prefix: metric.prefix ?? MetricPrefix.None,
         },
     });
@@ -115,9 +116,7 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
                             name={name}
                             label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.VALUE_LABEL}
                             value={value}
-                            onChange={(e) =>
-                                onChange(e.target.value.replace(/\D/g, '').replace(/\B(?=(\d{3})+(?!\d))/g, ' '))
-                            }
+                            onChange={(e) => onChange(formatNumberInput(e.target.value))}
                             onBlur={onBlur}
                             error={errors.value?.message}
                             maxLength={15}

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
@@ -1,11 +1,19 @@
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+
 import { Button } from '@/components/admin/button/Button';
 import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
 import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
 import { MultiSelectInput } from '@/components/admin/multi-select-input/MultiSelectInput';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
-import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
+import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
 import { Metric, MetricPrefix } from '@/types/admin/main-page';
-import { useState } from 'react';
+import {
+    MetricFormValues,
+    metricEditSchema,
+} from '@/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema';
+
 import styles from './StatisticsMetricEditPanel.module.scss';
 
 interface StatisticsMetricEditPanelProps {
@@ -20,64 +28,36 @@ const PREFIX_OPTIONS = [
     { id: MetricPrefix.Percent, name: '%' },
 ];
 
-const formatThousands = (value: string | number): string => {
-    const raw = String(value).replace(/\D/g, '');
-    return raw.replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
-};
-
-const parseThousands = (value: string): number => {
-    return parseInt(value.replace(/\s/g, ''), 10) || 0;
-};
-
 export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: StatisticsMetricEditPanelProps) => {
-    const initUa = metric.localizations?.find((l) => l.languageId === 1)?.name || '';
-    const initEn = metric.localizations?.find((l) => l.languageId === 2)?.name || '';
-    const initValue = formatThousands(metric.value);
-    const initPrefix = PREFIX_OPTIONS.find((p) => p.id === metric.prefix) || PREFIX_OPTIONS[0];
-
-    const [nameUa, setNameUa] = useState(initUa);
-    const [nameEn, setNameEn] = useState(initEn);
-    const [value, setValue] = useState(initValue);
-    const [prefix, setPrefix] = useState([initPrefix]);
     const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
 
-    const isChanged = nameUa !== initUa || nameEn !== initEn || value !== initValue || prefix[0].id !== initPrefix.id;
+    const {
+        control,
+        handleSubmit,
+        formState: { errors, isDirty, isValid },
+    } = useForm<MetricFormValues>({
+        mode: 'onBlur',
+        resolver: yupResolver(metricEditSchema),
+        defaultValues: {
+            nameUa: metric.localizations?.find((l) => l.languageId === 1)?.name || '',
+            nameEn: metric.localizations?.find((l) => l.languageId === 2)?.name || '',
+            value: String(metric.value).replace(/\B(?=(\d{3})+(?!\d))/g, ' '),
+            prefix: metric.prefix || MetricPrefix.None,
+        },
+    });
 
-    const isValid = nameUa.trim().length >= 2 && nameEn.trim().length >= 2 && parseThousands(value) > 0;
-    const isSaveDisabled = !isChanged || !isValid;
-
-    const handleValueChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const formatted = formatThousands(e.target.value);
-        setValue(formatted);
-    };
-
-    const handleCancelClick = () => {
-        if (isChanged) {
-            setIsCancelModalOpen(true);
-        } else {
-            onCancel();
-        }
-    };
-
-    const handleConfirmCancel = () => {
-        setIsCancelModalOpen(false);
-        onCancel();
-    };
-
-    const handleSave = () => {
-        if (isSaveDisabled) return;
-
+    const onValidSubmit = (data: MetricFormValues) => {
         const updatedLocalizations =
             metric.localizations?.map((loc) => {
-                if (loc.languageId === 1) return { ...loc, name: nameUa.trim() };
-                if (loc.languageId === 2) return { ...loc, name: nameEn.trim() };
+                if (loc.languageId === 1) return { ...loc, name: data.nameUa.trim() };
+                if (loc.languageId === 2) return { ...loc, name: data.nameEn.trim() };
                 return loc;
             }) || [];
 
         const updatedMetric: Metric = {
             ...metric,
-            value: parseThousands(value),
-            prefix: prefix[0].id as MetricPrefix,
+            value: parseInt(data.value.replace(/\s/g, ''), 10),
+            prefix: data.prefix,
             localizations: updatedLocalizations,
         };
 
@@ -87,53 +67,88 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
     return (
         <div className={styles.panel}>
             <div className={styles.header}>{MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.TITLE}</div>
+
             <div className={styles.formGrid}>
-                <InputWithCharacterLimitGroup
-                    id={`metric-ua-${metric.id}`}
+                <Controller
                     name="nameUa"
-                    label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UKR_NAME_LABEL}
-                    value={nameUa}
-                    onChange={(e) => setNameUa(e.target.value)}
-                    maxLength={20}
-                    isRequired
+                    control={control}
+                    render={({ field: { onChange, onBlur, value, name } }) => (
+                        <InputWithCharacterLimitGroup
+                            id={`metric-ua-${metric.id}`}
+                            name={name}
+                            label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UKR_NAME_LABEL}
+                            value={value}
+                            onChange={onChange}
+                            onBlur={onBlur}
+                            error={errors.nameUa?.message}
+                            maxLength={MAIN_PAGE_VALIDATION.editPanel.name.max}
+                            isRequired
+                        />
+                    )}
                 />
-                <InputWithCharacterLimitGroup
-                    id={`metric-en-${metric.id}`}
+
+                <Controller
                     name="nameEn"
-                    label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.ENG_NAME_LABEL}
-                    value={nameEn}
-                    onChange={(e) => setNameEn(e.target.value)}
-                    maxLength={20}
-                    isRequired
+                    control={control}
+                    render={({ field: { onChange, onBlur, value, name } }) => (
+                        <InputWithCharacterLimitGroup
+                            id={`metric-en-${metric.id}`}
+                            name={name}
+                            label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.ENG_NAME_LABEL}
+                            value={value}
+                            onChange={onChange}
+                            onBlur={onBlur}
+                            error={errors.nameEn?.message}
+                            maxLength={MAIN_PAGE_VALIDATION.editPanel.name.max}
+                            isRequired
+                        />
+                    )}
                 />
-                <InputWithCharacterLimitGroup
-                    id={`metric-val-${metric.id}`}
+
+                <Controller
                     name="value"
-                    label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.VALUE_LABEL}
-                    value={value}
-                    onChange={handleValueChange}
-                    maxLength={15}
-                    isRequired
+                    control={control}
+                    render={({ field: { onChange, onBlur, value, name } }) => (
+                        <InputWithCharacterLimitGroup
+                            id={`metric-val-${metric.id}`}
+                            name={name}
+                            label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.VALUE_LABEL}
+                            value={value}
+                            onChange={(e) =>
+                                onChange(e.target.value.replace(/\D/g, '').replace(/\B(?=(\d{3})+(?!\d))/g, ' '))
+                            }
+                            onBlur={onBlur}
+                            error={errors.value?.message}
+                            maxLength={15}
+                            isRequired
+                        />
+                    )}
                 />
+
                 <div className={styles.prefixGroup}>
                     <label className={styles.prefixLabel}>{MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.PREFIX_LABEL}</label>
-                    <MultiSelectInput
-                        id={`metric-prefix-${metric.id}`}
-                        options={PREFIX_OPTIONS}
-                        value={prefix}
-                        getOptionId={(opt) => opt.id}
-                        getOptionName={(opt) => opt.name}
-                        onChange={(selected) =>
-                            setPrefix(selected.length ? [selected[selected.length - 1]] : [PREFIX_OPTIONS[0]])
-                        }
+                    <Controller
+                        name="prefix"
+                        control={control}
+                        render={({ field: { onChange, value } }) => (
+                            <MultiSelectInput
+                                id={`metric-prefix-${metric.id}`}
+                                options={PREFIX_OPTIONS}
+                                value={[PREFIX_OPTIONS.find((p) => p.id === value) || PREFIX_OPTIONS[0]]}
+                                getOptionId={(opt) => opt.id}
+                                getOptionName={(opt) => opt.name}
+                                onChange={(selected) => onChange(selected[0]?.id || MetricPrefix.None)}
+                            />
+                        )}
                     />
                 </div>
             </div>
+
             <div className={styles.actions}>
-                <Button buttonStyle="secondary" onClick={handleCancelClick}>
+                <Button buttonStyle="secondary" onClick={() => (isDirty ? setIsCancelModalOpen(true) : onCancel())}>
                     {MAIN_PAGE_TEXT.BUTTONS.CANCEL}
                 </Button>
-                <Button buttonStyle="primary" onClick={handleSave} disabled={isSaveDisabled}>
+                <Button buttonStyle="primary" onClick={handleSubmit(onValidSubmit)} disabled={!isDirty || !isValid}>
                     {MAIN_PAGE_TEXT.BUTTONS.SAVE}
                 </Button>
             </div>
@@ -142,7 +157,10 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
                 isOpen={isCancelModalOpen}
                 onClose={() => setIsCancelModalOpen(false)}
                 title={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.CANCEL_MODAL_TITLE}
-                onConfirm={handleConfirmCancel}
+                onConfirm={() => {
+                    setIsCancelModalOpen(false);
+                    onCancel();
+                }}
                 onCancel={() => setIsCancelModalOpen(false)}
                 confirmText={COMMON_TEXT_ADMIN.BUTTON.YES}
                 cancelText={COMMON_TEXT_ADMIN.BUTTON.NO}

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.module.scss
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.module.scss
@@ -27,7 +27,8 @@
 
 .table :global(.draggable-item),
 .table :global(.drag-preview-wrapper) {
-    height: 40px;
+    height: auto;
+    min-height: 40px;
     align-items: stretch;
     box-shadow: none;
     border-bottom: none;
@@ -36,7 +37,8 @@
 .table :global(.draggable-item .item-data),
 .table :global(.drag-preview .item-data) {
     padding: 0 10px;
-    height: 40px;
+    height: auto;
+    min-height: 40px;
     display: flex;
     align-items: center;
     width: 100%;
@@ -44,6 +46,7 @@
 
 .table :global(.dragger) {
     width: 32px;
+    height: 40px;
 }
 
 .row {

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
@@ -66,91 +66,53 @@ const metrics: Metric[] = [
 ];
 
 describe('StatisticsMetricsList', () => {
-    it('renders metrics list', () => {
-        render(
-            <StatisticsMetricsList
-                metrics={metrics}
-                hiddenMetricIds={[]}
-                onToggleVisibility={jest.fn()}
-                onReorder={jest.fn()}
-                onMetricUpdate={jest.fn()}
-            />,
-        );
+    const setup = (propsOverrides: Partial<React.ComponentProps<typeof StatisticsMetricsList>> = {}) => {
+        const defaultProps = {
+            metrics,
+            hiddenMetricIds: [],
+            onToggleVisibility: jest.fn(),
+            onReorder: jest.fn(),
+            onMetricUpdate: jest.fn(),
+        };
 
+        const finalProps = { ...defaultProps, ...propsOverrides };
+        render(<StatisticsMetricsList {...finalProps} />);
+
+        return {
+            onToggleVisibility: finalProps.onToggleVisibility,
+            onMetricUpdate: finalProps.onMetricUpdate,
+        };
+    };
+
+    it('renders metrics list', () => {
+        setup();
         expect(screen.getByText('Партнерів')).toBeInTheDocument();
         expect(screen.getByText('20+')).toBeInTheDocument();
     });
 
     it('falls back to metric name when localization is missing', () => {
-        render(
-            <StatisticsMetricsList
-                metrics={metrics}
-                hiddenMetricIds={[]}
-                onToggleVisibility={jest.fn()}
-                onReorder={jest.fn()}
-                onMetricUpdate={jest.fn()}
-            />,
-        );
-
+        setup();
         expect(screen.getByText('Engagement')).toBeInTheDocument();
     });
 
     it('formats percent values', () => {
-        render(
-            <StatisticsMetricsList
-                metrics={metrics}
-                hiddenMetricIds={[]}
-                onToggleVisibility={jest.fn()}
-                onReorder={jest.fn()}
-                onMetricUpdate={jest.fn()}
-            />,
-        );
-
+        setup();
         expect(screen.getByText('50%')).toBeInTheDocument();
     });
 
     it('uses "Show metric" label when metric is hidden', () => {
-        render(
-            <StatisticsMetricsList
-                metrics={metrics}
-                hiddenMetricIds={[2]}
-                onToggleVisibility={jest.fn()}
-                onReorder={jest.fn()}
-                onMetricUpdate={jest.fn()}
-            />,
-        );
-
+        setup({ hiddenMetricIds: [2] });
         expect(screen.getByLabelText('Show metric')).toBeInTheDocument();
     });
 
     it('calls onToggleVisibility on eye click', () => {
-        const onToggleVisibility = jest.fn();
-        render(
-            <StatisticsMetricsList
-                metrics={metrics}
-                hiddenMetricIds={[]}
-                onToggleVisibility={onToggleVisibility}
-                onReorder={jest.fn()}
-                onMetricUpdate={jest.fn()}
-            />,
-        );
-
+        const { onToggleVisibility } = setup();
         fireEvent.click(screen.getAllByTestId('icon-Hide metric')[0]);
         expect(onToggleVisibility).toHaveBeenCalledWith(1);
     });
 
     it('does not call onToggleVisibility when metric id is missing', () => {
-        const onToggleVisibility = jest.fn();
-        render(
-            <StatisticsMetricsList
-                metrics={[{ ...metrics[0], id: undefined } as Metric]}
-                hiddenMetricIds={[]}
-                onToggleVisibility={onToggleVisibility}
-                onReorder={jest.fn()}
-                onMetricUpdate={jest.fn()}
-            />,
-        );
-
+        const { onToggleVisibility } = setup({ metrics: [{ ...metrics[0], id: undefined } as Metric] });
         fireEvent.click(screen.getByTestId('icon-Hide metric'));
         expect(onToggleVisibility).not.toHaveBeenCalled();
     });
@@ -164,60 +126,24 @@ describe('StatisticsMetricsList', () => {
             localizations: [],
             name: 'NoPrefix',
         };
-        render(
-            <StatisticsMetricsList
-                metrics={[noPrefix]}
-                hiddenMetricIds={[]}
-                onToggleVisibility={jest.fn()}
-                onReorder={jest.fn()}
-                onMetricUpdate={jest.fn()}
-            />,
-        );
+        setup({ metrics: [noPrefix] });
         expect(screen.getByText('100')).toBeInTheDocument();
     });
 
     it('disables toggle button for last visible metric', () => {
-        render(
-            <StatisticsMetricsList
-                metrics={[metrics[0]]}
-                hiddenMetricIds={[]}
-                onToggleVisibility={jest.fn()}
-                onReorder={jest.fn()}
-                onMetricUpdate={jest.fn()}
-            />,
-        );
+        setup({ metrics: [metrics[0]] });
         const eyeButton = screen.getByTestId('icon-Hide metric');
         expect(eyeButton).toBeDisabled();
     });
 
     it('does not toggle visibility when last metric is visible', () => {
-        const onToggleVisibility = jest.fn();
-        render(
-            <StatisticsMetricsList
-                metrics={[metrics[0]]}
-                hiddenMetricIds={[]}
-                onToggleVisibility={onToggleVisibility}
-                onReorder={jest.fn()}
-                onMetricUpdate={jest.fn()}
-            />,
-        );
-
+        const { onToggleVisibility } = setup({ metrics: [metrics[0]] });
         fireEvent.click(screen.getByTestId('icon-Hide metric'));
         expect(onToggleVisibility).not.toHaveBeenCalled();
     });
 
     it('renders edit panel and saves updated metric', () => {
-        const onMetricUpdate = jest.fn();
-        render(
-            <StatisticsMetricsList
-                metrics={metrics}
-                hiddenMetricIds={[]}
-                onToggleVisibility={jest.fn()}
-                onReorder={jest.fn()}
-                onMetricUpdate={onMetricUpdate}
-            />,
-        );
-
+        const { onMetricUpdate } = setup();
         fireEvent.click(screen.getAllByTestId('icon-edit')[0]);
         expect(screen.getByTestId('metric-edit-panel')).toBeInTheDocument();
 
@@ -226,16 +152,7 @@ describe('StatisticsMetricsList', () => {
     });
 
     it('closes edit panel on cancel', () => {
-        render(
-            <StatisticsMetricsList
-                metrics={metrics}
-                hiddenMetricIds={[]}
-                onToggleVisibility={jest.fn()}
-                onReorder={jest.fn()}
-                onMetricUpdate={jest.fn()}
-            />,
-        );
-
+        setup();
         fireEvent.click(screen.getAllByTestId('icon-edit')[0]);
         expect(screen.getByTestId('metric-edit-panel')).toBeInTheDocument();
 

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
@@ -144,7 +144,7 @@ describe('StatisticsMetricsList', () => {
 
     it('renders edit panel and saves updated metric', () => {
         const { onMetricUpdate } = setup();
-        fireEvent.click(screen.getAllByTestId('icon-edit')[0]);
+        fireEvent.click(screen.getAllByTestId('icon-Edit metric')[0]);
         expect(screen.getByTestId('metric-edit-panel')).toBeInTheDocument();
 
         fireEvent.click(screen.getByTestId('save-edit'));
@@ -153,7 +153,7 @@ describe('StatisticsMetricsList', () => {
 
     it('closes edit panel on cancel', () => {
         setup();
-        fireEvent.click(screen.getAllByTestId('icon-edit')[0]);
+        fireEvent.click(screen.getAllByTestId('icon-Edit metric')[0]);
         expect(screen.getByTestId('metric-edit-panel')).toBeInTheDocument();
 
         fireEvent.click(screen.getByTestId('cancel-edit'));

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
@@ -5,8 +5,38 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { StatisticsMetricsList } from './StatisticsMetricsList';
 
 jest.mock('@/components/admin/draggable-list-item/DraggableListItem', () => ({
-    DraggableListItem: ({ renderEntityComponent, entity }: any) => (
-        <div data-testid="draggable-row">{renderEntityComponent(entity)}</div>
+    DraggableListItem: ({ renderEntityComponent, entity, idSelector }: any) => {
+        const id = idSelector?.(entity);
+        return (
+            <div data-testid="draggable-row" data-entity-id={id}>
+                {renderEntityComponent(entity)}
+            </div>
+        );
+    },
+}));
+
+jest.mock('@/components/admin/icon-button/IconButton', () => ({
+    IconButton: ({ onClick, disabled, 'aria-label': ariaLabel }: any) => (
+        <button
+            type="button"
+            data-testid={ariaLabel ? `icon-${ariaLabel}` : 'icon-edit'}
+            aria-label={ariaLabel}
+            onClick={onClick}
+            disabled={disabled}
+        />
+    ),
+}));
+
+jest.mock('../statistics-metric-edit-panel/StatisticsMetricEditPanel', () => ({
+    StatisticsMetricEditPanel: ({ metric, onSave, onCancel }: any) => (
+        <div data-testid="metric-edit-panel">
+            <button
+                type="button"
+                data-testid="save-edit"
+                onClick={() => onSave({ ...metric, name: 'Updated Metric' })}
+            />
+            <button type="button" data-testid="cancel-edit" onClick={onCancel} />
+        </div>
     ),
 }));
 
@@ -43,6 +73,7 @@ describe('StatisticsMetricsList', () => {
                 hiddenMetricIds={[]}
                 onToggleVisibility={jest.fn()}
                 onReorder={jest.fn()}
+                onMetricUpdate={jest.fn()}
             />,
         );
 
@@ -57,6 +88,7 @@ describe('StatisticsMetricsList', () => {
                 hiddenMetricIds={[]}
                 onToggleVisibility={jest.fn()}
                 onReorder={jest.fn()}
+                onMetricUpdate={jest.fn()}
             />,
         );
 
@@ -70,6 +102,7 @@ describe('StatisticsMetricsList', () => {
                 hiddenMetricIds={[]}
                 onToggleVisibility={jest.fn()}
                 onReorder={jest.fn()}
+                onMetricUpdate={jest.fn()}
             />,
         );
 
@@ -83,6 +116,7 @@ describe('StatisticsMetricsList', () => {
                 hiddenMetricIds={[2]}
                 onToggleVisibility={jest.fn()}
                 onReorder={jest.fn()}
+                onMetricUpdate={jest.fn()}
             />,
         );
 
@@ -97,11 +131,11 @@ describe('StatisticsMetricsList', () => {
                 hiddenMetricIds={[]}
                 onToggleVisibility={onToggleVisibility}
                 onReorder={jest.fn()}
+                onMetricUpdate={jest.fn()}
             />,
         );
 
-        const buttons = screen.getAllByRole('button');
-        fireEvent.click(buttons[1]); // eye button
+        fireEvent.click(screen.getAllByTestId('icon-Hide metric')[0]);
         expect(onToggleVisibility).toHaveBeenCalledWith(1);
     });
 
@@ -113,11 +147,11 @@ describe('StatisticsMetricsList', () => {
                 hiddenMetricIds={[]}
                 onToggleVisibility={onToggleVisibility}
                 onReorder={jest.fn()}
+                onMetricUpdate={jest.fn()}
             />,
         );
 
-        const buttons = screen.getAllByRole('button');
-        fireEvent.click(buttons[1]);
+        fireEvent.click(screen.getByTestId('icon-Hide metric'));
         expect(onToggleVisibility).not.toHaveBeenCalled();
     });
 
@@ -136,6 +170,7 @@ describe('StatisticsMetricsList', () => {
                 hiddenMetricIds={[]}
                 onToggleVisibility={jest.fn()}
                 onReorder={jest.fn()}
+                onMetricUpdate={jest.fn()}
             />,
         );
         expect(screen.getByText('100')).toBeInTheDocument();
@@ -148,10 +183,63 @@ describe('StatisticsMetricsList', () => {
                 hiddenMetricIds={[]}
                 onToggleVisibility={jest.fn()}
                 onReorder={jest.fn()}
+                onMetricUpdate={jest.fn()}
             />,
         );
-        const buttons = screen.getAllByRole('button');
-        const eyeButton = buttons[1];
+        const eyeButton = screen.getByTestId('icon-Hide metric');
         expect(eyeButton).toBeDisabled();
+    });
+
+    it('does not toggle visibility when last metric is visible', () => {
+        const onToggleVisibility = jest.fn();
+        render(
+            <StatisticsMetricsList
+                metrics={[metrics[0]]}
+                hiddenMetricIds={[]}
+                onToggleVisibility={onToggleVisibility}
+                onReorder={jest.fn()}
+                onMetricUpdate={jest.fn()}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('icon-Hide metric'));
+        expect(onToggleVisibility).not.toHaveBeenCalled();
+    });
+
+    it('renders edit panel and saves updated metric', () => {
+        const onMetricUpdate = jest.fn();
+        render(
+            <StatisticsMetricsList
+                metrics={metrics}
+                hiddenMetricIds={[]}
+                onToggleVisibility={jest.fn()}
+                onReorder={jest.fn()}
+                onMetricUpdate={onMetricUpdate}
+            />,
+        );
+
+        fireEvent.click(screen.getAllByTestId('icon-edit')[0]);
+        expect(screen.getByTestId('metric-edit-panel')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('save-edit'));
+        expect(onMetricUpdate).toHaveBeenCalledWith([{ ...metrics[0], name: 'Updated Metric' }, metrics[1]]);
+    });
+
+    it('closes edit panel on cancel', () => {
+        render(
+            <StatisticsMetricsList
+                metrics={metrics}
+                hiddenMetricIds={[]}
+                onToggleVisibility={jest.fn()}
+                onReorder={jest.fn()}
+                onMetricUpdate={jest.fn()}
+            />,
+        );
+
+        fireEvent.click(screen.getAllByTestId('icon-edit')[0]);
+        expect(screen.getByTestId('metric-edit-panel')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('cancel-edit'));
+        expect(screen.queryByTestId('metric-edit-panel')).not.toBeInTheDocument();
     });
 });

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
@@ -6,6 +6,8 @@ import { IconButton } from '@/components/admin/icon-button/IconButton';
 import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
 import { Metric } from '@/types/admin/main-page';
 import { formatMetricValue, getMetricName } from '@/utils/functions/formatters/metric-formatters';
+import { useState } from 'react';
+import { StatisticsMetricEditPanel } from '../statistics-metric-edit-panel/StatisticsMetricEditPanel';
 import styles from './StatisticsMetricsList.module.scss';
 
 interface StatisticsMetricsListProps {
@@ -13,6 +15,7 @@ interface StatisticsMetricsListProps {
     hiddenMetricIds: number[];
     onToggleVisibility: (id: number) => void;
     onReorder: (items: Metric[]) => void;
+    onMetricUpdate: (updatedMetrics: Metric[]) => void;
 }
 
 export const StatisticsMetricsList = ({
@@ -20,9 +23,28 @@ export const StatisticsMetricsList = ({
     hiddenMetricIds,
     onToggleVisibility,
     onReorder,
+    onMetricUpdate,
 }: StatisticsMetricsListProps) => {
+    const [editingMetricId, setEditingMetricId] = useState<number | null>(null);
     const visibleMetricsCount = metrics.length - hiddenMetricIds.length;
+
+    const handleSaveMetric = (updatedMetric: Metric) => {
+        const newMetrics = metrics.map((m) => (m.id === updatedMetric.id ? updatedMetric : m));
+        onMetricUpdate(newMetrics);
+        setEditingMetricId(null);
+    };
+
     const renderRow = (metric: Metric) => {
+        if (editingMetricId === metric.id) {
+            return (
+                <StatisticsMetricEditPanel
+                    metric={metric}
+                    onSave={handleSaveMetric}
+                    onCancel={() => setEditingMetricId(null)}
+                />
+            );
+        }
+
         const isHidden = hiddenMetricIds.includes(metric.id ?? 0);
         const isLastVisible = !isHidden && visibleMetricsCount <= 1;
 
@@ -39,7 +61,12 @@ export const StatisticsMetricsList = ({
                 </div>
 
                 <div className={styles.actions}>
-                    <IconButton type="button" DefaultIcon={EditIcon} className={styles.iconButton} />
+                    <IconButton
+                        type="button"
+                        DefaultIcon={EditIcon}
+                        className={styles.iconButton}
+                        onClick={() => setEditingMetricId(metric.id ?? null)}
+                    />
                     <IconButton
                         type="button"
                         aria-label={isHidden ? 'Show metric' : 'Hide metric'}
@@ -59,7 +86,6 @@ export const StatisticsMetricsList = ({
     return (
         <div className={styles.list}>
             <div className={styles.header}>{MAIN_PAGE_TEXT.BLOCKS.STATISTICS.METRICS_TITLE}</div>
-
             <div className={styles.table}>
                 {metrics.map((metric) => (
                     <DraggableListItem

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
@@ -4,9 +4,10 @@ import { ReactComponent as EyeOpenedIcon } from '@/assets/icons/eye-opened.svg';
 import { DraggableListItem } from '@/components/admin/draggable-list-item/DraggableListItem';
 import { IconButton } from '@/components/admin/icon-button/IconButton';
 import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
-import { Metric } from '@/types/admin/main-page';
+import { Metric, MetricType } from '@/types/admin/main-page';
 import { formatMetricValue, getMetricName } from '@/utils/functions/formatters/metric-formatters';
 import { useState } from 'react';
+import { RaisedMetricEditPanel } from '../raised-metric-edit-panel/RaisedMetricEditPanel';
 import { StatisticsMetricEditPanel } from '../statistics-metric-edit-panel/StatisticsMetricEditPanel';
 import styles from './StatisticsMetricsList.module.scss';
 
@@ -36,6 +37,10 @@ export const StatisticsMetricsList = ({
 
     const renderRow = (metric: Metric) => {
         if (editingMetricId === metric.id) {
+            if (metric.type === MetricType.Raised) {
+                return <RaisedMetricEditPanel metric={metric} onCancel={() => setEditingMetricId(null)} />;
+            }
+
             return (
                 <StatisticsMetricEditPanel
                     metric={metric}

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
@@ -69,8 +69,13 @@ export const StatisticsMetricsList = ({
                     <IconButton
                         type="button"
                         DefaultIcon={EditIcon}
+                        aria-label="Edit metric"
                         className={styles.iconButton}
-                        onClick={() => setEditingMetricId(metric.id ?? null)}
+                        onClick={() => {
+                            if (editingMetricId !== null && editingMetricId !== metric.id) return;
+                            setEditingMetricId(metric.id ?? null);
+                        }}
+                        disabled={editingMetricId !== null && editingMetricId !== metric.id}
                     />
                     <IconButton
                         type="button"

--- a/src/pages/admin/main/components/statistics-block/components/statistics-preview/StatisticsPreview.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-preview/StatisticsPreview.test.tsx
@@ -66,6 +66,21 @@ describe('StatisticsPreview', () => {
         expect(onLanguageChange).toHaveBeenCalledWith('EN');
     });
 
+    it('switches to UA language when UA tab is clicked', () => {
+        const onLanguageChange = jest.fn();
+        render(
+            <StatisticsPreview
+                language="EN"
+                onLanguageChange={onLanguageChange}
+                metrics={metrics}
+                hiddenMetricIds={[]}
+            />,
+        );
+
+        fireEvent.click(screen.getByText('UKR'));
+        expect(onLanguageChange).toHaveBeenCalledWith('UA');
+    });
+
     it('hides metrics by hiddenMetricIds', () => {
         render(<StatisticsPreview language="UA" onLanguageChange={() => {}} metrics={metrics} hiddenMetricIds={[2]} />);
 
@@ -91,5 +106,25 @@ describe('StatisticsPreview', () => {
             <StatisticsPreview language="UA" onLanguageChange={() => {}} metrics={[noPrefix]} hiddenMetricIds={[]} />,
         );
         expect(screen.getByText('999')).toBeInTheDocument();
+    });
+
+    it('hides metrics when id is undefined and hiddenMetricIds includes fallback 0', () => {
+        const noIdMetric: Metric = {
+            ...metrics[0],
+            id: undefined,
+            name: 'NoIdMetric',
+            localizations: [],
+        };
+
+        render(
+            <StatisticsPreview
+                language="UA"
+                onLanguageChange={() => {}}
+                metrics={[noIdMetric]}
+                hiddenMetricIds={[0]}
+            />,
+        );
+
+        expect(screen.queryByText('NoIdMetric')).not.toBeInTheDocument();
     });
 });

--- a/src/types/admin/main-page.ts
+++ b/src/types/admin/main-page.ts
@@ -246,7 +246,7 @@ export interface UpdateMetricDto {
     name: string;
     type: MetricType;
     prefix?: MetricPrefix | null;
-    localizations?: UpdateMetricLocalizationDto[];
+    localization?: UpdateMetricLocalizationDto | null;
 }
 
 export interface UpdateImpactStatisticDto {
@@ -316,6 +316,7 @@ export interface MainPageFormValues {
     statisticsTitleUa: string;
     statisticsTitleEn: string;
     statisticsImage: Image | ImageValues | null;
+    metrics?: Metric[];
 }
 
 export const MAIN_PAGE_FORM_DEFAULTS: MainPageFormValues = {
@@ -338,4 +339,5 @@ export const MAIN_PAGE_FORM_DEFAULTS: MainPageFormValues = {
     statisticsTitleUa: '',
     statisticsTitleEn: '',
     statisticsImage: null,
+    metrics: [],
 };

--- a/src/types/admin/main-page.ts
+++ b/src/types/admin/main-page.ts
@@ -7,16 +7,16 @@ import {
 import { Image, ImageValues } from '../common/image';
 
 export enum MetricPrefix {
-    None = 'None',
-    Plus = 'Plus',
-    Percent = 'Percent',
+    None = 0,
+    Plus = 1,
+    Percent = 2,
 }
 
 export enum MetricType {
-    Partners = 'Partners',
-    Programs = 'Programs',
-    Raised = 'Raised',
-    TherapyHours = 'TherapyHours',
+    Partners = 0,
+    Programs = 1,
+    Raised = 2,
+    TherapyHours = 3,
 }
 
 // Domain/UI Localizations

--- a/src/utils/functions/formatters/format-number.test.ts
+++ b/src/utils/functions/formatters/format-number.test.ts
@@ -1,20 +1,69 @@
-import { formatNumberDecimalComma } from '@/utils/functions/formatters/format-number';
+import {
+    formatNumberDecimalComma,
+    formatNumberInput,
+    formatWithSpaces,
+} from '@/utils/functions/formatters/format-number';
 
-describe('formatNumberDecimalComma', () => {
-    it('returns empty string for null and undefined', () => {
-        expect(formatNumberDecimalComma(null)).toBe('');
-        expect(formatNumberDecimalComma(undefined)).toBe('');
+describe('format-number formatters', () => {
+    describe('formatNumberDecimalComma', () => {
+        it('returns empty string for null and undefined', () => {
+            expect(formatNumberDecimalComma(null)).toBe('');
+            expect(formatNumberDecimalComma(undefined)).toBe('');
+        });
+
+        it('formats numbers and strings with dot to comma', () => {
+            expect(formatNumberDecimalComma(123)).toBe('123');
+            expect(formatNumberDecimalComma(123.45)).toBe('123,45');
+            expect(formatNumberDecimalComma('1000.5')).toBe('1000,5');
+            // only the first dot is replaced (keeps previous behaviour)
+            expect(formatNumberDecimalComma('1.2.3')).toBe('1,2.3');
+        });
+
+        it('leaves strings without dot unchanged', () => {
+            expect(formatNumberDecimalComma('1000')).toBe('1000');
+        });
     });
 
-    it('formats numbers and strings with dot to comma', () => {
-        expect(formatNumberDecimalComma(123)).toBe('123');
-        expect(formatNumberDecimalComma(123.45)).toBe('123,45');
-        expect(formatNumberDecimalComma('1000.5')).toBe('1000,5');
-        // only the first dot is replaced (keeps previous behaviour)
-        expect(formatNumberDecimalComma('1.2.3')).toBe('1,2.3');
+    describe('formatWithSpaces', () => {
+        it('formats numbers with spaces as thousands separators', () => {
+            expect(formatWithSpaces(1000)).toBe('1 000');
+            expect(formatWithSpaces(1234567)).toBe('1 234 567');
+            expect(formatWithSpaces('987654321')).toBe('987 654 321');
+        });
+
+        it('handles zero correctly', () => {
+            expect(formatWithSpaces(0)).toBe('0');
+            expect(formatWithSpaces('0')).toBe('0');
+        });
+
+        it('preserves fractional parts without rounding', () => {
+            expect(formatWithSpaces(1234.5678)).toBe('1 234.5678');
+            expect(formatWithSpaces('9876.54321')).toBe('9 876.54321');
+        });
+
+        it('returns empty string for invalid numeric strings', () => {
+            expect(formatWithSpaces('abc')).toBe('');
+            expect(formatWithSpaces('12a')).toBe('');
+            expect(formatWithSpaces('NaN')).toBe('');
+        });
     });
 
-    it('leaves strings without dot unchanged', () => {
-        expect(formatNumberDecimalComma('1000')).toBe('1000');
+    describe('formatNumberInput', () => {
+        it('formats strings with only digits', () => {
+            expect(formatNumberInput('1234')).toBe('1 234');
+            expect(formatNumberInput('1234567')).toBe('1 234 567');
+        });
+
+        it('removes non-digit characters before formatting', () => {
+            expect(formatNumberInput('12a34')).toBe('1 234');
+            expect(formatNumberInput('12 34')).toBe('1 234');
+            expect(formatNumberInput('a-1b.2_3')).toBe('123');
+        });
+
+        it('returns empty string if input contains no digits or is empty', () => {
+            expect(formatNumberInput('')).toBe('');
+            expect(formatNumberInput('abc')).toBe('');
+            expect(formatNumberInput('!@#$')).toBe('');
+        });
     });
 });

--- a/src/utils/functions/formatters/format-number.ts
+++ b/src/utils/functions/formatters/format-number.ts
@@ -5,3 +5,16 @@ export const formatNumberDecimalComma = (value: number | string | null | undefin
 
     return String(value).replace('.', ',');
 };
+
+export const formatWithSpaces = (value: number | string): string => {
+    const num = Number(value);
+
+    if (Number.isNaN(num)) return '';
+
+    return new Intl.NumberFormat('en-US', { maximumFractionDigits: 20 }).format(num).replace(/,/g, ' ');
+};
+
+export const formatNumberInput = (inputValue: string): string => {
+    const digits = inputValue.replace(/\D/g, '');
+    return digits ? formatWithSpaces(digits) : '';
+};

--- a/src/utils/functions/mappers/admin/main-page/main-page-mappers.test.ts
+++ b/src/utils/functions/mappers/admin/main-page/main-page-mappers.test.ts
@@ -2,7 +2,6 @@ import {
     MAIN_PAGE_FORM_DEFAULTS,
     MainPage,
     MainPageFormValues,
-    Metric,
     MetricPrefix,
     MetricType,
 } from '@/types/admin/main-page';
@@ -11,13 +10,7 @@ import {
     mapEntityWithLocalizations,
     mapLocalizationDtoToModel,
 } from '@/utils/functions/mappers/common/localization/localization-mappers';
-import {
-    mapFormValuesToMainPagePatch,
-    mapMainPageToFormValues,
-    mapMetricsWithResolvedPrefix,
-    resolvePrefix,
-    serializePrefix,
-} from './main-page-mappers';
+import { mapFormValuesToMainPagePatch, mapMainPageToFormValues } from './main-page-mappers';
 
 describe('main-page-mappers', () => {
     const languages: LocalizationLanguage[] = [
@@ -114,9 +107,7 @@ describe('main-page-mappers', () => {
 
         it('handles null/empty MainPage fields gracefully with defaults', () => {
             const emptyPage: MainPage = {} as any;
-
             const result = mapMainPageToFormValues(emptyPage, languages);
-
             expect(result).toEqual(MAIN_PAGE_FORM_DEFAULTS);
         });
 
@@ -127,7 +118,6 @@ describe('main-page-mappers', () => {
             } as any;
 
             const result = mapMainPageToFormValues(page, []);
-
             expect(result.titleEn).toBe('UA Title');
         });
     });
@@ -203,7 +193,7 @@ describe('main-page-mappers', () => {
                 value: 100,
                 name: 'UA Metric',
                 type: MetricType.Partners,
-                prefix: 1,
+                prefix: 1, // MetricPrefix.Plus is 1
                 localization: undefined,
             });
 
@@ -222,55 +212,6 @@ describe('main-page-mappers', () => {
 
             expect(patch.impactStatistics?.metrics).toEqual([]);
             expect(patch.impactStatistics?.id).toBeUndefined();
-        });
-    });
-
-    describe('prefix helpers', () => {
-        it('resolvePrefix normalizes numeric and enum values', () => {
-            expect(resolvePrefix(MetricPrefix.Plus)).toBe(MetricPrefix.Plus);
-            expect(resolvePrefix(1 as any)).toBe(MetricPrefix.Plus);
-            expect(resolvePrefix(2 as any)).toBe(MetricPrefix.Percent);
-            expect(resolvePrefix(null)).toBe(MetricPrefix.None);
-            expect(resolvePrefix(undefined)).toBe(MetricPrefix.None);
-            expect(resolvePrefix(99 as any)).toBe(MetricPrefix.None);
-        });
-
-        it('serializePrefix maps enum and numeric values to backend codes', () => {
-            expect(serializePrefix(null)).toBeNull();
-            expect(serializePrefix(MetricPrefix.None)).toBe(0);
-            expect(serializePrefix(MetricPrefix.Plus)).toBe(1);
-            expect(serializePrefix(MetricPrefix.Percent)).toBe(2);
-            expect(serializePrefix(1 as any)).toBe(1);
-        });
-
-        it('mapMetricsWithResolvedPrefix normalizes metric prefixes', () => {
-            const metrics: Metric[] = [
-                {
-                    id: 1,
-                    name: 'Metric 1',
-                    value: 10,
-                    type: MetricType.Partners,
-                    prefix: 1 as any,
-                    isHidden: false,
-                    priority: 1,
-                    localizations: [],
-                },
-                {
-                    id: 2,
-                    name: 'Metric 2',
-                    value: 20,
-                    type: MetricType.Programs,
-                    prefix: null,
-                    isHidden: false,
-                    priority: 2,
-                    localizations: [],
-                },
-            ];
-
-            const result = mapMetricsWithResolvedPrefix(metrics);
-
-            expect(result[0].prefix).toBe(MetricPrefix.Plus);
-            expect(result[1].prefix).toBe(MetricPrefix.None);
         });
     });
 });

--- a/src/utils/functions/mappers/admin/main-page/main-page-mappers.test.ts
+++ b/src/utils/functions/mappers/admin/main-page/main-page-mappers.test.ts
@@ -2,6 +2,7 @@ import {
     MAIN_PAGE_FORM_DEFAULTS,
     MainPage,
     MainPageFormValues,
+    Metric,
     MetricPrefix,
     MetricType,
 } from '@/types/admin/main-page';
@@ -10,7 +11,13 @@ import {
     mapEntityWithLocalizations,
     mapLocalizationDtoToModel,
 } from '@/utils/functions/mappers/common/localization/localization-mappers';
-import { mapFormValuesToMainPagePatch, mapMainPageToFormValues } from './main-page-mappers';
+import {
+    mapFormValuesToMainPagePatch,
+    mapMainPageToFormValues,
+    mapMetricsWithResolvedPrefix,
+    resolvePrefix,
+    serializePrefix,
+} from './main-page-mappers';
 
 describe('main-page-mappers', () => {
     const languages: LocalizationLanguage[] = [
@@ -196,11 +203,11 @@ describe('main-page-mappers', () => {
                 value: 100,
                 name: 'UA Metric',
                 type: MetricType.Partners,
-                prefix: MetricPrefix.Plus,
-                localizations: [{ languageId: 2, name: 'EN Metric' }],
+                prefix: 1,
+                localization: undefined,
             });
 
-            expect(metrics?.[1].localizations).toBeUndefined();
+            expect(metrics?.[1].localization).toBeUndefined();
         });
 
         it('handles missing languages array and null originalPage', () => {
@@ -215,6 +222,55 @@ describe('main-page-mappers', () => {
 
             expect(patch.impactStatistics?.metrics).toEqual([]);
             expect(patch.impactStatistics?.id).toBeUndefined();
+        });
+    });
+
+    describe('prefix helpers', () => {
+        it('resolvePrefix normalizes numeric and enum values', () => {
+            expect(resolvePrefix(MetricPrefix.Plus)).toBe(MetricPrefix.Plus);
+            expect(resolvePrefix(1 as any)).toBe(MetricPrefix.Plus);
+            expect(resolvePrefix(2 as any)).toBe(MetricPrefix.Percent);
+            expect(resolvePrefix(null)).toBe(MetricPrefix.None);
+            expect(resolvePrefix(undefined)).toBe(MetricPrefix.None);
+            expect(resolvePrefix(99 as any)).toBe(MetricPrefix.None);
+        });
+
+        it('serializePrefix maps enum and numeric values to backend codes', () => {
+            expect(serializePrefix(null)).toBeNull();
+            expect(serializePrefix(MetricPrefix.None)).toBe(0);
+            expect(serializePrefix(MetricPrefix.Plus)).toBe(1);
+            expect(serializePrefix(MetricPrefix.Percent)).toBe(2);
+            expect(serializePrefix(1 as any)).toBe(1);
+        });
+
+        it('mapMetricsWithResolvedPrefix normalizes metric prefixes', () => {
+            const metrics: Metric[] = [
+                {
+                    id: 1,
+                    name: 'Metric 1',
+                    value: 10,
+                    type: MetricType.Partners,
+                    prefix: 1 as any,
+                    isHidden: false,
+                    priority: 1,
+                    localizations: [],
+                },
+                {
+                    id: 2,
+                    name: 'Metric 2',
+                    value: 20,
+                    type: MetricType.Programs,
+                    prefix: null,
+                    isHidden: false,
+                    priority: 2,
+                    localizations: [],
+                },
+            ];
+
+            const result = mapMetricsWithResolvedPrefix(metrics);
+
+            expect(result[0].prefix).toBe(MetricPrefix.Plus);
+            expect(result[1].prefix).toBe(MetricPrefix.None);
         });
     });
 });

--- a/src/utils/functions/mappers/admin/main-page/main-page-mappers.ts
+++ b/src/utils/functions/mappers/admin/main-page/main-page-mappers.ts
@@ -2,6 +2,7 @@ import {
     MAIN_PAGE_FORM_DEFAULTS,
     MainPage,
     MainPageFormValues,
+    Metric,
     MetricPrefix,
     UpdateMainPageDto,
     UpdateMetricDto,
@@ -34,6 +35,13 @@ export const serializePrefix = (prefix: MetricPrefix | null | undefined): number
     if (prefix == null) return null;
     const resolved = resolvePrefix(prefix);
     return PREFIX_TO_NUMERIC[resolved] ?? 0;
+};
+
+export const mapMetricsWithResolvedPrefix = (metrics: Metric[] = []): Metric[] => {
+    return metrics.map((metric) => ({
+        ...metric,
+        prefix: resolvePrefix(metric.prefix),
+    }));
 };
 
 export function mapMainPageToFormValues(page: MainPage, languages?: LocalizationLanguage[]): MainPageFormValues {

--- a/src/utils/functions/mappers/admin/main-page/main-page-mappers.ts
+++ b/src/utils/functions/mappers/admin/main-page/main-page-mappers.ts
@@ -18,10 +18,22 @@ const NUMERIC_TO_PREFIX: Record<number, MetricPrefix> = {
     2: MetricPrefix.Percent,
 };
 
+const PREFIX_TO_NUMERIC: Record<MetricPrefix, number> = {
+    [MetricPrefix.None]: 0,
+    [MetricPrefix.Plus]: 1,
+    [MetricPrefix.Percent]: 2,
+};
+
 export const resolvePrefix = (prefix: MetricPrefix | null | undefined): MetricPrefix => {
     if (prefix == null) return MetricPrefix.None;
     if (Object.values(MetricPrefix).includes(prefix as MetricPrefix)) return prefix as MetricPrefix;
     return NUMERIC_TO_PREFIX[Number(prefix)] ?? MetricPrefix.None;
+};
+
+export const serializePrefix = (prefix: MetricPrefix | null | undefined): number | null => {
+    if (prefix == null) return null;
+    const resolved = resolvePrefix(prefix);
+    return PREFIX_TO_NUMERIC[resolved] ?? 0;
 };
 
 export function mapMainPageToFormValues(page: MainPage, languages?: LocalizationLanguage[]): MainPageFormValues {
@@ -99,26 +111,20 @@ export function mapFormValuesToMainPagePatch(
     const statTitleUk = str(formValues.statisticsTitleUa);
     const statTitleEn = str(formValues.statisticsTitleEn);
 
-    const existingMetrics = currentMetrics ?? originalPage?.impactStatistics?.metrics ?? [];
+    const existingMetrics = currentMetrics?.length ? currentMetrics : (originalPage?.impactStatistics?.metrics ?? []);
 
     const safeMetricsPayload: UpdateMetricDto[] = existingMetrics.map((m) => {
-        const enLoc = m.localizations?.find((l) => resolveLocaleCode(l as any, languages) === 'en');
+        const enLoc = m.localizations?.find((l) =>
+            enLanguageId ? l.languageId === enLanguageId : resolveLocaleCode(l as any, languages) === 'en',
+        );
 
         return {
             id: m.id,
             value: m.value,
             name: m.name,
             type: m.type,
-            prefix: resolvePrefix(m.prefix),
-            localizations:
-                enLanguageId && enLoc
-                    ? [
-                          {
-                              languageId: enLanguageId,
-                              name: enLoc.name,
-                          },
-                      ]
-                    : undefined,
+            prefix: serializePrefix(m.prefix) as any,
+            localization: enLanguageId && enLoc ? { languageId: enLanguageId, name: enLoc.name } : undefined,
         } as UpdateMetricDto;
     });
 

--- a/src/utils/functions/mappers/admin/main-page/main-page-mappers.ts
+++ b/src/utils/functions/mappers/admin/main-page/main-page-mappers.ts
@@ -2,8 +2,6 @@ import {
     MAIN_PAGE_FORM_DEFAULTS,
     MainPage,
     MainPageFormValues,
-    Metric,
-    MetricPrefix,
     UpdateMainPageDto,
     UpdateMetricDto,
 } from '@/types/admin/main-page';
@@ -12,37 +10,6 @@ import {
     getLanguageIdByCode,
     resolveLocaleCode,
 } from '@/utils/functions/mappers/common/localization/localization-mappers';
-
-const NUMERIC_TO_PREFIX: Record<number, MetricPrefix> = {
-    0: MetricPrefix.None,
-    1: MetricPrefix.Plus,
-    2: MetricPrefix.Percent,
-};
-
-const PREFIX_TO_NUMERIC: Record<MetricPrefix, number> = {
-    [MetricPrefix.None]: 0,
-    [MetricPrefix.Plus]: 1,
-    [MetricPrefix.Percent]: 2,
-};
-
-export const resolvePrefix = (prefix: MetricPrefix | null | undefined): MetricPrefix => {
-    if (prefix == null) return MetricPrefix.None;
-    if (Object.values(MetricPrefix).includes(prefix as MetricPrefix)) return prefix as MetricPrefix;
-    return NUMERIC_TO_PREFIX[Number(prefix)] ?? MetricPrefix.None;
-};
-
-export const serializePrefix = (prefix: MetricPrefix | null | undefined): number | null => {
-    if (prefix == null) return null;
-    const resolved = resolvePrefix(prefix);
-    return PREFIX_TO_NUMERIC[resolved] ?? 0;
-};
-
-export const mapMetricsWithResolvedPrefix = (metrics: Metric[] = []): Metric[] => {
-    return metrics.map((metric) => ({
-        ...metric,
-        prefix: resolvePrefix(metric.prefix),
-    }));
-};
 
 export function mapMainPageToFormValues(page: MainPage, languages?: LocalizationLanguage[]): MainPageFormValues {
     const pageLocalizations = page.localizations ?? [];
@@ -131,7 +98,7 @@ export function mapFormValuesToMainPagePatch(
             value: m.value,
             name: m.name,
             type: m.type,
-            prefix: serializePrefix(m.prefix) as any,
+            prefix: m.prefix,
             localization: enLanguageId && enLoc ? { languageId: enLanguageId, name: enLoc.name } : undefined,
         } as UpdateMetricDto;
     });

--- a/src/utils/functions/mappers/admin/main-page/main-page-mappers.ts
+++ b/src/utils/functions/mappers/admin/main-page/main-page-mappers.ts
@@ -2,6 +2,7 @@ import {
     MAIN_PAGE_FORM_DEFAULTS,
     MainPage,
     MainPageFormValues,
+    MetricPrefix,
     UpdateMainPageDto,
     UpdateMetricDto,
 } from '@/types/admin/main-page';
@@ -10,6 +11,18 @@ import {
     getLanguageIdByCode,
     resolveLocaleCode,
 } from '@/utils/functions/mappers/common/localization/localization-mappers';
+
+const NUMERIC_TO_PREFIX: Record<number, MetricPrefix> = {
+    0: MetricPrefix.None,
+    1: MetricPrefix.Plus,
+    2: MetricPrefix.Percent,
+};
+
+export const resolvePrefix = (prefix: MetricPrefix | null | undefined): MetricPrefix => {
+    if (prefix == null) return MetricPrefix.None;
+    if (Object.values(MetricPrefix).includes(prefix as MetricPrefix)) return prefix as MetricPrefix;
+    return NUMERIC_TO_PREFIX[Number(prefix)] ?? MetricPrefix.None;
+};
 
 export function mapMainPageToFormValues(page: MainPage, languages?: LocalizationLanguage[]): MainPageFormValues {
     const pageLocalizations = page.localizations ?? [];
@@ -55,6 +68,9 @@ export function mapFormValuesToMainPagePatch(
     formValues: MainPageFormValues,
     originalPage: MainPage | null,
     languages?: LocalizationLanguage[],
+    currentMetrics?: MainPage['impactStatistics'] extends null | undefined
+        ? never
+        : NonNullable<MainPage['impactStatistics']>['metrics'],
 ): UpdateMainPageDto {
     const ukLanguageId = getLanguageIdByCode(languages, 'uk');
     const enLanguageId = getLanguageIdByCode(languages, 'en');
@@ -83,19 +99,19 @@ export function mapFormValuesToMainPagePatch(
     const statTitleUk = str(formValues.statisticsTitleUa);
     const statTitleEn = str(formValues.statisticsTitleEn);
 
-    const existingMetrics = originalPage?.impactStatistics?.metrics ?? [];
+    const existingMetrics = currentMetrics ?? originalPage?.impactStatistics?.metrics ?? [];
+
     const safeMetricsPayload: UpdateMetricDto[] = existingMetrics.map((m) => {
         const enLoc = m.localizations?.find((l) => resolveLocaleCode(l as any, languages) === 'en');
-        const canHaveLocalization = true;
 
         return {
             id: m.id,
             value: m.value,
             name: m.name,
             type: m.type,
-            prefix: m.prefix,
+            prefix: resolvePrefix(m.prefix),
             localizations:
-                canHaveLocalization && enLanguageId && enLoc
+                enLanguageId && enLoc
                     ? [
                           {
                               languageId: enLanguageId,

--- a/src/validation/admin/main-page-schema/main-page-schema.ts
+++ b/src/validation/admin/main-page-schema/main-page-schema.ts
@@ -50,6 +50,7 @@ export const MainPageValidationSchema: Yup.ObjectSchema<MainPageFormValues> = Yu
     statisticsTitleUa: buildStringValidation(MAIN_PAGE_VALIDATION.statisticsBlock.title),
     statisticsTitleEn: buildStringValidation(MAIN_PAGE_VALIDATION.statisticsBlock.title),
     statisticsImage: imageSchema,
+    metrics: Yup.array().optional(),
 });
 
 export const MAIN_PAGE_VALIDATION_FUNCTIONS = {

--- a/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.test.ts
+++ b/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.test.ts
@@ -1,0 +1,52 @@
+import { MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
+import { MetricPrefix } from '@/types/admin/main-page';
+
+import { metricEditSchema } from './metric-edit-schema';
+
+describe('metricEditSchema', () => {
+    const validPayload = {
+        nameUa: 'Назва UA',
+        nameEn: 'Name EN',
+        value: '1 000',
+        prefix: MetricPrefix.Plus,
+    };
+
+    it('accepts valid payload', async () => {
+        await expect(metricEditSchema.validate(validPayload)).resolves.toEqual(validPayload);
+    });
+
+    it('requires nameUa', async () => {
+        await expect(metricEditSchema.validate({ ...validPayload, nameUa: '' })).rejects.toThrow(
+            MAIN_PAGE_VALIDATION.common.REQUIRED,
+        );
+    });
+
+    it('requires nameEn', async () => {
+        await expect(metricEditSchema.validate({ ...validPayload, nameEn: '' })).rejects.toThrow(
+            MAIN_PAGE_VALIDATION.common.REQUIRED,
+        );
+    });
+
+    it('enforces min/max name length', async () => {
+        const tooShort = 'a'.repeat(MAIN_PAGE_VALIDATION.editPanel.name.min - 1);
+        const tooLong = 'a'.repeat(MAIN_PAGE_VALIDATION.editPanel.name.max + 1);
+
+        await expect(metricEditSchema.validate({ ...validPayload, nameUa: tooShort })).rejects.toThrow(
+            MAIN_PAGE_VALIDATION.editPanel.name.getMinError(),
+        );
+
+        await expect(metricEditSchema.validate({ ...validPayload, nameEn: tooLong })).rejects.toThrow(
+            MAIN_PAGE_VALIDATION.editPanel.name.getMaxError(),
+        );
+    });
+
+    it('requires positive value', async () => {
+        await expect(metricEditSchema.validate({ ...validPayload, value: '0' })).rejects.toThrow(
+            MAIN_PAGE_VALIDATION.common.REQUIRED,
+        );
+    });
+
+    it('requires prefix', async () => {
+        await expect(metricEditSchema.validate({ ...validPayload, prefix: undefined })).rejects.toThrow();
+    });
+});

--- a/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.ts
+++ b/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.ts
@@ -18,7 +18,7 @@ export const metricEditSchema = Yup.object({
     value: Yup.string()
         .required(MAIN_PAGE_VALIDATION.common.REQUIRED)
         .test('is-positive', MAIN_PAGE_VALIDATION.common.REQUIRED, (val) => parseThousands(val || '') > 0),
-    prefix: Yup.mixed<MetricPrefix>().required(),
+    prefix: Yup.mixed<MetricPrefix>().required(MAIN_PAGE_VALIDATION.common.REQUIRED),
 });
 
 export type MetricFormValues = Yup.InferType<typeof metricEditSchema>;

--- a/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.ts
+++ b/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.ts
@@ -1,0 +1,24 @@
+import { MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
+import { MetricPrefix } from '@/types/admin/main-page';
+import * as Yup from 'yup';
+
+const parseThousands = (value: string): number => {
+    return parseInt((value || '').replace(/\s/g, ''), 10) || 0;
+};
+
+export const metricEditSchema = Yup.object({
+    nameUa: Yup.string()
+        .required(MAIN_PAGE_VALIDATION.common.REQUIRED)
+        .min(MAIN_PAGE_VALIDATION.editPanel.name.min, MAIN_PAGE_VALIDATION.editPanel.name.getMinError())
+        .max(MAIN_PAGE_VALIDATION.editPanel.name.max, MAIN_PAGE_VALIDATION.editPanel.name.getMaxError()),
+    nameEn: Yup.string()
+        .required(MAIN_PAGE_VALIDATION.common.REQUIRED)
+        .min(MAIN_PAGE_VALIDATION.editPanel.name.min, MAIN_PAGE_VALIDATION.editPanel.name.getMinError())
+        .max(MAIN_PAGE_VALIDATION.editPanel.name.max, MAIN_PAGE_VALIDATION.editPanel.name.getMaxError()),
+    value: Yup.string()
+        .required(MAIN_PAGE_VALIDATION.common.REQUIRED)
+        .test('is-positive', MAIN_PAGE_VALIDATION.common.REQUIRED, (val) => parseThousands(val || '') > 0),
+    prefix: Yup.mixed<MetricPrefix>().required(),
+});
+
+export type MetricFormValues = Yup.InferType<typeof metricEditSchema>;


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2365
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2367
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2405

## Description

An inline editing panel for standard metrics has been added, allowing users to quickly update the name, value and prefix with validation. A feature to undo changes has been implemented, with confirmation and the option to revert to previous values. A feature to save changes has been added, with a refreshed UI and the activation of the “Publish” button.

## How it looks

https://github.com/user-attachments/assets/94f97914-9339-4b26-a526-55bb7162f6d4

## Summary of change

- Inline edit panel for standard metrics (name, value, prefix).
- Validation of data entered in the edit panel.
- Undo flow: confirmation pop-up, reverting values, different behaviour depending on whether changes have been made or not.
- Save flow: save, UI update after saving, activation of ‘Publish’.
- Updated states of UI elements in edit mode.

## How to recreate changes

1. Log in to the admin panel, go to the Mainpage, Statistics section. (`/admin-panel/main`)
2. Open inline editing for the metric.
3. Change the name/value/prefix and check the validation.
4. Click ‘Cancel’:
   - if there are changes - check the confirmation pop-up and revert;
   - if there are no changes - check that it closes without a pop-up.
5. Click ‘Save’ and check that the UI has updated and the ‘Publish’ button is active.
6. Open inline editing for Raised metric.
7. Ensure there's no implementation. (Will be implemented in future PR)


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metric editing UI with form fields for metric names, values, and prefix options
  * New Cancel and Save action buttons for managing edits
  * Metric name validation enforcing 2-20 character limits

* **Bug Fixes**
  * Improved error handling for failed metric operations with toast notifications

* **Refactor**
  * Updated form data structures to support metrics array management
  * Refined metric prefix and type handling in the data layer

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ita-social-projects/VictoryCenter-Client/pull/407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->