### PR TITLE
Fix/issue-2655 [Programs] Incorrect Button Labels in Program Deletion Confirmation Pop-up

### DIFF
--- a/src/pages/admin/programs/components/programs-page-modals/delete-program-modal/DeleteProgramModal.test.tsx
+++ b/src/pages/admin/programs/components/programs-page-modals/delete-program-modal/DeleteProgramModal.test.tsx
@@ -88,8 +88,8 @@ describe('DeleteProgramModal', () => {
     const renderDeleteProgramModal = (overrideProps: Partial<DeleteProgramModalProps> = {}) =>
         render(<DeleteProgramModal {...defaultProps} {...overrideProps} />);
 
-    const getCancelButton = () => screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL);
-    const getDeleteButton = () => screen.getByText(COMMON_TEXT_ADMIN.BUTTON.DELETE);
+    const getCancelButton = () => screen.getByText(COMMON_TEXT_ADMIN.BUTTON.NO);
+    const getDeleteButton = () => screen.getByText(COMMON_TEXT_ADMIN.BUTTON.YES);
     const getModal = () => screen.queryByTestId('delete-program-modal');
     const getErrorMessage = () => screen.queryByText(PROGRAMS_TEXT.FORM.MESSAGE.FAIL_TO_DELETE_PROGRAM);
     const getTitle = () => screen.queryByText(PROGRAMS_TEXT.FORM.TITLE.DELETE_PROGRAM);

--- a/src/pages/admin/programs/components/programs-page-modals/delete-program-modal/DeleteProgramModal.tsx
+++ b/src/pages/admin/programs/components/programs-page-modals/delete-program-modal/DeleteProgramModal.tsx
@@ -49,10 +49,10 @@ export const DeleteProgramModal = ({ isOpen, onClose, onDeleteProgram, programTo
             <Modal.Content>{error && <div className="delete-program-error-container">{error}</div>}</Modal.Content>
             <Modal.Actions>
                 <Button onClick={handleClose} buttonStyle="secondary" disabled={isSubmitting}>
-                    {COMMON_TEXT_ADMIN.BUTTON.CANCEL}
+                    {COMMON_TEXT_ADMIN.BUTTON.NO}
                 </Button>
                 <Button onClick={handleConfirmDelete} buttonStyle="primary" disabled={isSubmitting}>
-                    {COMMON_TEXT_ADMIN.BUTTON.DELETE}
+                    {COMMON_TEXT_ADMIN.BUTTON.YES}
                 </Button>
             </Modal.Actions>
         </Modal>


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2655)

## Description
This PR fixes a UI consistency bug in the Admin Panel where the program deletion confirmation modal used "Delete"
      (Видалити) and "Cancel" (Відмінити) labels instead of the expected "Yes" (Так) and "No" (Ні).
## Summary of change
- Updated `DeleteProgramModal.tsx` to use `COMMON_TEXT_ADMIN.BUTTON.YES` and `COMMON_TEXT_ADMIN.BUTTON.NO`
      constants for the action buttons.
- Updated the corresponding unit tests in `DeleteProgramModal.test.tsx` to verify the correct "Так" and "Ні"
      labels.
   ## How to recreate changes

   1.  Log in to the **Admin Panel**.
   2.  Navigate to the **Programs** (Програми) page.
   3.  Click the **Delete** (кошик) icon on any existing program.
   4.  Observe the confirmation pop-up text: **"Видалити програму?"**.
   5.  Verify that the buttons are now labeled **"Так"** (primary) and **"Ні"** (secondary).

   ## CHECK LIST
   - [x]  New tests was added or existing was modified
   - [ ]  Changes has severe impact on users
   - [ ]  Changes has medium impact on users
   - [x]  Changes has light impact on users
   - [ ]  Test covetage was updated
   - [x]  PR meets all conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated button labels in the delete program modal from "Cancel"/"Delete" to "No"/"Yes" for improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ita-social-projects/VictoryCenter-Client/pull/416?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->