### PR TITLE
Feature/issue-1754: [Reports] Delete program expenses

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -310,6 +310,10 @@ export const FUNDS_EXPENDITURES_TEXT = {
 };
 
 export const PROGRAM_EXPENSES_TEXT = {
+    MESSAGE: {
+        RECORD_DELETED_SUCCESSFULLY: 'Запис успішно видалено',
+        RECORD_DELETE_FAILED_RETRY: 'Не вдалося видалити запис. Спробуйте ще раз',
+    },
     BUTTON: {
         ADD_PROGRAM_EXPENSE: 'Витрата по програмі',
     },
@@ -322,6 +326,9 @@ export const PROGRAM_EXPENSES_TEXT = {
             SUBMIT_BUTTON: 'Додати витрату',
             CONFIRM_CLOSE_TITLE: 'Дані буде втрачено. Бажаєте продовжити?',
             PROGRAM_NO_AVAILABLE: 'Немає доступних програм',
+        },
+        DELETE: {
+            TITLE: 'Видалити запис?',
         },
     },
     VALIDATION: {

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from '@testing-library/rea
 import '@testing-library/jest-dom';
 import { ProgramExpensesSection } from './ProgramExpensesSection';
 import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { ProgramExpensesReadOnlyData } from '@/types/admin/reports';
 import { ProgramExpensesApi } from '@/services/api/admin/reports/program-expenses-api';
 
@@ -61,6 +62,7 @@ const mockGetReadOnlyData = jest.fn();
 jest.mock('@/services/api/admin/reports/program-expenses-api', () => ({
     ProgramExpensesApi: {
         getReadOnlyData: (...args: unknown[]) => mockGetReadOnlyData(...args),
+        delete: jest.fn(),
     },
 }));
 
@@ -68,9 +70,16 @@ jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
     useAdminClient: () => 'mock-client',
 }));
 
+const mockAddToast = jest.fn();
+jest.mock('@/contexts/admin/toast-context-provider/ToastContextProvider', () => ({
+    useToast: () => ({ addToast: mockAddToast }),
+}));
+
+const mockRefetch = jest.fn();
 let mockUseDataFetchResult = {
     data: MOCK_PROGRAM_EXPENSES_DATA,
     isLoading: false,
+    refetch: mockRefetch,
 };
 
 const mockUseDataFetch = jest.fn();
@@ -96,6 +105,39 @@ jest.mock('./components/common/add-program-expense-record-modal/AddProgramExpens
             AddProgramExpenseRecordModal
         </div>
     ),
+}));
+
+jest.mock('../funds-expenditures-section/components/common/delete-record-modal/DeleteRecordModal', () => ({
+    DeleteRecordModal: ({
+        isOpen,
+        title,
+        confirmText,
+        cancelText,
+        isButtonsDisabled,
+        onConfirm,
+        onCancel,
+    }: {
+        isOpen: boolean;
+        title: string;
+        confirmText: string;
+        cancelText: string;
+        isButtonsDisabled?: boolean;
+        onConfirm: () => void;
+        onCancel: () => void;
+    }) => {
+        if (!isOpen) return null;
+        return (
+            <div data-testid="delete-record-modal">
+                <span>{title}</span>
+                <button onClick={onConfirm} disabled={isButtonsDisabled}>
+                    {confirmText}
+                </button>
+                <button onClick={onCancel} disabled={isButtonsDisabled}>
+                    {cancelText}
+                </button>
+            </div>
+        );
+    },
 }));
 
 jest.mock('@/components/admin/multi-select-input/MultiSelectInput', () => ({
@@ -156,6 +198,7 @@ describe('ProgramExpensesSection', () => {
         mockUseDataFetchResult = {
             data: MOCK_PROGRAM_EXPENSES_DATA,
             isLoading: false,
+            refetch: mockRefetch,
         };
         mockUseDataFetch.mockImplementation(() => mockUseDataFetchResult);
     });
@@ -172,6 +215,7 @@ describe('ProgramExpensesSection', () => {
                 records: [],
             },
             isLoading: true,
+            refetch: mockRefetch,
         };
 
         render(<ProgramExpensesSection />);
@@ -255,6 +299,7 @@ describe('ProgramExpensesSection', () => {
                 records: MOCK_PROGRAM_EXPENSES_DATA.records.filter((record) => record.programId !== 2),
             },
             isLoading: false,
+            refetch: mockRefetch,
         };
 
         rerender(<ProgramExpensesSection />);
@@ -278,6 +323,7 @@ describe('ProgramExpensesSection', () => {
         mockUseDataFetchResult = {
             data: EMPTY_PROGRAM_EXPENSES_DATA,
             isLoading: false,
+            refetch: mockRefetch,
         };
 
         render(<ProgramExpensesSection />);
@@ -337,10 +383,99 @@ describe('ProgramExpensesSection', () => {
                 ],
             },
             isLoading: false,
+            refetch: mockRefetch,
         };
 
         render(<ProgramExpensesSection isEditing />);
 
         expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE })).toBeDisabled();
+    });
+
+    it('should open delete confirmation modal when delete icon is clicked', () => {
+        render(<ProgramExpensesSection isEditing />);
+
+        fireEvent.click(screen.getByLabelText('Delete record 1'));
+
+        expect(screen.getByTestId('delete-record-modal')).toBeInTheDocument();
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.MODAL.DELETE.TITLE)).toBeInTheDocument();
+    });
+
+    it('should not show delete icons when not in edit mode', () => {
+        render(<ProgramExpensesSection />);
+
+        expect(screen.queryByLabelText('Delete record 1')).not.toBeInTheDocument();
+    });
+
+    it('should close delete modal when Cancel is clicked without calling API', () => {
+        render(<ProgramExpensesSection isEditing />);
+
+        fireEvent.click(screen.getByLabelText('Delete record 1'));
+        expect(screen.getByTestId('delete-record-modal')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.NO));
+
+        expect(screen.queryByTestId('delete-record-modal')).not.toBeInTheDocument();
+        expect(ProgramExpensesApi.delete).not.toHaveBeenCalled();
+    });
+
+    it('should delete record after confirmation and show success toast', async () => {
+        (ProgramExpensesApi.delete as jest.Mock).mockResolvedValueOnce(undefined);
+
+        render(<ProgramExpensesSection isEditing />);
+
+        fireEvent.click(screen.getByLabelText('Delete record 1'));
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.MODAL.DELETE.TITLE)).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.YES));
+
+        await waitFor(() => {
+            expect(ProgramExpensesApi.delete).toHaveBeenCalledWith('mock-client', 1);
+            expect(mockAddToast).toHaveBeenCalledWith(
+                PROGRAM_EXPENSES_TEXT.MESSAGE.RECORD_DELETED_SUCCESSFULLY,
+                'success',
+            );
+            expect(mockRefetch).toHaveBeenCalled();
+            expect(screen.queryByTestId('delete-record-modal')).not.toBeInTheDocument();
+        });
+    });
+
+    it('should show error toast and keep modal open when delete fails', async () => {
+        (ProgramExpensesApi.delete as jest.Mock).mockRejectedValueOnce(new Error('delete failed'));
+
+        render(<ProgramExpensesSection isEditing />);
+
+        fireEvent.click(screen.getByLabelText('Delete record 1'));
+        fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.YES));
+
+        await waitFor(() => {
+            expect(ProgramExpensesApi.delete).toHaveBeenCalledWith('mock-client', 1);
+            expect(mockAddToast).toHaveBeenCalledWith(
+                PROGRAM_EXPENSES_TEXT.MESSAGE.RECORD_DELETE_FAILED_RETRY,
+                'error',
+            );
+            expect(screen.getByTestId('delete-record-modal')).toBeInTheDocument();
+        });
+    });
+
+    it('should disable modal buttons while delete request is in flight', async () => {
+        let resolveDelete!: () => void;
+        (ProgramExpensesApi.delete as jest.Mock).mockImplementationOnce(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolveDelete = resolve;
+                }),
+        );
+
+        render(<ProgramExpensesSection isEditing />);
+
+        fireEvent.click(screen.getByLabelText('Delete record 1'));
+        fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.YES));
+
+        await waitFor(() => {
+            expect(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.YES)).toBeDisabled();
+            expect(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.NO)).toBeDisabled();
+        });
+
+        resolveDelete();
     });
 });

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
@@ -1,13 +1,18 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { InlineLoader } from '@/components/common/inline-loader/InlineLoader';
 import { useDataFetch } from '@/hooks/common/use-data-fetch/useDataFetch';
 import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
 import { ProgramExpensesApi } from '@/services/api/admin/reports/program-expenses-api';
-import { ProgramExpensesReadOnlyData } from '@/types/admin/reports';
+import { ProgramExpensesReadOnlyData, ProgramExpensesRecord } from '@/types/admin/reports';
+import { ToastType } from '@/types/admin/toast';
 import { ProgramExpensesToolbar } from './components/program-expenses-toolbar/ProgramExpensesToolbar';
 import { ProgramExpensesSummaryCard } from './components/program-expenses-summary-card/ProgramExpensesSummaryCard';
 import { ProgramExpensesTable } from './components/program-expenses-table/ProgramExpensesTable';
 import { AddProgramExpenseRecordModal } from './components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal';
+import { DeleteRecordModal } from '../funds-expenditures-section/components/common/delete-record-modal/DeleteRecordModal';
+import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextProvider';
 import styles from './ProgramExpensesSection.module.scss';
 
 const INITIAL_PROGRAM_EXPENSES_DATA: ProgramExpensesReadOnlyData = {
@@ -28,15 +33,23 @@ interface ProgramExpensesSectionProps {
 
 export const ProgramExpensesSection = ({ isEditing = false }: ProgramExpensesSectionProps) => {
     const adminClient = useAdminClient();
+    const { addToast } = useToast();
     const [selectedProgramIds, setSelectedProgramIds] = useState<number[]>([]);
     const [isAddProgramExpenseModalOpen, setIsAddProgramExpenseModalOpen] = useState(false);
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+    const [recordToDelete, setRecordToDelete] = useState<ProgramExpensesRecord | null>(null);
+    const [isDeletingRecord, setIsDeletingRecord] = useState(false);
 
     const fetchReadOnlyData = useCallback(
         (options = {}) => ProgramExpensesApi.getReadOnlyData(adminClient, options),
         [adminClient],
     );
 
-    const { data, isLoading } = useDataFetch<ProgramExpensesReadOnlyData>({
+    const {
+        data,
+        isLoading,
+        refetch: refetchReadOnlyData,
+    } = useDataFetch<ProgramExpensesReadOnlyData>({
         initialData: INITIAL_PROGRAM_EXPENSES_DATA,
         fetchHandler: fetchReadOnlyData,
     });
@@ -80,6 +93,34 @@ export const ProgramExpensesSection = ({ isEditing = false }: ProgramExpensesSec
         setIsAddProgramExpenseModalOpen(false);
     }, []);
 
+    const handleDeleteClick = useCallback((record: ProgramExpensesRecord) => {
+        setRecordToDelete(record);
+        setIsDeleteModalOpen(true);
+    }, []);
+
+    const handleConfirmDelete = useCallback(async () => {
+        if (!recordToDelete) return;
+
+        setIsDeletingRecord(true);
+
+        try {
+            await ProgramExpensesApi.delete(adminClient, recordToDelete.id);
+            refetchReadOnlyData();
+            addToast(PROGRAM_EXPENSES_TEXT.MESSAGE.RECORD_DELETED_SUCCESSFULLY, ToastType.Success);
+            setIsDeleteModalOpen(false);
+        } catch {
+            addToast(PROGRAM_EXPENSES_TEXT.MESSAGE.RECORD_DELETE_FAILED_RETRY, ToastType.Error);
+        } finally {
+            setIsDeletingRecord(false);
+            setRecordToDelete(null);
+        }
+    }, [recordToDelete, adminClient, addToast, refetchReadOnlyData]);
+
+    const handleCancelDelete = useCallback(() => {
+        setIsDeleteModalOpen(false);
+        setRecordToDelete(null);
+    }, []);
+
     if (isInitialLoading) {
         return (
             <div className={styles.section}>
@@ -110,6 +151,7 @@ export const ProgramExpensesSection = ({ isEditing = false }: ProgramExpensesSec
                     isEditing={isEditing}
                     isAddProgramExpenseDisabled={isAddProgramExpenseDisabled || !isEditing}
                     onAddProgramExpense={isEditing ? handleOpenAddProgramExpenseModal : undefined}
+                    onDeleteRecord={isEditing ? handleDeleteClick : undefined}
                 />
             </div>
 
@@ -119,6 +161,17 @@ export const ProgramExpensesSection = ({ isEditing = false }: ProgramExpensesSec
                 records={data.records}
                 exchangeRate={exchangeRate}
                 onClose={handleCloseAddProgramExpenseModal}
+            />
+
+            <DeleteRecordModal
+                isOpen={isDeleteModalOpen}
+                title={PROGRAM_EXPENSES_TEXT.MODAL.DELETE.TITLE}
+                confirmText={COMMON_TEXT_ADMIN.BUTTON.YES}
+                cancelText={COMMON_TEXT_ADMIN.BUTTON.NO}
+                isButtonsDisabled={isDeletingRecord}
+                onConfirm={handleConfirmDelete}
+                onCancel={handleCancelDelete}
+                onClose={handleCancelDelete}
             />
         </div>
     );


### PR DESCRIPTION
## Github ticket
* [#1754](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1754)

## Description
This PR implements the ability for an Admin to delete a single program expense record
in the 'Програмні витрати' tab of the Reports page.
After deletion, the summary card 'Всього Програмні Витрати' is automatically
recalculated by refetching the latest data from the server.

## How it looks
<img width="1293" height="520" alt="Знімок екрана 2026-05-30 124907" src="https://github.com/user-attachments/assets/c64c0d02-fb56-4d4a-9ed1-25e32698b635" />

<img width="1286" height="506" alt="Знімок екрана 2026-05-30 124919" src="https://github.com/user-attachments/assets/300c08b1-06f9-4d83-b6be-c7c6e80b2f9a" />

## Summary of change
- Added `isDeleteModalOpen`, `recordToDelete`, `isDeletingRecord` state to `ProgramExpensesSection`
- Added `handleDeleteClick`, `handleConfirmDelete`, `handleCancelDelete` handlers
- Wired `onDeleteRecord` prop to `ProgramExpensesTable` (only in edit mode)
- Integrated `DeleteRecordModal` component (reused from `FundsExpendituresSection`)
- Added `refetch` from `useDataFetch` to recalculate summary after deletion
- Added `useToast` for success/error feedback
- Added delete-related constants to `PROGRAM_EXPENSES_TEXT`
- Updated `ProgramExpensesSection` tests

## How to recreate changes
1. Go to the 'Звітність' page in the Admin panel
2. Open the 'Програмні витрати' tab
3. Click the Edit button to enter edit mode
4. Click the delete icon next to any record
5. Verify the confirmation modal "Видалити запис?" appears
6. Click **НІ** - modal should close, record should remain
7. Click the delete icon again, then click **ТАК**
8. Verify the record is removed and the 'Всього Програмні Витрати' card updates

## CHECK LIST
- [x] New tests was added or existing was modified
- [ ] Changes has severe impact on users
- [ ] Changes has medium impact on users
- [x] Changes has light impact on users
- [x] Test coverage was updated
- [x] PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to delete program expense records with a confirmation modal
  * Success and error notifications provide feedback on deletion results
  * Table automatically refreshes after successful record removal

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ita-social-projects/VictoryCenter-Client/pull/422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->