### PR TITLE
Feature/issue-2401: [Main] Open inline panel for raised funds metric (bilingual) Statistics block

### DIFF
--- a/src/components/admin/toggle/Toggle.module.scss
+++ b/src/components/admin/toggle/Toggle.module.scss
@@ -1,0 +1,54 @@
+@use '@/assets/sass/variables/colors' as c;
+
+.wrapper {
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+    vertical-align: middle;
+    user-select: none;
+    -webkit-tap-highlight-color: transparent;
+
+    &.disabled {
+        cursor: not-allowed;
+        opacity: 0.6;
+    }
+}
+
+.input {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+    margin: 0;
+}
+
+.track {
+    position: relative;
+    display: inline-block;
+    width: 30px;
+    height: 12px;
+    background-color: c.$grey-700;
+    border-radius: 12px;
+    transition: background-color 0.2s ease-in-out;
+    box-sizing: border-box;
+
+    &.checked {
+        background-color: c.$blue-500;
+
+        .thumb {
+            transform: translateX(15px);
+        }
+    }
+}
+
+.thumb {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 13px;
+    height: 8px;
+    background-color: c.$white;
+    border-radius: 8px;
+    transition: transform 0.2s ease-in-out;
+    box-shadow: 0px 1px 2px rgba(c.$black, 0.1);
+}

--- a/src/components/admin/toggle/Toggle.test.tsx
+++ b/src/components/admin/toggle/Toggle.test.tsx
@@ -1,0 +1,33 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { Toggle } from './Toggle';
+
+describe('Toggle', () => {
+    it('renders checked state correctly', () => {
+        const { rerender } = render(<Toggle checked={true} onChange={jest.fn()} />);
+        expect(screen.getByRole('switch')).toBeChecked();
+
+        rerender(<Toggle checked={false} onChange={jest.fn()} />);
+        expect(screen.getByRole('switch')).not.toBeChecked();
+    });
+
+    it('calls onChange with new value when clicked', () => {
+        const onChangeSpy = jest.fn();
+        render(<Toggle checked={false} onChange={onChangeSpy} />);
+
+        fireEvent.click(screen.getByRole('switch'));
+        expect(onChangeSpy).toHaveBeenCalledWith(true);
+    });
+
+    it('is disabled when disabled prop is true', () => {
+        const onChangeSpy = jest.fn();
+        render(<Toggle checked={false} onChange={onChangeSpy} disabled={true} />);
+
+        const toggle = screen.getByRole('switch');
+        expect(toggle).toBeDisabled();
+
+        fireEvent.click(toggle);
+        expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+});

--- a/src/components/admin/toggle/Toggle.tsx
+++ b/src/components/admin/toggle/Toggle.tsx
@@ -1,0 +1,36 @@
+import { ChangeEvent } from 'react';
+import styles from './Toggle.module.scss';
+
+interface ToggleProps {
+    checked: boolean;
+    onChange: (checked: boolean) => void;
+    disabled?: boolean;
+    id?: string;
+    name?: string;
+    className?: string;
+}
+
+export const Toggle = ({ checked, onChange, disabled = false, id, name, className = '' }: ToggleProps) => {
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+        onChange(e.target.checked);
+    };
+
+    return (
+        <label className={`${styles.wrapper} ${disabled ? styles.disabled : ''} ${className}`} htmlFor={id}>
+            <input
+                id={id}
+                name={name}
+                type="checkbox"
+                className={styles.input}
+                checked={checked}
+                onChange={handleChange}
+                disabled={disabled}
+                role="switch"
+                aria-checked={checked}
+            />
+            <span className={`${styles.track} ${checked ? styles.checked : ''}`}>
+                <span className={styles.thumb} />
+            </span>
+        </label>
+    );
+};

--- a/src/components/admin/toggle/Toggle.tsx
+++ b/src/components/admin/toggle/Toggle.tsx
@@ -8,9 +8,20 @@ interface ToggleProps {
     id?: string;
     name?: string;
     className?: string;
+    ariaLabel?: string;
+    ariaLabelledBy?: string;
 }
 
-export const Toggle = ({ checked, onChange, disabled = false, id, name, className = '' }: ToggleProps) => {
+export const Toggle = ({
+    checked,
+    onChange,
+    disabled = false,
+    id,
+    name,
+    className = '',
+    ariaLabel,
+    ariaLabelledBy,
+}: ToggleProps) => {
     const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
         if (disabled) return;
 
@@ -29,6 +40,8 @@ export const Toggle = ({ checked, onChange, disabled = false, id, name, classNam
                 disabled={disabled}
                 role="switch"
                 aria-checked={checked}
+                aria-label={ariaLabel}
+                aria-labelledby={ariaLabelledBy}
             />
             <span className={`${styles.track} ${checked ? styles.checked : ''}`}>
                 <span className={styles.thumb} />

--- a/src/components/admin/toggle/Toggle.tsx
+++ b/src/components/admin/toggle/Toggle.tsx
@@ -12,6 +12,8 @@ interface ToggleProps {
 
 export const Toggle = ({ checked, onChange, disabled = false, id, name, className = '' }: ToggleProps) => {
     const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+        if (disabled) return;
+
         onChange(e.target.checked);
     };
 

--- a/src/const/admin/main-page.ts
+++ b/src/const/admin/main-page.ts
@@ -127,4 +127,12 @@ export const MAIN_PAGE_VALIDATION = {
             getMaxError: () => COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(20),
         },
     },
+
+    raisedFunds: {
+        REQUIRED: "Поле обов'язкове",
+        ONLY_NUMBERS: 'Дозволено лише цифри',
+        MAX_DIGITS: 'Не більше 9 цифр до коми',
+        NEGATIVE: "Сума не може бути від'ємною",
+        ZERO: 'Сума не може дорівнювати 0',
+    },
 } as const;

--- a/src/const/admin/main-page.ts
+++ b/src/const/admin/main-page.ts
@@ -33,9 +33,13 @@ export const MAIN_PAGE_TEXT = {
             UKR_NAME_LABEL: 'UKR Назва',
             ENG_NAME_LABEL: 'ENG Назва',
             VALUE_LABEL: 'Значення',
+            UAH_VALUE_LABEL: 'UAH Сума коштів',
+            USD_VALUE_LABEL: 'USD Сума коштів',
             PREFIX_LABEL: 'Префікс',
             CANCEL_MODAL_TITLE: 'Відмінити зміни?',
             PREFIX_NONE: 'Без префікса',
+            SYNC_ON_TEXT: 'Суми зібраних коштів підтягуються автоматично з вашої системи звітності.',
+            SYNC_OFF_TEXT: 'Коли перемикач вимкнено, дані не синхронізуються автоматично і задаються вручну.',
         },
         PARTNERS: {
             TITLE_LABEL: COMMON_TEXT_ADMIN.TYPE.TITLE,

--- a/src/pages/admin/main/components/main-page-content/MainPageContent.tsx
+++ b/src/pages/admin/main/components/main-page-content/MainPageContent.tsx
@@ -80,11 +80,18 @@ export const MainPageContent = () => {
                 if (!isMounted) return;
                 setHasLoadError(false);
                 setOriginalData(page);
+
                 const values = mapMainPageToFormValues(page, languages);
-                savedValuesRef.current = values;
-                if (!methods.formState.isDirty) {
-                    methods.reset(values);
-                }
+
+                const sanitizedValues = {
+                    ...values,
+                    statisticsTitleUa: values.statisticsTitleUa ?? '',
+                    statisticsTitleEn: values.statisticsTitleEn ?? '',
+                };
+
+                savedValuesRef.current = sanitizedValues;
+
+                methods.reset(sanitizedValues, { keepDefaultValues: false });
             } catch (error) {
                 setHasLoadError(true);
                 addToast('Помилка завантаження даних', ToastType.Error, 3000);
@@ -136,9 +143,16 @@ export const MainPageContent = () => {
 
             setOriginalData(page);
             const nextValues = mapMainPageToFormValues(page, updatedLanguages);
-            savedValuesRef.current = nextValues;
 
-            methods.reset(nextValues);
+            const sanitizedNextValues = {
+                ...nextValues,
+                statisticsTitleUa: nextValues.statisticsTitleUa ?? '',
+                statisticsTitleEn: nextValues.statisticsTitleEn ?? '',
+            };
+
+            savedValuesRef.current = sanitizedNextValues;
+
+            methods.reset(sanitizedNextValues, { keepDefaultValues: false });
             setCurrentMetrics([]);
 
             addToast('Зміни успішно опубліковано', ToastType.Success, 3000);

--- a/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.test.tsx
@@ -371,11 +371,10 @@ describe('StatisticsBlockForm', () => {
 
     it('does not keep form dirty when prefix is reverted to initial value', async () => {
         const setValueSpy = jest.fn();
+        const initialMetrics = mockInitialData.impactStatistics?.metrics ?? [];
+
         render(
-            <FormWrapper
-                defaultValues={{ metrics: mockInitialData.impactStatistics?.metrics ?? [] }}
-                onSetValue={setValueSpy}
-            >
+            <FormWrapper defaultValues={{ metrics: initialMetrics }} onSetValue={setValueSpy}>
                 <StatisticsBlockForm
                     initialData={mockInitialData}
                     isPublishDisabled={false}
@@ -394,8 +393,12 @@ describe('StatisticsBlockForm', () => {
 
         await waitFor(() => {
             const lastCall = setValueSpy.mock.calls[setValueSpy.mock.calls.length - 1];
-            const options = lastCall?.[2];
-            expect(options?.shouldDirty).toBe(false);
+            const passedMetrics = lastCall[1];
+            const options = lastCall[2];
+
+            expect(options?.shouldDirty).toBe(true);
+
+            expect(passedMetrics).toEqual(initialMetrics);
         });
     });
 

--- a/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
+++ b/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
@@ -70,10 +70,12 @@ export const StatisticsBlockForm = ({
             prefix: metric.prefix,
             isHidden: metric.isHidden,
             priority: metric.priority,
+            isAutoSynced: (metric as any).isAutoSynced ?? false,
             localizations: (metric.localizations ?? [])
                 .map((loc) => ({
                     languageId: loc.languageId ?? null,
                     name: (loc.name ?? '').trim(),
+                    value: loc.value ? String(loc.value).trim() : '',
                 }))
                 .sort((a, b) => (a.languageId ?? 0) - (b.languageId ?? 0)),
         }));

--- a/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
+++ b/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
@@ -70,7 +70,7 @@ export const StatisticsBlockForm = ({
             prefix: metric.prefix,
             isHidden: metric.isHidden,
             priority: metric.priority,
-            isAutoSynced: (metric as any).isAutoSynced ?? false,
+            isAutoSynced: metric.isAutoSynced ?? false,
             localizations: (metric.localizations ?? [])
                 .map((loc) => ({
                     languageId: loc.languageId ?? null,

--- a/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
+++ b/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
@@ -58,7 +58,7 @@ export const StatisticsBlockForm = ({
     const {
         control,
         setValue,
-        formState: { errors },
+        formState: { errors, defaultValues },
     } = useFormContext<MainPageFormValues>();
 
     const toComparableMetrics = (items: Metric[]) =>
@@ -84,19 +84,13 @@ export const StatisticsBlockForm = ({
     useEffect(() => {
         if (initialData?.impactStatistics?.metrics) {
             const apiMetrics = initialData.impactStatistics.metrics;
-
             setMetrics(apiMetrics);
             initialMetricsRef.current = apiMetrics;
-            setValue('metrics', apiMetrics, {
-                shouldDirty: false,
-                shouldTouch: false,
-                shouldValidate: false,
-            });
 
             const hiddenIds = apiMetrics.filter((m) => m.isHidden).map((m) => m.id as number);
             setHiddenMetricIds(hiddenIds);
         }
-    }, [initialData, setValue]);
+    }, [initialData]);
 
     const handleToggleVisibility = async (id: number) => {
         const isCurrentlyHidden = hiddenMetricIds.includes(id);
@@ -140,11 +134,21 @@ export const StatisticsBlockForm = ({
         setMetrics(updatedMetrics);
         onMetricsChange?.(updatedMetrics);
 
-        setValue('metrics', updatedMetrics, {
-            shouldDirty: hasChanges,
-            shouldTouch: true,
-            shouldValidate: true,
-        });
+        if (!hasChanges) {
+            const originalFormMetrics = defaultValues?.metrics || [];
+
+            setValue('metrics', originalFormMetrics as Metric[], {
+                shouldDirty: true,
+                shouldTouch: true,
+                shouldValidate: true,
+            });
+        } else {
+            setValue('metrics', updatedMetrics, {
+                shouldDirty: true,
+                shouldTouch: true,
+                shouldValidate: true,
+            });
+        }
     };
 
     return (

--- a/src/pages/admin/main/components/statistics-block/components/common/metric-edit-actions/MetricEditActions.module.scss
+++ b/src/pages/admin/main/components/statistics-block/components/common/metric-edit-actions/MetricEditActions.module.scss
@@ -1,0 +1,6 @@
+.actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    margin-top: 8px;
+}

--- a/src/pages/admin/main/components/statistics-block/components/common/metric-edit-actions/MetricEditActions.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/common/metric-edit-actions/MetricEditActions.test.tsx
@@ -1,0 +1,115 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
+import { MetricEditActions } from './MetricEditActions';
+
+jest.mock('@/components/admin/button/Button', () => ({
+    __esModule: true,
+    Button: ({ children, disabled, onClick }: any) => (
+        <button type="button" disabled={disabled} onClick={onClick}>
+            {children}
+        </button>
+    ),
+}));
+
+jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
+    ConfirmationModal: ({ isOpen, onConfirm, onCancel, title }: any) => {
+        if (!isOpen) return null;
+        return (
+            <div data-testid="mock-modal">
+                <p>{title}</p>
+                <button onClick={onConfirm}>Yes</button>
+                <button onClick={onCancel}>No</button>
+            </div>
+        );
+    },
+}));
+
+describe('MetricEditActions', () => {
+    const defaultProps = {
+        isFormDirty: false,
+        isValid: true,
+        onCancel: jest.fn(),
+        onSave: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('Save Button Logic', () => {
+        it('is disabled when form is not dirty', () => {
+            render(<MetricEditActions {...defaultProps} isFormDirty={false} isValid={true} />);
+            const saveButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.SAVE });
+            expect(saveButton).toBeDisabled();
+        });
+
+        it('is disabled when form is not valid', () => {
+            render(<MetricEditActions {...defaultProps} isFormDirty={true} isValid={false} />);
+            const saveButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.SAVE });
+            expect(saveButton).toBeDisabled();
+        });
+
+        it('is enabled when form is dirty and valid', () => {
+            render(<MetricEditActions {...defaultProps} isFormDirty={true} isValid={true} />);
+            const saveButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.SAVE });
+            expect(saveButton).not.toBeDisabled();
+        });
+
+        it('calls onSave when clicked', () => {
+            render(<MetricEditActions {...defaultProps} isFormDirty={true} isValid={true} />);
+            const saveButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.SAVE });
+
+            fireEvent.click(saveButton);
+            expect(defaultProps.onSave).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('Cancel Button Logic', () => {
+        it('calls onCancel immediately if form is NOT dirty', () => {
+            render(<MetricEditActions {...defaultProps} isFormDirty={false} />);
+            const cancelButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.CANCEL });
+
+            fireEvent.click(cancelButton);
+
+            expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+            expect(screen.queryByTestId('mock-modal')).not.toBeInTheDocument();
+        });
+
+        it('opens confirmation modal if form IS dirty', () => {
+            render(<MetricEditActions {...defaultProps} isFormDirty={true} />);
+            const cancelButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.CANCEL });
+
+            fireEvent.click(cancelButton);
+
+            expect(defaultProps.onCancel).not.toHaveBeenCalled();
+            expect(screen.getByTestId('mock-modal')).toBeInTheDocument();
+            expect(screen.getByText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.CANCEL_MODAL_TITLE)).toBeInTheDocument();
+        });
+    });
+
+    describe('Confirmation Modal Logic', () => {
+        it('calls onCancel and closes modal when "Yes" is clicked', () => {
+            render(<MetricEditActions {...defaultProps} isFormDirty={true} />);
+
+            fireEvent.click(screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.CANCEL }));
+
+            fireEvent.click(screen.getByText('Yes'));
+
+            expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+            expect(screen.queryByTestId('mock-modal')).not.toBeInTheDocument();
+        });
+
+        it('does NOT call onCancel and closes modal when "No" is clicked', () => {
+            render(<MetricEditActions {...defaultProps} isFormDirty={true} />);
+
+            fireEvent.click(screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.CANCEL }));
+
+            fireEvent.click(screen.getByText('No'));
+
+            expect(defaultProps.onCancel).not.toHaveBeenCalled();
+            expect(screen.queryByTestId('mock-modal')).not.toBeInTheDocument();
+        });
+    });
+});

--- a/src/pages/admin/main/components/statistics-block/components/common/metric-edit-actions/MetricEditActions.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/common/metric-edit-actions/MetricEditActions.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+
+import { Button } from '@/components/admin/button/Button';
+import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
+
+import styles from './MetricEditActions.module.scss';
+
+interface MetricEditActionsProps {
+    isFormDirty: boolean;
+    isValid: boolean;
+    onCancel: () => void;
+    onSave: () => void;
+}
+
+export const MetricEditActions = ({ isFormDirty, isValid, onCancel, onSave }: MetricEditActionsProps) => {
+    const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
+
+    const handleCancelClick = () => {
+        if (isFormDirty) {
+            setIsCancelModalOpen(true);
+        } else {
+            onCancel();
+        }
+    };
+
+    const handleConfirmCancel = () => {
+        setIsCancelModalOpen(false);
+        onCancel();
+    };
+
+    return (
+        <>
+            <div className={styles.actions}>
+                <Button buttonStyle="secondary" onClick={handleCancelClick}>
+                    {MAIN_PAGE_TEXT.BUTTONS.CANCEL}
+                </Button>
+                <Button buttonStyle="primary" onClick={onSave} disabled={!isFormDirty || !isValid}>
+                    {MAIN_PAGE_TEXT.BUTTONS.SAVE}
+                </Button>
+            </div>
+
+            <ConfirmationModal
+                isOpen={isCancelModalOpen}
+                onClose={() => setIsCancelModalOpen(false)}
+                title={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.CANCEL_MODAL_TITLE}
+                onConfirm={handleConfirmCancel}
+                onCancel={() => setIsCancelModalOpen(false)}
+                confirmText={COMMON_TEXT_ADMIN.BUTTON.YES}
+                cancelText={COMMON_TEXT_ADMIN.BUTTON.NO}
+            />
+        </>
+    );
+};

--- a/src/pages/admin/main/components/statistics-block/components/common/metric-name-fields/MetricNameFields.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/common/metric-name-fields/MetricNameFields.test.tsx
@@ -28,7 +28,7 @@ const Wrapper = ({
     defaultValues = { nameUa: '', nameEn: '' },
     errors = {},
 }: {
-    metricId?: number | undefined;
+    metricId?: number;
     idPrefix?: string;
     defaultValues?: { nameUa: string; nameEn: string };
     errors?: FieldErrors<{ nameUa: string; nameEn: string }>;

--- a/src/pages/admin/main/components/statistics-block/components/common/metric-name-fields/MetricNameFields.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/common/metric-name-fields/MetricNameFields.test.tsx
@@ -1,0 +1,107 @@
+import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { FieldErrors, useForm } from 'react-hook-form';
+import { MetricNameFields } from './MetricNameFields';
+
+jest.mock('@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup', () => ({
+    InputWithCharacterLimitGroup: ({ id, label, value, onChange, onBlur, error, maxLength, isRequired }: any) => (
+        <div>
+            <label htmlFor={id}>{label}</label>
+            <input
+                id={id}
+                value={value ?? ''}
+                onChange={onChange}
+                onBlur={onBlur}
+                maxLength={maxLength}
+                required={isRequired}
+                data-testid={id}
+            />
+            {error && <span data-testid={`${id}-error`}>{error}</span>}
+        </div>
+    ),
+}));
+
+const Wrapper = ({
+    metricId = 1,
+    idPrefix,
+    defaultValues = { nameUa: '', nameEn: '' },
+    errors = {},
+}: {
+    metricId?: number | undefined;
+    idPrefix?: string;
+    defaultValues?: { nameUa: string; nameEn: string };
+    errors?: FieldErrors<{ nameUa: string; nameEn: string }>;
+}) => {
+    const { control } = useForm({ defaultValues });
+    return <MetricNameFields metricId={metricId} control={control} errors={errors} idPrefix={idPrefix} />;
+};
+
+describe('MetricNameFields', () => {
+    it('renders UA and EN inputs with correct labels', () => {
+        render(<Wrapper />);
+
+        expect(screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UKR_NAME_LABEL)).toBeInTheDocument();
+        expect(screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.ENG_NAME_LABEL)).toBeInTheDocument();
+    });
+
+    it('renders inputs with default idPrefix "metric"', () => {
+        render(<Wrapper metricId={5} />);
+
+        expect(screen.getByTestId('metric-ua-5')).toBeInTheDocument();
+        expect(screen.getByTestId('metric-en-5')).toBeInTheDocument();
+    });
+
+    it('renders inputs with custom idPrefix', () => {
+        render(<Wrapper metricId={3} idPrefix="raised-metric" />);
+
+        expect(screen.getByTestId('raised-metric-ua-3')).toBeInTheDocument();
+        expect(screen.getByTestId('raised-metric-en-3')).toBeInTheDocument();
+    });
+
+    it('renders initial values from form defaultValues', () => {
+        render(<Wrapper defaultValues={{ nameUa: 'Назва UA', nameEn: 'Name EN' }} />);
+
+        expect(screen.getByTestId('metric-ua-1')).toHaveValue('Назва UA');
+        expect(screen.getByTestId('metric-en-1')).toHaveValue('Name EN');
+    });
+
+    it('shows error message for nameUa when passed via errors prop', () => {
+        render(<Wrapper errors={{ nameUa: { message: 'UA name is required', type: 'required' } }} />);
+
+        expect(screen.getByTestId('metric-ua-1-error')).toHaveTextContent('UA name is required');
+        expect(screen.queryByTestId('metric-en-1-error')).not.toBeInTheDocument();
+    });
+
+    it('shows error message for nameEn when passed via errors prop', () => {
+        render(<Wrapper errors={{ nameEn: { message: 'EN name is required', type: 'required' } }} />);
+
+        expect(screen.getByTestId('metric-en-1-error')).toHaveTextContent('EN name is required');
+        expect(screen.queryByTestId('metric-ua-1-error')).not.toBeInTheDocument();
+    });
+
+    it('does not render error when errors prop is empty', () => {
+        render(<Wrapper />);
+
+        expect(screen.queryByTestId('metric-ua-1-error')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('metric-en-1-error')).not.toBeInTheDocument();
+    });
+
+    it('updates UA input value on change', () => {
+        render(<Wrapper />);
+
+        const uaInput = screen.getByTestId('metric-ua-1');
+        fireEvent.change(uaInput, { target: { value: 'Нова назва' } });
+
+        expect(uaInput).toHaveValue('Нова назва');
+    });
+
+    it('updates EN input value on change', () => {
+        render(<Wrapper />);
+
+        const enInput = screen.getByTestId('metric-en-1');
+        fireEvent.change(enInput, { target: { value: 'New name' } });
+
+        expect(enInput).toHaveValue('New name');
+    });
+});

--- a/src/pages/admin/main/components/statistics-block/components/common/metric-name-fields/MetricNameFields.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/common/metric-name-fields/MetricNameFields.tsx
@@ -1,0 +1,50 @@
+import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
+import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
+import { Control, Controller, FieldErrors } from 'react-hook-form';
+
+interface MetricNameFieldsProps {
+    metricId: number | undefined;
+    control: Control<any>;
+    errors: FieldErrors<any>;
+    idPrefix?: string;
+}
+
+export const MetricNameFields = ({ metricId, control, errors, idPrefix = 'metric' }: MetricNameFieldsProps) => (
+    <>
+        <Controller
+            name="nameUa"
+            control={control}
+            render={({ field: { onChange, onBlur, value, name } }) => (
+                <InputWithCharacterLimitGroup
+                    id={`${idPrefix}-ua-${metricId}`}
+                    name={name}
+                    label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UKR_NAME_LABEL}
+                    value={value}
+                    onChange={onChange}
+                    onBlur={onBlur}
+                    error={errors.nameUa?.message as string}
+                    maxLength={MAIN_PAGE_VALIDATION.editPanel.name.max}
+                    isRequired
+                />
+            )}
+        />
+
+        <Controller
+            name="nameEn"
+            control={control}
+            render={({ field: { onChange, onBlur, value, name } }) => (
+                <InputWithCharacterLimitGroup
+                    id={`${idPrefix}-en-${metricId}`}
+                    name={name}
+                    label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.ENG_NAME_LABEL}
+                    value={value}
+                    onChange={onChange}
+                    onBlur={onBlur}
+                    error={errors.nameEn?.message as string}
+                    maxLength={MAIN_PAGE_VALIDATION.editPanel.name.max}
+                    isRequired
+                />
+            )}
+        />
+    </>
+);

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.module.scss
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.module.scss
@@ -49,10 +49,3 @@
     line-height: 1.4;
     flex: 1;
 }
-
-.actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 12px;
-    margin-top: 8px;
-}

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.module.scss
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.module.scss
@@ -28,15 +28,26 @@
     }
 }
 
-.prefixGroup {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
+.divider {
+    height: 1px;
+    background-color: c.$grey-300;
+    width: 100%;
+    margin: 4px 0;
 }
 
-.prefixLabel {
+.syncRow {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 24px;
+    margin-bottom: 4px;
+}
+
+.syncText {
     font-size: 14px;
-    color: c.$donate-tooltip-color;
+    color: c.$grey-900;
+    line-height: 1.4;
+    flex: 1;
 }
 
 .actions {

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.test.tsx
@@ -1,31 +1,22 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
-import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
+import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
 import { Metric, MetricLocalization, MetricPrefix, MetricType } from '@/types/admin/main-page';
 
 import { RaisedMetricEditPanel } from './RaisedMetricEditPanel';
 
-jest.mock('@/components/admin/button/Button', () => ({
-    __esModule: true,
-    Button: ({ children, disabled, onClick }: any) => (
-        <button type="button" disabled={disabled} onClick={onClick}>
-            {children}
-        </button>
+jest.mock('../common/metric-edit-actions/MetricEditActions', () => ({
+    MetricEditActions: ({ isFormDirty, isValid, onCancel, onSave }: any) => (
+        <div data-testid="metric-actions">
+            <button type="button" data-testid="mock-cancel" onClick={onCancel}>
+                Cancel
+            </button>
+            <button type="button" data-testid="mock-save" onClick={onSave} disabled={!isFormDirty || !isValid}>
+                Save
+            </button>
+        </div>
     ),
-}));
-
-jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
-    ConfirmationModal: ({ isOpen, onConfirm, onCancel, title }: any) => {
-        if (!isOpen) return null;
-        return (
-            <div data-testid="mock-modal">
-                <p>{title}</p>
-                <button onClick={onConfirm}>Yes</button>
-                <button onClick={onCancel}>No</button>
-            </div>
-        );
-    },
 }));
 
 const createMetric = (overrides: Partial<Metric> = {}): Metric => ({
@@ -67,7 +58,7 @@ describe('RaisedMetricEditPanel', () => {
     it('enables Save button when form values are changed', async () => {
         render(<RaisedMetricEditPanel metric={createMetric()} onCancel={jest.fn()} />);
 
-        const saveButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.SAVE });
+        const saveButton = screen.getByTestId('mock-save');
         expect(saveButton).toBeDisabled();
 
         const uaNameInput = screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UKR_NAME_LABEL, { exact: false });
@@ -103,7 +94,7 @@ describe('RaisedMetricEditPanel', () => {
         const usdInput = screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.USD_VALUE_LABEL, { exact: false });
         fireEvent.change(usdInput, { target: { value: '30000' } });
 
-        const saveButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.SAVE });
+        const saveButton = screen.getByTestId('mock-save');
 
         await waitFor(() => {
             expect(saveButton).not.toBeDisabled();
@@ -120,33 +111,77 @@ describe('RaisedMetricEditPanel', () => {
         });
     });
 
-    it('calls onCancel directly if form is untouched', () => {
+    it('calls onCancel when cancel action is triggered', () => {
         const onCancelMock = jest.fn();
         render(<RaisedMetricEditPanel metric={createMetric()} onCancel={onCancelMock} />);
 
-        const cancelButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.CANCEL });
-        fireEvent.click(cancelButton);
+        fireEvent.click(screen.getByTestId('mock-cancel'));
 
         expect(onCancelMock).toHaveBeenCalledTimes(1);
     });
 
-    it('opens confirmation modal when canceling with dirty form', async () => {
-        const onCancelMock = jest.fn();
-        render(<RaisedMetricEditPanel metric={createMetric()} onCancel={onCancelMock} />);
+    describe('Validation and editing manually', () => {
+        it('shows inline error when input is emptied and removes it when corrected', async () => {
+            render(<RaisedMetricEditPanel metric={createMetric()} onCancel={jest.fn()} />);
 
-        const uaNameInput = screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UKR_NAME_LABEL, { exact: false });
-        fireEvent.change(uaNameInput, { target: { value: 'Modified' } });
+            const syncToggle = screen.getByRole('switch');
+            fireEvent.click(syncToggle);
 
-        const cancelButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.CANCEL });
-        fireEvent.click(cancelButton);
+            const uahInput = await screen.findByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UAH_VALUE_LABEL, {
+                exact: false,
+            });
 
-        expect(onCancelMock).not.toHaveBeenCalled();
+            fireEvent.change(uahInput, { target: { value: '' } });
+            fireEvent.blur(uahInput);
 
-        await waitFor(() => {
-            expect(screen.getByTestId('mock-modal')).toBeInTheDocument();
+            await waitFor(() => {
+                expect(screen.getByText(MAIN_PAGE_VALIDATION.raisedFunds.REQUIRED)).toBeInTheDocument();
+            });
+
+            const saveButton = screen.getByTestId('mock-save');
+            expect(saveButton).toBeDisabled();
+
+            fireEvent.change(uahInput, { target: { value: '500' } });
+            fireEvent.blur(uahInput);
+
+            await waitFor(() => {
+                expect(screen.queryByText(MAIN_PAGE_VALIDATION.raisedFunds.REQUIRED)).not.toBeInTheDocument();
+                expect(saveButton).not.toBeDisabled();
+            });
         });
 
-        fireEvent.click(screen.getByText('Yes'));
-        expect(onCancelMock).toHaveBeenCalledTimes(1);
+        it('shows inline error for negative numbers', async () => {
+            render(<RaisedMetricEditPanel metric={createMetric()} onCancel={jest.fn()} />);
+
+            fireEvent.click(screen.getByRole('switch'));
+
+            const usdInput = await screen.findByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.USD_VALUE_LABEL, {
+                exact: false,
+            });
+
+            fireEvent.change(usdInput, { target: { value: '-10' } });
+            fireEvent.blur(usdInput);
+
+            await waitFor(() => {
+                expect(screen.getByText(MAIN_PAGE_VALIDATION.raisedFunds.NEGATIVE)).toBeInTheDocument();
+            });
+        });
+
+        it('shows inline error for zero', async () => {
+            render(<RaisedMetricEditPanel metric={createMetric()} onCancel={jest.fn()} />);
+
+            fireEvent.click(screen.getByRole('switch'));
+
+            const uahInput = await screen.findByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UAH_VALUE_LABEL, {
+                exact: false,
+            });
+
+            fireEvent.change(uahInput, { target: { value: '0' } });
+            fireEvent.blur(uahInput);
+
+            await waitFor(() => {
+                expect(screen.getByText(MAIN_PAGE_VALIDATION.raisedFunds.ZERO)).toBeInTheDocument();
+            });
+        });
     });
 });

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.test.tsx
@@ -78,6 +78,57 @@ describe('RaisedMetricEditPanel', () => {
         });
     });
 
+    it('uses saved auto-sync state and makes values editable immediately after switching it off', async () => {
+        render(<RaisedMetricEditPanel metric={createMetric({ isAutoSynced: true })} onCancel={jest.fn()} />);
+
+        const uahInput = screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UAH_VALUE_LABEL, { exact: false });
+        const usdInput = screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.USD_VALUE_LABEL, { exact: false });
+
+        expect(screen.getByRole('switch')).toBeChecked();
+        expect(uahInput).toBeDisabled();
+        expect(usdInput).toBeDisabled();
+        expect(uahInput).toHaveValue('1 000 000');
+        expect(usdInput).toHaveValue('25 000');
+
+        fireEvent.click(screen.getByRole('switch'));
+
+        await waitFor(() => {
+            expect(uahInput).not.toBeDisabled();
+            expect(usdInput).not.toBeDisabled();
+            expect(uahInput).toHaveValue('1 000 000');
+            expect(usdInput).toHaveValue('25 000');
+        });
+    });
+
+    it('preserves decimal raised values on save', async () => {
+        const onSaveMock = jest.fn();
+        render(<RaisedMetricEditPanel metric={createMetric()} onSave={onSaveMock} onCancel={jest.fn()} />);
+
+        const uahInput = screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UAH_VALUE_LABEL, { exact: false });
+        const usdInput = screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.USD_VALUE_LABEL, { exact: false });
+
+        fireEvent.change(uahInput, { target: { value: '1234567,89' } });
+        fireEvent.change(usdInput, { target: { value: '30000.75' } });
+        fireEvent.blur(uahInput);
+        fireEvent.blur(usdInput);
+
+        const saveButton = screen.getByTestId('mock-save');
+
+        await waitFor(() => {
+            expect(saveButton).not.toBeDisabled();
+        });
+
+        fireEvent.click(saveButton);
+
+        await waitFor(() => {
+            const savedMetric = onSaveMock.mock.calls[0][0];
+            const engLocalization = savedMetric.localizations.find((l: any) => l.languageId === 2);
+
+            expect(savedMetric.value).toBe(1234567.89);
+            expect(engLocalization.value).toBe('30000.75');
+        });
+    });
+
     it('calls onSave with updated values mapped correctly', async () => {
         const onSaveMock = jest.fn();
         render(<RaisedMetricEditPanel metric={createMetric()} onSave={onSaveMock} onCancel={jest.fn()} />);
@@ -115,9 +166,6 @@ describe('RaisedMetricEditPanel', () => {
         it('shows inline error when input is emptied and removes it when corrected', async () => {
             render(<RaisedMetricEditPanel metric={createMetric()} onCancel={jest.fn()} />);
 
-            const syncToggle = screen.getByRole('switch');
-            fireEvent.click(syncToggle);
-
             const uahInput = await screen.findByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UAH_VALUE_LABEL, {
                 exact: false,
             });
@@ -141,10 +189,8 @@ describe('RaisedMetricEditPanel', () => {
             });
         });
 
-        it('shows inline error for non-numeric input (e.g. minus sign)', async () => {
+        it('shows inline error for negative input', async () => {
             render(<RaisedMetricEditPanel metric={createMetric()} onCancel={jest.fn()} />);
-
-            fireEvent.click(screen.getByRole('switch'));
 
             const usdInput = await screen.findByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.USD_VALUE_LABEL, {
                 exact: false,
@@ -154,14 +200,12 @@ describe('RaisedMetricEditPanel', () => {
             fireEvent.blur(usdInput);
 
             await waitFor(() => {
-                expect(screen.getByText(MAIN_PAGE_VALIDATION.raisedFunds.ONLY_NUMBERS)).toBeInTheDocument();
+                expect(screen.getByText(MAIN_PAGE_VALIDATION.raisedFunds.NEGATIVE)).toBeInTheDocument();
             });
         });
 
         it('shows inline error for zero', async () => {
             render(<RaisedMetricEditPanel metric={createMetric()} onCancel={jest.fn()} />);
-
-            fireEvent.click(screen.getByRole('switch'));
 
             const uahInput = await screen.findByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UAH_VALUE_LABEL, {
                 exact: false,

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.test.tsx
@@ -150,7 +150,7 @@ describe('RaisedMetricEditPanel', () => {
             });
         });
 
-        it('shows inline error for negative numbers', async () => {
+        it('shows inline error for non-numeric input (e.g. minus sign)', async () => {
             render(<RaisedMetricEditPanel metric={createMetric()} onCancel={jest.fn()} />);
 
             fireEvent.click(screen.getByRole('switch'));
@@ -163,7 +163,7 @@ describe('RaisedMetricEditPanel', () => {
             fireEvent.blur(usdInput);
 
             await waitFor(() => {
-                expect(screen.getByText(MAIN_PAGE_VALIDATION.raisedFunds.NEGATIVE)).toBeInTheDocument();
+                expect(screen.getByText(MAIN_PAGE_VALIDATION.raisedFunds.ONLY_NUMBERS)).toBeInTheDocument();
             });
         });
 

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.test.tsx
@@ -3,20 +3,11 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
 import { Metric, MetricLocalization, MetricPrefix, MetricType } from '@/types/admin/main-page';
-
+import { MockMetricEditActions } from '@/utils/test-mocks/main-page-mocks';
 import { RaisedMetricEditPanel } from './RaisedMetricEditPanel';
 
 jest.mock('../common/metric-edit-actions/MetricEditActions', () => ({
-    MetricEditActions: ({ isFormDirty, isValid, onCancel, onSave }: any) => (
-        <div data-testid="metric-actions">
-            <button type="button" data-testid="mock-cancel" onClick={onCancel}>
-                Cancel
-            </button>
-            <button type="button" data-testid="mock-save" onClick={onSave} disabled={!isFormDirty || !isValid}>
-                Save
-            </button>
-        </div>
-    ),
+    MetricEditActions: (props: any) => <MockMetricEditActions {...props} />,
 }));
 
 const createMetric = (overrides: Partial<Metric> = {}): Metric => ({

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.test.tsx
@@ -1,8 +1,8 @@
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
-import { Metric, MetricPrefix, MetricType } from '@/types/admin/main-page';
+import { Metric, MetricLocalization, MetricPrefix, MetricType } from '@/types/admin/main-page';
 
 import { RaisedMetricEditPanel } from './RaisedMetricEditPanel';
 
@@ -15,6 +15,19 @@ jest.mock('@/components/admin/button/Button', () => ({
     ),
 }));
 
+jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
+    ConfirmationModal: ({ isOpen, onConfirm, onCancel, title }: any) => {
+        if (!isOpen) return null;
+        return (
+            <div data-testid="mock-modal">
+                <p>{title}</p>
+                <button onClick={onConfirm}>Yes</button>
+                <button onClick={onCancel}>No</button>
+            </div>
+        );
+    },
+}));
+
 const createMetric = (overrides: Partial<Metric> = {}): Metric => ({
     id: 3,
     name: 'Залучених коштів',
@@ -23,36 +36,117 @@ const createMetric = (overrides: Partial<Metric> = {}): Metric => ({
     prefix: MetricPrefix.None,
     isHidden: false,
     priority: 3,
-    localizations: [],
+    localizations: [
+        { languageId: 1, name: 'Залучених коштів' },
+        { languageId: 2, name: 'Funds raised', value: '25000' },
+    ] as MetricLocalization[],
     ...overrides,
 });
 
 describe('RaisedMetricEditPanel', () => {
-    it('renders the panel with header and placeholder message', () => {
+    it('renders initial values correctly mapped from UAH and USD localizations', () => {
         const metric = createMetric();
         render(<RaisedMetricEditPanel metric={metric} onCancel={jest.fn()} />);
 
-        expect(screen.getByText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.TITLE)).toBeInTheDocument();
-        expect(screen.getByText(`Редагування метрики "${metric.name}" наразі недоступне.`)).toBeInTheDocument();
+        expect(screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UKR_NAME_LABEL, { exact: false })).toHaveValue(
+            'Залучених коштів',
+        );
+        expect(screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.ENG_NAME_LABEL, { exact: false })).toHaveValue(
+            'Funds raised',
+        );
+        expect(screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UAH_VALUE_LABEL, { exact: false })).toHaveValue(
+            '1 000 000',
+        );
+        expect(screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.USD_VALUE_LABEL, { exact: false })).toHaveValue(
+            '25 000',
+        );
+
+        expect(screen.getByRole('switch')).not.toBeChecked();
     });
 
-    it('renders active Cancel button and disabled Save button', () => {
+    it('enables Save button when form values are changed', async () => {
         render(<RaisedMetricEditPanel metric={createMetric()} onCancel={jest.fn()} />);
 
-        const cancelButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.CANCEL });
         const saveButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.SAVE });
-
-        expect(cancelButton).not.toBeDisabled();
         expect(saveButton).toBeDisabled();
+
+        const uaNameInput = screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UKR_NAME_LABEL, { exact: false });
+        fireEvent.change(uaNameInput, { target: { value: 'Нова назва' } });
+
+        await waitFor(() => {
+            expect(saveButton).not.toBeDisabled();
+        });
     });
 
-    it('calls onCancel when Cancel button is clicked', () => {
+    it('disables value inputs when auto-sync toggle is switched on', async () => {
+        render(<RaisedMetricEditPanel metric={createMetric()} onCancel={jest.fn()} />);
+
+        const uahInput = screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UAH_VALUE_LABEL, { exact: false });
+        const usdInput = screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.USD_VALUE_LABEL, { exact: false });
+
+        expect(uahInput).not.toBeDisabled();
+        expect(usdInput).not.toBeDisabled();
+
+        const syncToggle = screen.getByRole('switch');
+        fireEvent.click(syncToggle);
+
+        await waitFor(() => {
+            expect(uahInput).toBeDisabled();
+            expect(usdInput).toBeDisabled();
+        });
+    });
+
+    it('calls onSave with updated values mapped correctly', async () => {
+        const onSaveMock = jest.fn();
+        render(<RaisedMetricEditPanel metric={createMetric()} onSave={onSaveMock} onCancel={jest.fn()} />);
+
+        const usdInput = screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.USD_VALUE_LABEL, { exact: false });
+        fireEvent.change(usdInput, { target: { value: '30000' } });
+
+        const saveButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.SAVE });
+
+        await waitFor(() => {
+            expect(saveButton).not.toBeDisabled();
+        });
+
+        fireEvent.click(saveButton);
+
+        await waitFor(() => {
+            expect(onSaveMock).toHaveBeenCalledTimes(1);
+            const savedMetric = onSaveMock.mock.calls[0][0];
+
+            const engLocalization = savedMetric.localizations.find((l: any) => l.languageId === 2);
+            expect(engLocalization.value).toBe('30000');
+        });
+    });
+
+    it('calls onCancel directly if form is untouched', () => {
         const onCancelMock = jest.fn();
         render(<RaisedMetricEditPanel metric={createMetric()} onCancel={onCancelMock} />);
 
         const cancelButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.CANCEL });
         fireEvent.click(cancelButton);
 
+        expect(onCancelMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('opens confirmation modal when canceling with dirty form', async () => {
+        const onCancelMock = jest.fn();
+        render(<RaisedMetricEditPanel metric={createMetric()} onCancel={onCancelMock} />);
+
+        const uaNameInput = screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UKR_NAME_LABEL, { exact: false });
+        fireEvent.change(uaNameInput, { target: { value: 'Modified' } });
+
+        const cancelButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.CANCEL });
+        fireEvent.click(cancelButton);
+
+        expect(onCancelMock).not.toHaveBeenCalled();
+
+        await waitFor(() => {
+            expect(screen.getByTestId('mock-modal')).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByText('Yes'));
         expect(onCancelMock).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.test.tsx
@@ -46,6 +46,21 @@ describe('RaisedMetricEditPanel', () => {
         expect(screen.getByRole('switch')).not.toBeChecked();
     });
 
+    it('renders formatted saved USD localization without blanking the field', () => {
+        const metric = createMetric({
+            localizations: [
+                { languageId: 1, name: 'Залучених коштів' },
+                { languageId: 2, name: 'Funds raised', value: '120 000' },
+            ] as MetricLocalization[],
+        });
+
+        render(<RaisedMetricEditPanel metric={metric} onCancel={jest.fn()} />);
+
+        expect(screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.USD_VALUE_LABEL, { exact: false })).toHaveValue(
+            '120 000',
+        );
+    });
+
     it('enables Save button when form values are changed', async () => {
         render(<RaisedMetricEditPanel metric={createMetric()} onCancel={jest.fn()} />);
 

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.tsx
@@ -5,7 +5,12 @@ import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/in
 import { Toggle } from '@/components/admin/toggle/Toggle';
 import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
 import { Metric, MetricLocalization, MetricPrefix } from '@/types/admin/main-page';
-import { formatCurrencyInput, formatWithSpaces } from '@/utils/functions/formatters/format-number';
+import {
+    formatCurrencyInput,
+    formatWithSpaces,
+    normalizeFormattedNumber,
+    parseFormattedNumber,
+} from '@/utils/functions/formatters/format-number';
 import {
     RaisedMetricFormValues,
     raisedMetricEditSchema,
@@ -25,10 +30,10 @@ export const RaisedMetricEditPanel = ({ metric, onSave, onCancel }: RaisedMetric
     const usdLocalization = metric.localizations?.find((l) => l.languageId === 2);
     const defaultNameEn = usdLocalization?.name || '';
 
-    const defaultIsAutoSynced = false;
+    const defaultIsAutoSynced = metric.isAutoSynced ?? false;
 
     const defaultValueUah = formatWithSpaces(metric.value ?? 0);
-    const defaultValueUsd = formatWithSpaces(usdLocalization?.value ? parseInt(usdLocalization.value, 10) : 0);
+    const defaultValueUsd = formatWithSpaces(usdLocalization?.value ?? 0);
 
     const {
         control,
@@ -61,7 +66,8 @@ export const RaisedMetricEditPanel = ({ metric, onSave, onCancel }: RaisedMetric
         currentValueUsd !== defaultValueUsd;
 
     const onValidSubmit = (data: RaisedMetricFormValues) => {
-        const cleanUsdValue = data.valueUsd.replace(/\s/g, '');
+        const cleanUsdValue = normalizeFormattedNumber(data.valueUsd);
+        const cleanUahValue = parseFormattedNumber(data.valueUah) ?? 0;
 
         let updatedLocalizations =
             metric.localizations?.map((loc) => {
@@ -86,10 +92,10 @@ export const RaisedMetricEditPanel = ({ metric, onSave, onCancel }: RaisedMetric
         const updatedMetric: Metric = {
             ...metric,
             name: data.nameUa.trim(),
-            value: parseInt(data.valueUah.replace(/\s/g, ''), 10),
+            value: cleanUahValue,
             prefix: metric.prefix ?? MetricPrefix.None,
             localizations: updatedLocalizations,
-            ...({ isAutoSynced: data.isAutoSynced } as any),
+            isAutoSynced: data.isAutoSynced,
         };
 
         if (onSave) onSave(updatedMetric);

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.tsx
@@ -3,7 +3,7 @@ import { Controller, useForm } from 'react-hook-form';
 
 import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
 import { Toggle } from '@/components/admin/toggle/Toggle';
-import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
+import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
 import { Metric, MetricLocalization, MetricPrefix } from '@/types/admin/main-page';
 import { formatCurrencyInput, formatWithSpaces } from '@/utils/functions/formatters/format-number';
 import {
@@ -11,7 +11,7 @@ import {
     raisedMetricEditSchema,
 } from '@/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema';
 import { MetricEditActions } from '../common/metric-edit-actions/MetricEditActions';
-
+import { MetricNameFields } from '../common/metric-name-fields/MetricNameFields';
 import styles from './RaisedMetricEditPanel.module.scss';
 
 interface RaisedMetricEditPanelProps {
@@ -100,41 +100,7 @@ export const RaisedMetricEditPanel = ({ metric, onSave, onCancel }: RaisedMetric
             <div className={styles.header}>{MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.TITLE}</div>
 
             <div className={styles.formGrid}>
-                <Controller
-                    name="nameUa"
-                    control={control}
-                    render={({ field: { onChange, onBlur, value, name } }) => (
-                        <InputWithCharacterLimitGroup
-                            id={`raised-metric-ua-${metric.id}`}
-                            name={name}
-                            label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UKR_NAME_LABEL}
-                            value={value}
-                            onChange={onChange}
-                            onBlur={onBlur}
-                            error={errors.nameUa?.message}
-                            maxLength={MAIN_PAGE_VALIDATION.editPanel.name.max}
-                            isRequired
-                        />
-                    )}
-                />
-
-                <Controller
-                    name="nameEn"
-                    control={control}
-                    render={({ field: { onChange, onBlur, value, name } }) => (
-                        <InputWithCharacterLimitGroup
-                            id={`raised-metric-en-${metric.id}`}
-                            name={name}
-                            label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.ENG_NAME_LABEL}
-                            value={value}
-                            onChange={onChange}
-                            onBlur={onBlur}
-                            error={errors.nameEn?.message}
-                            maxLength={MAIN_PAGE_VALIDATION.editPanel.name.max}
-                            isRequired
-                        />
-                    )}
-                />
+                <MetricNameFields metricId={metric.id} control={control} errors={errors} idPrefix="raised-metric" />
             </div>
 
             <div className={styles.divider} />

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.tsx
@@ -33,7 +33,8 @@ export const RaisedMetricEditPanel = ({ metric, onSave, onCancel }: RaisedMetric
     const defaultIsAutoSynced = metric.isAutoSynced ?? false;
 
     const defaultValueUah = formatWithSpaces(metric.value ?? 0);
-    const defaultValueUsd = formatWithSpaces(usdLocalization?.value ?? 0);
+    const parsedDefaultValueUsd = usdLocalization?.value ? parseFormattedNumber(usdLocalization.value) : null;
+    const defaultValueUsd = formatWithSpaces(parsedDefaultValueUsd ?? usdLocalization?.value ?? 0);
 
     const {
         control,

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.tsx
@@ -5,7 +5,7 @@ import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/in
 import { Toggle } from '@/components/admin/toggle/Toggle';
 import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
 import { Metric, MetricLocalization, MetricPrefix } from '@/types/admin/main-page';
-import { formatNumberInput, formatWithSpaces } from '@/utils/functions/formatters/format-number';
+import { formatCurrencyInput, formatWithSpaces } from '@/utils/functions/formatters/format-number';
 import {
     RaisedMetricFormValues,
     raisedMetricEditSchema,
@@ -150,7 +150,12 @@ export const RaisedMetricEditPanel = ({ metric, onSave, onCancel }: RaisedMetric
                     name="isAutoSynced"
                     control={control}
                     render={({ field: { onChange, value } }) => (
-                        <Toggle id={`sync-toggle-${metric.id}`} checked={value} onChange={onChange} />
+                        <Toggle
+                            id={`sync-toggle-${metric.id}`}
+                            checked={value}
+                            onChange={onChange}
+                            ariaLabel="Автоматична синхронізація"
+                        />
                     )}
                 />
             </div>
@@ -165,7 +170,7 @@ export const RaisedMetricEditPanel = ({ metric, onSave, onCancel }: RaisedMetric
                             name={name}
                             label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UAH_VALUE_LABEL}
                             value={value}
-                            onChange={(e) => onChange(formatNumberInput(e.target.value))}
+                            onChange={(e) => onChange(formatCurrencyInput(e.target.value))}
                             onBlur={onBlur}
                             error={errors.valueUah?.message}
                             maxLength={15}
@@ -184,7 +189,7 @@ export const RaisedMetricEditPanel = ({ metric, onSave, onCancel }: RaisedMetric
                             name={name}
                             label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.USD_VALUE_LABEL}
                             value={value}
-                            onChange={(e) => onChange(formatNumberInput(e.target.value))}
+                            onChange={(e) => onChange(formatCurrencyInput(e.target.value))}
                             onBlur={onBlur}
                             error={errors.valueUsd?.message}
                             maxLength={15}

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.tsx
@@ -1,31 +1,225 @@
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+
 import { Button } from '@/components/admin/button/Button';
-import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
-import { Metric } from '@/types/admin/main-page';
+import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
+import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
+import { Toggle } from '@/components/admin/toggle/Toggle';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
+import { Metric, MetricLocalization, MetricPrefix } from '@/types/admin/main-page';
+import { formatNumberInput, formatWithSpaces } from '@/utils/functions/formatters/format-number';
+import {
+    RaisedMetricFormValues,
+    raisedMetricEditSchema,
+} from '@/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema';
 
 import styles from './RaisedMetricEditPanel.module.scss';
 
 interface RaisedMetricEditPanelProps {
     metric: Metric;
+    onSave?: (updatedMetric: Metric) => void;
     onCancel: () => void;
 }
 
-export const RaisedMetricEditPanel = ({ metric, onCancel }: RaisedMetricEditPanelProps) => {
+export const RaisedMetricEditPanel = ({ metric, onSave, onCancel }: RaisedMetricEditPanelProps) => {
+    const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
+
+    const defaultNameUa = metric.name || '';
+    const usdLocalization = metric.localizations?.find((l) => l.languageId === 2);
+    const defaultNameEn = usdLocalization?.name || '';
+
+    const defaultIsAutoSynced = false;
+
+    const defaultValueUah = formatWithSpaces(metric.value ?? 0);
+    const defaultValueUsd = formatWithSpaces(usdLocalization?.value ? parseInt(usdLocalization.value, 10) : 0);
+
+    const {
+        control,
+        handleSubmit,
+        watch,
+        formState: { errors, isValid },
+    } = useForm<RaisedMetricFormValues>({
+        mode: 'onBlur',
+        resolver: yupResolver(raisedMetricEditSchema),
+        defaultValues: {
+            nameUa: defaultNameUa,
+            nameEn: defaultNameEn,
+            isAutoSynced: defaultIsAutoSynced,
+            valueUah: defaultValueUah,
+            valueUsd: defaultValueUsd,
+        },
+    });
+
+    const currentNameUa = watch('nameUa');
+    const currentNameEn = watch('nameEn');
+    const currentIsAutoSynced = watch('isAutoSynced');
+    const currentValueUah = watch('valueUah');
+    const currentValueUsd = watch('valueUsd');
+
+    const isFormDirty =
+        currentNameUa.trim() !== defaultNameUa.trim() ||
+        currentNameEn.trim() !== defaultNameEn.trim() ||
+        currentIsAutoSynced !== defaultIsAutoSynced ||
+        currentValueUah !== defaultValueUah ||
+        currentValueUsd !== defaultValueUsd;
+
+    const onValidSubmit = (data: RaisedMetricFormValues) => {
+        const cleanUsdValue = data.valueUsd.replace(/\s/g, '');
+
+        let updatedLocalizations =
+            metric.localizations?.map((loc) => {
+                if (loc.languageId === 1) return { ...loc, name: data.nameUa.trim() };
+                if (loc.languageId === 2)
+                    return {
+                        ...loc,
+                        name: data.nameEn.trim(),
+                        value: cleanUsdValue,
+                    };
+                return loc;
+            }) || [];
+
+        if (!updatedLocalizations.some((l) => l.languageId === 2)) {
+            updatedLocalizations.push({
+                languageId: 2,
+                name: data.nameEn.trim(),
+                value: cleanUsdValue,
+            } as MetricLocalization);
+        }
+
+        const updatedMetric: Metric = {
+            ...metric,
+            name: data.nameUa.trim(),
+            value: parseInt(data.valueUah.replace(/\s/g, ''), 10),
+            prefix: metric.prefix ?? MetricPrefix.None,
+            localizations: updatedLocalizations,
+        };
+
+        if (onSave) onSave(updatedMetric);
+    };
+
     return (
         <div className={styles.panel}>
             <div className={styles.header}>{MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.TITLE}</div>
 
-            <div style={{ padding: '24px 0', color: '#666', fontSize: '14px' }}>
-                Редагування метрики "{metric.name}" наразі недоступне.
+            <div className={styles.formGrid}>
+                <Controller
+                    name="nameUa"
+                    control={control}
+                    render={({ field: { onChange, onBlur, value, name } }) => (
+                        <InputWithCharacterLimitGroup
+                            id={`raised-metric-ua-${metric.id}`}
+                            name={name}
+                            label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UKR_NAME_LABEL}
+                            value={value}
+                            onChange={onChange}
+                            onBlur={onBlur}
+                            error={errors.nameUa?.message}
+                            maxLength={MAIN_PAGE_VALIDATION.editPanel.name.max}
+                            isRequired
+                        />
+                    )}
+                />
+
+                <Controller
+                    name="nameEn"
+                    control={control}
+                    render={({ field: { onChange, onBlur, value, name } }) => (
+                        <InputWithCharacterLimitGroup
+                            id={`raised-metric-en-${metric.id}`}
+                            name={name}
+                            label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.ENG_NAME_LABEL}
+                            value={value}
+                            onChange={onChange}
+                            onBlur={onBlur}
+                            error={errors.nameEn?.message}
+                            maxLength={MAIN_PAGE_VALIDATION.editPanel.name.max}
+                            isRequired
+                        />
+                    )}
+                />
+            </div>
+
+            <div className={styles.divider} />
+
+            <div className={styles.syncRow}>
+                <span className={styles.syncText}>
+                    {currentIsAutoSynced
+                        ? MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.SYNC_ON_TEXT
+                        : MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.SYNC_OFF_TEXT}
+                </span>
+
+                <Controller
+                    name="isAutoSynced"
+                    control={control}
+                    render={({ field: { onChange, value } }) => (
+                        <Toggle id={`sync-toggle-${metric.id}`} checked={value} onChange={onChange} />
+                    )}
+                />
+            </div>
+
+            <div className={styles.formGrid}>
+                <Controller
+                    name="valueUah"
+                    control={control}
+                    render={({ field: { onChange, onBlur, value, name } }) => (
+                        <InputWithCharacterLimitGroup
+                            id={`raised-val-uah-${metric.id}`}
+                            name={name}
+                            label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UAH_VALUE_LABEL}
+                            value={value}
+                            onChange={(e) => onChange(formatNumberInput(e.target.value))}
+                            onBlur={onBlur}
+                            error={errors.valueUah?.message}
+                            maxLength={15}
+                            isRequired
+                            disabled={currentIsAutoSynced}
+                        />
+                    )}
+                />
+
+                <Controller
+                    name="valueUsd"
+                    control={control}
+                    render={({ field: { onChange, onBlur, value, name } }) => (
+                        <InputWithCharacterLimitGroup
+                            id={`raised-val-usd-${metric.id}`}
+                            name={name}
+                            label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.USD_VALUE_LABEL}
+                            value={value}
+                            onChange={(e) => onChange(formatNumberInput(e.target.value))}
+                            onBlur={onBlur}
+                            error={errors.valueUsd?.message}
+                            maxLength={15}
+                            isRequired
+                            disabled={currentIsAutoSynced}
+                        />
+                    )}
+                />
             </div>
 
             <div className={styles.actions}>
-                <Button buttonStyle="secondary" onClick={onCancel}>
+                <Button buttonStyle="secondary" onClick={() => (isFormDirty ? setIsCancelModalOpen(true) : onCancel())}>
                     {MAIN_PAGE_TEXT.BUTTONS.CANCEL}
                 </Button>
-                <Button buttonStyle="primary" disabled>
+                <Button buttonStyle="primary" onClick={handleSubmit(onValidSubmit)} disabled={!isFormDirty || !isValid}>
                     {MAIN_PAGE_TEXT.BUTTONS.SAVE}
                 </Button>
             </div>
+
+            <ConfirmationModal
+                isOpen={isCancelModalOpen}
+                onClose={() => setIsCancelModalOpen(false)}
+                title={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.CANCEL_MODAL_TITLE}
+                onConfirm={() => {
+                    setIsCancelModalOpen(false);
+                    onCancel();
+                }}
+                onCancel={() => setIsCancelModalOpen(false)}
+                confirmText={COMMON_TEXT_ADMIN.BUTTON.YES}
+                cancelText={COMMON_TEXT_ADMIN.BUTTON.NO}
+            />
         </div>
     );
 };

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.tsx
@@ -94,6 +94,7 @@ export const RaisedMetricEditPanel = ({ metric, onSave, onCancel }: RaisedMetric
             value: parseInt(data.valueUah.replace(/\s/g, ''), 10),
             prefix: metric.prefix ?? MetricPrefix.None,
             localizations: updatedLocalizations,
+            ...({ isAutoSynced: data.isAutoSynced } as any),
         };
 
         if (onSave) onSave(updatedMetric);

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.tsx
@@ -1,12 +1,8 @@
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
-import { Button } from '@/components/admin/button/Button';
-import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
 import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
 import { Toggle } from '@/components/admin/toggle/Toggle';
-import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
 import { Metric, MetricLocalization, MetricPrefix } from '@/types/admin/main-page';
 import { formatNumberInput, formatWithSpaces } from '@/utils/functions/formatters/format-number';
@@ -14,6 +10,7 @@ import {
     RaisedMetricFormValues,
     raisedMetricEditSchema,
 } from '@/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema';
+import { MetricEditActions } from '../common/metric-edit-actions/MetricEditActions';
 
 import styles from './RaisedMetricEditPanel.module.scss';
 
@@ -24,8 +21,6 @@ interface RaisedMetricEditPanelProps {
 }
 
 export const RaisedMetricEditPanel = ({ metric, onSave, onCancel }: RaisedMetricEditPanelProps) => {
-    const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
-
     const defaultNameUa = metric.name || '';
     const usdLocalization = metric.localizations?.find((l) => l.languageId === 2);
     const defaultNameEn = usdLocalization?.name || '';
@@ -200,26 +195,11 @@ export const RaisedMetricEditPanel = ({ metric, onSave, onCancel }: RaisedMetric
                 />
             </div>
 
-            <div className={styles.actions}>
-                <Button buttonStyle="secondary" onClick={() => (isFormDirty ? setIsCancelModalOpen(true) : onCancel())}>
-                    {MAIN_PAGE_TEXT.BUTTONS.CANCEL}
-                </Button>
-                <Button buttonStyle="primary" onClick={handleSubmit(onValidSubmit)} disabled={!isFormDirty || !isValid}>
-                    {MAIN_PAGE_TEXT.BUTTONS.SAVE}
-                </Button>
-            </div>
-
-            <ConfirmationModal
-                isOpen={isCancelModalOpen}
-                onClose={() => setIsCancelModalOpen(false)}
-                title={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.CANCEL_MODAL_TITLE}
-                onConfirm={() => {
-                    setIsCancelModalOpen(false);
-                    onCancel();
-                }}
-                onCancel={() => setIsCancelModalOpen(false)}
-                confirmText={COMMON_TEXT_ADMIN.BUTTON.YES}
-                cancelText={COMMON_TEXT_ADMIN.BUTTON.NO}
+            <MetricEditActions
+                isFormDirty={isFormDirty}
+                isValid={isValid}
+                onCancel={onCancel}
+                onSave={handleSubmit(onValidSubmit)}
             />
         </div>
     );

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.module.scss
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.module.scss
@@ -38,10 +38,3 @@
     font-size: 14px;
     color: c.$donate-tooltip-color;
 }
-
-.actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 12px;
-    margin-top: 8px;
-}

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.test.tsx
@@ -92,6 +92,18 @@ describe('StatisticsMetricEditPanel', () => {
         ]);
     });
 
+    it('preserves decimal value when saving', async () => {
+        const onSave = jest.fn();
+        render(<StatisticsMetricEditPanel metric={createMetric()} onSave={onSave} onCancel={jest.fn()} />);
+
+        fireEvent.change(screen.getByTestId('metric-val-1'), { target: { value: '2 345.75' } });
+        fireEvent.change(screen.getByTestId('metric-ua-1'), { target: { value: 'Нова UA' } });
+
+        const updatedMetric = await submitForm(onSave);
+
+        expect(updatedMetric.value).toBe(2345.75);
+    });
+
     it('uses fallback defaults when name and localizations are missing', () => {
         render(
             <StatisticsMetricEditPanel

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { Metric, MetricPrefix, MetricType } from '@/types/admin/main-page';
-
+import { MockMetricEditActions } from '@/utils/test-mocks/main-page-mocks';
 import { StatisticsMetricEditPanel } from './StatisticsMetricEditPanel';
 
 jest.mock('@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup', () => ({
@@ -31,16 +31,7 @@ jest.mock('@/components/admin/multi-select-input/MultiSelectInput', () => ({
 }));
 
 jest.mock('../common/metric-edit-actions/MetricEditActions', () => ({
-    MetricEditActions: ({ isFormDirty, isValid, onCancel, onSave }: any) => (
-        <div data-testid="metric-actions">
-            <button type="button" data-testid="mock-cancel" onClick={onCancel}>
-                Cancel
-            </button>
-            <button type="button" data-testid="mock-save" onClick={onSave} disabled={!isFormDirty || !isValid}>
-                Save
-            </button>
-        </div>
-    ),
+    MetricEditActions: (props: any) => <MockMetricEditActions {...props} />,
 }));
 
 const createMetric = (overrides: Partial<Metric> = {}): Metric => ({

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.test.tsx
@@ -1,7 +1,6 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
-import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
 import { Metric, MetricPrefix, MetricType } from '@/types/admin/main-page';
 
 import { StatisticsMetricEditPanel } from './StatisticsMetricEditPanel';
@@ -11,34 +10,6 @@ jest.mock('@/components/admin/input-groups/input-with-character-limit-group/Inpu
     InputWithCharacterLimitGroup: ({ id, value, onChange, onBlur }: any) => (
         <input data-testid={id} value={value ?? ''} onChange={onChange} onBlur={onBlur} />
     ),
-}));
-
-jest.mock('@/components/admin/button/Button', () => ({
-    __esModule: true,
-    Button: ({ children, buttonStyle: _buttonStyle, ...props }: any) => (
-        <button type="button" {...props}>
-            {children}
-        </button>
-    ),
-}));
-
-jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
-    __esModule: true,
-    ConfirmationModal: ({ isOpen, onConfirm, onCancel, onClose, title }: any) =>
-        isOpen ? (
-            <div data-testid="confirm-modal">
-                <div>{title}</div>
-                <button type="button" data-testid="confirm-action" onClick={onConfirm}>
-                    Confirm
-                </button>
-                <button type="button" data-testid="cancel-action" onClick={onCancel}>
-                    Cancel
-                </button>
-                <button type="button" data-testid="close-action" onClick={onClose}>
-                    Close
-                </button>
-            </div>
-        ) : null,
 }));
 
 jest.mock('@/components/admin/multi-select-input/MultiSelectInput', () => ({
@@ -59,6 +30,19 @@ jest.mock('@/components/admin/multi-select-input/MultiSelectInput', () => ({
     ),
 }));
 
+jest.mock('../common/metric-edit-actions/MetricEditActions', () => ({
+    MetricEditActions: ({ isFormDirty, isValid, onCancel, onSave }: any) => (
+        <div data-testid="metric-actions">
+            <button type="button" data-testid="mock-cancel" onClick={onCancel}>
+                Cancel
+            </button>
+            <button type="button" data-testid="mock-save" onClick={onSave} disabled={!isFormDirty || !isValid}>
+                Save
+            </button>
+        </div>
+    ),
+}));
+
 const createMetric = (overrides: Partial<Metric> = {}): Metric => ({
     id: 1,
     name: 'Назва UA',
@@ -72,13 +56,12 @@ const createMetric = (overrides: Partial<Metric> = {}): Metric => ({
 });
 
 describe('StatisticsMetricEditPanel', () => {
-    // Хелпер для усунення дублювання логіки сабміту в тестах
     const submitForm = async (onSaveMock: jest.Mock) => {
         fireEvent.blur(screen.getByTestId('metric-ua-1'));
         fireEvent.blur(screen.getByTestId('metric-en-1'));
         fireEvent.blur(screen.getByTestId('metric-val-1'));
 
-        const saveButton = screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.SAVE });
+        const saveButton = screen.getByTestId('mock-save');
         await waitFor(() => expect(saveButton).not.toBeDisabled());
         fireEvent.click(saveButton);
 
@@ -166,55 +149,6 @@ describe('StatisticsMetricEditPanel', () => {
         expect(updatedMetric.prefix).toBe(MetricPrefix.Plus);
     });
 
-    it('opens cancel modal when form is dirty and confirms cancel', async () => {
-        const onCancel = jest.fn();
-        render(<StatisticsMetricEditPanel metric={createMetric()} onSave={jest.fn()} onCancel={onCancel} />);
-
-        fireEvent.change(screen.getByTestId('metric-ua-1'), { target: { value: 'Зміна' } });
-
-        fireEvent.click(screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.CANCEL }));
-
-        expect(await screen.findByTestId('confirm-modal')).toBeInTheDocument();
-        fireEvent.click(screen.getByTestId('confirm-action'));
-
-        expect(onCancel).toHaveBeenCalledTimes(1);
-    });
-
-    it('closes cancel modal without triggering onCancel', async () => {
-        const onCancel = jest.fn();
-        render(<StatisticsMetricEditPanel metric={createMetric()} onSave={jest.fn()} onCancel={onCancel} />);
-
-        fireEvent.change(screen.getByTestId('metric-ua-1'), { target: { value: 'Зміна' } });
-        fireEvent.click(screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.CANCEL }));
-
-        expect(await screen.findByTestId('confirm-modal')).toBeInTheDocument();
-
-        fireEvent.click(screen.getByTestId('cancel-action'));
-        await waitFor(() => {
-            expect(screen.queryByTestId('confirm-modal')).not.toBeInTheDocument();
-        });
-
-        fireEvent.click(screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.CANCEL }));
-        expect(await screen.findByTestId('confirm-modal')).toBeInTheDocument();
-
-        fireEvent.click(screen.getByTestId('close-action'));
-        await waitFor(() => {
-            expect(screen.queryByTestId('confirm-modal')).not.toBeInTheDocument();
-        });
-
-        expect(onCancel).not.toHaveBeenCalled();
-    });
-
-    it('cancels immediately when form is not dirty', () => {
-        const onCancel = jest.fn();
-        render(<StatisticsMetricEditPanel metric={createMetric()} onSave={jest.fn()} onCancel={onCancel} />);
-
-        fireEvent.click(screen.getByRole('button', { name: MAIN_PAGE_TEXT.BUTTONS.CANCEL }));
-
-        expect(onCancel).toHaveBeenCalledTimes(1);
-        expect(screen.queryByTestId('confirm-modal')).not.toBeInTheDocument();
-    });
-
     it('handles saving when localizations are undefined', async () => {
         const onSave = jest.fn();
         const metric = createMetric({ localizations: undefined as any });
@@ -249,5 +183,14 @@ describe('StatisticsMetricEditPanel', () => {
         await waitFor(() => {
             expect(screen.getByTestId('metric-prefix-1')).toBeInTheDocument();
         });
+    });
+
+    it('calls onCancel when cancel action is triggered', () => {
+        const onCancelMock = jest.fn();
+        render(<StatisticsMetricEditPanel metric={createMetric()} onSave={jest.fn()} onCancel={onCancelMock} />);
+
+        fireEvent.click(screen.getByTestId('mock-cancel'));
+
+        expect(onCancelMock).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
@@ -5,7 +5,11 @@ import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/in
 import { MultiSelectInput } from '@/components/admin/multi-select-input/MultiSelectInput';
 import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
 import { Metric, MetricPrefix } from '@/types/admin/main-page';
-import { formatCurrencyInput, formatWithSpaces } from '@/utils/functions/formatters/format-number';
+import {
+    formatCurrencyInput,
+    formatWithSpaces,
+    parseFormattedNumber,
+} from '@/utils/functions/formatters/format-number';
 import {
     MetricFormValues,
     metricEditSchema,
@@ -71,7 +75,7 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
         const updatedMetric: Metric = {
             ...metric,
             name: data.nameUa.trim(),
-            value: parseInt(data.value.replace(/\s/g, ''), 10),
+            value: parseFormattedNumber(data.value) ?? 0,
             prefix: data.prefix,
             localizations: updatedLocalizations,
         };

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
@@ -1,11 +1,15 @@
+import { yupResolver } from '@hookform/resolvers/yup';
 import { Controller, useForm } from 'react-hook-form';
 
 import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
 import { MultiSelectInput } from '@/components/admin/multi-select-input/MultiSelectInput';
 import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
 import { Metric, MetricPrefix } from '@/types/admin/main-page';
-import { formatNumberInput, formatWithSpaces } from '@/utils/functions/formatters/format-number';
-import { MetricFormValues } from '@/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema';
+import { formatCurrencyInput, formatWithSpaces } from '@/utils/functions/formatters/format-number';
+import {
+    MetricFormValues,
+    metricEditSchema,
+} from '@/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema';
 import { MetricEditActions } from '../common/metric-edit-actions/MetricEditActions';
 
 import styles from './StatisticsMetricEditPanel.module.scss';
@@ -35,6 +39,7 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
         formState: { errors, isValid },
     } = useForm<MetricFormValues>({
         mode: 'onBlur',
+        resolver: yupResolver(metricEditSchema),
         defaultValues: {
             nameUa: defaultNameUa,
             nameEn: defaultNameEn,
@@ -123,7 +128,7 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
                             name={name}
                             label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.VALUE_LABEL}
                             value={value}
-                            onChange={(e) => onChange(formatNumberInput(e.target.value))}
+                            onChange={(e) => onChange(formatCurrencyInput(e.target.value))}
                             onBlur={onBlur}
                             error={errors.value?.message}
                             maxLength={15}

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
@@ -1,15 +1,12 @@
-import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
-import { Button } from '@/components/admin/button/Button';
-import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
 import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
 import { MultiSelectInput } from '@/components/admin/multi-select-input/MultiSelectInput';
-import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
 import { Metric, MetricPrefix } from '@/types/admin/main-page';
 import { formatNumberInput, formatWithSpaces } from '@/utils/functions/formatters/format-number';
 import { MetricFormValues } from '@/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema';
+import { MetricEditActions } from '../common/metric-edit-actions/MetricEditActions';
 
 import styles from './StatisticsMetricEditPanel.module.scss';
 
@@ -26,8 +23,6 @@ const PREFIX_OPTIONS = [
 ];
 
 export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: StatisticsMetricEditPanelProps) => {
-    const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
-
     const defaultNameUa = metric.name || '';
     const defaultNameEn = metric.localizations?.find((l) => l.languageId === 2)?.name || '';
     const defaultValueStr = formatWithSpaces(metric.value ?? 0);
@@ -159,26 +154,11 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
                 </div>
             </div>
 
-            <div className={styles.actions}>
-                <Button buttonStyle="secondary" onClick={() => (isFormDirty ? setIsCancelModalOpen(true) : onCancel())}>
-                    {MAIN_PAGE_TEXT.BUTTONS.CANCEL}
-                </Button>
-                <Button buttonStyle="primary" onClick={handleSubmit(onValidSubmit)} disabled={!isFormDirty || !isValid}>
-                    {MAIN_PAGE_TEXT.BUTTONS.SAVE}
-                </Button>
-            </div>
-
-            <ConfirmationModal
-                isOpen={isCancelModalOpen}
-                onClose={() => setIsCancelModalOpen(false)}
-                title={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.CANCEL_MODAL_TITLE}
-                onConfirm={() => {
-                    setIsCancelModalOpen(false);
-                    onCancel();
-                }}
-                onCancel={() => setIsCancelModalOpen(false)}
-                confirmText={COMMON_TEXT_ADMIN.BUTTON.YES}
-                cancelText={COMMON_TEXT_ADMIN.BUTTON.NO}
+            <MetricEditActions
+                isFormDirty={isFormDirty}
+                isValid={isValid}
+                onCancel={onCancel}
+                onSave={handleSubmit(onValidSubmit)}
             />
         </div>
     );

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
@@ -3,7 +3,7 @@ import { Controller, useForm } from 'react-hook-form';
 
 import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
 import { MultiSelectInput } from '@/components/admin/multi-select-input/MultiSelectInput';
-import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
+import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
 import { Metric, MetricPrefix } from '@/types/admin/main-page';
 import { formatCurrencyInput, formatWithSpaces } from '@/utils/functions/formatters/format-number';
 import {
@@ -11,6 +11,7 @@ import {
     metricEditSchema,
 } from '@/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema';
 import { MetricEditActions } from '../common/metric-edit-actions/MetricEditActions';
+import { MetricNameFields } from '../common/metric-name-fields/MetricNameFields';
 
 import styles from './StatisticsMetricEditPanel.module.scss';
 
@@ -83,41 +84,7 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
             <div className={styles.header}>{MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.TITLE}</div>
 
             <div className={styles.formGrid}>
-                <Controller
-                    name="nameUa"
-                    control={control}
-                    render={({ field: { onChange, onBlur, value, name } }) => (
-                        <InputWithCharacterLimitGroup
-                            id={`metric-ua-${metric.id}`}
-                            name={name}
-                            label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UKR_NAME_LABEL}
-                            value={value}
-                            onChange={onChange}
-                            onBlur={onBlur}
-                            error={errors.nameUa?.message}
-                            maxLength={MAIN_PAGE_VALIDATION.editPanel.name.max}
-                            isRequired
-                        />
-                    )}
-                />
-
-                <Controller
-                    name="nameEn"
-                    control={control}
-                    render={({ field: { onChange, onBlur, value, name } }) => (
-                        <InputWithCharacterLimitGroup
-                            id={`metric-en-${metric.id}`}
-                            name={name}
-                            label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.ENG_NAME_LABEL}
-                            value={value}
-                            onChange={onChange}
-                            onBlur={onBlur}
-                            error={errors.nameEn?.message}
-                            maxLength={MAIN_PAGE_VALIDATION.editPanel.name.max}
-                            isRequired
-                        />
-                    )}
-                />
+                <MetricNameFields metricId={metric.id} control={control} errors={errors} />
 
                 <Controller
                     name="value"

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
@@ -1,4 +1,3 @@
-import { yupResolver } from '@hookform/resolvers/yup';
 import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
@@ -10,10 +9,7 @@ import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { MAIN_PAGE_TEXT, MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
 import { Metric, MetricPrefix } from '@/types/admin/main-page';
 import { formatNumberInput, formatWithSpaces } from '@/utils/functions/formatters/format-number';
-import {
-    MetricFormValues,
-    metricEditSchema,
-} from '@/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema';
+import { MetricFormValues } from '@/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema';
 
 import styles from './StatisticsMetricEditPanel.module.scss';
 
@@ -32,20 +28,36 @@ const PREFIX_OPTIONS = [
 export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: StatisticsMetricEditPanelProps) => {
     const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
 
+    const defaultNameUa = metric.name || '';
+    const defaultNameEn = metric.localizations?.find((l) => l.languageId === 2)?.name || '';
+    const defaultValueStr = formatWithSpaces(metric.value ?? 0);
+    const defaultPrefix = metric.prefix ?? MetricPrefix.None;
+
     const {
         control,
         handleSubmit,
-        formState: { errors, isDirty, isValid },
+        watch,
+        formState: { errors, isValid },
     } = useForm<MetricFormValues>({
         mode: 'onBlur',
-        resolver: yupResolver(metricEditSchema),
         defaultValues: {
-            nameUa: metric.name || '',
-            nameEn: metric.localizations?.find((l) => l.languageId === 2)?.name || '',
-            value: formatWithSpaces(metric.value ?? 0),
-            prefix: metric.prefix ?? MetricPrefix.None,
+            nameUa: defaultNameUa,
+            nameEn: defaultNameEn,
+            value: defaultValueStr,
+            prefix: defaultPrefix,
         },
     });
+
+    const currentNameUa = watch('nameUa');
+    const currentNameEn = watch('nameEn');
+    const currentValue = watch('value');
+    const currentPrefix = watch('prefix');
+
+    const isFormDirty =
+        currentNameUa.trim() !== defaultNameUa.trim() ||
+        currentNameEn.trim() !== defaultNameEn.trim() ||
+        currentValue !== defaultValueStr ||
+        currentPrefix !== defaultPrefix;
 
     const onValidSubmit = (data: MetricFormValues) => {
         const updatedLocalizations =
@@ -148,10 +160,10 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
             </div>
 
             <div className={styles.actions}>
-                <Button buttonStyle="secondary" onClick={() => (isDirty ? setIsCancelModalOpen(true) : onCancel())}>
+                <Button buttonStyle="secondary" onClick={() => (isFormDirty ? setIsCancelModalOpen(true) : onCancel())}>
                     {MAIN_PAGE_TEXT.BUTTONS.CANCEL}
                 </Button>
-                <Button buttonStyle="primary" onClick={handleSubmit(onValidSubmit)} disabled={!isDirty || !isValid}>
+                <Button buttonStyle="primary" onClick={handleSubmit(onValidSubmit)} disabled={!isFormDirty || !isValid}>
                     {MAIN_PAGE_TEXT.BUTTONS.SAVE}
                 </Button>
             </div>

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.module.scss
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.module.scss
@@ -51,7 +51,7 @@
 
 .row {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 140px 64px;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 140px 64px;
     width: 100%;
     align-items: center;
     gap: 16px;
@@ -61,13 +61,13 @@
     border-radius: 8px;
 }
 
-.labels {
-    min-width: 0;
-}
-
-.ua {
+.ua,
+.en {
     @include type.body-2-medium;
     margin: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .values {

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.module.scss
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.module.scss
@@ -55,10 +55,17 @@
     width: 100%;
     align-items: center;
     gap: 16px;
-    height: 40px;
-    padding: 0;
+    min-height: 40px;
+    padding: 8px 0;
     border: none;
     border-radius: 8px;
+}
+
+.raisedValues {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 2px;
 }
 
 .ua,
@@ -71,6 +78,7 @@
 }
 
 .values {
+    margin: 0;
     text-align: left;
     justify-self: start;
 }
@@ -78,6 +86,7 @@
 .value {
     @include type.body-2-medium;
     margin: 0;
+    line-height: 1.2;
 }
 
 .actions {

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
@@ -51,6 +51,7 @@ const metrics: Metric[] = [
         priority: 1,
         localizations: [
             { language: { id: 1, code: 'uk' }, translationStatus: TranslationStatus.Relevant, name: 'Партнерів' },
+            { language: { id: 2, code: 'en' }, translationStatus: TranslationStatus.Relevant, name: 'Partners' },
         ],
     },
     {
@@ -87,12 +88,23 @@ describe('StatisticsMetricsList', () => {
     it('renders metrics list', () => {
         setup();
         expect(screen.getByText('Партнерів')).toBeInTheDocument();
+        expect(screen.getByText('Partners')).toBeInTheDocument();
         expect(screen.getByText('20+')).toBeInTheDocument();
     });
 
     it('falls back to metric name when localization is missing', () => {
-        setup();
-        expect(screen.getByText('Engagement')).toBeInTheDocument();
+        render(
+            <StatisticsMetricsList
+                metrics={metrics}
+                hiddenMetricIds={[]}
+                onToggleVisibility={jest.fn()}
+                onReorder={jest.fn()}
+            />,
+        );
+
+        const elements = screen.getAllByText('Engagement');
+        expect(elements).toHaveLength(2);
+        expect(elements[0]).toBeInTheDocument();
     });
 
     it('formats percent values', () => {

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
@@ -4,6 +4,8 @@ import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { StatisticsMetricsList } from './StatisticsMetricsList';
 
+const normalizeSpaces = (value: string) => value.replace(/\u00a0/g, ' ');
+
 jest.mock('@/components/admin/draggable-list-item/DraggableListItem', () => ({
     DraggableListItem: ({ renderEntityComponent, entity, idSelector }: any) => {
         const id = idSelector?.(entity);
@@ -40,6 +42,19 @@ jest.mock('../statistics-metric-edit-panel/StatisticsMetricEditPanel', () => ({
     ),
 }));
 
+jest.mock('../raised-metric-edit-panel/RaisedMetricEditPanel', () => ({
+    RaisedMetricEditPanel: ({ metric, onSave, onCancel }: any) => (
+        <div data-testid="raised-edit-panel">
+            <button
+                type="button"
+                data-testid="save-raised-edit"
+                onClick={() => onSave({ ...metric, name: 'Updated Raised' })}
+            />
+            <button type="button" data-testid="cancel-raised-edit" onClick={onCancel} />
+        </div>
+    ),
+}));
+
 const metrics: Metric[] = [
     {
         id: 1,
@@ -56,13 +71,13 @@ const metrics: Metric[] = [
     },
     {
         id: 2,
-        name: 'Engagement',
-        value: 50,
-        type: MetricType.Partners,
-        prefix: MetricPrefix.Percent,
+        name: 'Зібрано',
+        value: 5000000,
+        type: MetricType.Raised,
+        prefix: MetricPrefix.None,
         isHidden: false,
         priority: 2,
-        localizations: [],
+        localizations: [{ languageId: 2, name: 'Raised', value: '125000' } as any],
     },
 ];
 
@@ -85,32 +100,33 @@ describe('StatisticsMetricsList', () => {
         };
     };
 
-    it('renders metrics list', () => {
+    it('renders metrics list correctly', () => {
         setup();
         expect(screen.getByText('Партнерів')).toBeInTheDocument();
         expect(screen.getByText('Partners')).toBeInTheDocument();
         expect(screen.getByText('20+')).toBeInTheDocument();
     });
 
-    it('falls back to metric name when localization is missing', () => {
-        render(
-            <StatisticsMetricsList
-                metrics={metrics}
-                hiddenMetricIds={[]}
-                onToggleVisibility={jest.fn()}
-                onReorder={jest.fn()}
-                onMetricUpdate={jest.fn()}
-            />,
-        );
+    it('renders both UAH and USD values with symbols for Raised metric type', () => {
+        setup();
+        const raisedUahEl = screen.getByText((content) => normalizeSpaces(content).includes('₴5 000 000'));
+        expect(raisedUahEl).toBeInTheDocument();
 
-        const elements = screen.getAllByText('Engagement');
-        expect(elements).toHaveLength(2);
-        expect(elements[0]).toBeInTheDocument();
+        const raisedUsdEl = screen.getByText('$125,000');
+        expect(raisedUsdEl).toBeInTheDocument();
     });
 
-    it('formats percent values', () => {
-        setup();
-        expect(screen.getByText('50%')).toBeInTheDocument();
+    it('falls back to metric name when localization is missing', () => {
+        const metricWithoutLoc: Metric = {
+            ...metrics[0],
+            id: 99,
+            name: 'NoLocName',
+            localizations: [],
+        };
+        setup({ metrics: [metricWithoutLoc] });
+
+        const elements = screen.getAllByText('NoLocName');
+        expect(elements).toHaveLength(2);
     });
 
     it('uses "Show metric" label when metric is hidden', () => {
@@ -130,19 +146,6 @@ describe('StatisticsMetricsList', () => {
         expect(onToggleVisibility).not.toHaveBeenCalled();
     });
 
-    it('formats value with no prefix (default case)', () => {
-        const noPrefix: Metric = {
-            ...metrics[0],
-            id: 3,
-            value: 100,
-            prefix: undefined,
-            localizations: [],
-            name: 'NoPrefix',
-        };
-        setup({ metrics: [noPrefix] });
-        expect(screen.getByText('100')).toBeInTheDocument();
-    });
-
     it('disables toggle button for last visible metric', () => {
         setup({ metrics: [metrics[0]] });
         const eyeButton = screen.getByTestId('icon-Hide metric');
@@ -155,8 +158,9 @@ describe('StatisticsMetricsList', () => {
         expect(onToggleVisibility).not.toHaveBeenCalled();
     });
 
-    it('renders edit panel and saves updated metric', () => {
+    it('renders standard edit panel and saves updated metric', () => {
         const { onMetricUpdate } = setup();
+
         fireEvent.click(screen.getAllByTestId('icon-Edit metric')[0]);
         expect(screen.getByTestId('metric-edit-panel')).toBeInTheDocument();
 
@@ -164,12 +168,27 @@ describe('StatisticsMetricsList', () => {
         expect(onMetricUpdate).toHaveBeenCalledWith([{ ...metrics[0], name: 'Updated Metric' }, metrics[1]]);
     });
 
-    it('closes edit panel on cancel', () => {
+    it('renders raised edit panel and saves updated metric', () => {
+        const { onMetricUpdate } = setup();
+
+        fireEvent.click(screen.getAllByTestId('icon-Edit metric')[1]);
+        expect(screen.getByTestId('raised-edit-panel')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('save-raised-edit'));
+        expect(onMetricUpdate).toHaveBeenCalledWith([metrics[0], { ...metrics[1], name: 'Updated Raised' }]);
+    });
+
+    it('closes edit panels on cancel', () => {
         setup();
+
         fireEvent.click(screen.getAllByTestId('icon-Edit metric')[0]);
         expect(screen.getByTestId('metric-edit-panel')).toBeInTheDocument();
-
         fireEvent.click(screen.getByTestId('cancel-edit'));
         expect(screen.queryByTestId('metric-edit-panel')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getAllByTestId('icon-Edit metric')[1]);
+        expect(screen.getByTestId('raised-edit-panel')).toBeInTheDocument();
+        fireEvent.click(screen.getByTestId('cancel-raised-edit'));
+        expect(screen.queryByTestId('raised-edit-panel')).not.toBeInTheDocument();
     });
 });

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
@@ -1,5 +1,5 @@
-import { Metric, MetricPrefix, MetricType } from '@/types/admin/main-page';
-import { TranslationStatus } from '@/types/common/language';
+import { Metric } from '@/types/admin/main-page';
+import { metricPartners, metricRaised } from '@/utils/test-mocks/statistics-block-mocks';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { StatisticsMetricsList } from './StatisticsMetricsList';
@@ -55,31 +55,7 @@ jest.mock('../raised-metric-edit-panel/RaisedMetricEditPanel', () => ({
     ),
 }));
 
-const metrics: Metric[] = [
-    {
-        id: 1,
-        name: 'Партнерів',
-        value: 20,
-        type: MetricType.Partners,
-        prefix: MetricPrefix.Plus,
-        isHidden: false,
-        priority: 1,
-        localizations: [
-            { language: { id: 1, code: 'uk' }, translationStatus: TranslationStatus.Relevant, name: 'Партнерів' },
-            { language: { id: 2, code: 'en' }, translationStatus: TranslationStatus.Relevant, name: 'Partners' },
-        ],
-    },
-    {
-        id: 2,
-        name: 'Зібрано',
-        value: 5000000,
-        type: MetricType.Raised,
-        prefix: MetricPrefix.None,
-        isHidden: false,
-        priority: 2,
-        localizations: [{ languageId: 2, name: 'Raised', value: '125000' } as any],
-    },
-];
+const metrics: Metric[] = [metricPartners, metricRaised];
 
 describe('StatisticsMetricsList', () => {
     const setup = (propsOverrides: Partial<React.ComponentProps<typeof StatisticsMetricsList>> = {}) => {

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
@@ -99,6 +99,7 @@ describe('StatisticsMetricsList', () => {
                 hiddenMetricIds={[]}
                 onToggleVisibility={jest.fn()}
                 onReorder={jest.fn()}
+                onMetricUpdate={jest.fn()}
             />,
         );
 

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
@@ -52,6 +52,7 @@ export const StatisticsMetricsList = ({
 
         const isHidden = hiddenMetricIds.includes(metric.id ?? 0);
         const isLastVisible = !isHidden && visibleMetricsCount <= 1;
+        const usdValue = metric.localizations?.find((l) => l.languageId === 2)?.value;
 
         return (
             <div className={styles.row}>
@@ -60,9 +61,20 @@ export const StatisticsMetricsList = ({
                 <p className={`${styles.en} ${isHidden ? styles.hiddenText : ''}`}>{getMetricName(metric, 'EN')}</p>
 
                 <div className={styles.values}>
-                    <p className={`${styles.value} ${isHidden ? styles.hiddenText : ''}`}>
-                        {formatMetricValue(metric)}
-                    </p>
+                    {metric.type === MetricType.Raised ? (
+                        <div className={styles.raisedValues}>
+                            <p className={`${styles.value} ${isHidden ? styles.hiddenText : ''}`}>
+                                ₴{formatMetricValue(metric)}
+                            </p>
+                            <p className={`${styles.value} ${isHidden ? styles.hiddenText : ''}`}>
+                                ${usdValue ? formatMetricValue({ ...metric, value: parseInt(usdValue, 10) }) : '0'}
+                            </p>
+                        </div>
+                    ) : (
+                        <p className={`${styles.value} ${isHidden ? styles.hiddenText : ''}`}>
+                            {formatMetricValue(metric)}
+                        </p>
+                    )}
                 </div>
 
                 <div className={styles.actions}>

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
@@ -55,9 +55,9 @@ export const StatisticsMetricsList = ({
 
         return (
             <div className={styles.row}>
-                <div className={styles.labels}>
-                    <p className={`${styles.ua} ${isHidden ? styles.hiddenText : ''}`}>{getMetricName(metric)}</p>
-                </div>
+                <p className={`${styles.ua} ${isHidden ? styles.hiddenText : ''}`}>{getMetricName(metric, 'UA')}</p>
+
+                <p className={`${styles.en} ${isHidden ? styles.hiddenText : ''}`}>{getMetricName(metric, 'EN')}</p>
 
                 <div className={styles.values}>
                     <p className={`${styles.value} ${isHidden ? styles.hiddenText : ''}`}>

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
@@ -38,7 +38,13 @@ export const StatisticsMetricsList = ({
     const renderRow = (metric: Metric) => {
         if (editingMetricId === metric.id) {
             if (metric.type === MetricType.Raised) {
-                return <RaisedMetricEditPanel metric={metric} onCancel={() => setEditingMetricId(null)} />;
+                return (
+                    <RaisedMetricEditPanel
+                        metric={metric}
+                        onSave={handleSaveMetric}
+                        onCancel={() => setEditingMetricId(null)}
+                    />
+                );
             }
 
             return (
@@ -64,10 +70,10 @@ export const StatisticsMetricsList = ({
                     {metric.type === MetricType.Raised ? (
                         <div className={styles.raisedValues}>
                             <p className={`${styles.value} ${isHidden ? styles.hiddenText : ''}`}>
-                                ₴{formatMetricValue(metric)}
+                                ₴{formatMetricValue(metric, 'UA')}
                             </p>
                             <p className={`${styles.value} ${isHidden ? styles.hiddenText : ''}`}>
-                                ${usdValue ? formatMetricValue({ ...metric, value: parseInt(usdValue, 10) }) : '0'}
+                                ${formatMetricValue(metric, 'EN')}
                             </p>
                         </div>
                     ) : (

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
@@ -58,7 +58,6 @@ export const StatisticsMetricsList = ({
 
         const isHidden = hiddenMetricIds.includes(metric.id ?? 0);
         const isLastVisible = !isHidden && visibleMetricsCount <= 1;
-        const usdValue = metric.localizations?.find((l) => l.languageId === 2)?.value;
 
         return (
             <div className={styles.row}>

--- a/src/pages/admin/main/components/statistics-block/components/statistics-preview/StatisticsPreview.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-preview/StatisticsPreview.test.tsx
@@ -58,7 +58,14 @@ describe('StatisticsPreview', () => {
     });
 
     it('hides metrics by hiddenMetricIds', () => {
-        render(<StatisticsPreview language="UA" onLanguageChange={() => {}} metrics={metrics} hiddenMetricIds={[2]} />);
+        render(
+            <StatisticsPreview
+                language="UA"
+                onLanguageChange={() => {}}
+                metrics={metrics}
+                hiddenMetricIds={[metricEngagement.id ?? 0]}
+            />,
+        );
 
         expect(screen.getByText('Партнерів')).toBeInTheDocument();
         expect(screen.queryByText('Engagement')).not.toBeInTheDocument();

--- a/src/pages/admin/main/components/statistics-block/components/statistics-preview/StatisticsPreview.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-preview/StatisticsPreview.test.tsx
@@ -1,34 +1,10 @@
-import { Metric, MetricPrefix, MetricType } from '@/types/admin/main-page';
-import { TranslationStatus } from '@/types/common/language';
+import { Metric } from '@/types/admin/main-page';
+import { metricEngagement, metricPartners } from '@/utils/test-mocks/statistics-block-mocks';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { StatisticsPreview } from './StatisticsPreview';
 
-const metrics: Metric[] = [
-    {
-        id: 1,
-        name: 'Партнерів',
-        value: 20,
-        type: MetricType.Partners,
-        prefix: MetricPrefix.Plus,
-        isHidden: false,
-        priority: 1,
-        localizations: [
-            { language: { id: 1, code: 'uk' }, translationStatus: TranslationStatus.Relevant, name: 'Партнерів' },
-            { language: { id: 2, code: 'en' }, translationStatus: TranslationStatus.Relevant, name: 'Partners' },
-        ],
-    },
-    {
-        id: 2,
-        name: 'Engagement',
-        value: 50,
-        type: MetricType.Programs,
-        prefix: MetricPrefix.Percent,
-        isHidden: false,
-        priority: 2,
-        localizations: [],
-    },
-];
+const metrics: Metric[] = [metricPartners, metricEngagement];
 
 describe('StatisticsPreview', () => {
     it('renders preview title and metrics', () => {

--- a/src/types/admin/main-page.ts
+++ b/src/types/admin/main-page.ts
@@ -52,6 +52,7 @@ export interface MetricLocalization extends EntityLocalization {
     entityId?: number;
     languageId?: number;
     name?: string;
+    value?: string | null;
 }
 
 // Domain/UI Models
@@ -123,6 +124,7 @@ export interface ImpactStatisticLocalizationDto extends EntityLocalizationDto {
 export interface MetricLocalizationDto extends EntityLocalizationDto {
     entityId?: number;
     name?: string | null;
+    value?: string | null;
 }
 
 export interface MetricDto extends EntityWithDtoLocalizations<MetricLocalizationDto> {
@@ -169,6 +171,7 @@ export interface MainPageDto extends EntityWithDtoLocalizations<MainPageLocaliza
 export interface CreateMetricLocalizationDto {
     languageId?: number;
     name?: string;
+    value?: string | null;
 }
 
 export interface CreateMetricDto {
@@ -215,6 +218,7 @@ export interface CreateMainPageDto {
 export interface UpdateMetricLocalizationDto {
     languageId?: number;
     name?: string;
+    value?: string | null;
 }
 
 export interface UpdateImpactStatisticLocalizationDto {

--- a/src/types/admin/main-page.ts
+++ b/src/types/admin/main-page.ts
@@ -63,6 +63,7 @@ export interface Metric extends EntityWithLocalizations<MetricLocalization> {
     name: string;
     type: MetricType;
     prefix?: MetricPrefix | null;
+    isAutoSynced?: boolean;
     isHidden: boolean;
     priority: number;
 }
@@ -133,6 +134,7 @@ export interface MetricDto extends EntityWithDtoLocalizations<MetricLocalization
     name?: string | null;
     type?: MetricType;
     prefix?: MetricPrefix | null;
+    isAutoSynced?: boolean;
     isHidden?: boolean;
     priority?: number;
 }
@@ -250,6 +252,7 @@ export interface UpdateMetricDto {
     name: string;
     type: MetricType;
     prefix?: MetricPrefix | null;
+    isAutoSynced?: boolean;
     localization?: UpdateMetricLocalizationDto | null;
 }
 

--- a/src/utils/functions/formatters/format-number.test.ts
+++ b/src/utils/functions/formatters/format-number.test.ts
@@ -76,53 +76,48 @@ describe('format-number formatters', () => {
     });
 
     describe('formatCurrencyInput', () => {
-        it('removes invalid characters before formatting', () => {
-            expectFormatCases(formatCurrencyInput, [
-                ['abc', ''],
-                ['12abc', '12'],
-                ['1a2', '12'],
-            ]);
-        });
+        const formatCurrencyInputCases: Array<{
+            description: string;
+            cases: Array<[input: string, expected: string]>;
+        }> = [
+            {
+                description: 'removes invalid characters before formatting',
+                cases: [
+                    ['abc', ''],
+                    ['12abc', '12'],
+                    ['1a2', '12'],
+                ],
+            },
+            {
+                description: 'formats integers with spaces as thousands separators',
+                cases: [
+                    ['1000', '1 000'],
+                    ['1234567', '1 234 567'],
+                ],
+            },
+            {
+                description: 'replaces comma with dot before formatting',
+                cases: [
+                    ['1000,50', '1 000.50'],
+                    ['999,9', '999.9'],
+                    ['1,2,3', '1.23'],
+                ],
+            },
+            {
+                description: 'truncates the decimal part to 2 decimal places',
+                cases: [
+                    ['100.999', '100.99'],
+                    ['1.1234', '1.12'],
+                ],
+            },
+            {
+                description: 'ignores extra periods more than one',
+                cases: [['1.2.3', '1.23']],
+            },
+        ];
 
-        it('formats integers with spaces as thousands separators', () => {
-            expectFormatCases(formatCurrencyInput, [
-                ['1000', '1 000'],
-                ['1234567', '1 234 567'],
-            ]);
-        });
-
-        it('replaces comma with dot before formatting', () => {
-            expectFormatCases(formatCurrencyInput, [
-                ['1000,50', '1 000.50'],
-                ['999,9', '999.9'],
-                ['1,2,3', '1.23'],
-            ]);
-        });
-
-        it('truncates the decimal part to 2 decimal places', () => {
-            expectFormatCases(formatCurrencyInput, [
-                ['100.999', '100.99'],
-                ['1.1234', '1.12'],
-            ]);
-        });
-
-        it('ignores extra periods (more than one)', () => {
-            expect(formatCurrencyInput('1.2.3')).toBe('1.23');
-        });
-
-        it('returns empty string for empty input', () => {
-            expect(formatCurrencyInput('')).toBe('');
-        });
-
-        it('correctly handles spaces in the input (considered valid)', () => {
-            expect(formatCurrencyInput('1 000')).toBe('1 000');
-        });
-
-        it('preserves a leading minus for validation', () => {
-            expectFormatCases(formatCurrencyInput, [
-                ['-1000.50', '-1 000.50'],
-                ['10-00', '1 000'],
-            ]);
+        it.each(formatCurrencyInputCases)('$description', ({ cases }) => {
+            expectFormatCases(formatCurrencyInput, cases);
         });
     });
 

--- a/src/utils/functions/formatters/format-number.test.ts
+++ b/src/utils/functions/formatters/format-number.test.ts
@@ -1,4 +1,5 @@
 import {
+    formatCurrencyInput,
     formatNumberDecimalComma,
     formatNumberInput,
     formatWithSpaces,
@@ -64,6 +65,41 @@ describe('format-number formatters', () => {
             expect(formatNumberInput('')).toBe('');
             expect(formatNumberInput('abc')).toBe('');
             expect(formatNumberInput('!@#$')).toBe('');
+        });
+    });
+
+    describe('formatCurrencyInput', () => {
+        it('returns the string unchanged if it contains letters', () => {
+            expect(formatCurrencyInput('abc')).toBe('abc');
+            expect(formatCurrencyInput('12abc')).toBe('12abc');
+            expect(formatCurrencyInput('1a2')).toBe('1a2');
+        });
+
+        it('formats integers with spaces as thousands separators', () => {
+            expect(formatCurrencyInput('1000')).toBe('1 000');
+            expect(formatCurrencyInput('1234567')).toBe('1 234 567');
+        });
+
+        it('replaces comma with dot before formatting', () => {
+            expect(formatCurrencyInput('1000,50')).toBe('1 000.50');
+            expect(formatCurrencyInput('999,9')).toBe('999.9');
+        });
+
+        it('truncates the decimal part to 2 decimal places', () => {
+            expect(formatCurrencyInput('100.999')).toBe('100.99');
+            expect(formatCurrencyInput('1.1234')).toBe('1.12');
+        });
+
+        it('ignores extra periods (more than one)', () => {
+            expect(formatCurrencyInput('1.2.3')).toBe('1.23');
+        });
+
+        it('returns empty string for empty input', () => {
+            expect(formatCurrencyInput('')).toBe('');
+        });
+
+        it('correctly handles spaces in the input (considered valid)', () => {
+            expect(formatCurrencyInput('1 000')).toBe('1 000');
         });
     });
 });

--- a/src/utils/functions/formatters/format-number.test.ts
+++ b/src/utils/functions/formatters/format-number.test.ts
@@ -3,6 +3,8 @@ import {
     formatNumberDecimalComma,
     formatNumberInput,
     formatWithSpaces,
+    normalizeFormattedNumber,
+    parseFormattedNumber,
 } from '@/utils/functions/formatters/format-number';
 
 describe('format-number formatters', () => {
@@ -16,8 +18,7 @@ describe('format-number formatters', () => {
             expect(formatNumberDecimalComma(123)).toBe('123');
             expect(formatNumberDecimalComma(123.45)).toBe('123,45');
             expect(formatNumberDecimalComma('1000.5')).toBe('1000,5');
-            // only the first dot is replaced (keeps previous behaviour)
-            expect(formatNumberDecimalComma('1.2.3')).toBe('1,2.3');
+            expect(formatNumberDecimalComma('1.2.3')).toBe('1,2,3');
         });
 
         it('leaves strings without dot unchanged', () => {
@@ -69,10 +70,10 @@ describe('format-number formatters', () => {
     });
 
     describe('formatCurrencyInput', () => {
-        it('returns the string unchanged if it contains letters', () => {
-            expect(formatCurrencyInput('abc')).toBe('abc');
-            expect(formatCurrencyInput('12abc')).toBe('12abc');
-            expect(formatCurrencyInput('1a2')).toBe('1a2');
+        it('removes invalid characters before formatting', () => {
+            expect(formatCurrencyInput('abc')).toBe('');
+            expect(formatCurrencyInput('12abc')).toBe('12');
+            expect(formatCurrencyInput('1a2')).toBe('12');
         });
 
         it('formats integers with spaces as thousands separators', () => {
@@ -83,6 +84,7 @@ describe('format-number formatters', () => {
         it('replaces comma with dot before formatting', () => {
             expect(formatCurrencyInput('1000,50')).toBe('1 000.50');
             expect(formatCurrencyInput('999,9')).toBe('999.9');
+            expect(formatCurrencyInput('1,2,3')).toBe('1.23');
         });
 
         it('truncates the decimal part to 2 decimal places', () => {
@@ -100,6 +102,28 @@ describe('format-number formatters', () => {
 
         it('correctly handles spaces in the input (considered valid)', () => {
             expect(formatCurrencyInput('1 000')).toBe('1 000');
+        });
+
+        it('preserves a leading minus for validation', () => {
+            expect(formatCurrencyInput('-1000.50')).toBe('-1 000.50');
+            expect(formatCurrencyInput('10-00')).toBe('1 000');
+        });
+    });
+
+    describe('formatted number parsing', () => {
+        it('normalizes spaces and comma separators', () => {
+            expect(normalizeFormattedNumber('1 234,50')).toBe('1234.50');
+        });
+
+        it('parses valid formatted decimal numbers', () => {
+            expect(parseFormattedNumber('1 234,50')).toBe(1234.5);
+            expect(parseFormattedNumber('1 234.50')).toBe(1234.5);
+            expect(parseFormattedNumber('-1 234.50')).toBe(-1234.5);
+        });
+
+        it('returns null for malformed values', () => {
+            expect(parseFormattedNumber('1.2.3')).toBeNull();
+            expect(parseFormattedNumber('abc')).toBeNull();
         });
     });
 });

--- a/src/utils/functions/formatters/format-number.test.ts
+++ b/src/utils/functions/formatters/format-number.test.ts
@@ -7,6 +7,12 @@ import {
     parseFormattedNumber,
 } from '@/utils/functions/formatters/format-number';
 
+const expectFormatCases = (formatter: (value: string) => string, cases: Array<[string, string]>) => {
+    cases.forEach(([input, expected]) => {
+        expect(formatter(input)).toBe(expected);
+    });
+};
+
 describe('format-number formatters', () => {
     describe('formatNumberDecimalComma', () => {
         it('returns empty string for null and undefined', () => {
@@ -71,25 +77,33 @@ describe('format-number formatters', () => {
 
     describe('formatCurrencyInput', () => {
         it('removes invalid characters before formatting', () => {
-            expect(formatCurrencyInput('abc')).toBe('');
-            expect(formatCurrencyInput('12abc')).toBe('12');
-            expect(formatCurrencyInput('1a2')).toBe('12');
+            expectFormatCases(formatCurrencyInput, [
+                ['abc', ''],
+                ['12abc', '12'],
+                ['1a2', '12'],
+            ]);
         });
 
         it('formats integers with spaces as thousands separators', () => {
-            expect(formatCurrencyInput('1000')).toBe('1 000');
-            expect(formatCurrencyInput('1234567')).toBe('1 234 567');
+            expectFormatCases(formatCurrencyInput, [
+                ['1000', '1 000'],
+                ['1234567', '1 234 567'],
+            ]);
         });
 
         it('replaces comma with dot before formatting', () => {
-            expect(formatCurrencyInput('1000,50')).toBe('1 000.50');
-            expect(formatCurrencyInput('999,9')).toBe('999.9');
-            expect(formatCurrencyInput('1,2,3')).toBe('1.23');
+            expectFormatCases(formatCurrencyInput, [
+                ['1000,50', '1 000.50'],
+                ['999,9', '999.9'],
+                ['1,2,3', '1.23'],
+            ]);
         });
 
         it('truncates the decimal part to 2 decimal places', () => {
-            expect(formatCurrencyInput('100.999')).toBe('100.99');
-            expect(formatCurrencyInput('1.1234')).toBe('1.12');
+            expectFormatCases(formatCurrencyInput, [
+                ['100.999', '100.99'],
+                ['1.1234', '1.12'],
+            ]);
         });
 
         it('ignores extra periods (more than one)', () => {
@@ -105,8 +119,10 @@ describe('format-number formatters', () => {
         });
 
         it('preserves a leading minus for validation', () => {
-            expect(formatCurrencyInput('-1000.50')).toBe('-1 000.50');
-            expect(formatCurrencyInput('10-00')).toBe('1 000');
+            expectFormatCases(formatCurrencyInput, [
+                ['-1000.50', '-1 000.50'],
+                ['10-00', '1 000'],
+            ]);
         });
     });
 

--- a/src/utils/functions/formatters/format-number.ts
+++ b/src/utils/functions/formatters/format-number.ts
@@ -18,3 +18,17 @@ export const formatNumberInput = (inputValue: string): string => {
     const digits = inputValue.replace(/\D/g, '');
     return digits ? formatWithSpaces(digits) : '';
 };
+
+export const formatCurrencyInput = (raw: string): string => {
+    if (/[^0-9.,\s]/.test(raw)) return raw;
+
+    let cleaned = raw.replace(',', '.');
+    cleaned = cleaned.replace(/[^0-9.]/g, '');
+    const parts = cleaned.split('.');
+    if (parts.length > 2) {
+        cleaned = parts[0] + '.' + parts.slice(1).join('');
+    }
+    const [intPart, fracPart] = cleaned.split('.');
+    const formattedInt = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
+    return fracPart !== undefined ? `${formattedInt}.${fracPart.slice(0, 2)}` : formattedInt;
+};

--- a/src/utils/functions/formatters/format-number.ts
+++ b/src/utils/functions/formatters/format-number.ts
@@ -29,6 +29,6 @@ export const formatCurrencyInput = (raw: string): string => {
         cleaned = parts[0] + '.' + parts.slice(1).join('');
     }
     const [intPart, fracPart] = cleaned.split('.');
-    const formattedInt = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
+    const formattedInt = intPart.replace(/(\d)(?=(\d{3})+$)/g, '$1 ');
     return fracPart !== undefined ? `${formattedInt}.${fracPart.slice(0, 2)}` : formattedInt;
 };

--- a/src/utils/functions/formatters/format-number.ts
+++ b/src/utils/functions/formatters/format-number.ts
@@ -3,7 +3,34 @@ export const formatNumberDecimalComma = (value: number | string | null | undefin
         return '';
     }
 
-    return String(value).replace('.', ',');
+    return String(value).replace(/\./g, ',');
+};
+
+const formatIntegerWithSpaces = (value: string): string => {
+    const sign = value.startsWith('-') ? '-' : '';
+    const digits = sign ? value.slice(1) : value;
+
+    if (digits.length <= 3) return `${sign}${digits}`;
+
+    const firstGroupLength = digits.length % 3 || 3;
+    const groups = [digits.slice(0, firstGroupLength)];
+
+    for (let index = firstGroupLength; index < digits.length; index += 3) {
+        groups.push(digits.slice(index, index + 3));
+    }
+
+    return `${sign}${groups.join(' ')}`;
+};
+
+export const normalizeFormattedNumber = (value: string): string => value.replace(/\s/g, '').replace(/,/g, '.');
+
+export const parseFormattedNumber = (value: string): number | null => {
+    const normalizedValue = normalizeFormattedNumber(value);
+    if (!normalizedValue) return null;
+
+    const parsedValue = Number(normalizedValue);
+
+    return Number.isFinite(parsedValue) ? parsedValue : null;
 };
 
 export const formatWithSpaces = (value: number | string): string => {
@@ -20,15 +47,23 @@ export const formatNumberInput = (inputValue: string): string => {
 };
 
 export const formatCurrencyInput = (raw: string): string => {
-    if (/[^0-9.,\s]/.test(raw)) return raw;
+    const hasLeadingMinus = raw.trimStart().startsWith('-');
+    const sanitized = raw
+        .replace(/,/g, '.')
+        .replace(/[^0-9.-]/g, '')
+        .replace(/-/g, '');
+    let cleaned = hasLeadingMinus ? `-${sanitized}` : sanitized;
+    const sign = cleaned.startsWith('-') ? '-' : '';
 
-    let cleaned = raw.replace(',', '.');
-    cleaned = cleaned.replace(/[^0-9.]/g, '');
+    cleaned = sign ? cleaned.slice(1) : cleaned;
+
     const parts = cleaned.split('.');
     if (parts.length > 2) {
         cleaned = parts[0] + '.' + parts.slice(1).join('');
     }
+
     const [intPart, fracPart] = cleaned.split('.');
-    const formattedInt = intPart.replace(/(\d)(?=(\d{3})+$)/g, '$1 ');
+    const formattedInt = `${sign}${formatIntegerWithSpaces(intPart)}`;
+
     return fracPart !== undefined ? `${formattedInt}.${fracPart.slice(0, 2)}` : formattedInt;
 };

--- a/src/utils/functions/formatters/metric-formatters.test.ts
+++ b/src/utils/functions/formatters/metric-formatters.test.ts
@@ -124,24 +124,14 @@ describe('metric-formatters', () => {
                 expect(normalizeSpaces(formatMetricValue(metric, 'UA'))).toBe('5 000 000');
             });
 
-            it('should extract and format USD value from localization for EN locale', () => {
-                const metric = createRaisedMetric(5000000, '120000');
-                expect(formatMetricValue(metric, 'EN')).toBe('120,000');
-            });
-
-            it('should preserve decimal USD values from localization for EN locale', () => {
-                const metric = createRaisedMetric(5000000, '120000.75');
-                expect(formatMetricValue(metric, 'EN')).toBe('120,000.75');
-            });
-
-            it('should normalize formatted USD localization values before formatting', () => {
-                const metric = createRaisedMetric(5000000, '120 000,75');
-                expect(formatMetricValue(metric, 'EN')).toBe('120,000.75');
-            });
-
-            it('should fall back to UAH value for EN locale if localization value is missing or invalid', () => {
-                const metric = createRaisedMetric(5000000, 'invalid-string');
-                expect(formatMetricValue(metric, 'EN')).toBe('5,000,000');
+            it.each([
+                ['extract and format USD value from localization', '120000', '120,000'],
+                ['preserve decimal USD values from localization', '120000.75', '120,000.75'],
+                ['normalize formatted USD localization values', '120 000,75', '120,000.75'],
+                ['fall back to UAH value when localization value is invalid', 'invalid-string', '5,000,000'],
+            ])('should %s for EN locale', (_caseName, usdValue, expectedValue) => {
+                const metric = createRaisedMetric(5000000, usdValue);
+                expect(formatMetricValue(metric, 'EN')).toBe(expectedValue);
             });
         });
     });

--- a/src/utils/functions/formatters/metric-formatters.test.ts
+++ b/src/utils/functions/formatters/metric-formatters.test.ts
@@ -102,7 +102,7 @@ describe('metric-formatters', () => {
         });
 
         it('should not append any suffix for MetricPrefix.None/default', () => {
-            const metric = createMetric(42); // Without prefix
+            const metric = createMetric(42);
             expect(formatMetricValue(metric, 'UA')).toBe('42');
         });
 
@@ -110,6 +110,29 @@ describe('metric-formatters', () => {
             const metric = createMetric(1000.5);
             expect(normalizeSpaces(formatMetricValue(metric, 'UA'))).toBe('1 000,5');
             expect(formatMetricValue(metric, 'EN')).toBe('1,000.5');
+        });
+
+        describe('Raised metric type behavior', () => {
+            const createRaisedMetric = (uahValue: number, usdValueStr: string): Metric => ({
+                ...createMetric(uahValue),
+                type: MetricType.Raised,
+                localizations: [{ languageId: 2, value: usdValueStr } as any],
+            });
+
+            it('should use base UAH value for UA locale', () => {
+                const metric = createRaisedMetric(5000000, '120000');
+                expect(normalizeSpaces(formatMetricValue(metric, 'UA'))).toBe('5 000 000');
+            });
+
+            it('should extract and format USD value from localization for EN locale', () => {
+                const metric = createRaisedMetric(5000000, '120000');
+                expect(formatMetricValue(metric, 'EN')).toBe('120,000');
+            });
+
+            it('should fall back to UAH value for EN locale if localization value is missing or invalid', () => {
+                const metric = createRaisedMetric(5000000, 'invalid-string');
+                expect(formatMetricValue(metric, 'EN')).toBe('5,000,000');
+            });
         });
     });
 });

--- a/src/utils/functions/formatters/metric-formatters.test.ts
+++ b/src/utils/functions/formatters/metric-formatters.test.ts
@@ -129,6 +129,16 @@ describe('metric-formatters', () => {
                 expect(formatMetricValue(metric, 'EN')).toBe('120,000');
             });
 
+            it('should preserve decimal USD values from localization for EN locale', () => {
+                const metric = createRaisedMetric(5000000, '120000.75');
+                expect(formatMetricValue(metric, 'EN')).toBe('120,000.75');
+            });
+
+            it('should normalize formatted USD localization values before formatting', () => {
+                const metric = createRaisedMetric(5000000, '120 000,75');
+                expect(formatMetricValue(metric, 'EN')).toBe('120,000.75');
+            });
+
             it('should fall back to UAH value for EN locale if localization value is missing or invalid', () => {
                 const metric = createRaisedMetric(5000000, 'invalid-string');
                 expect(formatMetricValue(metric, 'EN')).toBe('5,000,000');

--- a/src/utils/functions/formatters/metric-formatters.ts
+++ b/src/utils/functions/formatters/metric-formatters.ts
@@ -1,4 +1,5 @@
 import { Metric, MetricPrefix, MetricType } from '@/types/admin/main-page';
+import { parseFormattedNumber } from '@/utils/functions/formatters/format-number';
 
 export const getMetricName = (metric: Metric, language: 'UA' | 'EN' = 'UA') => {
     const code = language === 'UA' ? 'uk' : 'en';
@@ -25,8 +26,8 @@ export const formatMetricValue = (metric: Metric, language: 'UA' | 'EN' = 'UA') 
         );
 
         if (enLoc && enLoc.value) {
-            const parsedValue = parseInt(enLoc.value, 10);
-            if (!isNaN(parsedValue)) {
+            const parsedValue = parseFormattedNumber(enLoc.value);
+            if (parsedValue !== null) {
                 numValue = parsedValue;
             }
         }

--- a/src/utils/functions/formatters/metric-formatters.ts
+++ b/src/utils/functions/formatters/metric-formatters.ts
@@ -1,4 +1,4 @@
-import { Metric, MetricPrefix } from '@/types/admin/main-page';
+import { Metric, MetricPrefix, MetricType } from '@/types/admin/main-page';
 
 export const getMetricName = (metric: Metric, language: 'UA' | 'EN' = 'UA') => {
     const code = language === 'UA' ? 'uk' : 'en';
@@ -16,14 +16,30 @@ export const getMetricName = (metric: Metric, language: 'UA' | 'EN' = 'UA') => {
 
 export const formatMetricValue = (metric: Metric, language: 'UA' | 'EN' = 'UA') => {
     const locale = language === 'UA' ? 'uk-UA' : 'en-US';
-    const value = metric.value.toLocaleString(locale);
+
+    let numValue = metric.value;
+
+    if (metric.type === MetricType.Raised && language === 'EN') {
+        const enLoc = metric.localizations?.find(
+            (l: any) => l?.language?.code === 'en' || l?.localizationInfoDto?.code === 'en' || l?.languageId === 2,
+        );
+
+        if (enLoc && enLoc.value) {
+            const parsedValue = parseInt(enLoc.value, 10);
+            if (!isNaN(parsedValue)) {
+                numValue = parsedValue;
+            }
+        }
+    }
+
+    const valueStr = numValue.toLocaleString(locale);
 
     switch (metric.prefix) {
         case MetricPrefix.Plus:
-            return `${value}+`;
+            return `${valueStr}+`;
         case MetricPrefix.Percent:
-            return `${value}%`;
+            return `${valueStr}%`;
         default:
-            return value;
+            return valueStr;
     }
 };

--- a/src/utils/functions/mappers/admin/main-page/main-page-mappers.test.ts
+++ b/src/utils/functions/mappers/admin/main-page/main-page-mappers.test.ts
@@ -156,6 +156,7 @@ describe('main-page-mappers', () => {
                             name: 'UA Metric',
                             type: MetricType.Partners,
                             prefix: MetricPrefix.Plus,
+                            isAutoSynced: true,
                             localizations: [{ localizationInfoDto: { code: 'en' }, name: 'EN Metric' } as any],
                         } as any,
                         {
@@ -194,6 +195,7 @@ describe('main-page-mappers', () => {
                 name: 'UA Metric',
                 type: MetricType.Partners,
                 prefix: 1, // MetricPrefix.Plus is 1
+                isAutoSynced: true,
                 localization: undefined,
             });
 

--- a/src/utils/functions/mappers/admin/main-page/main-page-mappers.ts
+++ b/src/utils/functions/mappers/admin/main-page/main-page-mappers.ts
@@ -99,6 +99,7 @@ export function mapFormValuesToMainPagePatch(
             name: m.name,
             type: m.type,
             prefix: m.prefix,
+            isAutoSynced: m.isAutoSynced,
             localization: enLoc
                 ? {
                       ...(enLanguageId ? { languageId: enLanguageId } : {}),

--- a/src/utils/functions/mappers/admin/main-page/main-page-mappers.ts
+++ b/src/utils/functions/mappers/admin/main-page/main-page-mappers.ts
@@ -99,8 +99,13 @@ export function mapFormValuesToMainPagePatch(
             name: m.name,
             type: m.type,
             prefix: m.prefix,
-            localization:
-                enLanguageId && enLoc ? { languageId: enLanguageId, name: enLoc.name, value: enLoc.value } : undefined,
+            localization: enLoc
+                ? {
+                      ...(enLanguageId ? { languageId: enLanguageId } : {}),
+                      name: enLoc.name,
+                      value: enLoc.value,
+                  }
+                : undefined,
         } as UpdateMetricDto;
     });
 

--- a/src/utils/functions/mappers/admin/main-page/main-page-mappers.ts
+++ b/src/utils/functions/mappers/admin/main-page/main-page-mappers.ts
@@ -99,7 +99,8 @@ export function mapFormValuesToMainPagePatch(
             name: m.name,
             type: m.type,
             prefix: m.prefix,
-            localization: enLanguageId && enLoc ? { languageId: enLanguageId, name: enLoc.name } : undefined,
+            localization:
+                enLanguageId && enLoc ? { languageId: enLanguageId, name: enLoc.name, value: enLoc.value } : undefined,
         } as UpdateMetricDto;
     });
 

--- a/src/utils/test-mocks/main-page-mocks.tsx
+++ b/src/utils/test-mocks/main-page-mocks.tsx
@@ -37,3 +37,14 @@ export const MockMainPageCategoryBar = ({ categories, onCategorySelect, selected
         ))}
     </div>
 );
+
+export const MockMetricEditActions = ({ isFormDirty, isValid, onCancel, onSave }: any) => (
+    <div data-testid="metric-actions">
+        <button type="button" data-testid="mock-cancel" onClick={onCancel}>
+            Cancel
+        </button>
+        <button type="button" data-testid="mock-save" onClick={onSave} disabled={!isFormDirty || !isValid}>
+            Save
+        </button>
+    </div>
+);

--- a/src/utils/test-mocks/statistics-block-mocks.ts
+++ b/src/utils/test-mocks/statistics-block-mocks.ts
@@ -1,0 +1,38 @@
+import { Metric, MetricPrefix, MetricType } from '@/types/admin/main-page';
+import { TranslationStatus } from '@/types/common/language';
+
+export const metricPartners: Metric = {
+    id: 1,
+    name: 'Партнерів',
+    value: 20,
+    type: MetricType.Partners,
+    prefix: MetricPrefix.Plus,
+    isHidden: false,
+    priority: 1,
+    localizations: [
+        { language: { id: 1, code: 'uk' }, translationStatus: TranslationStatus.Relevant, name: 'Партнерів' },
+        { language: { id: 2, code: 'en' }, translationStatus: TranslationStatus.Relevant, name: 'Partners' },
+    ],
+};
+
+export const metricRaised: Metric = {
+    id: 2,
+    name: 'Зібрано',
+    value: 5000000,
+    type: MetricType.Raised,
+    prefix: MetricPrefix.None,
+    isHidden: false,
+    priority: 2,
+    localizations: [{ languageId: 2, name: 'Raised', value: '125000' } as any],
+};
+
+export const metricEngagement: Metric = {
+    id: 2,
+    name: 'Engagement',
+    value: 50,
+    type: MetricType.Programs,
+    prefix: MetricPrefix.Percent,
+    isHidden: false,
+    priority: 2,
+    localizations: [],
+};

--- a/src/utils/test-mocks/statistics-block-mocks.ts
+++ b/src/utils/test-mocks/statistics-block-mocks.ts
@@ -27,7 +27,7 @@ export const metricRaised: Metric = {
 };
 
 export const metricEngagement: Metric = {
-    id: 2,
+    id: 3,
     name: 'Engagement',
     value: 50,
     type: MetricType.Programs,

--- a/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.test.ts
+++ b/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.test.ts
@@ -1,7 +1,7 @@
 import { MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
 import { MetricPrefix } from '@/types/admin/main-page';
 
-import { metricEditSchema } from './metric-edit-schema';
+import { metricEditSchema, raisedMetricEditSchema } from './metric-edit-schema';
 
 describe('metricEditSchema', () => {
     const validPayload = {
@@ -48,5 +48,46 @@ describe('metricEditSchema', () => {
 
     it('requires prefix', async () => {
         await expect(metricEditSchema.validate({ ...validPayload, prefix: undefined })).rejects.toThrow();
+    });
+});
+
+describe('raisedMetricEditSchema', () => {
+    const validRaisedPayload = {
+        nameUa: 'Зібрано',
+        nameEn: 'Raised',
+        isAutoSynced: false,
+        valueUah: '1 000 000',
+        valueUsd: '25 000',
+    };
+
+    it('accepts valid payload', async () => {
+        await expect(raisedMetricEditSchema.validate(validRaisedPayload)).resolves.toEqual(validRaisedPayload);
+    });
+
+    it('requires nameUa and nameEn', async () => {
+        await expect(raisedMetricEditSchema.validate({ ...validRaisedPayload, nameUa: '' })).rejects.toThrow(
+            MAIN_PAGE_VALIDATION.common.REQUIRED,
+        );
+        await expect(raisedMetricEditSchema.validate({ ...validRaisedPayload, nameEn: '' })).rejects.toThrow(
+            MAIN_PAGE_VALIDATION.common.REQUIRED,
+        );
+    });
+
+    it('requires boolean for auto sync', async () => {
+        await expect(
+            raisedMetricEditSchema.validate({ ...validRaisedPayload, isAutoSynced: undefined }),
+        ).rejects.toThrow(MAIN_PAGE_VALIDATION.common.REQUIRED);
+    });
+
+    it('requires positive UAH value', async () => {
+        await expect(raisedMetricEditSchema.validate({ ...validRaisedPayload, valueUah: '0' })).rejects.toThrow(
+            MAIN_PAGE_VALIDATION.common.REQUIRED,
+        );
+    });
+
+    it('requires positive USD value', async () => {
+        await expect(raisedMetricEditSchema.validate({ ...validRaisedPayload, valueUsd: '-100' })).rejects.toThrow(
+            MAIN_PAGE_VALIDATION.common.REQUIRED,
+        );
     });
 });

--- a/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.test.ts
+++ b/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.test.ts
@@ -81,13 +81,13 @@ describe('raisedMetricEditSchema', () => {
 
     it('requires positive UAH value', async () => {
         await expect(raisedMetricEditSchema.validate({ ...validRaisedPayload, valueUah: '0' })).rejects.toThrow(
-            MAIN_PAGE_VALIDATION.common.REQUIRED,
+            MAIN_PAGE_VALIDATION.raisedFunds.ZERO,
         );
     });
 
     it('requires positive USD value', async () => {
         await expect(raisedMetricEditSchema.validate({ ...validRaisedPayload, valueUsd: '-100' })).rejects.toThrow(
-            MAIN_PAGE_VALIDATION.common.REQUIRED,
+            MAIN_PAGE_VALIDATION.raisedFunds.ONLY_NUMBERS,
         );
     });
 });

--- a/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.test.ts
+++ b/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.test.ts
@@ -64,6 +64,12 @@ describe('raisedMetricEditSchema', () => {
         await expect(raisedMetricEditSchema.validate(validRaisedPayload)).resolves.toEqual(validRaisedPayload);
     });
 
+    it('accepts decimal payload values with dot or comma separators', async () => {
+        const payload = { ...validRaisedPayload, valueUah: '1 000,50', valueUsd: '25 000.75' };
+
+        await expect(raisedMetricEditSchema.validate(payload)).resolves.toEqual(payload);
+    });
+
     it('requires nameUa and nameEn', async () => {
         await expect(raisedMetricEditSchema.validate({ ...validRaisedPayload, nameUa: '' })).rejects.toThrow(
             MAIN_PAGE_VALIDATION.common.REQUIRED,
@@ -79,15 +85,27 @@ describe('raisedMetricEditSchema', () => {
         ).rejects.toThrow(MAIN_PAGE_VALIDATION.common.REQUIRED);
     });
 
-    it('requires positive UAH value', async () => {
+    it('rejects zero UAH value with zero-specific message', async () => {
         await expect(raisedMetricEditSchema.validate({ ...validRaisedPayload, valueUah: '0' })).rejects.toThrow(
             MAIN_PAGE_VALIDATION.raisedFunds.ZERO,
         );
     });
 
-    it('requires positive USD value', async () => {
+    it('rejects negative USD value with negative-specific message', async () => {
         await expect(raisedMetricEditSchema.validate({ ...validRaisedPayload, valueUsd: '-100' })).rejects.toThrow(
+            MAIN_PAGE_VALIDATION.raisedFunds.NEGATIVE,
+        );
+    });
+
+    it('rejects non-numeric value', async () => {
+        await expect(raisedMetricEditSchema.validate({ ...validRaisedPayload, valueUsd: 'abc' })).rejects.toThrow(
             MAIN_PAGE_VALIDATION.raisedFunds.ONLY_NUMBERS,
         );
+    });
+
+    it('rejects values with more than 9 digits before decimal separator', async () => {
+        await expect(
+            raisedMetricEditSchema.validate({ ...validRaisedPayload, valueUah: '1 000 000 000,50' }),
+        ).rejects.toThrow(MAIN_PAGE_VALIDATION.raisedFunds.MAX_DIGITS);
     });
 });

--- a/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.ts
+++ b/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.ts
@@ -6,6 +6,34 @@ const parseThousands = (value: string): number => {
     return parseInt((value || '').replace(/\s/g, ''), 10) || 0;
 };
 
+const raisedFundsValidator = Yup.string()
+    .required(MAIN_PAGE_VALIDATION.raisedFunds.REQUIRED)
+    .test('not-empty', MAIN_PAGE_VALIDATION.raisedFunds.REQUIRED, (val) => {
+        if (!val) return false;
+        return val.trim().length > 0;
+    })
+    .test('only-numbers', MAIN_PAGE_VALIDATION.raisedFunds.ONLY_NUMBERS, (val) => {
+        if (!val) return false;
+        const stripped = val.replace(/\s/g, '').replace(',', '.');
+        return !isNaN(Number(stripped)) && /^[0-9.,]+$/.test(stripped);
+    })
+    .test('not-negative', MAIN_PAGE_VALIDATION.raisedFunds.NEGATIVE, (val) => {
+        if (!val) return false;
+        const stripped = val.replace(/\s/g, '').replace(',', '.');
+        return Number(stripped) >= 0;
+    })
+    .test('not-zero', MAIN_PAGE_VALIDATION.raisedFunds.ZERO, (val) => {
+        if (!val) return false;
+        const stripped = val.replace(/\s/g, '').replace(',', '.');
+        return Number(stripped) !== 0;
+    })
+    .test('max-digits', MAIN_PAGE_VALIDATION.raisedFunds.MAX_DIGITS, (val) => {
+        if (!val) return false;
+        const stripped = val.replace(/\s/g, '');
+        const beforeDecimal = stripped.split(/[.,]/)[0];
+        return beforeDecimal.length <= 9;
+    });
+
 export const metricEditSchema = Yup.object({
     nameUa: Yup.string()
         .required(MAIN_PAGE_VALIDATION.common.REQUIRED)
@@ -31,12 +59,8 @@ export const raisedMetricEditSchema = Yup.object({
         .min(MAIN_PAGE_VALIDATION.editPanel.name.min, MAIN_PAGE_VALIDATION.editPanel.name.getMinError())
         .max(MAIN_PAGE_VALIDATION.editPanel.name.max, MAIN_PAGE_VALIDATION.editPanel.name.getMaxError()),
     isAutoSynced: Yup.boolean().required(MAIN_PAGE_VALIDATION.common.REQUIRED),
-    valueUah: Yup.string()
-        .required(MAIN_PAGE_VALIDATION.common.REQUIRED)
-        .test('is-positive', MAIN_PAGE_VALIDATION.common.REQUIRED, (val) => parseThousands(val || '') > 0),
-    valueUsd: Yup.string()
-        .required(MAIN_PAGE_VALIDATION.common.REQUIRED)
-        .test('is-positive', MAIN_PAGE_VALIDATION.common.REQUIRED, (val) => parseThousands(val || '') > 0),
+    valueUah: raisedFundsValidator,
+    valueUsd: raisedFundsValidator,
 });
 
 export type MetricFormValues = Yup.InferType<typeof metricEditSchema>;

--- a/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.ts
+++ b/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.ts
@@ -1,9 +1,10 @@
 import { MAIN_PAGE_VALIDATION } from '@/const/admin/main-page';
 import { MetricPrefix } from '@/types/admin/main-page';
+import { normalizeFormattedNumber, parseFormattedNumber } from '@/utils/functions/formatters/format-number';
 import * as Yup from 'yup';
 
 const parseThousands = (value: string): number => {
-    return parseInt((value || '').replace(/\s/g, ''), 10) || 0;
+    return parseFormattedNumber(value || '') ?? 0;
 };
 
 const raisedFundsValidator = Yup.string()
@@ -14,23 +15,23 @@ const raisedFundsValidator = Yup.string()
     })
     .test('only-numbers', MAIN_PAGE_VALIDATION.raisedFunds.ONLY_NUMBERS, (val) => {
         if (!val) return false;
-        const stripped = val.replace(/\s/g, '').replace(',', '.');
-        return !isNaN(Number(stripped)) && /^[0-9.,]+$/.test(stripped);
+        const stripped = normalizeFormattedNumber(val);
+        return /^-?\d+(\.\d*)?$/.test(stripped) && parseFormattedNumber(val) !== null;
     })
     .test('not-negative', MAIN_PAGE_VALIDATION.raisedFunds.NEGATIVE, (val) => {
         if (!val) return false;
-        const stripped = val.replace(/\s/g, '').replace(',', '.');
-        return Number(stripped) >= 0;
+        const parsedValue = parseFormattedNumber(val);
+        return parsedValue !== null && parsedValue >= 0;
     })
     .test('not-zero', MAIN_PAGE_VALIDATION.raisedFunds.ZERO, (val) => {
         if (!val) return false;
-        const stripped = val.replace(/\s/g, '').replace(',', '.');
-        return Number(stripped) !== 0;
+        const parsedValue = parseFormattedNumber(val);
+        return parsedValue !== null && parsedValue !== 0;
     })
     .test('max-digits', MAIN_PAGE_VALIDATION.raisedFunds.MAX_DIGITS, (val) => {
         if (!val) return false;
-        const stripped = val.replace(/\s/g, '');
-        const beforeDecimal = stripped.split(/[.,]/)[0];
+        const stripped = normalizeFormattedNumber(val);
+        const beforeDecimal = stripped.split('.')[0].replace('-', '');
         return beforeDecimal.length <= 9;
     });
 

--- a/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.ts
+++ b/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.ts
@@ -21,4 +21,23 @@ export const metricEditSchema = Yup.object({
     prefix: Yup.mixed<MetricPrefix>().required(MAIN_PAGE_VALIDATION.common.REQUIRED),
 });
 
+export const raisedMetricEditSchema = Yup.object({
+    nameUa: Yup.string()
+        .required(MAIN_PAGE_VALIDATION.common.REQUIRED)
+        .min(MAIN_PAGE_VALIDATION.editPanel.name.min, MAIN_PAGE_VALIDATION.editPanel.name.getMinError())
+        .max(MAIN_PAGE_VALIDATION.editPanel.name.max, MAIN_PAGE_VALIDATION.editPanel.name.getMaxError()),
+    nameEn: Yup.string()
+        .required(MAIN_PAGE_VALIDATION.common.REQUIRED)
+        .min(MAIN_PAGE_VALIDATION.editPanel.name.min, MAIN_PAGE_VALIDATION.editPanel.name.getMinError())
+        .max(MAIN_PAGE_VALIDATION.editPanel.name.max, MAIN_PAGE_VALIDATION.editPanel.name.getMaxError()),
+    isAutoSynced: Yup.boolean().required(MAIN_PAGE_VALIDATION.common.REQUIRED),
+    valueUah: Yup.string()
+        .required(MAIN_PAGE_VALIDATION.common.REQUIRED)
+        .test('is-positive', MAIN_PAGE_VALIDATION.common.REQUIRED, (val) => parseThousands(val || '') > 0),
+    valueUsd: Yup.string()
+        .required(MAIN_PAGE_VALIDATION.common.REQUIRED)
+        .test('is-positive', MAIN_PAGE_VALIDATION.common.REQUIRED, (val) => parseThousands(val || '') > 0),
+});
+
 export type MetricFormValues = Yup.InferType<typeof metricEditSchema>;
+export type RaisedMetricFormValues = Yup.InferType<typeof raisedMetricEditSchema>;


### PR DESCRIPTION
## Github tickets

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2401
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2414
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2444
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2364

## Description

The main goal of this PR is to implement a specific inline editing panel for the "Raised Funds" (Зібрано) metric on the Main Page's Statistics block. It introduces the ability for administrators to manually manage both UAH and USD values for this metric independently, supported by validation rules. It also sets up the UI and state management foundation for the auto-sync toggle (manual vs. synced mode).

## How it looks

<details>
<summary> Screenshots </summary>


<img width="790" height="617" alt="image" src="https://github.com/user-attachments/assets/8409b5e4-0ca8-4148-92ef-98ef6ca13ba0" />

---

<img width="786" height="551" alt="image" src="https://github.com/user-attachments/assets/6e00c5ee-d198-4eb8-be74-dda78249895c" />

---

<img width="705" height="225" alt="image" src="https://github.com/user-attachments/assets/1eeccde5-7288-4037-9d89-969faa097b1d" />

---

<img width="353" height="129" alt="image" src="https://github.com/user-attachments/assets/ba8a573c-b31e-4e68-bc8c-ff306c9a3172" />

---

<img width="1191" height="420" alt="image" src="https://github.com/user-attachments/assets/c12aa67b-631b-4aeb-851e-b95d41105b3a" />

</details>

## Summary of change

* **Added `RaisedMetricEditPanel` Component:** Created a dedicated edit panel for the Raised Funds metric featuring UA/EN name inputs, a sync toggle, and UAH/USD value inputs.
* **Implemented Custom Validation:** Added `raisedMetricEditSchema` using Yup to enforce strict rules for fund inputs (required, positive, non-zero, max 9 digits before decimal, numbers only) matching the requirements from #1493.
* **Updated UI Data Presentation:** Modified `StatisticsMetricsList` and `StatisticsPreview` to concurrently display both ₴ (UAH) and $ (USD) values specifically for the `MetricType.Raised`.
* **Enhanced Metric Formatters:** Updated `formatMetricValue` to intelligently extract and format the USD value from the English localization array when requested.
* **Fixed DTO Mapping:** Corrected `mapFormValuesToMainPagePatch` to ensure the USD `value` field from the English localization is properly mapped and sent in the PUT request payload.
* **Testing:** Added and updated unit tests for components (`Toggle`, `RaisedMetricEditPanel`), mappers, formatters, and Yup validation schemas to ensure 100% coverage of the new logic.

## How to recreate changes

1. Open the Admin Panel and navigate to the **Main Page** -> **Statistics** tab. (`/admin-panel/main`)
2. Locate the "Funds Raised" (Зібрано) metric in the list and click the **Edit** (pencil) icon.
3. Verify that the "Відмінити" button is active and "Зберегти" is disabled initially.
4. Ensure the toggle is in the OFF state and the UAH/USD fields are editable.
5. Empty the "Сума коштів" fields or input invalid data (e.g., negative numbers, 0) to trigger inline validation errors ("Поле обов'язкове", "Сума не може дорівнювати 0", etc.).
6. Enter valid values in both fields and click **Зберегти**.
7. Observe the updated values in the list view (displaying both ₴ and $ values).
8. Click **Опублікувати** and verify that the backend receives the correct payload (specifically the USD value inside the English localization array).


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin accessible toggle/switch component
  * Editable Raised metric UI: dual-currency inputs, auto-sync toggle, name fields, save/cancel flow, centralized action controls
  * MetricNameFields component and new currency input formatter/parsers (normalize/parse/format helpers)
  * Exposed validation schema for raised-metric editing
  * Types extended to support metric values and auto-sync flag

* **Bug Fixes**
  * Form reset and value sanitization to prevent stale/dirty state

* **Tests**
  * Expanded coverage for new components, validators, and formatters

* **Style**
  * Metrics list and edit-panel layout/typography refinements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->