### PR TITLE
fix: update confirm close title text in program expenses modal

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -320,7 +320,7 @@ export const PROGRAM_EXPENSES_TEXT = {
             PROGRAM_LABEL: 'Категорія програми',
             PROGRAM_PLACEHOLDER: 'Оберіть програму',
             SUBMIT_BUTTON: 'Додати витрату',
-            CONFIRM_CLOSE_TITLE: 'Дані буде втрачено. Бажаєте продовжити?',
+            CONFIRM_CLOSE_TITLE: 'Зміни будуть втрачені. Бажаєте продовжити?',
             PROGRAM_NO_AVAILABLE: 'Немає доступних програм',
         },
     },


### PR DESCRIPTION
## Github ticket
* [#1832](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1832)

## Description
Updated the confirmation popup text in the 'Додати витрату по програмі' modal to match the acceptance criteria. The text was inconsistent with the required wording specified in #1753.

## How it looks
<img width="936" height="888" alt="Знімок екрана 2026-05-29 131218" src="https://github.com/user-attachments/assets/058ab5ea-dcfa-48f5-9edd-0cd360eaeba1" />

## Summary of change
- Updated `CONFIRM_CLOSE_TITLE` in `PROGRAM_EXPENSES_TEXT.MODAL.ADD` from `'Дані буде втрачено. Бажаєте продовжити?'` to `'Зміни будуть втрачені. Бажаєте продовжити?'`

## How to recreate changes
1. Open the "Звітність" page as Admin
2. Navigate to the 'Звіт та аналітика' tab
3. Click the 'Редагувати доходи та витрати' button
4. Select the 'Програмні витрати' section
5. Click the 'Витрата по програмі' button to open the modal
6. Fill in at least one field
7. Click the 'Відмінити' button or the 'X' button
8. Verify the confirmation popup displays 'Зміни будуть втрачені. Бажаєте продовжити?'

## CHECK LIST
- [ ] New tests was added or existing was modified
- [ ] Changes has severe impact on users
- [ ] Changes has medium impact on users
- [x] Changes has light impact on users
- [ ] Test coverage was updated
- [x] PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated confirmation dialog text in the admin reports section to provide clearer messaging when users attempt to close a form with unsaved modifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ita-social-projects/VictoryCenter-Client/pull/421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->