### PR TITLE
Fix/issue 2485 [Team] 'Редагування члена команди' modal window is closed when user clicks HI in a confirmation pop-up "Опублікувати нового члена команди?"

### DIFF
--- a/src/hooks/admin/use-generic-modal/useGenericModal.test.ts
+++ b/src/hooks/admin/use-generic-modal/useGenericModal.test.ts
@@ -114,11 +114,17 @@ describe('useGenericModal', () => {
         expect(result.current.showFormConfirmModal).toBe(true);
     });
 
-    it('handleCancelConfirmation resets pending state', () => {
+    it('handleCancelConfirmation hides the action confirmation and resets pending state', () => {
         const { result } = renderHook(() => useGenericModal(defaultConfig));
         act(() => result.current.handleCancelConfirmation());
         expect(result.current.showFormConfirmModal).toBe(false);
         expect(result.current.isSubmitting).toBe(false);
+    });
+
+    it('handleCancelConfirmation does NOT close the parent modal (regression: "НІ" must keep edit modal open)', () => {
+        const { result } = renderHook(() => useGenericModal(defaultConfig));
+        act(() => result.current.handleCancelConfirmation());
+        expect(onClose).not.toHaveBeenCalled();
     });
 
     it('handleConfirmAction does nothing if no pending data', async () => {

--- a/src/hooks/admin/use-generic-modal/useGenericModal.test.ts
+++ b/src/hooks/admin/use-generic-modal/useGenericModal.test.ts
@@ -127,6 +127,24 @@ describe('useGenericModal', () => {
         expect(onClose).not.toHaveBeenCalled();
     });
 
+    it('handleDismissConfirmation hides the action confirmation and resets pending state without closing the modal', () => {
+        const { result } = renderHook(() => useGenericModal(defaultConfig));
+
+        result.current.formRef.current = makeFormRef({ isValid: () => true });
+        act(() => {
+            result.current.handleFormSubmit({ field: 'value' }, VisibilityStatus.Published);
+        });
+        expect(result.current.showFormConfirmModal).toBe(true);
+
+        act(() => {
+            result.current.handleDismissConfirmation();
+        });
+
+        expect(result.current.showFormConfirmModal).toBe(false);
+        expect(result.current.isSubmitting).toBe(false);
+        expect(onClose).not.toHaveBeenCalled();
+    });
+
     it('handleConfirmAction does nothing if no pending data', async () => {
         const { result } = renderHook(() => useGenericModal(defaultConfig));
         await act(async () => {

--- a/src/hooks/admin/use-generic-modal/useGenericModal.ts
+++ b/src/hooks/admin/use-generic-modal/useGenericModal.ts
@@ -122,10 +122,9 @@ export const useGenericModal = <
 
     const handleCancelConfirmation = useCallback(() => {
         setShowFormConfirmModal(false);
-        onClose();
         resetPendingState();
         setIsSubmitting(false);
-    }, [onClose, resetPendingState]);
+    }, [resetPendingState]);
 
     const handleConfirmAction = useCallback(async () => {
         if (!pendingFormData || pendingAction === null) return;

--- a/src/pages/admin/programs/components/programs-page-modals/program-modal/ProgramModal.test.tsx
+++ b/src/pages/admin/programs/components/programs-page-modals/program-modal/ProgramModal.test.tsx
@@ -661,7 +661,7 @@ describe('ProgramModal', () => {
             expect(getPublishButton()).not.toBeDisabled();
         });
 
-        it('should cancel the submission, not call the API, and close the modal', async () => {
+        it('should cancel the submission, not call the API, and KEEP the modal open', async () => {
             render(<ProgramModal {...addModeProps} />);
             simulateFormBecomesValid();
 
@@ -674,7 +674,8 @@ describe('ProgramModal', () => {
 
             expect(mockedProgramsApi.addProgram).not.toHaveBeenCalled();
             expect(mockOnAddProgram).not.toHaveBeenCalled();
-            expect(mockOnClose).toHaveBeenCalledTimes(1);
+
+            expect(mockOnClose).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2485)

## Description

The main goal of this PR is to fix a bug where cancelling a confirmation pop-up incorrectly closes the parent modal window. Previously, clicking "Ні" on actions like "Опублікувати нового члена команди?" would completely close the editor, forcing users to lose their context. By refining the generic modal hook, the confirmation pop-up now closes independently, keeping the main modal displayed and active.

## How it looks

https://github.com/user-attachments/assets/1b5ec44c-ecd0-471f-9d07-d697bbd333c7

## Summary of change

* Updated `useGenericModal.ts`: Removed the `onClose()` call from the `handleCancelConfirmation` function. This ensures that cancelling a confirmation pop-up only resets the submission state and closes the pop-up itself, rather than closing the parent modal.
* Fixed Unit Tests in `ProgramModal.test.tsx`: Corrected a legacy test in the Add Mode suite that was actively enforcing the old bug. Updated the assertions to verify that `mockOnClose` is not called when the user clicks "Ні" on the publish confirmation.
* Updated Unit Tests in `useGenericModal.test.ts`: Adjusted the hook's test assertions to accurately reflect the new, corrected behavior.

## How to recreate changes

1. Log in to the admin panel.
2. Open the Team page.
3. Locate a team member whose profile is saved as a draft and click the 'Edit' button.
4.Make changes (i.e., add a photo).
5. Click the 'Опублікувати' button.
6.In the confirmation pop-up ("Опублікувати нового члена команди?"), click "Ні".
7.Verify that the confirmation pop-up closes, but the 'Редагування члена команди' modal remains fully displayed and active.

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where canceling a confirmation dialog during edit workflows incorrectly closed the parent modal. The modal now properly remains open when canceling confirmation prompts.

* **Tests**
  * Enhanced test coverage for confirmation dialog cancellation and dismissal behavior to ensure parent modals remain open as intended.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ita-social-projects/VictoryCenter-Client/pull/417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->