### PR TITLE
Feature/issue-1331: [Reports] Implement Translation Indicators for Dislaimer

### DIFF
--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.module.scss
@@ -26,7 +26,7 @@
     gap: 20px;
 }
 
-.disclaimer-header {
+.disclaimer-top-row {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -34,7 +34,7 @@
 
 .disclaimer-label {
     @include type.subtitle-1-medium;
-    font-weight: 700;
+    font-weight: 500;
     line-height: 24px;
     color: c.$grey-900;
 }

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
@@ -13,7 +13,9 @@ import {
     ReportFundsExpendituresCategory,
     ReportFundsExpendituresRecord,
     ReportFundsExpendituresSettings,
+    ReportFundsExpendituresSettingsLocalizationDto,
 } from '@/types/admin/reports';
+import { LocalizationLanguage, TranslationStatus } from '@/types/common/language';
 
 const MOCK_FUNDS_EXPENDITURES_SETTINGS: ReportFundsExpendituresSettings = {
     id: 1,
@@ -54,6 +56,7 @@ const MOCK_FUNDS_EXPENDITURES_SUMMARY: FundsExpendituresSummary = {
 jest.mock('./FundsExpendituresSection.module.scss', () => ({
     section: 'section',
     disclaimer: 'disclaimer',
+    'disclaimer-top-row': 'disclaimer-top-row',
     'disclaimer-label': 'disclaimer-label',
     'disclaimer-text-area': 'disclaimer-text-area',
     'disclaimer-text': 'disclaimer-text',
@@ -64,10 +67,12 @@ jest.mock('./FundsExpendituresSection.module.scss', () => ({
     'edit-icon': 'edit-icon',
     'section-footer': 'section-footer',
     'footer-button': 'footer-button',
+    'translate-btn': 'translate-btn',
 }));
 
+const stableAdminClient = {};
 jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
-    useAdminClient: () => ({}),
+    useAdminClient: () => stableAdminClient,
 }));
 
 const mockAddToast = jest.fn();
@@ -322,6 +327,57 @@ jest.mock('@/services/api/admin/reports/funds-expenditures-api', () => ({
     },
 }));
 
+const mockGetByEntityId = jest.fn();
+jest.mock(
+    '@/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api',
+    () => ({
+        ReportFundsExpendituresSettingsLocalizationsApi: {
+            getByEntityId: (...args: unknown[]) => mockGetByEntityId(...args),
+        },
+    }),
+);
+
+jest.mock('@/utils/functions/mappers/common/localization/localization-mappers', () => ({
+    mapLocalizationDtoToModel: (dto: ReportFundsExpendituresSettingsLocalizationDto) => ({
+        ...dto,
+        language: dto.localizationInfoDto,
+    }),
+}));
+
+jest.mock('@/components/admin/localization-statuses/LocalizationStatuses', () => ({
+    LocalizationStatuses: ({ localizedEntity }: { localizedEntity: { translationStatuses: unknown[] } }) => (
+        <div data-testid="localization-statuses" data-status-count={localizedEntity.translationStatuses.length} />
+    ),
+}));
+
+const mockTranslateDisclaimerModalOnTranslateSuccess = jest.fn();
+jest.mock('./components/common/translate-disclaimer-modal/TranslateDisclaimerModal', () => ({
+    TranslateDisclaimerModal: ({
+        isOpen,
+        onClose,
+        existingLocalizations,
+        onTranslateSuccess,
+    }: {
+        isOpen: boolean;
+        onClose: () => void;
+        existingLocalizations: unknown[];
+        onTranslateSuccess: (loc: unknown) => void;
+    }) => {
+        mockTranslateDisclaimerModalOnTranslateSuccess.mockImplementation(onTranslateSuccess);
+        return (
+            <div
+                data-testid="translate-disclaimer-modal"
+                data-open={String(isOpen)}
+                data-existing-count={existingLocalizations.length}
+            >
+                <button data-testid="translate-modal-close" onClick={onClose}>
+                    Close
+                </button>
+            </div>
+        );
+    },
+}));
+
 const setupMockDataFetch = (
     settings: ReportFundsExpendituresSettings | null = MOCK_FUNDS_EXPENDITURES_SETTINGS,
     categories: ReportFundsExpendituresCategory[] = MOCK_FUNDS_EXPENDITURES_CATEGORIES,
@@ -348,6 +404,7 @@ describe('FundsExpenditureSection', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         setupMockDataFetch();
+        mockGetByEntityId.mockResolvedValue([]);
     });
 
     it('should show success toast when record is saved from table', async () => {
@@ -923,6 +980,7 @@ describe('FundsExpenditureSection bulk delete flow', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         setupMockDataFetch(settingsMock, categoriesMock, recordsMock, summaryMock);
+        mockGetByEntityId.mockResolvedValue([]);
     });
 
     it('select all via header checkbox and cancel bulk delete clears selection', async () => {
@@ -964,5 +1022,158 @@ describe('FundsExpenditureSection bulk delete flow', () => {
             expect(mockBulkDelete).toHaveBeenCalledWith(expect.anything(), [1, 2]);
             expect(mockAddToast).toHaveBeenCalledWith(FUNDS_EXPENDITURES_TEXT.BULK.DELETE_SUCCESS, 'success');
         });
+    });
+});
+
+const MOCK_LANG_EN: LocalizationLanguage = { id: 2, code: 'en', name: 'Англійська' };
+
+const MOCK_LOCALIZATION_DTO: ReportFundsExpendituresSettingsLocalizationDto = {
+    entityId: 1,
+    disclaimerTitle: 'Financial report',
+    localizationInfoDto: { id: 2, code: 'en' },
+    translationStatus: TranslationStatus.Relevant,
+};
+
+describe('FundsExpenditureSection disclaimer localizations', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        setupMockDataFetch();
+        mockGetByEntityId.mockResolvedValue([]);
+    });
+
+    it('fetches disclaimer localizations on mount when settings are loaded', async () => {
+        render(<FundsExpenditureSection />);
+
+        await waitFor(() => {
+            expect(mockGetByEntityId).toHaveBeenCalledWith(expect.anything(), MOCK_FUNDS_EXPENDITURES_SETTINGS.id);
+        });
+    });
+
+    it('does not fetch disclaimer localizations when settings have no id', async () => {
+        setupMockDataFetch(null);
+        render(<FundsExpenditureSection />);
+
+        await waitFor(() => {
+            expect(mockGetByEntityId).not.toHaveBeenCalled();
+        });
+    });
+
+    it('renders localization-statuses indicator when disclaimer is visible', async () => {
+        render(<FundsExpenditureSection />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('localization-statuses')).toBeInTheDocument();
+        });
+    });
+
+    it('passes fetched localizations to the indicator', async () => {
+        mockGetByEntityId.mockResolvedValue([MOCK_LOCALIZATION_DTO]);
+
+        render(<FundsExpenditureSection translationLanguages={[MOCK_LANG_EN]} />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('localization-statuses')).toHaveAttribute('data-status-count', '1');
+        });
+    });
+
+    it('renders translate disclaimer modal closed by default', () => {
+        render(<FundsExpenditureSection />);
+
+        expect(screen.getByTestId('translate-disclaimer-modal')).toHaveAttribute('data-open', 'false');
+    });
+
+    it('passes existing localizations to the translate modal', async () => {
+        mockGetByEntityId.mockResolvedValue([MOCK_LOCALIZATION_DTO]);
+
+        render(<FundsExpenditureSection translationLanguages={[MOCK_LANG_EN]} />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('translate-disclaimer-modal')).toHaveAttribute('data-existing-count', '1');
+        });
+    });
+
+    it('updates localization indicator when translate success fires', async () => {
+        mockGetByEntityId.mockResolvedValue([]);
+
+        render(<FundsExpenditureSection translationLanguages={[MOCK_LANG_EN]} />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('localization-statuses')).toHaveAttribute('data-status-count', '0');
+        });
+
+        const newLocalization = {
+            disclaimerTitle: 'Financial report',
+            language: { id: 2, code: 'en' },
+            translationStatus: TranslationStatus.Relevant,
+        };
+        mockTranslateDisclaimerModalOnTranslateSuccess(newLocalization);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('localization-statuses')).toHaveAttribute('data-status-count', '1');
+        });
+    });
+
+    it('replaces localization in indicator when same language is re-translated', async () => {
+        const outdatedDto: ReportFundsExpendituresSettingsLocalizationDto = {
+            ...MOCK_LOCALIZATION_DTO,
+            translationStatus: TranslationStatus.Outdated,
+        };
+        mockGetByEntityId.mockResolvedValue([outdatedDto]);
+
+        render(<FundsExpenditureSection translationLanguages={[MOCK_LANG_EN]} />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('localization-statuses')).toHaveAttribute('data-status-count', '1');
+        });
+
+        const updatedLocalization = {
+            disclaimerTitle: 'Updated report',
+            language: { id: 2, code: 'en' },
+            translationStatus: TranslationStatus.Relevant,
+        };
+        mockTranslateDisclaimerModalOnTranslateSuccess(updatedLocalization);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('localization-statuses')).toHaveAttribute('data-status-count', '1');
+        });
+    });
+
+    it('refetches disclaimer localizations after successful publish', async () => {
+        mockUpdateSettings.mockResolvedValueOnce({
+            id: 1,
+            disclaimerTitle: 'Updated disclaimer',
+            exchangeRate: '44.00',
+        });
+
+        render(<FundsExpenditureSection />);
+
+        await waitFor(() => {
+            expect(mockGetByEntityId).toHaveBeenCalled();
+        });
+        const callsAfterMount = mockGetByEntityId.mock.calls.length;
+
+        fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
+        fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED));
+
+        await waitFor(() => {
+            expect(mockGetByEntityId.mock.calls.length).toBeGreaterThan(callsAfterMount);
+        });
+    });
+
+    it('does not refetch disclaimer localizations when publish fails', async () => {
+        mockUpdateSettings.mockRejectedValueOnce(new Error('publish failed'));
+
+        render(<FundsExpenditureSection />);
+
+        fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
+
+        mockGetByEntityId.mockClear();
+        fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED));
+
+        await waitFor(() => {
+            expect(mockAddToast).toHaveBeenCalledWith(REPORTS_TEXT.MESSAGE.FAIL_TO_UPDATE_REPORT, 'error');
+        });
+
+        expect(mockGetByEntityId).not.toHaveBeenCalled();
     });
 });

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -12,8 +12,10 @@ import {
     validateFundsExpendituresExchangeRate,
 } from '@/validation/admin/reports-schema/funds-expenditures-exchange-rate-schema/funds-expenditures-exchange-rate-schema';
 import { Button } from '@/components/admin/button/Button';
+import { LocalizationStatuses } from '@/components/admin/localization-statuses/LocalizationStatuses';
 import { ACTION_ICONS } from '@/const/common/action-icons';
 import { FundsExpendituresApi } from '@/services/api/admin/reports/funds-expenditures-api';
+import { ReportFundsExpendituresSettingsLocalizationsApi } from '@/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api';
 import {
     FundsExpendituresTransactionType,
     FundsExpendituresSummary,
@@ -23,6 +25,7 @@ import {
     ReportFundsExpendituresSettingsLocalization,
 } from '@/types/admin/reports';
 import { LocalizationLanguage } from '@/types/common/language';
+import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/localization/localization-mappers';
 import { useDataFetch } from '@/hooks/common/use-data-fetch/useDataFetch';
 import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
 import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextProvider';
@@ -100,8 +103,9 @@ export const FundsExpenditureSection = ({
     const [activeRecordModalType, setActiveRecordModalType] = useState<FundsExpendituresTransactionType | null>(null);
 
     const [isTranslateDisclaimerModalOpen, setIsTranslateDisclaimerModalOpen] = useState(false);
-    const [disclaimerLocalization, setDisclaimerLocalization] =
-        useState<ReportFundsExpendituresSettingsLocalization | null>(null);
+    const [disclaimerLocalizations, setDisclaimerLocalizations] = useState<
+        ReportFundsExpendituresSettingsLocalization[]
+    >([]);
 
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
     const [recordToDelete, setRecordToDelete] = useState<ReportFundsExpendituresRecord | null>(null);
@@ -229,6 +233,26 @@ export const FundsExpenditureSection = ({
         (isSettingsLoading || isCategoriesLoading || isRecordsLoading || isSummaryLoading) &&
         categories.length === 0 &&
         recordsState.length === 0;
+
+    const fetchDisclaimerLocalizations = useCallback(
+        (settingsId: number) => {
+            ReportFundsExpendituresSettingsLocalizationsApi.getByEntityId(adminClient, settingsId)
+                .then((dtos) => {
+                    setDisclaimerLocalizations(
+                        dtos.map((dto) =>
+                            mapLocalizationDtoToModel<typeof dto, ReportFundsExpendituresSettingsLocalization>(dto),
+                        ),
+                    );
+                })
+                .catch(() => {});
+        },
+        [adminClient],
+    );
+
+    useEffect(() => {
+        if (!settings?.id) return;
+        fetchDisclaimerLocalizations(settings.id);
+    }, [fetchDisclaimerLocalizations, settings?.id]);
 
     useEffect(() => {
         setRecordsState(allRecords);
@@ -474,6 +498,20 @@ export const FundsExpenditureSection = ({
         }
     }, [recordToDelete, adminClient, addToast, refetchSummary]);
 
+    const handleTranslateDisclaimerSuccess = useCallback(
+        (localization: ReportFundsExpendituresSettingsLocalization) => {
+            setDisclaimerLocalizations((prev) => {
+                const exists = prev.some((l) => l.language.id === localization.language.id);
+                return exists
+                    ? prev.map((l) => (l.language.id === localization.language.id ? localization : l))
+                    : [...prev, localization];
+            });
+            setIsTranslateDisclaimerModalOpen(false);
+            addToast(COMMON_TEXT_ADMIN.MESSAGE.TRANSLATION_SAVED_SUCCESS, ToastType.Success);
+        },
+        [addToast],
+    );
+
     const handlePublish = useCallback(async () => {
         try {
             const updatedSettings = await FundsExpendituresApi.updateSettings(adminClient, {
@@ -488,6 +526,7 @@ export const FundsExpenditureSection = ({
             onEditModeChange?.(false);
 
             refetchSettings();
+            fetchDisclaimerLocalizations(updatedSettings.id);
 
             addToast(COMMON_TEXT_ADMIN.MESSAGE.SUCCESSFULLY_PUBLISHED, ToastType.Success);
         } catch {
@@ -498,6 +537,7 @@ export const FundsExpenditureSection = ({
         adminClient,
         disclaimerValue,
         exchangeRateValue,
+        fetchDisclaimerLocalizations,
         onEditModeChange,
         onExchangeRateValueChange,
         refetchSettings,
@@ -548,10 +588,16 @@ export const FundsExpenditureSection = ({
             ) : (
                 settings?.disclaimerTitle && (
                     <div className={styles.disclaimer}>
-                        <div className={styles['disclaimer-header']}>
-                            <span className={styles['disclaimer-label']}>
-                                {FUNDS_EXPENDITURES_TEXT.DISCLAIMER_LABEL}
-                            </span>
+                        <div className={styles['disclaimer-top-row']}>
+                            <LocalizationStatuses
+                                languages={translationLanguages}
+                                localizedEntity={{
+                                    translationStatuses: disclaimerLocalizations.map((l) => ({
+                                        languageId: l.language.id,
+                                        translationStatus: l.translationStatus,
+                                    })),
+                                }}
+                            />
                             <button
                                 type="button"
                                 className={styles['translate-btn']}
@@ -561,6 +607,7 @@ export const FundsExpenditureSection = ({
                                 <TranslateIcon />
                             </button>
                         </div>
+                        <span className={styles['disclaimer-label']}>{FUNDS_EXPENDITURES_TEXT.DISCLAIMER_LABEL}</span>
                         <div className={styles['disclaimer-text-area']}>
                             <p className={styles['disclaimer-text']}>{settings.disclaimerTitle}</p>
                         </div>
@@ -701,12 +748,8 @@ export const FundsExpenditureSection = ({
                 onClose={() => setIsTranslateDisclaimerModalOpen(false)}
                 settings={settings}
                 translationLanguages={translationLanguages}
-                existingLocalization={disclaimerLocalization}
-                onTranslateSuccess={(localization) => {
-                    setDisclaimerLocalization(localization);
-                    setIsTranslateDisclaimerModalOpen(false);
-                    addToast(COMMON_TEXT_ADMIN.MESSAGE.TRANSLATION_SAVED_SUCCESS, ToastType.Success);
-                }}
+                existingLocalizations={disclaimerLocalizations}
+                onTranslateSuccess={handleTranslateDisclaimerSuccess}
             />
         </div>
     );

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-disclaimer-modal/TranslateDisclaimerModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-disclaimer-modal/TranslateDisclaimerModal.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
-import { LocalizationLanguage } from '@/types/common/language';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { LocalizationLanguage, TranslationStatus } from '@/types/common/language';
+import { ReportFundsExpendituresSettingsLocalization } from '@/types/admin/reports';
 import { TranslateDisclaimerModal } from './TranslateDisclaimerModal';
 
 jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
@@ -90,7 +92,7 @@ const defaultProps = {
     onClose: jest.fn(),
     translationLanguages: [languageEn],
     settings: null,
-    existingLocalization: null,
+    existingLocalizations: [],
     onTranslateSuccess: jest.fn(),
 };
 
@@ -197,5 +199,77 @@ describe('TranslateDisclaimerModal', () => {
         render(<TranslateDisclaimerModal {...defaultProps} />);
 
         expect(screen.getByTestId('form-disabled')).toHaveTextContent('false');
+    });
+
+    describe('existingLocalizations mode detection', () => {
+        const existingLocalization: ReportFundsExpendituresSettingsLocalization = {
+            disclaimerTitle: 'Financial report',
+            language: { id: 2, code: 'en' },
+            translationStatus: TranslationStatus.Relevant,
+        };
+
+        it('uses add-mode title when existingLocalizations is empty', () => {
+            render(<TranslateDisclaimerModal {...defaultProps} existingLocalizations={[]} />);
+
+            expect(screen.getByTestId('modal-title')).toHaveTextContent(
+                FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_DISCLAIMER.TITLE,
+            );
+        });
+
+        it('uses edit-mode title when selected language has an existing localization', () => {
+            render(
+                <TranslateDisclaimerModal
+                    {...defaultProps}
+                    translationLanguages={[languageEn]}
+                    existingLocalizations={[existingLocalization]}
+                />,
+            );
+
+            expect(screen.getByTestId('modal-title')).toHaveTextContent(
+                COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.UPDATE_TRANSLATION,
+            );
+        });
+
+        it('uses add-mode title when selected language has no localization but another language does', () => {
+            render(
+                <TranslateDisclaimerModal
+                    {...defaultProps}
+                    translationLanguages={[languageEn, languageUk]}
+                    existingLocalizations={[existingLocalization]}
+                />,
+            );
+
+            // EN is selected by default and has a localization → edit mode title
+            expect(screen.getByTestId('modal-title')).toHaveTextContent(
+                COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.UPDATE_TRANSLATION,
+            );
+
+            // Switch to UK which has no localization → add mode title
+            fireEvent.click(screen.getByTestId('lang-uk'));
+
+            expect(screen.getByTestId('modal-title')).toHaveTextContent(
+                FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_DISCLAIMER.TITLE,
+            );
+        });
+
+        it('switches from add to edit mode title when language with localization is selected', () => {
+            render(
+                <TranslateDisclaimerModal
+                    {...defaultProps}
+                    translationLanguages={[languageEn, languageUk]}
+                    existingLocalizations={[existingLocalization]}
+                />,
+            );
+
+            fireEvent.click(screen.getByTestId('lang-uk'));
+            expect(screen.getByTestId('modal-title')).toHaveTextContent(
+                FUNDS_EXPENDITURES_TEXT.MODAL.TRANSLATE_DISCLAIMER.TITLE,
+            );
+
+            fireEvent.click(screen.getByTestId('lang-en'));
+            expect(screen.getByTestId('modal-title')).toHaveTextContent(
+                COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.UPDATE_TRANSLATION,
+            );
+        });
     });
 });

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-disclaimer-modal/TranslateDisclaimerModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/translate-disclaimer-modal/TranslateDisclaimerModal.tsx
@@ -20,7 +20,7 @@ interface TranslateDisclaimerModalProps {
     onClose: () => void;
     settings: ReportFundsExpendituresSettings | null;
     translationLanguages: LocalizationLanguage[];
-    existingLocalization: ReportFundsExpendituresSettingsLocalization | null;
+    existingLocalizations: ReportFundsExpendituresSettingsLocalization[];
     onTranslateSuccess: (localization: ReportFundsExpendituresSettingsLocalization) => void;
 }
 
@@ -29,7 +29,7 @@ export const TranslateDisclaimerModal = ({
     onClose,
     settings,
     translationLanguages,
-    existingLocalization,
+    existingLocalizations,
     onTranslateSuccess,
 }: TranslateDisclaimerModalProps) => {
     const formRef = useRef<TranslateDisclaimerFormRef>(null);
@@ -43,6 +43,11 @@ export const TranslateDisclaimerModal = ({
             (prev) => prev ?? translationLanguages.find((l) => l.code !== DEFAULT_LOCALE) ?? translationLanguages[0],
         );
     }, [translationLanguages]);
+
+    const existingLocalization = useMemo(
+        () => existingLocalizations.find((l) => l.language.id === selectedLanguage?.id) ?? null,
+        [existingLocalizations, selectedLanguage],
+    );
 
     const mode = existingLocalization ? ModalMode.Edit : ModalMode.Add;
 

--- a/src/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api.test.ts
+++ b/src/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api.test.ts
@@ -19,6 +19,43 @@ describe('ReportFundsExpendituresSettingsLocalizationsApi', () => {
         jest.clearAllMocks();
     });
 
+    describe('getByEntityId', () => {
+        it('should call client.get with correct url and return response data', async () => {
+            const mockClient = { get: jest.fn().mockResolvedValueOnce({ data: [mockLocalizationDto] }) };
+
+            const result = await ReportFundsExpendituresSettingsLocalizationsApi.getByEntityId(mockClient as any, 1);
+
+            expect(mockClient.get).toHaveBeenCalledTimes(1);
+            expect(mockClient.get).toHaveBeenCalledWith(
+                `${API_ROUTES.REPORT_FUNDS_EXPENDITURES_SETTINGS_LOCALIZATIONS.BASE}/1`,
+                { signal: undefined },
+            );
+            expect(result).toEqual([mockLocalizationDto]);
+        });
+
+        it('should forward the cancellation signal when provided', async () => {
+            const controller = new AbortController();
+            const mockClient = { get: jest.fn().mockResolvedValueOnce({ data: [] }) };
+
+            await ReportFundsExpendituresSettingsLocalizationsApi.getByEntityId(mockClient as any, 2, {
+                cancellationSignal: controller.signal,
+            });
+
+            expect(mockClient.get).toHaveBeenCalledWith(
+                `${API_ROUTES.REPORT_FUNDS_EXPENDITURES_SETTINGS_LOCALIZATIONS.BASE}/2`,
+                { signal: controller.signal },
+            );
+        });
+
+        it('should return an empty array when the server returns no localizations', async () => {
+            const mockClient = { get: jest.fn().mockResolvedValueOnce({ data: [] }) };
+
+            const result = await ReportFundsExpendituresSettingsLocalizationsApi.getByEntityId(mockClient as any, 1);
+
+            expect(result).toEqual([]);
+        });
+    });
+
     describe('create', () => {
         it('should call client.post with correct url and payload and return response data', async () => {
             const mockClient = { post: jest.fn().mockResolvedValueOnce({ data: mockLocalizationDto }) };

--- a/src/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api.test.ts
+++ b/src/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api.test.ts
@@ -14,16 +14,18 @@ const mockLocalizationDto: ReportFundsExpendituresSettingsLocalizationDto = {
     translationStatus: TranslationStatus.Relevant,
 };
 
+const { getByEntityId: fetchByEntityId, create, update } = ReportFundsExpendituresSettingsLocalizationsApi;
+
 describe('ReportFundsExpendituresSettingsLocalizationsApi', () => {
     afterEach(() => {
         jest.clearAllMocks();
     });
 
-    describe('getByEntityId', () => {
+    describe('fetchByEntityId', () => {
         it('should call client.get with correct url and return response data', async () => {
             const mockClient = { get: jest.fn().mockResolvedValueOnce({ data: [mockLocalizationDto] }) };
 
-            const result = await ReportFundsExpendituresSettingsLocalizationsApi.getByEntityId(mockClient as any, 1);
+            const result = await fetchByEntityId(mockClient as any, 1);
 
             expect(mockClient.get).toHaveBeenCalledTimes(1);
             expect(mockClient.get).toHaveBeenCalledWith(
@@ -37,7 +39,7 @@ describe('ReportFundsExpendituresSettingsLocalizationsApi', () => {
             const controller = new AbortController();
             const mockClient = { get: jest.fn().mockResolvedValueOnce({ data: [] }) };
 
-            await ReportFundsExpendituresSettingsLocalizationsApi.getByEntityId(mockClient as any, 2, {
+            await fetchByEntityId(mockClient as any, 2, {
                 cancellationSignal: controller.signal,
             });
 
@@ -50,7 +52,7 @@ describe('ReportFundsExpendituresSettingsLocalizationsApi', () => {
         it('should return an empty array when the server returns no localizations', async () => {
             const mockClient = { get: jest.fn().mockResolvedValueOnce({ data: [] }) };
 
-            const result = await ReportFundsExpendituresSettingsLocalizationsApi.getByEntityId(mockClient as any, 1);
+            const result = await fetchByEntityId(mockClient as any, 1);
 
             expect(result).toEqual([]);
         });
@@ -66,7 +68,7 @@ describe('ReportFundsExpendituresSettingsLocalizationsApi', () => {
                 disclaimerTitle: 'Translated disclaimer',
             };
 
-            const result = await ReportFundsExpendituresSettingsLocalizationsApi.create(mockClient as any, payload);
+            const result = await create(mockClient as any, payload);
 
             expect(mockClient.post).toHaveBeenCalledTimes(1);
             expect(mockClient.post).toHaveBeenCalledWith(
@@ -87,12 +89,7 @@ describe('ReportFundsExpendituresSettingsLocalizationsApi', () => {
                 disclaimerTitle: 'Updated disclaimer',
             };
 
-            const result = await ReportFundsExpendituresSettingsLocalizationsApi.update(
-                mockClient as any,
-                entityId,
-                languageId,
-                payload,
-            );
+            const result = await update(mockClient as any, entityId, languageId, payload);
 
             expect(mockClient.put).toHaveBeenCalledTimes(1);
             expect(mockClient.put).toHaveBeenCalledWith(

--- a/src/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api.ts
+++ b/src/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api.ts
@@ -4,9 +4,22 @@ import {
     ReportFundsExpendituresSettingsLocalizationDto,
     UpdateReportFundsExpendituresSettingsLocalizationDto,
 } from '@/types/admin/reports';
+import { RequestOptions } from '@/types/common/api';
 import { AxiosInstance } from 'axios';
 
 export const ReportFundsExpendituresSettingsLocalizationsApi = {
+    getByEntityId: async (
+        client: AxiosInstance,
+        entityId: number,
+        options: RequestOptions = {},
+    ): Promise<ReportFundsExpendituresSettingsLocalizationDto[]> => {
+        const response = await client.get<ReportFundsExpendituresSettingsLocalizationDto[]>(
+            `${API_ROUTES.REPORT_FUNDS_EXPENDITURES_SETTINGS_LOCALIZATIONS.BASE}/${entityId}`,
+            { signal: options.cancellationSignal },
+        );
+        return response.data;
+    },
+
     create: async (
         client: AxiosInstance,
         data: CreateReportFundsExpendituresSettingsLocalizationDto,


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1331

## Description

This PR implements translation indicators for disclaimer.

## How it looks


https://github.com/user-attachments/assets/1a52fe95-c2cd-46c6-9705-598a7831bf60



## Summary of change

Added translation status indicators for disclaimer translations in the "Доходи та витрати" tab.

## How to recreate changes

1. Open the Admin Panel
2. Navigate to the "Доходи та витрати" tab
3. Locate the disclaimer section

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added disclaimer translation management, enabling multi-language localization support with status tracking.
  * Introduced a localization status indicator for disclaimer translations.

* **Style**
  * Refined disclaimer label typography for improved visual hierarchy.

* **Tests**
  * Expanded test coverage for disclaimer localization workflows and translation success handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ita-social-projects/VictoryCenter-Client/pull/420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->