### PR TITLE
fix/issue-2409 [Single Program] Template layout issues: misaligned fields... fix/issue-2500 [Single Program][UI] Multiple UI inconsistencies in Frame 633433... fix/issue-2501 [Single Program] [UI] Title field border misalignment...

### DIFF
--- a/src/assets/icons/arrow-left.svg
+++ b/src/assets/icons/arrow-left.svg
@@ -1,3 +1,3 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 19L5 12M5 12L12 5M5 12H19" stroke="#061125" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="round"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+	<path d="M19 12H5M12 5L5 12L12 19" stroke="#FDFDFB" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="round"/>
 </svg>

--- a/src/assets/icons/arrow-right.svg
+++ b/src/assets/icons/arrow-right.svg
@@ -1,3 +1,3 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M5 12H19M19 12L12 5M19 12L12 19" stroke="#061125" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="round"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+	<path d="M5 12H19M12 19L19 12L12 5" stroke="#FDFDFB" stroke-width="1.5" stroke-linecap="square" stroke-linejoin="round"/>
 </svg>

--- a/src/components/admin/input-groups/input-group.scss
+++ b/src/components/admin/input-groups/input-group.scss
@@ -2,5 +2,5 @@
     position: relative;
     display: flex;
     flex-direction: column;
-    gap: 0.375rem;
+    gap: 8px;
 }

--- a/src/components/admin/input-label/InputLabel.scss
+++ b/src/components/admin/input-label/InputLabel.scss
@@ -3,6 +3,7 @@
 .input-label {
     color: colors.$grey-900;
     font-size: 16px;
+    height: 24px;
 
     .required-field {
         color: colors.$error;

--- a/src/components/common/section-templates/single-title-description-author-pairs/SingleTitleDescriptionAuthorPairs.module.scss
+++ b/src/components/common/section-templates/single-title-description-author-pairs/SingleTitleDescriptionAuthorPairs.module.scss
@@ -14,7 +14,7 @@
     --pair-card-width: 432px;
     --pair-card-height: 259px;
 
-    --gap: 24px;
+    --gap: 16px;
     --peek: 0.55;
 
     --carousel-max-width: calc(
@@ -22,7 +22,7 @@
     );
 
     @media (min-width: 560px) {
-        padding: 64px 0px 64px 64px;
+        padding: 64px 0px 64px 0;
     }
 }
 
@@ -39,7 +39,7 @@
 }
 
 .editable {
-    padding: 64px clamp(16px, 3vw, 0px);
+    padding: 64px 0 64px 0;
     box-sizing: border-box;
 
     --pair-card-width: 432px;
@@ -47,7 +47,7 @@
 }
 
 .title-block {
-    margin-bottom: 24px;
+    margin-bottom: 18px;
 }
 
 .container:not(.editable) .title-block {
@@ -58,6 +58,7 @@
     @include type.h3-bold;
     color: c.$blue-900;
     text-transform: uppercase;
+    padding-left: 56px;
 }
 
 .template .title {
@@ -66,7 +67,7 @@
 
 .title-input-group {
     width: 721px;
-    margin-left: 50px;
+    margin-left: 56px;
     margin-bottom: 50px;
 
     :global(.char-limit-textarea) {

--- a/src/components/common/section-templates/single-title-description-author-pairs/card-carousel/CardCarousel.module.scss
+++ b/src/components/common/section-templates/single-title-description-author-pairs/card-carousel/CardCarousel.module.scss
@@ -31,4 +31,6 @@
     align-items: stretch;
     width: max-content;
     padding-bottom: 2px;
+    padding-left: 56px;
+    padding-right: 56px;
 }

--- a/src/components/common/section-templates/single-title-description-author-pairs/card-carousel/CardCarousel.test.tsx
+++ b/src/components/common/section-templates/single-title-description-author-pairs/card-carousel/CardCarousel.test.tsx
@@ -145,7 +145,7 @@ describe('CardCarousel', () => {
         const { viewport } = setup();
 
         const scrollToMock = jest.fn();
-        (viewport as any).scrollTo = scrollToMock;
+        viewport.scrollTo = scrollToMock;
 
         const firstCard = viewport.querySelector('.track > *');
         if (firstCard) {
@@ -154,7 +154,7 @@ describe('CardCarousel', () => {
 
         const track = viewport.querySelector('.track');
         if (track) {
-            jest.spyOn(window, 'getComputedStyle').mockImplementation((elem) => {
+            jest.spyOn(globalThis, 'getComputedStyle').mockImplementation((elem) => {
                 if (elem === track) return { gap: '5px' } as CSSStyleDeclaration;
                 return {} as CSSStyleDeclaration;
             });
@@ -170,7 +170,7 @@ describe('CardCarousel', () => {
         const { viewport } = setup();
 
         const scrollToMock = jest.fn();
-        (viewport as any).scrollTo = scrollToMock;
+        viewport.scrollTo = scrollToMock;
 
         const firstCard = viewport.querySelector('.track > *');
         if (firstCard) {
@@ -179,7 +179,7 @@ describe('CardCarousel', () => {
 
         const track = viewport.querySelector('.track');
         if (track) {
-            jest.spyOn(window, 'getComputedStyle').mockImplementation((elem) => {
+            jest.spyOn(globalThis, 'getComputedStyle').mockImplementation((elem) => {
                 if (elem === track) return { gap: '5px' } as CSSStyleDeclaration;
                 return {} as CSSStyleDeclaration;
             });
@@ -197,7 +197,7 @@ describe('CardCarousel', () => {
         const { viewport } = setup();
 
         const scrollToMock = jest.fn();
-        (viewport as any).scrollTo = scrollToMock;
+        viewport.scrollTo = scrollToMock;
 
         const firstCard = viewport.querySelector('.track > *');
         if (firstCard) {
@@ -206,7 +206,7 @@ describe('CardCarousel', () => {
 
         const track = viewport.querySelector('.track');
         if (track) {
-            jest.spyOn(window, 'getComputedStyle').mockImplementation((elem) => {
+            jest.spyOn(globalThis, 'getComputedStyle').mockImplementation((elem) => {
                 if (elem === track) return { gap: 'nope' } as CSSStyleDeclaration;
                 return {} as CSSStyleDeclaration;
             });

--- a/src/components/common/section-templates/single-title-description-author-pairs/card-carousel/CardCarousel.test.tsx
+++ b/src/components/common/section-templates/single-title-description-author-pairs/card-carousel/CardCarousel.test.tsx
@@ -48,6 +48,30 @@ const mockCssVars = (vars: Record<string, string>) => {
         }) as any) as any;
 };
 
+const setupScrollMock = (gapValue: string, initialScrollLeft: number) => {
+    const { viewport } = setup();
+
+    const scrollToMock = jest.fn();
+    viewport.scrollTo = scrollToMock;
+
+    const firstCard = viewport.querySelector('.track > *');
+    if (firstCard) {
+        firstCard.getBoundingClientRect = jest.fn(() => ({ width: 10 }) as DOMRect);
+    }
+
+    const track = viewport.querySelector('.track');
+    if (track) {
+        jest.spyOn(globalThis, 'getComputedStyle').mockImplementation((elem) => {
+            if (elem === track) return { gap: gapValue } as CSSStyleDeclaration;
+            return {} as CSSStyleDeclaration;
+        });
+    }
+
+    sync(viewport, { scrollLeft: initialScrollLeft, clientWidth: 100, scrollWidth: 200 });
+
+    return { scrollToMock };
+};
+
 const setup = (props: Partial<React.ComponentProps<typeof CardCarousel>> = {}) => {
     mockNavButton.mockClear();
 
@@ -93,6 +117,7 @@ describe('CardCarousel', () => {
         window.getComputedStyle = originalGetComputedStyle;
         window.requestAnimationFrame = originalRaf;
         mockNavButton.mockClear();
+        jest.restoreAllMocks();
     });
 
     it('renders children', () => {
@@ -142,82 +167,27 @@ describe('CardCarousel', () => {
     });
 
     it('scrolls forward on right click', () => {
-        const { viewport } = setup();
+        const { scrollToMock } = setupScrollMock('5px', 0);
 
-        const scrollToMock = jest.fn();
-        viewport.scrollTo = scrollToMock;
-
-        const firstCard = viewport.querySelector('.track > *');
-        if (firstCard) {
-            firstCard.getBoundingClientRect = jest.fn(() => ({ width: 10 }) as DOMRect);
-        }
-
-        const track = viewport.querySelector('.track');
-        if (track) {
-            jest.spyOn(globalThis, 'getComputedStyle').mockImplementation((elem) => {
-                if (elem === track) return { gap: '5px' } as CSSStyleDeclaration;
-                return {} as CSSStyleDeclaration;
-            });
-        }
-
-        sync(viewport, { scrollLeft: 0, clientWidth: 100, scrollWidth: 200 });
         fireEvent.click(screen.getByTestId('nav-right'));
 
         expect(scrollToMock).toHaveBeenCalledWith({ left: 15, behavior: 'smooth' });
     });
 
     it('scrolls backward on left click', () => {
-        const { viewport } = setup();
+        const { scrollToMock } = setupScrollMock('5px', 50);
 
-        const scrollToMock = jest.fn();
-        viewport.scrollTo = scrollToMock;
-
-        const firstCard = viewport.querySelector('.track > *');
-        if (firstCard) {
-            firstCard.getBoundingClientRect = jest.fn(() => ({ width: 10 }) as DOMRect);
-        }
-
-        const track = viewport.querySelector('.track');
-        if (track) {
-            jest.spyOn(globalThis, 'getComputedStyle').mockImplementation((elem) => {
-                if (elem === track) return { gap: '5px' } as CSSStyleDeclaration;
-                return {} as CSSStyleDeclaration;
-            });
-        }
-
-        sync(viewport, { scrollLeft: 50, clientWidth: 100, scrollWidth: 200 });
         fireEvent.click(screen.getByTestId('nav-left'));
 
         expect(scrollToMock).toHaveBeenCalledWith({ left: 30, behavior: 'smooth' });
-
-        jest.restoreAllMocks();
     });
 
     it('uses 0 for gap when css gap is invalid or missing', () => {
-        const { viewport } = setup();
+        const { scrollToMock } = setupScrollMock('nope', 0);
 
-        const scrollToMock = jest.fn();
-        viewport.scrollTo = scrollToMock;
-
-        const firstCard = viewport.querySelector('.track > *');
-        if (firstCard) {
-            firstCard.getBoundingClientRect = jest.fn(() => ({ width: 10 }) as DOMRect);
-        }
-
-        const track = viewport.querySelector('.track');
-        if (track) {
-            jest.spyOn(globalThis, 'getComputedStyle').mockImplementation((elem) => {
-                if (elem === track) return { gap: 'nope' } as CSSStyleDeclaration;
-                return {} as CSSStyleDeclaration;
-            });
-        }
-
-        sync(viewport, { scrollLeft: 0, clientWidth: 100, scrollWidth: 200 });
         fireEvent.click(screen.getByTestId('nav-right'));
 
         expect(scrollToMock).toHaveBeenCalledWith({ left: 10, behavior: 'smooth' });
-
-        jest.restoreAllMocks();
     });
 
     it('updates nav on window resize', () => {

--- a/src/components/common/section-templates/single-title-description-author-pairs/card-carousel/CardCarousel.test.tsx
+++ b/src/components/common/section-templates/single-title-description-author-pairs/card-carousel/CardCarousel.test.tsx
@@ -144,43 +144,80 @@ describe('CardCarousel', () => {
     it('scrolls forward on right click', () => {
         const { viewport } = setup();
 
-        const scrollBy = jest.fn();
-        (viewport as any).scrollBy = scrollBy;
+        const scrollToMock = jest.fn();
+        (viewport as any).scrollTo = scrollToMock;
 
-        mockCssVars({ '--pair-card-width': '10px', '--gap': '5px' });
+        const firstCard = viewport.querySelector('.track > *');
+        if (firstCard) {
+            firstCard.getBoundingClientRect = jest.fn(() => ({ width: 10 }) as DOMRect);
+        }
+
+        const track = viewport.querySelector('.track');
+        if (track) {
+            jest.spyOn(window, 'getComputedStyle').mockImplementation((elem) => {
+                if (elem === track) return { gap: '5px' } as CSSStyleDeclaration;
+                return {} as CSSStyleDeclaration;
+            });
+        }
 
         sync(viewport, { scrollLeft: 0, clientWidth: 100, scrollWidth: 200 });
         fireEvent.click(screen.getByTestId('nav-right'));
 
-        expect(scrollBy).toHaveBeenCalledWith({ left: 15, behavior: 'smooth' });
+        expect(scrollToMock).toHaveBeenCalledWith({ left: 15, behavior: 'smooth' });
     });
 
     it('scrolls backward on left click', () => {
         const { viewport } = setup();
 
-        const scrollBy = jest.fn();
-        (viewport as any).scrollBy = scrollBy;
+        const scrollToMock = jest.fn();
+        (viewport as any).scrollTo = scrollToMock;
 
-        mockCssVars({ '--pair-card-width': '10px', '--gap': '5px' });
+        const firstCard = viewport.querySelector('.track > *');
+        if (firstCard) {
+            firstCard.getBoundingClientRect = jest.fn(() => ({ width: 10 }) as DOMRect);
+        }
+
+        const track = viewport.querySelector('.track');
+        if (track) {
+            jest.spyOn(window, 'getComputedStyle').mockImplementation((elem) => {
+                if (elem === track) return { gap: '5px' } as CSSStyleDeclaration;
+                return {} as CSSStyleDeclaration;
+            });
+        }
 
         sync(viewport, { scrollLeft: 50, clientWidth: 100, scrollWidth: 200 });
         fireEvent.click(screen.getByTestId('nav-left'));
 
-        expect(scrollBy).toHaveBeenCalledWith({ left: -15, behavior: 'smooth' });
+        expect(scrollToMock).toHaveBeenCalledWith({ left: 30, behavior: 'smooth' });
+
+        jest.restoreAllMocks();
     });
 
-    it('uses 0 scroll step when css vars are invalid', () => {
+    it('uses 0 for gap when css gap is invalid or missing', () => {
         const { viewport } = setup();
 
-        const scrollBy = jest.fn();
-        (viewport as any).scrollBy = scrollBy;
+        const scrollToMock = jest.fn();
+        (viewport as any).scrollTo = scrollToMock;
 
-        mockCssVars({ '--pair-card-width': 'nope', '--gap': '' });
+        const firstCard = viewport.querySelector('.track > *');
+        if (firstCard) {
+            firstCard.getBoundingClientRect = jest.fn(() => ({ width: 10 }) as DOMRect);
+        }
+
+        const track = viewport.querySelector('.track');
+        if (track) {
+            jest.spyOn(window, 'getComputedStyle').mockImplementation((elem) => {
+                if (elem === track) return { gap: 'nope' } as CSSStyleDeclaration;
+                return {} as CSSStyleDeclaration;
+            });
+        }
 
         sync(viewport, { scrollLeft: 0, clientWidth: 100, scrollWidth: 200 });
         fireEvent.click(screen.getByTestId('nav-right'));
 
-        expect(scrollBy).toHaveBeenCalledWith({ left: 0, behavior: 'smooth' });
+        expect(scrollToMock).toHaveBeenCalledWith({ left: 10, behavior: 'smooth' });
+
+        jest.restoreAllMocks();
     });
 
     it('updates nav on window resize', () => {

--- a/src/components/common/section-templates/single-title-description-author-pairs/card-carousel/CardCarousel.tsx
+++ b/src/components/common/section-templates/single-title-description-author-pairs/card-carousel/CardCarousel.tsx
@@ -16,7 +16,7 @@ export interface CardCarouselProps {
 export const CardCarousel = ({ children, itemsCount, LeftIcon, RightIcon, variant = 'default' }: CardCarouselProps) => {
     const viewportRef = useRef<HTMLDivElement | null>(null);
     const targetScroll = useRef<number | null>(null);
-    const scrollTimeout = useRef<NodeJS.Timeout | null>(null);
+    const scrollTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
     const [canLeft, setCanLeft] = useState(false);
     const [canRight, setCanRight] = useState(false);
 
@@ -24,7 +24,7 @@ export const CardCarousel = ({ children, itemsCount, LeftIcon, RightIcon, varian
         const el = viewportRef.current;
         if (!el) return;
 
-        const left = Math.floor(el.scrollLeft) > 56;
+        const left = Math.floor(el.scrollLeft) > 0;
         const right = Math.ceil(el.scrollLeft + el.clientWidth) < Math.ceil(el.scrollWidth);
 
         setCanLeft((p) => (p === left ? p : left));
@@ -38,7 +38,10 @@ export const CardCarousel = ({ children, itemsCount, LeftIcon, RightIcon, varian
     useEffect(() => {
         const onResize = () => syncNav();
         window.addEventListener('resize', onResize);
-        return () => window.removeEventListener('resize', onResize);
+        return () => {
+            window.removeEventListener('resize', onResize);
+            if (scrollTimeout.current) clearTimeout(scrollTimeout.current);
+        };
     }, [syncNav]);
 
     const scrollByCard = useCallback(

--- a/src/components/common/section-templates/single-title-description-author-pairs/card-carousel/CardCarousel.tsx
+++ b/src/components/common/section-templates/single-title-description-author-pairs/card-carousel/CardCarousel.tsx
@@ -58,12 +58,12 @@ export const CardCarousel = ({ children, itemsCount, LeftIcon, RightIcon, varian
             const cardWidth = firstCard.getBoundingClientRect().width;
 
             const trackStyle = getComputedStyle(track);
-            const gap = parseFloat(trackStyle.gap) || 0;
+            const gap = Number.parseFloat(trackStyle.gap) || 0;
 
             const step = cardWidth + gap;
 
             const maxScroll = el.scrollWidth - el.clientWidth;
-            const currentScroll = targetScroll.current !== null ? targetScroll.current : el.scrollLeft;
+            const currentScroll = targetScroll.current ?? el.scrollLeft;
 
             const currentIndex = Math.round(currentScroll / step);
             let nextScroll = (currentIndex + dir) * step;

--- a/src/components/common/section-templates/single-title-description-author-pairs/card-carousel/CardCarousel.tsx
+++ b/src/components/common/section-templates/single-title-description-author-pairs/card-carousel/CardCarousel.tsx
@@ -13,14 +13,10 @@ export interface CardCarouselProps {
     variant?: 'default' | 'template' | 'editable';
 }
 
-const readPxVar = (cs: CSSStyleDeclaration, name: string) => {
-    const raw = cs.getPropertyValue(name).trim();
-    const value = Number.parseFloat(raw);
-    return Number.isFinite(value) ? value : 0;
-};
-
 export const CardCarousel = ({ children, itemsCount, LeftIcon, RightIcon, variant = 'default' }: CardCarouselProps) => {
     const viewportRef = useRef<HTMLDivElement | null>(null);
+    const targetScroll = useRef<number | null>(null);
+    const scrollTimeout = useRef<NodeJS.Timeout | null>(null);
     const [canLeft, setCanLeft] = useState(false);
     const [canRight, setCanRight] = useState(false);
 
@@ -28,7 +24,7 @@ export const CardCarousel = ({ children, itemsCount, LeftIcon, RightIcon, varian
         const el = viewportRef.current;
         if (!el) return;
 
-        const left = Math.floor(el.scrollLeft) > 0;
+        const left = Math.floor(el.scrollLeft) > 56;
         const right = Math.ceil(el.scrollLeft + el.clientWidth) < Math.ceil(el.scrollWidth);
 
         setCanLeft((p) => (p === left ? p : left));
@@ -50,11 +46,36 @@ export const CardCarousel = ({ children, itemsCount, LeftIcon, RightIcon, varian
             const el = viewportRef.current;
             if (!el) return;
 
-            const cs = getComputedStyle(el);
-            const step = readPxVar(cs, '--pair-card-width') + readPxVar(cs, '--gap');
+            const track = el.firstElementChild as HTMLElement;
+            if (!track) return;
 
-            el.scrollBy({ left: dir * step, behavior: 'smooth' });
+            const firstCard = track.firstElementChild as HTMLElement;
+            if (!firstCard) return;
+
+            const cardWidth = firstCard.getBoundingClientRect().width;
+
+            const trackStyle = getComputedStyle(track);
+            const gap = parseFloat(trackStyle.gap) || 0;
+
+            const step = cardWidth + gap;
+
+            const maxScroll = el.scrollWidth - el.clientWidth;
+            const currentScroll = targetScroll.current !== null ? targetScroll.current : el.scrollLeft;
+
+            const currentIndex = Math.round(currentScroll / step);
+            let nextScroll = (currentIndex + dir) * step;
+
+            if (nextScroll < 0) nextScroll = 0;
+            if (nextScroll > maxScroll) nextScroll = maxScroll;
+
+            targetScroll.current = nextScroll;
+            el.scrollTo({ left: nextScroll, behavior: 'smooth' });
             requestAnimationFrame(syncNav);
+
+            if (scrollTimeout.current) clearTimeout(scrollTimeout.current);
+            scrollTimeout.current = setTimeout(() => {
+                targetScroll.current = null;
+            }, 500);
         },
         [syncNav],
     );

--- a/src/components/common/section-templates/single-title-description-author-pairs/card-carousel/CarouselNavButton/CarouselNavButton.module.scss
+++ b/src/components/common/section-templates/single-title-description-author-pairs/card-carousel/CarouselNavButton/CarouselNavButton.module.scss
@@ -19,8 +19,8 @@
     z-index: 2;
 
     svg {
-        width: 14px;
-        height: 14px;
+        width: 24px;
+        height: 24px;
     }
 
     svg :global(path) {
@@ -29,17 +29,17 @@
 }
 
 .left {
-    left: 0;
+    left: 20px;
 }
 
 .right {
-    right: 0;
+    right: 20px;
 }
 
 .template.left {
-    left: 24px;
+    left: 20px;
 }
 
 .template.right {
-    right: 24px;
+    right: 20px;
 }

--- a/src/components/common/section-templates/single-title-description-author-pairs/description-author-pair-card/DescriptionAuthorPairCard.module.scss
+++ b/src/components/common/section-templates/single-title-description-author-pairs/description-author-pair-card/DescriptionAuthorPairCard.module.scss
@@ -46,7 +46,7 @@ $field-width: 366px;
 .delete-button {
     position: absolute;
     top: 32px;
-    left: calc(34px + #{$field-width} - 24px);
+    left: $field-width + 34px - 24px;
     width: 24px;
     height: 24px;
     border: none;

--- a/src/components/common/section-templates/single-title-description-author-pairs/description-author-pair-card/DescriptionAuthorPairCard.module.scss
+++ b/src/components/common/section-templates/single-title-description-author-pairs/description-author-pair-card/DescriptionAuthorPairCard.module.scss
@@ -6,10 +6,11 @@ $field-width: 366px;
 
 .card {
     width: var(--pair-card-width, 432px);
+    height: var(--pair-card-height, 259px);
     background-color: c.$light-blue-50;
     border-radius: $radius;
     box-sizing: border-box;
-    padding: 24px;
+    padding: 32px;
     display: flex;
     flex-direction: column;
     gap: 16px;
@@ -18,7 +19,7 @@ $field-width: 366px;
 }
 
 .editable {
-    padding: 20px 24px 24px 24px;
+    padding: 64px 32px 24px 34px;
 }
 
 .description {
@@ -44,10 +45,10 @@ $field-width: 366px;
 
 .delete-button {
     position: absolute;
-    top: 12px;
-    right: 12px;
-    width: 32px;
-    height: 32px;
+    top: 32px;
+    left: calc(34px + #{$field-width} - 24px);
+    width: 24px;
+    height: 24px;
     border: none;
     background: transparent;
     display: flex;
@@ -58,8 +59,8 @@ $field-width: 366px;
     --icon-btn-hover-color: #{c.$blue-900};
 
     svg {
-        width: 18px;
-        height: 18.75px;
+        width: 24px;
+        height: 24px;
     }
 }
 


### PR DESCRIPTION
### GitHub ticket
[#2409](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2409)
[#2500](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2500)
[#2501](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2501)

### Summary of issue
The visual layout of the card carousel (`DescriptionAuthorPairCard`) and its control elements needed to be updated to match the design (paddings, icon sizes, positioning). Additionally, the previous carousel scrolling logic relied on hardcoded CSS variables, making it prone to bugs during rapid clicking or when the container was resized.

### Root cause
The carousel step width was calculated by reading CSS variables (`--pair-card-width`), which did not always reflect the actual dimensions of the elements in the DOM. The icon sizes (arrows and delete button) and spacings (`padding`, `gap`) had outdated values and required updating.

### Summary of change
* **Carousel logic (`CardCarousel.tsx`):** Updated the scrolling mechanism. The scroll step is now dynamically calculated based on the actual width of the first card (`getBoundingClientRect`) and the current `gap` from `getComputedStyle`. Added a target scroll mechanism (`targetScroll`) with a timeout to ensure smooth transitions and prevent jittering during rapid consecutive clicks.
* **UI & Styles:**
  * Updated the sizes of the arrow and delete button SVG icons (increased to `24x24`).
  * Adjusted the positioning of the carousel control elements and the delete button within the cards.
  * Tweaked the `padding` and `gap` values in the `SingleTitleDescriptionAuthorPairs`, `DescriptionAuthorPairCard`, and `CardCarousel` components (including adding `56px` side paddings for the carousel track).
  * Minor style fixes in `input-group` (`gap: 8px`) and `InputLabel` (`height: 24px`).

### Testing approach
1. Log in as Admin (or a user with access to pages containing this component).
2. Navigate to the page/form where the `SingleTitleDescriptionAuthorPairs` carousel is used.
3. Visually verify the updated paddings between the cards, the navigation buttons, and the delete button (they should be larger and better aligned).
4. Test the carousel functionality: click the "left" and "right" arrows, including rapidly clicking them several times in a row.
5. Verify that the carousel scrolls smoothly by exactly one card at a time, does not glitch, and correctly disables the arrows at the beginning and end of the list (taking into account the new `56px` paddings).

### CHECK LIST
- [ ] CI passed
- [ ] Code coverage >=95%
- [ ] PR is reviewed manually again (to make sure you have 100% ready code)
- [ ] All reviewers agreed to merge the PR
- [ ] I've checked new feature as logged in and logged out user if needed
- [ ] PR meets all conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined spacing, padding and sizing across input controls, section templates, cards, and carousel elements for improved visual consistency and alignment.
  * Increased carousel nav icon size and adjusted button positioning.

* **Bug Fixes**
  * Improved carousel scrolling logic for more accurate, smooth card-by-card navigation and more reliable scroll bounds handling.

* **Tests**
  * Updated carousel tests to validate the new scrolling behavior and measurement-based offsets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ita-social-projects/VictoryCenter-Client/pull/411?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->