### PR TITLE
Feature/issue-1884 [Reports] UAH Expenses Amount Entry with USD Conversion

### DIFF
--- a/src/hooks/admin/use-amount-blur/useAmountBlur.test.ts
+++ b/src/hooks/admin/use-amount-blur/useAmountBlur.test.ts
@@ -1,0 +1,49 @@
+import { act, renderHook } from '@testing-library/react';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { useAmountBlur } from './useAmountBlur';
+
+const createFormState = (overrides = {}) => ({
+    amountUah: '',
+    amountUsd: '',
+    errors: {},
+    ...overrides,
+});
+
+const triggerAmountUsdBlur = (hook: ReturnType<typeof useAmountBlur>, formState: object) => {
+    const setFormState = jest.fn();
+    let nextState: any;
+
+    act(() => {
+        hook.handleAmountBlur('amountUsd', setFormState);
+        nextState = setFormState.mock.calls[0][0](formState);
+    });
+    return nextState;
+};
+
+describe('useAmountBlur', () => {
+    it('sets usdMismatchMessage when USD does not match converted UAH value on blur', () => {
+        const { result } = renderHook(() => useAmountBlur('40'));
+
+        const nextState = triggerAmountUsdBlur(result.current, createFormState({ amountUah: '100', amountUsd: '999' }));
+
+        expect(result.current.usdMismatchMessage).toBe(FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH);
+        expect(nextState.amountUsd).toBe('999');
+        expect(nextState.errors.amountUsd).toBeUndefined();
+    });
+
+    it('clears usdMismatchMessage when USD matches converted UAH value on blur', () => {
+        const { result } = renderHook(() => useAmountBlur('40'));
+
+        triggerAmountUsdBlur(result.current, createFormState({ amountUah: '100', amountUsd: '2,50' }));
+
+        expect(result.current.usdMismatchMessage).toBeUndefined();
+    });
+
+    it('normalizes amountUsd and sets error on blur when value is zero', () => {
+        const { result } = renderHook(() => useAmountBlur('40'));
+
+        const nextState = triggerAmountUsdBlur(result.current, createFormState({ amountUah: '100', amountUsd: '0' }));
+
+        expect(nextState.errors.amountUsd).toBe(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_ZERO);
+    });
+});

--- a/src/hooks/admin/use-amount-blur/useAmountBlur.ts
+++ b/src/hooks/admin/use-amount-blur/useAmountBlur.ts
@@ -1,0 +1,50 @@
+import { useCallback, useState } from 'react';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { updateFundsAmounts } from '@/utils/functions/update-funds-amounts/update-funds-amounts';
+import { isUsdAmountMismatch } from '@/utils/functions/validate-usd-amount-mismatch/validate-usd-amount-mismatch';
+import {
+    normalizeFundsExpendituresAmountInput,
+    validateFundsExpendituresAmount,
+} from '@/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema';
+
+export const useAmountBlur = (exchangeRate: string | null) => {
+    const [usdMismatchMessage, setUsdMismatchMessage] = useState<string | undefined>();
+
+    const handleAmountBlur = useCallback(
+        (field: 'amountUah' | 'amountUsd', setFormState: React.Dispatch<React.SetStateAction<any>>) => {
+            if (field === 'amountUsd') {
+                setFormState((prev: any) => {
+                    const normalizedAmountUsd = normalizeFundsExpendituresAmountInput(prev.amountUsd, true);
+                    const amountUsdError = validateFundsExpendituresAmount(normalizedAmountUsd, 'blur');
+
+                    const hasMismatch = isUsdAmountMismatch(prev.amountUah, normalizedAmountUsd, exchangeRate);
+                    setUsdMismatchMessage(
+                        hasMismatch ? FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH : undefined,
+                    );
+
+                    return {
+                        ...prev,
+                        amountUsd: normalizedAmountUsd,
+                        errors: {
+                            ...prev.errors,
+                            amountUsd: amountUsdError,
+                        },
+                    };
+                });
+                return;
+            }
+
+            setFormState((prev: any) => {
+                const updated = {
+                    ...prev,
+                    ...updateFundsAmounts(field, prev[field], exchangeRate, 'blur')(prev),
+                };
+                setUsdMismatchMessage(undefined);
+                return updated;
+            });
+        },
+        [exchangeRate],
+    );
+
+    return { usdMismatchMessage, setUsdMismatchMessage, handleAmountBlur };
+};

--- a/src/hooks/admin/use-funds-expenditures-record-form/useFundsExpendituresRecordForm.test.ts
+++ b/src/hooks/admin/use-funds-expenditures-record-form/useFundsExpendituresRecordForm.test.ts
@@ -50,48 +50,6 @@ describe('useFundsExpendituresRecordForm', () => {
         );
     });
 
-    it('updates amount values and sets usd mismatch on blur', () => {
-        const { result } = renderUseFundsForm();
-
-        act(() => {
-            result.current.handleAmountChange('100');
-            result.current.handleUsdChange('1');
-            result.current.handleAmountBlur('amountUsd');
-        });
-
-        expect(result.current.usdMismatchMessage).toBe(FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH);
-    });
-
-    it('keeps usd mismatch message undefined when amounts match on blur', () => {
-        const { result } = renderUseFundsForm();
-
-        act(() => {
-            result.current.handleAmountChange('100');
-            result.current.handleUsdChange('10');
-            result.current.handleAmountBlur('amountUsd');
-        });
-
-        expect(result.current.usdMismatchMessage).toBeUndefined();
-    });
-
-    it('clears usd mismatch after amount uah blur recalculation', () => {
-        const { result } = renderUseFundsForm();
-
-        act(() => {
-            result.current.handleAmountChange('100');
-            result.current.handleUsdChange('1');
-            result.current.handleAmountBlur('amountUsd');
-        });
-
-        expect(result.current.usdMismatchMessage).toBe(FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH);
-
-        act(() => {
-            result.current.handleAmountBlur('amountUah');
-        });
-
-        expect(result.current.usdMismatchMessage).toBeUndefined();
-    });
-
     it('does not submit invalid form and closes confirmation state', async () => {
         const onSubmit = jest.fn().mockResolvedValue(true);
         const { result } = renderUseFundsForm({ onSubmit });

--- a/src/hooks/admin/use-funds-expenditures-record-form/useFundsExpendituresRecordForm.ts
+++ b/src/hooks/admin/use-funds-expenditures-record-form/useFundsExpendituresRecordForm.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
 import {
     FundsExpendituresTransactionType,
     ReportFundsExpendituresCategory,
@@ -12,7 +11,7 @@ import {
     validateFundsExpendituresCategory,
     validateFundsExpendituresReportingYear,
 } from '@/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema';
-import { isUsdAmountMismatch } from '@/utils/functions/validate-usd-amount-mismatch/validate-usd-amount-mismatch';
+import { useAmountBlur } from '@/hooks/admin/use-amount-blur/useAmountBlur';
 
 interface FundsExpendituresRecordFormState {
     reportingYear: string | undefined;
@@ -61,7 +60,11 @@ export const useFundsExpendituresRecordForm = ({
     const [formState, setFormState] = useState<FundsExpendituresRecordFormState>(INITIAL_STATE);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [isAddConfirmationOpen, setIsAddConfirmationOpen] = useState(false);
-    const [usdMismatchMessage, setUsdMismatchMessage] = useState<string | undefined>();
+    const {
+        usdMismatchMessage,
+        setUsdMismatchMessage,
+        handleAmountBlur: handleAmountBlurBase,
+    } = useAmountBlur(exchangeRate);
 
     const filteredCategories = useMemo(() => {
         return categories
@@ -90,7 +93,7 @@ export const useFundsExpendituresRecordForm = ({
                 },
             }));
         }
-    }, [isCategorySelectDisabled, isOpen]);
+    }, [isCategorySelectDisabled, isOpen, setUsdMismatchMessage]);
 
     const getCategoryError = useCallback(
         (categoryId: number | undefined, trigger: 'change' | 'blur'): string | undefined => {
@@ -113,46 +116,12 @@ export const useFundsExpendituresRecordForm = ({
             }));
             setUsdMismatchMessage(undefined);
         },
-        [exchangeRate],
+        [exchangeRate, setUsdMismatchMessage],
     );
 
     const handleAmountBlur = useCallback(
-        (field: 'amountUah' | 'amountUsd') => {
-            if (field === 'amountUsd') {
-                setFormState((prev) => {
-                    const normalizedAmountUsd = normalizeFundsExpendituresAmountInput(prev.amountUsd, true);
-                    const amountUsdError = validateFundsExpendituresAmount(normalizedAmountUsd, 'blur');
-
-                    const hasMismatch = isUsdAmountMismatch(prev.amountUah, normalizedAmountUsd, exchangeRate);
-                    setUsdMismatchMessage(
-                        hasMismatch ? FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH : undefined,
-                    );
-
-                    return {
-                        ...prev,
-                        amountUsd: normalizedAmountUsd,
-                        errors: {
-                            ...prev.errors,
-                            amountUsd: amountUsdError,
-                        },
-                    };
-                });
-
-                return;
-            }
-
-            setFormState((prev) => {
-                const updated = {
-                    ...prev,
-                    ...updateFundsAmounts(field, prev[field], exchangeRate, 'blur')(prev),
-                };
-
-                setUsdMismatchMessage(undefined);
-
-                return updated;
-            });
-        },
-        [exchangeRate],
+        (field: 'amountUah' | 'amountUsd') => handleAmountBlurBase(field, setFormState),
+        [handleAmountBlurBase],
     );
 
     const handleUsdChange = useCallback(
@@ -163,7 +132,7 @@ export const useFundsExpendituresRecordForm = ({
             }));
             setUsdMismatchMessage(undefined);
         },
-        [exchangeRate],
+        [exchangeRate, setUsdMismatchMessage],
     );
 
     const handleSubmit = useCallback(async () => {
@@ -209,7 +178,7 @@ export const useFundsExpendituresRecordForm = ({
         } finally {
             setIsSubmitting(false);
         }
-    }, [formState, getCategoryError, onSubmit, transactionType]);
+    }, [formState, getCategoryError, onSubmit, transactionType, setUsdMismatchMessage]);
 
     const isDirty =
         Boolean(formState.reportingYear) ||

--- a/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.test.ts
+++ b/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.test.ts
@@ -156,7 +156,7 @@ describe('useProgramExpenseRecordForm', () => {
             result.current.handleAmountChange('100');
         });
 
-        expect(result.current.formState.amountUsd).toBe('2.50');
+        expect(result.current.formState.amountUsd).toBe('2,5');
     });
 
     it('does not recalculate UAH when USD is changed manually', () => {
@@ -168,30 +168,5 @@ describe('useProgramExpenseRecordForm', () => {
         });
 
         expect(result.current.formState.amountUah).toBe('100');
-    });
-
-    it('sets usdMismatchMessage on USD blur when USD does not match converted value', () => {
-        const { result } = renderUseProgramExpenseForm({ exchangeRate: '40' });
-
-        act(() => {
-            result.current.handleAmountChange('100');
-            result.current.handleUsdChange('999');
-            result.current.handleAmountBlur('amountUsd');
-        });
-
-        expect(result.current.usdMismatchMessage).toBe(FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH);
-    });
-
-    it('clears usdMismatchMessage when UAH amount changes', () => {
-        const { result } = renderUseProgramExpenseForm({ exchangeRate: '40' });
-
-        act(() => {
-            result.current.handleAmountChange('100');
-            result.current.handleUsdChange('999');
-            result.current.handleAmountBlur('amountUsd');
-            result.current.handleAmountChange('200');
-        });
-
-        expect(result.current.usdMismatchMessage).toBeUndefined();
     });
 });

--- a/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.test.ts
+++ b/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.test.ts
@@ -27,6 +27,7 @@ const createHookParams = (
     isOpen: true,
     programs,
     records,
+    exchangeRate: null,
     ...overrides,
 });
 
@@ -58,8 +59,8 @@ describe('useProgramExpenseRecordForm', () => {
         act(() => {
             result.current.handleReportingYearChange('2026');
             result.current.handleProgramChange(1);
-            result.current.handleAmountChange('amountUah', '100');
-            result.current.handleAmountChange('amountUsd', '10');
+            result.current.handleAmountChange('100');
+            result.current.handleUsdChange('10');
         });
 
         expect(result.current.formState.errors.programId).toBe(PROGRAM_EXPENSES_TEXT.VALIDATION.PROGRAM_UNIQUE);
@@ -72,8 +73,8 @@ describe('useProgramExpenseRecordForm', () => {
         act(() => {
             result.current.handleReportingYearChange('2026');
             result.current.handleProgramChange(2);
-            result.current.handleAmountChange('amountUah', '100');
-            result.current.handleAmountChange('amountUsd', '10');
+            result.current.handleAmountChange('100');
+            result.current.handleUsdChange('10');
         });
 
         expect(result.current.isSubmitDisabled).toBe(false);
@@ -83,8 +84,8 @@ describe('useProgramExpenseRecordForm', () => {
         const { result } = renderUseProgramExpenseForm();
 
         act(() => {
-            result.current.handleAmountChange('amountUah', '1234567890');
-            result.current.handleAmountChange('amountUsd', '0');
+            result.current.handleAmountChange('1234567890');
+            result.current.handleUsdChange('0');
         });
 
         expect(result.current.formState.errors.amountUah).toBe(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DIGITS);
@@ -104,6 +105,7 @@ describe('useProgramExpenseRecordForm', () => {
                     isOpen,
                     programs,
                     records,
+                    exchangeRate: null,
                 }),
             { initialProps: { isOpen: true } },
         );
@@ -111,7 +113,7 @@ describe('useProgramExpenseRecordForm', () => {
         act(() => {
             result.current.handleReportingYearChange('2026');
             result.current.handleProgramChange(2);
-            result.current.handleAmountChange('amountUah', '100');
+            result.current.handleAmountChange('100');
         });
 
         expect(result.current.isDirty).toBe(true);
@@ -131,6 +133,7 @@ describe('useProgramExpenseRecordForm', () => {
                     isOpen: true,
                     programs: nextPrograms,
                     records,
+                    exchangeRate: null,
                 }),
             { initialProps: { nextPrograms: programs } },
         );
@@ -144,5 +147,51 @@ describe('useProgramExpenseRecordForm', () => {
         rerender({ nextPrograms: programs.filter((program) => program.id !== 2) });
 
         expect(result.current.formState.programId).toBeUndefined();
+    });
+
+    it('automatically converts UAH to USD when UAH amount is entered', () => {
+        const { result } = renderUseProgramExpenseForm({ exchangeRate: '40' });
+
+        act(() => {
+            result.current.handleAmountChange('100');
+        });
+
+        expect(result.current.formState.amountUsd).toBe('2.50');
+    });
+
+    it('does not recalculate UAH when USD is changed manually', () => {
+        const { result } = renderUseProgramExpenseForm({ exchangeRate: '40' });
+
+        act(() => {
+            result.current.handleAmountChange('100');
+            result.current.handleUsdChange('999');
+        });
+
+        expect(result.current.formState.amountUah).toBe('100');
+    });
+
+    it('sets usdMismatchMessage on USD blur when USD does not match converted value', () => {
+        const { result } = renderUseProgramExpenseForm({ exchangeRate: '40' });
+
+        act(() => {
+            result.current.handleAmountChange('100');
+            result.current.handleUsdChange('999');
+            result.current.handleAmountBlur('amountUsd');
+        });
+
+        expect(result.current.usdMismatchMessage).toBe(FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH);
+    });
+
+    it('clears usdMismatchMessage when UAH amount changes', () => {
+        const { result } = renderUseProgramExpenseForm({ exchangeRate: '40' });
+
+        act(() => {
+            result.current.handleAmountChange('100');
+            result.current.handleUsdChange('999');
+            result.current.handleAmountBlur('amountUsd');
+            result.current.handleAmountChange('200');
+        });
+
+        expect(result.current.usdMismatchMessage).toBeUndefined();
     });
 });

--- a/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.ts
+++ b/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.ts
@@ -1,14 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ProgramExpensesProgram, ProgramExpensesRecord } from '@/types/admin/reports';
-import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
 import { updateFundsAmounts } from '@/utils/functions/update-funds-amounts/update-funds-amounts';
-import { isUsdAmountMismatch } from '@/utils/functions/validate-usd-amount-mismatch/validate-usd-amount-mismatch';
+import { useAmountBlur } from '@/hooks/admin/use-amount-blur/useAmountBlur';
+import { validateProgramExpenseProgram } from '@/validation/admin/reports-schema/program-expenses-record-schema/program-expenses-record-schema';
 import {
-    normalizeProgramExpenseAmountInput,
-    validateProgramExpenseAmount,
-    validateProgramExpenseProgram,
-    validateProgramExpenseReportingYear,
-} from '@/validation/admin/reports-schema/program-expenses-record-schema/program-expenses-record-schema';
+    validateFundsExpendituresAmount,
+    validateFundsExpendituresReportingYear,
+} from '@/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema';
 
 interface ProgramExpenseFormState {
     reportingYear: string | undefined;
@@ -45,7 +43,11 @@ export const useProgramExpenseRecordForm = ({
     exchangeRate,
 }: UseProgramExpenseRecordFormParams) => {
     const [formState, setFormState] = useState<ProgramExpenseFormState>(INITIAL_STATE);
-    const [usdMismatchMessage, setUsdMismatchMessage] = useState<string | undefined>();
+    const {
+        usdMismatchMessage,
+        setUsdMismatchMessage,
+        handleAmountBlur: handleAmountBlurBase,
+    } = useAmountBlur(exchangeRate);
 
     const programOptions = useMemo(
         () =>
@@ -88,7 +90,7 @@ export const useProgramExpenseRecordForm = ({
                 },
             }));
         }
-    }, [formState.programId, isOpen, isProgramSelectDisabled, programOptions]);
+    }, [formState.programId, isOpen, isProgramSelectDisabled, programOptions, setUsdMismatchMessage]);
 
     const handleAmountChange = useCallback(
         (value: string) => {
@@ -98,7 +100,7 @@ export const useProgramExpenseRecordForm = ({
             }));
             setUsdMismatchMessage(undefined);
         },
-        [exchangeRate],
+        [exchangeRate, setUsdMismatchMessage],
     );
 
     const handleUsdChange = useCallback(
@@ -109,43 +111,12 @@ export const useProgramExpenseRecordForm = ({
             }));
             setUsdMismatchMessage(undefined);
         },
-        [exchangeRate],
+        [exchangeRate, setUsdMismatchMessage],
     );
 
     const handleAmountBlur = useCallback(
-        (field: 'amountUah' | 'amountUsd') => {
-            if (field === 'amountUsd') {
-                setFormState((prev) => {
-                    const normalizedAmountUsd = normalizeProgramExpenseAmountInput(prev.amountUsd, true);
-                    const amountUsdError = validateProgramExpenseAmount(normalizedAmountUsd, 'blur');
-
-                    const hasMismatch = isUsdAmountMismatch(prev.amountUah, normalizedAmountUsd, exchangeRate);
-                    setUsdMismatchMessage(
-                        hasMismatch ? FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH : undefined,
-                    );
-
-                    return {
-                        ...prev,
-                        amountUsd: normalizedAmountUsd,
-                        errors: {
-                            ...prev.errors,
-                            amountUsd: amountUsdError,
-                        },
-                    };
-                });
-                return;
-            }
-
-            setFormState((prev) => {
-                const updated = {
-                    ...prev,
-                    ...updateFundsAmounts(field, prev[field], exchangeRate, 'blur')(prev),
-                };
-                setUsdMismatchMessage(undefined);
-                return updated;
-            });
-        },
-        [exchangeRate],
+        (field: 'amountUah' | 'amountUsd') => handleAmountBlurBase(field, setFormState),
+        [handleAmountBlurBase],
     );
 
     const handleReportingYearChange = useCallback((reportingYear: string | undefined) => {
@@ -154,7 +125,7 @@ export const useProgramExpenseRecordForm = ({
             reportingYear,
             errors: {
                 ...previousState.errors,
-                reportingYear: validateProgramExpenseReportingYear(reportingYear, 'change'),
+                reportingYear: validateFundsExpendituresReportingYear(reportingYear, 'change'),
             },
         }));
     }, []);
@@ -164,7 +135,7 @@ export const useProgramExpenseRecordForm = ({
             ...previousState,
             errors: {
                 ...previousState.errors,
-                reportingYear: validateProgramExpenseReportingYear(previousState.reportingYear, 'blur'),
+                reportingYear: validateFundsExpendituresReportingYear(previousState.reportingYear, 'blur'),
             },
         }));
     }, []);
@@ -200,10 +171,10 @@ export const useProgramExpenseRecordForm = ({
         formState.amountUsd.trim() !== '';
 
     const isSubmitDisabled =
-        Boolean(validateProgramExpenseReportingYear(formState.reportingYear, 'save')) ||
+        Boolean(validateFundsExpendituresReportingYear(formState.reportingYear, 'save')) ||
         Boolean(getProgramError(formState.programId, 'blur')) ||
-        Boolean(validateProgramExpenseAmount(formState.amountUah, 'save')) ||
-        Boolean(validateProgramExpenseAmount(formState.amountUsd, 'save'));
+        Boolean(validateFundsExpendituresAmount(formState.amountUah, 'save')) ||
+        Boolean(validateFundsExpendituresAmount(formState.amountUsd, 'save'));
 
     return {
         formState,

--- a/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.ts
+++ b/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.ts
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ProgramExpensesProgram, ProgramExpensesRecord } from '@/types/admin/reports';
+import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
+import { updateFundsAmounts } from '@/utils/functions/update-funds-amounts/update-funds-amounts';
+import { isUsdAmountMismatch } from '@/utils/functions/validate-usd-amount-mismatch/validate-usd-amount-mismatch';
 import {
     normalizeProgramExpenseAmountInput,
     validateProgramExpenseAmount,
@@ -24,6 +27,7 @@ interface UseProgramExpenseRecordFormParams {
     isOpen: boolean;
     programs: ProgramExpensesProgram[];
     records: ProgramExpensesRecord[];
+    exchangeRate: string | null;
 }
 
 const INITIAL_STATE: ProgramExpenseFormState = {
@@ -34,8 +38,14 @@ const INITIAL_STATE: ProgramExpenseFormState = {
     errors: {},
 };
 
-export const useProgramExpenseRecordForm = ({ isOpen, programs, records }: UseProgramExpenseRecordFormParams) => {
+export const useProgramExpenseRecordForm = ({
+    isOpen,
+    programs,
+    records,
+    exchangeRate,
+}: UseProgramExpenseRecordFormParams) => {
     const [formState, setFormState] = useState<ProgramExpenseFormState>(INITIAL_STATE);
+    const [usdMismatchMessage, setUsdMismatchMessage] = useState<string | undefined>();
 
     const programOptions = useMemo(
         () =>
@@ -61,6 +71,7 @@ export const useProgramExpenseRecordForm = ({ isOpen, programs, records }: UsePr
     useEffect(() => {
         if (!isOpen) {
             setFormState(INITIAL_STATE);
+            setUsdMismatchMessage(undefined);
             return;
         }
 
@@ -79,33 +90,63 @@ export const useProgramExpenseRecordForm = ({ isOpen, programs, records }: UsePr
         }
     }, [formState.programId, isOpen, isProgramSelectDisabled, programOptions]);
 
-    const handleAmountChange = useCallback((field: 'amountUah' | 'amountUsd', value: string) => {
-        const normalizedValue = normalizeProgramExpenseAmountInput(value);
+    const handleAmountChange = useCallback(
+        (value: string) => {
+            setFormState((prev) => ({
+                ...prev,
+                ...updateFundsAmounts('amountUah', value, exchangeRate, 'change')(prev),
+            }));
+            setUsdMismatchMessage(undefined);
+        },
+        [exchangeRate],
+    );
 
-        setFormState((previousState) => ({
-            ...previousState,
-            [field]: normalizedValue,
-            errors: {
-                ...previousState.errors,
-                [field]: validateProgramExpenseAmount(normalizedValue, 'change'),
-            },
-        }));
-    }, []);
+    const handleUsdChange = useCallback(
+        (value: string) => {
+            setFormState((prev) => ({
+                ...prev,
+                ...updateFundsAmounts('amountUsd', value, exchangeRate, 'change')(prev),
+            }));
+            setUsdMismatchMessage(undefined);
+        },
+        [exchangeRate],
+    );
 
-    const handleAmountBlur = useCallback((field: 'amountUah' | 'amountUsd') => {
-        setFormState((previousState) => {
-            const normalizedValue = normalizeProgramExpenseAmountInput(previousState[field], true);
+    const handleAmountBlur = useCallback(
+        (field: 'amountUah' | 'amountUsd') => {
+            if (field === 'amountUsd') {
+                setFormState((prev) => {
+                    const normalizedAmountUsd = normalizeProgramExpenseAmountInput(prev.amountUsd, true);
+                    const amountUsdError = validateProgramExpenseAmount(normalizedAmountUsd, 'blur');
 
-            return {
-                ...previousState,
-                [field]: normalizedValue,
-                errors: {
-                    ...previousState.errors,
-                    [field]: validateProgramExpenseAmount(normalizedValue, 'blur'),
-                },
-            };
-        });
-    }, []);
+                    const hasMismatch = isUsdAmountMismatch(prev.amountUah, normalizedAmountUsd, exchangeRate);
+                    setUsdMismatchMessage(
+                        hasMismatch ? FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH : undefined,
+                    );
+
+                    return {
+                        ...prev,
+                        amountUsd: normalizedAmountUsd,
+                        errors: {
+                            ...prev.errors,
+                            amountUsd: amountUsdError,
+                        },
+                    };
+                });
+                return;
+            }
+
+            setFormState((prev) => {
+                const updated = {
+                    ...prev,
+                    ...updateFundsAmounts(field, prev[field], exchangeRate, 'blur')(prev),
+                };
+                setUsdMismatchMessage(undefined);
+                return updated;
+            });
+        },
+        [exchangeRate],
+    );
 
     const handleReportingYearChange = useCallback((reportingYear: string | undefined) => {
         setFormState((previousState) => ({
@@ -170,11 +211,13 @@ export const useProgramExpenseRecordForm = ({ isOpen, programs, records }: UsePr
         isProgramSelectDisabled,
         isDirty,
         isSubmitDisabled,
+        usdMismatchMessage,
         handleReportingYearChange,
         handleReportingYearBlur,
         handleProgramChange,
         handleProgramBlur,
         handleAmountChange,
+        handleUsdChange,
         handleAmountBlur,
     };
 };

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.module.scss
@@ -316,3 +316,25 @@
         width: 100%;
     }
 }
+
+.info {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.info-icon {
+    width: 18px;
+    height: 18px;
+
+    path {
+        stroke: c.$blue-500;
+    }
+}
+
+.info-text {
+    @include type.small-text-medium;
+    margin: 0;
+    color: c.$blue-500;
+    white-space: nowrap;
+}

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.test.tsx
@@ -201,7 +201,6 @@ describe('AddProgramExpenseRecordModal', () => {
         selectOption(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER, '2026');
         selectOption(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER, 'Program A');
         fireEvent.change(screen.getByTestId('add-program-expense-amount-uah'), { target: { value: '100' } });
-        fireEvent.change(screen.getByTestId('add-program-expense-amount-usd'), { target: { value: '10' } });
 
         expect(screen.getByText(PROGRAM_EXPENSES_TEXT.VALIDATION.PROGRAM_UNIQUE)).toBeInTheDocument();
         expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.MODAL.ADD.SUBMIT_BUTTON })).toBeDisabled();
@@ -213,7 +212,6 @@ describe('AddProgramExpenseRecordModal', () => {
         selectOption(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER, '2026');
         selectOption(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER, 'Program B');
         fireEvent.change(screen.getByTestId('add-program-expense-amount-uah'), { target: { value: '100' } });
-        fireEvent.change(screen.getByTestId('add-program-expense-amount-usd'), { target: { value: '10' } });
 
         expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.MODAL.ADD.SUBMIT_BUTTON })).toBeEnabled();
     });
@@ -290,5 +288,18 @@ describe('AddProgramExpenseRecordModal', () => {
         expect(screen.getByTestId('add-program-expense-amount-uah')).toHaveValue('');
         expect(screen.queryByTestId('close-confirmation')).not.toBeInTheDocument();
         expect(screen.getByLabelText(FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL)).toHaveValue('');
+    });
+
+    it('auto-fills USD when UAH is entered and shows mismatch message on manual USD change', () => {
+        renderModal({ exchangeRate: '40' });
+
+        fireEvent.change(screen.getByTestId('add-program-expense-amount-uah'), { target: { value: '100' } });
+
+        expect(screen.getByTestId('add-program-expense-amount-usd')).not.toHaveValue('');
+
+        fireEvent.change(screen.getByTestId('add-program-expense-amount-usd'), { target: { value: '999' } });
+        fireEvent.blur(screen.getByTestId('add-program-expense-amount-usd'));
+
+        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH)).toBeInTheDocument();
     });
 });

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.tsx
@@ -79,11 +79,12 @@ interface AmountFieldProps {
     value: string;
     error?: string;
     headerAddon?: ReactNode;
+    footer?: ReactNode;
     onChange: (event: ChangeEvent<HTMLInputElement>) => void;
     onBlur: () => void;
 }
 
-const AmountField = ({ id, name, label, value, error, headerAddon, onChange, onBlur }: AmountFieldProps) => (
+const AmountField = ({ id, name, label, value, error, headerAddon, footer, onChange, onBlur }: AmountFieldProps) => (
     <div className={styles.field}>
         <div className={headerAddon ? styles['amount-usd-header'] : undefined}>
             <RequiredFieldLabel>{label}</RequiredFieldLabel>
@@ -102,6 +103,7 @@ const AmountField = ({ id, name, label, value, error, headerAddon, onChange, onB
             hasError={Boolean(error)}
         />
         <FieldError message={error} />
+        {footer}
     </div>
 );
 
@@ -239,13 +241,15 @@ export const AddProgramExpenseRecordModal = ({
                                 headerAddon={<ExchangeRateChip exchangeRate={exchangeRate} />}
                                 onChange={(event) => handleUsdChange(event.target.value)}
                                 onBlur={() => handleAmountBlur('amountUsd')}
+                                footer={
+                                    usdMismatchMessage && (
+                                        <div className={styles.info}>
+                                            <InfoIcon className={styles['info-icon']} aria-hidden="true" />
+                                            <p className={styles['info-text']}>{usdMismatchMessage}</p>
+                                        </div>
+                                    )
+                                }
                             />
-                            {usdMismatchMessage && (
-                                <div className={styles.info}>
-                                    <InfoIcon className={styles['info-icon']} aria-hidden="true" />
-                                    <p className={styles['info-text']}>{usdMismatchMessage}</p>
-                                </div>
-                            )}
                         </div>
 
                         <div className={styles.actions}>

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.tsx
@@ -11,6 +11,7 @@ import { useProgramExpenseRecordForm } from '@/hooks/admin/use-program-expense-r
 import { ProgramExpensesProgram, ProgramExpensesRecord } from '@/types/admin/reports';
 import { getReportingYearOptions } from '@/utils/functions/get-reporting-year-options/get-reporting-year-options';
 import styles from './AddProgramExpenseRecordModal.module.scss';
+import { ReactComponent as InfoIcon } from '@/assets/icons/info.svg';
 
 interface AddProgramExpenseRecordModalProps {
     isOpen: boolean;
@@ -120,16 +121,19 @@ export const AddProgramExpenseRecordModal = ({
         isProgramSelectDisabled,
         isDirty,
         isSubmitDisabled,
+        usdMismatchMessage,
         handleReportingYearChange,
         handleReportingYearBlur,
         handleProgramChange,
         handleProgramBlur,
         handleAmountChange,
+        handleUsdChange,
         handleAmountBlur,
     } = useProgramExpenseRecordForm({
         isOpen,
         programs,
         records,
+        exchangeRate,
     });
 
     const { isCloseConfirmOpen, handleRequestClose, handleConfirmClose, handleCancelClose } =
@@ -222,7 +226,7 @@ export const AddProgramExpenseRecordModal = ({
                                 label={FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.AMOUNT_UAH_LABEL}
                                 value={formState.amountUah}
                                 error={formState.errors.amountUah}
-                                onChange={(event) => handleAmountChange('amountUah', event.target.value)}
+                                onChange={(event) => handleAmountChange(event.target.value)}
                                 onBlur={() => handleAmountBlur('amountUah')}
                             />
 
@@ -233,9 +237,15 @@ export const AddProgramExpenseRecordModal = ({
                                 value={formState.amountUsd}
                                 error={formState.errors.amountUsd}
                                 headerAddon={<ExchangeRateChip exchangeRate={exchangeRate} />}
-                                onChange={(event) => handleAmountChange('amountUsd', event.target.value)}
+                                onChange={(event) => handleUsdChange(event.target.value)}
                                 onBlur={() => handleAmountBlur('amountUsd')}
                             />
+                            {usdMismatchMessage && (
+                                <div className={styles.info}>
+                                    <InfoIcon className={styles['info-icon']} aria-hidden="true" />
+                                    <p className={styles['info-text']}>{usdMismatchMessage}</p>
+                                </div>
+                            )}
                         </div>
 
                         <div className={styles.actions}>

--- a/src/validation/admin/reports-schema/program-expenses-record-schema/program-expenses-record-schema.test.ts
+++ b/src/validation/admin/reports-schema/program-expenses-record-schema/program-expenses-record-schema.test.ts
@@ -1,12 +1,7 @@
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
-import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+import { PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
 import { ProgramExpensesRecord } from '@/types/admin/reports';
-import {
-    normalizeProgramExpenseAmountInput,
-    validateProgramExpenseAmount,
-    validateProgramExpenseProgram,
-    validateProgramExpenseReportingYear,
-} from './program-expenses-record-schema';
+import { validateProgramExpenseProgram } from './program-expenses-record-schema';
 
 describe('PROGRAM_EXPENSES_RECORD_VALIDATION_FUNCTIONS', () => {
     const records: ProgramExpensesRecord[] = [
@@ -29,25 +24,6 @@ describe('PROGRAM_EXPENSES_RECORD_VALIDATION_FUNCTIONS', () => {
             amountUsd: '20',
         },
     ];
-
-    it('reuses funds amount normalization and validation rules', () => {
-        expect(normalizeProgramExpenseAmountInput('1200.567')).toBe('1200,56');
-        expect(validateProgramExpenseAmount('1234567890', 'change')).toBe(
-            FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DIGITS,
-        );
-        expect(validateProgramExpenseAmount('0', 'save')).toBe(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_ZERO);
-        expect(validateProgramExpenseAmount('1200')).toBeUndefined();
-        expect(validateProgramExpenseAmount('1200,50', 'save')).toBeUndefined();
-    });
-
-    it('reuses reporting year required validation', () => {
-        expect(validateProgramExpenseReportingYear(undefined, 'change')).toBeUndefined();
-        expect(validateProgramExpenseReportingYear(undefined)).toBeUndefined();
-        expect(validateProgramExpenseReportingYear(undefined, 'blur')).toBe(
-            COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED,
-        );
-        expect(validateProgramExpenseReportingYear('2026', 'save')).toBeUndefined();
-    });
 
     it('validates required program category on blur', () => {
         expect(

--- a/src/validation/admin/reports-schema/program-expenses-record-schema/program-expenses-record-schema.ts
+++ b/src/validation/admin/reports-schema/program-expenses-record-schema/program-expenses-record-schema.ts
@@ -1,13 +1,6 @@
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
 import { ProgramExpensesRecord } from '@/types/admin/reports';
-import {
-    FundsExpendituresAmountValidationTrigger,
-    FundsExpendituresReportingYearValidationTrigger,
-    normalizeFundsExpendituresAmountInput,
-    validateFundsExpendituresAmount,
-    validateFundsExpendituresReportingYear,
-} from '@/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema';
 
 export type ProgramExpenseProgramValidationTrigger = 'change' | 'blur';
 
@@ -17,18 +10,6 @@ interface ValidateProgramExpenseProgramParams {
     records: ProgramExpensesRecord[];
     trigger?: ProgramExpenseProgramValidationTrigger;
 }
-
-export const normalizeProgramExpenseAmountInput = normalizeFundsExpendituresAmountInput;
-
-export const validateProgramExpenseAmount = (
-    value: string,
-    trigger: FundsExpendituresAmountValidationTrigger = 'change',
-): string | undefined => validateFundsExpendituresAmount(value, trigger);
-
-export const validateProgramExpenseReportingYear = (
-    value: string | undefined,
-    trigger: FundsExpendituresReportingYearValidationTrigger = 'change',
-): string | undefined => validateFundsExpendituresReportingYear(value, trigger);
 
 export const validateProgramExpenseProgram = ({
     recordId,


### PR DESCRIPTION
## Github ticket
* [#1884](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1884)

## Description
This PR implements automatic UAH to USD conversion in the 'Додати витрату по програмі' modal,
applying the same behavior as #1751 to the program expense context.

## Summary of change
- Added `exchangeRate` parameter to `useProgramExpenseRecordForm` hook
- Split amount change handling into `handleAmountChange` (UAH) and `handleUsdChange` (USD)
- UAH input auto-converts to USD using `updateFundsAmounts` utility
- USD field remains manually editable without recalculating UAH
- Added `usdMismatchMessage` state — displays a warning when manually entered USD does not match the converted value
- Updated `AddProgramExpenseRecordModal` to pass `exchangeRate` to the hook and render the mismatch message with an info icon
- Added unit tests for conversion logic, mismatch detection, and state reset

## How to recreate changes
1. Open the 'Звітність' page as Admin
2. Navigate to the 'Звіт та аналітика' tab
3. Click the 'Редагувати доходи та витрати' button
4. Select the 'Програмні витрати' section
5. Click the 'Витрата по програмі' button to open the modal
6. Enter a value in the 'Сума (UAH)' field, 'Сума (USD)' should auto-fill based on the exchange rate
7. Manually change the 'Сума (USD)' value to something that doesn't match
8. Click outside the USD field, the warning message 'Сума в USD не відповідає сумі и UAH' should appear
9. Change the UAH amount again, the warning should disappear and USD should recalculate

## CHECK LIST
- [x] New tests was added or existing was modified
- [ ] Changes has severe impact on users
- [x] Changes has medium impact on users
- [ ] Changes has light impact on users
- [x] Test coverage was updated
- [x] PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-populate USD when entering UAH using an exchange rate; display an inline info panel for USD mismatch messages.
  * New blur handling improves normalization and mismatch detection for amount fields.

* **Bug Fixes**
  * Shows validation message when manually entered USD does not match converted UAH.
  * Form state (including mismatch message) resets when the modal closes.

* **Tests**
  * Added and updated tests covering conversion, blur behavior, and mismatch messaging.

* **Refactor**
  * Centralized blur/mismatch logic into a dedicated hook and simplified validation exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->