### PR TITLE
Fix/issue-2559 [Programs][Visitor] Layout of Static quote section doesn't correspond to Mock-up

### DIFF
--- a/src/components/public/cta/CtaSection.module.scss
+++ b/src/components/public/cta/CtaSection.module.scss
@@ -17,7 +17,7 @@
     }
 
     @media (min-width: 1440px) {
-        height: 810px;
+        height: 748px;
     }
 }
 
@@ -59,7 +59,7 @@
 
 .description {
     @include type.body-2-medium;
-    margin: auto 0 32px;
+    margin: auto auto 32px;
 
     @media (min-width: 768px) {
         @include type.body-1-medium;
@@ -67,7 +67,7 @@
 
     @media (min-width: 1440px) {
         margin-bottom: 16px;
-        text-wrap: balance;
+        max-width: 656px;
     }
 }
 


### PR DESCRIPTION
## JIRA or Github ticker

#[2559](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2559)

## Description

This PR fixes a layout discrepancy in the "Static quote" section (implemented as the CtaSection component) on the
Program Details page. The implementation was verified against the provided mockup to ensure pixel-perfect height and
correct text wrapping for the description paragraph.

## How to recreate changes

1.  Navigate to any detailed program page (e.g., https://victorycenter.online/programs/koni-likuyut).
2.  Scroll down to the "Хочете підтримати програму?" (CtaSection) at the bottom of the page.
 3.  Inspect the element at a viewport width of `1440px`.
 4.  Observe that the section height is exactly `748px`.
 5.  Observe that the description text wraps into exactly **3 lines**.

 ## CHECK LIST
 - [ ]  New tests was added or existing was modified
 - [ ]  Changes has severe impact on users
 - [ ]  Changes has medium impact on users
 - [x]  Changes has light impact on users
 - [ ]  Test covetage was updated
 - [x]  PR meets all conventions
