### PR TITLE
Feature/issue-2442: [Main] Update automatically the raised funds metric value Statistics block

### DIFF
--- a/src/const/admin/main-page.ts
+++ b/src/const/admin/main-page.ts
@@ -40,6 +40,7 @@ export const MAIN_PAGE_TEXT = {
             PREFIX_NONE: 'Без префікса',
             SYNC_ON_TEXT: 'Суми зібраних коштів підтягуються автоматично з вашої системи звітності.',
             SYNC_OFF_TEXT: 'Коли перемикач вимкнено, дані не синхронізуються автоматично і задаються вручну.',
+            SYNC_CONFIRM_TITLE: 'Оновити суми зібраних коштів відповідно до сторінки "Звітність"?',
         },
         PARTNERS: {
             TITLE_LABEL: COMMON_TEXT_ADMIN.TYPE.TITLE,
@@ -57,6 +58,7 @@ export const MAIN_PAGE_TEXT = {
         LOAD_FAILED: 'Виникла помилка, не вдалося завантажити дані сторінки',
         TOGGLE_VISIBILITY_FAILED: 'Не вдалося змінити видимість',
         REORDER_FAILED: 'Не вдалося зберегти порядок',
+        RAISED_FUNDS_SYNC_FAILED: 'Не вдалося оновити суми зібраних коштів.',
     },
 } as const;
 

--- a/src/pages/admin/main/components/main-page-content/MainPageContent.test.tsx
+++ b/src/pages/admin/main/components/main-page-content/MainPageContent.test.tsx
@@ -1,6 +1,7 @@
 import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
 import { ImageApi } from '@/services/api/admin/image/image-api';
 import { MainPageApi } from '@/services/api/admin/main-page/main-page-api';
+import { MetricType } from '@/types/admin/main-page';
 import '@testing-library/jest-dom';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MainPageContent } from './MainPageContent';
@@ -60,9 +61,43 @@ jest.mock('../partners-block/PartnersBlockForm', () => ({
 
 jest.mock('../statistics-block/StatisticsBlockForm', () => ({
     __esModule: true,
-    StatisticsBlockForm: (props: any) => (
-        <MockFormBlock testId="statistics-block-form" btnTestId="publish-btn-statistics" {...props} />
-    ),
+    StatisticsBlockForm: ({ onMetricsChange, ...props }: any) => {
+        const { useFormContext } = require('react-hook-form');
+        const { MetricPrefix, MetricType } = require('@/types/admin/main-page');
+        const { setValue } = useFormContext();
+        const syncedMetric = {
+            id: 3,
+            name: 'Залучених коштів',
+            value: 7654321,
+            type: MetricType.Raised,
+            prefix: MetricPrefix.None,
+            isHidden: false,
+            priority: 3,
+            isAutoSynced: true,
+            localizations: [{ languageId: 2, name: 'Funds raised', value: '182500.5' }],
+        };
+
+        return (
+            <div data-testid="statistics-block-form">
+                <button
+                    data-testid="publish-btn-statistics-dirty"
+                    onClick={() => {
+                        onMetricsChange?.([syncedMetric]);
+                        setValue('metrics', [syncedMetric], { shouldDirty: true, shouldValidate: true });
+                    }}
+                >
+                    Make Dirty
+                </button>
+                <button
+                    data-testid="publish-btn-statistics"
+                    onClick={props.onPublish}
+                    disabled={props.isPublishDisabled}
+                >
+                    Publish
+                </button>
+            </div>
+        );
+    },
 }));
 
 jest.mock('../main-page-publish-modal/MainPagePublishModal', () => ({
@@ -127,7 +162,10 @@ describe('MainPageContent', () => {
             description: 'Test Description',
             impactStatistics: { metrics: [] },
         },
-        languages: [{ id: 1, code: 'uk', name: 'UA' }],
+        languages: [
+            { id: 1, code: 'uk', name: 'UA' },
+            { id: 2, code: 'en', name: 'EN' },
+        ],
     };
 
     const mockPublishedData = {
@@ -137,7 +175,10 @@ describe('MainPageContent', () => {
             description: 'Updated Description',
             impactStatistics: { metrics: [] },
         },
-        languages: [{ id: 1, code: 'uk', name: 'UA' }],
+        languages: [
+            { id: 1, code: 'uk', name: 'UA' },
+            { id: 2, code: 'en', name: 'EN' },
+        ],
     };
 
     beforeEach(() => {
@@ -297,6 +338,33 @@ describe('MainPageContent', () => {
         expect(screen.getByTestId(formTestId)).toBeInTheDocument();
 
         await triggerFormDirtyAndOpenModal(btnTestId);
+    });
+
+    it('publishes raised funds metric with isAutoSynced=true after statistics save flow', async () => {
+        await renderAndLoadContent();
+
+        fireEvent.click(screen.getByTestId('tab-btn-statistics'));
+        await triggerFormDirtyAndOpenModal('publish-btn-statistics');
+        fireEvent.click(screen.getByTestId('confirm-publish'));
+
+        await waitFor(() => {
+            expect(MainPageApi.publish).toHaveBeenCalled();
+        });
+
+        const patch = (MainPageApi.publish as jest.Mock).mock.calls[0][1];
+        expect(patch.impactStatistics.metrics).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: 3,
+                    value: 7654321,
+                    type: MetricType.Raised,
+                    isAutoSynced: true,
+                    localization: expect.objectContaining({
+                        value: '182500.5',
+                    }),
+                }),
+            ]),
+        );
     });
 
     it('does not publish when already publishing', async () => {

--- a/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.test.tsx
@@ -37,7 +37,13 @@ jest.mock('./components/statistics-preview/StatisticsPreview', () => ({
 }));
 
 jest.mock('./components/statistics-metrics-list/StatisticsMetricsList', () => ({
-    StatisticsMetricsList: ({ metrics, onToggleVisibility, onReorder, onMetricUpdate }: any) => {
+    StatisticsMetricsList: ({
+        metrics,
+        onToggleVisibility,
+        onReorder,
+        onMetricUpdate,
+        onRaisedFundsSyncErrorChange,
+    }: any) => {
         const { MetricPrefix } = require('@/types/admin/main-page');
         return (
             <div data-testid="metrics-list">
@@ -88,6 +94,16 @@ jest.mock('./components/statistics-metrics-list/StatisticsMetricsList', () => ({
                             },
                         ])
                     }
+                    type="button"
+                />
+                <button
+                    data-testid="trigger-raised-sync-error"
+                    onClick={() => onRaisedFundsSyncErrorChange?.(true)}
+                    type="button"
+                />
+                <button
+                    data-testid="clear-raised-sync-error"
+                    onClick={() => onRaisedFundsSyncErrorChange?.(false)}
                     type="button"
                 />
             </div>
@@ -494,6 +510,41 @@ describe('StatisticsBlockForm', () => {
                 ]),
             );
         });
+    });
+
+    it('shows and clears raised funds sync error message from metrics list flow', async () => {
+        renderComponent();
+
+        fireEvent.click(screen.getByTestId('trigger-raised-sync-error'));
+
+        expect(screen.getByText(MAIN_PAGE_TEXT.ERRORS.RAISED_FUNDS_SYNC_FAILED)).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('clear-raised-sync-error'));
+
+        await waitFor(() => {
+            expect(screen.queryByText(MAIN_PAGE_TEXT.ERRORS.RAISED_FUNDS_SYNC_FAILED)).not.toBeInTheDocument();
+        });
+    });
+
+    it('shows raised funds sync error when it is returned with the metric data', async () => {
+        const dataWithSyncError: MainPage = {
+            ...mockInitialData,
+            impactStatistics: {
+                ...mockInitialData.impactStatistics!,
+                metrics: [
+                    {
+                        ...mockInitialData.impactStatistics!.metrics[0],
+                        type: MetricType.Raised,
+                        isAutoSynced: true,
+                        isAutoSyncFailed: true,
+                    },
+                ],
+            },
+        };
+
+        renderComponent({ initialData: dataWithSyncError });
+
+        expect(screen.getByText(MAIN_PAGE_TEXT.ERRORS.RAISED_FUNDS_SYNC_FAILED)).toBeInTheDocument();
     });
 
     it('handles metrics with empty localizations arrays', async () => {

--- a/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
+++ b/src/pages/admin/main/components/statistics-block/StatisticsBlockForm.tsx
@@ -7,7 +7,7 @@ import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextPr
 import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
 import { ImageUploadForm } from '@/pages/admin/main/components/common/image-upload-form/ImageUploadForm';
 import { MainPageApi } from '@/services/api/admin/main-page/main-page-api';
-import { MainPage, MainPageFormValues, Metric } from '@/types/admin/main-page';
+import { MainPage, MainPageFormValues, Metric, MetricType } from '@/types/admin/main-page';
 import { ToastType } from '@/types/admin/toast';
 import { useEffect, useRef, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
@@ -53,6 +53,7 @@ export const StatisticsBlockForm = ({
 
     const [metrics, setMetrics] = useState<Metric[]>([]);
     const [hiddenMetricIds, setHiddenMetricIds] = useState<number[]>([]);
+    const [hasRaisedFundsSyncError, setHasRaisedFundsSyncError] = useState(false);
     const initialMetricsRef = useRef<Metric[]>([]);
 
     const {
@@ -83,11 +84,16 @@ export const StatisticsBlockForm = ({
     const areMetricsEqual = (left: Metric[], right: Metric[]) =>
         JSON.stringify(toComparableMetrics(left)) === JSON.stringify(toComparableMetrics(right));
 
+    const hasMetricSyncError = (metric: Metric) =>
+        metric.type === MetricType.Raised &&
+        Boolean(metric.isAutoSyncFailed || metric.autoSyncError || metric.syncError);
+
     useEffect(() => {
         if (initialData?.impactStatistics?.metrics) {
             const apiMetrics = initialData.impactStatistics.metrics;
             setMetrics(apiMetrics);
             initialMetricsRef.current = apiMetrics;
+            setHasRaisedFundsSyncError(apiMetrics.some(hasMetricSyncError));
 
             const hiddenIds = apiMetrics.filter((m) => m.isHidden).map((m) => m.id as number);
             setHiddenMetricIds(hiddenIds);
@@ -220,7 +226,12 @@ export const StatisticsBlockForm = ({
                         onToggleVisibility={handleToggleVisibility}
                         onReorder={handleReorderMetrics}
                         onMetricUpdate={handleMetricUpdate}
+                        onRaisedFundsSyncErrorChange={setHasRaisedFundsSyncError}
                     />
+
+                    {hasRaisedFundsSyncError && (
+                        <p className={styles.error}>{MAIN_PAGE_TEXT.ERRORS.RAISED_FUNDS_SYNC_FAILED}</p>
+                    )}
                 </div>
             </div>
 

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.test.tsx
@@ -6,9 +6,21 @@ import { Metric, MetricLocalization, MetricPrefix, MetricType } from '@/types/ad
 import { MockMetricEditActions } from '@/utils/test-mocks/main-page-mocks';
 import { RaisedMetricEditPanel } from './RaisedMetricEditPanel';
 
+jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
+    useAdminClient: jest.fn(() => ({})),
+}));
+
+jest.mock('@/services/api/admin/reports/funds-expenditures-api', () => ({
+    FundsExpendituresApi: {
+        getSummary: jest.fn(),
+    },
+}));
+
 jest.mock('../common/metric-edit-actions/MetricEditActions', () => ({
     MetricEditActions: (props: any) => <MockMetricEditActions {...props} />,
 }));
+
+const { FundsExpendituresApi } = require('@/services/api/admin/reports/funds-expenditures-api');
 
 const createMetric = (overrides: Partial<Metric> = {}): Metric => ({
     id: 3,
@@ -26,6 +38,14 @@ const createMetric = (overrides: Partial<Metric> = {}): Metric => ({
 });
 
 describe('RaisedMetricEditPanel', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        FundsExpendituresApi.getSummary.mockResolvedValue({
+            totalCollectedUah: 7654321,
+            totalCollectedUsd: 182500.5,
+        });
+    });
+
     it('renders initial values correctly mapped from UAH and USD localizations', () => {
         const metric = createMetric();
         render(<RaisedMetricEditPanel metric={metric} onCancel={jest.fn()} />);
@@ -75,21 +95,66 @@ describe('RaisedMetricEditPanel', () => {
         });
     });
 
-    it('disables value inputs when auto-sync toggle is switched on', async () => {
+    it('opens confirmation popup and keeps values editable when auto-sync toggle is switched on before confirmation', async () => {
         render(<RaisedMetricEditPanel metric={createMetric()} onCancel={jest.fn()} />);
 
         const uahInput = screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UAH_VALUE_LABEL, { exact: false });
         const usdInput = screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.USD_VALUE_LABEL, { exact: false });
+        const syncToggle = screen.getByRole('switch');
 
         expect(uahInput).not.toBeDisabled();
         expect(usdInput).not.toBeDisabled();
 
-        const syncToggle = screen.getByRole('switch');
         fireEvent.click(syncToggle);
 
+        expect(await screen.findByText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.SYNC_CONFIRM_TITLE)).toBeInTheDocument();
+        expect(syncToggle).not.toBeChecked();
+        expect(uahInput).not.toBeDisabled();
+        expect(usdInput).not.toBeDisabled();
+        expect(uahInput).toHaveValue('1 000 000');
+        expect(usdInput).toHaveValue('25 000');
+    });
+
+    it('closes confirmation popup and restores OFF state when auto-sync is declined', async () => {
+        render(<RaisedMetricEditPanel metric={createMetric()} onCancel={jest.fn()} />);
+
+        const uahInput = screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UAH_VALUE_LABEL, { exact: false });
+        const usdInput = screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.USD_VALUE_LABEL, { exact: false });
+        const saveButton = screen.getByTestId('mock-save');
+
+        fireEvent.click(screen.getByRole('switch'));
+        fireEvent.click(await screen.findByText('Ні'));
+
         await waitFor(() => {
+            expect(screen.queryByText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.SYNC_CONFIRM_TITLE)).not.toBeInTheDocument();
+        });
+
+        expect(screen.getByRole('switch')).not.toBeChecked();
+        expect(uahInput).toHaveValue('1 000 000');
+        expect(usdInput).toHaveValue('25 000');
+        expect(uahInput).not.toBeDisabled();
+        expect(usdInput).not.toBeDisabled();
+        expect(saveButton).toBeDisabled();
+        expect(FundsExpendituresApi.getSummary).not.toHaveBeenCalled();
+    });
+
+    it('loads reporting totals as preview, locks amount fields and activates Save when auto-sync is confirmed', async () => {
+        render(<RaisedMetricEditPanel metric={createMetric()} onCancel={jest.fn()} />);
+
+        const uahInput = screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.UAH_VALUE_LABEL, { exact: false });
+        const usdInput = screen.getByLabelText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.USD_VALUE_LABEL, { exact: false });
+        const saveButton = screen.getByTestId('mock-save');
+
+        fireEvent.click(screen.getByRole('switch'));
+        fireEvent.click(await screen.findByText('Так'));
+
+        await waitFor(() => {
+            expect(screen.getByRole('switch')).toBeChecked();
+            expect(uahInput).toHaveValue('7 654 321');
+            expect(usdInput).toHaveValue('182 500.5');
             expect(uahInput).toBeDisabled();
             expect(usdInput).toBeDisabled();
+            expect(saveButton).not.toBeDisabled();
         });
     });
 
@@ -165,6 +230,54 @@ describe('RaisedMetricEditPanel', () => {
 
             const engLocalization = savedMetric.localizations.find((l: any) => l.languageId === 2);
             expect(engLocalization.value).toBe('30000');
+        });
+    });
+
+    it('calls onSave with preview values and isAutoSynced=true after confirmed auto-sync', async () => {
+        const onSaveMock = jest.fn();
+        render(<RaisedMetricEditPanel metric={createMetric()} onSave={onSaveMock} onCancel={jest.fn()} />);
+
+        fireEvent.click(screen.getByRole('switch'));
+        fireEvent.click(await screen.findByText('Так'));
+
+        const saveButton = screen.getByTestId('mock-save');
+
+        await waitFor(() => {
+            expect(saveButton).not.toBeDisabled();
+        });
+
+        fireEvent.click(saveButton);
+
+        await waitFor(() => {
+            expect(onSaveMock).toHaveBeenCalledTimes(1);
+            const savedMetric = onSaveMock.mock.calls[0][0];
+            const engLocalization = savedMetric.localizations.find((l: any) => l.languageId === 2);
+
+            expect(savedMetric.isAutoSynced).toBe(true);
+            expect(savedMetric.value).toBe(7654321);
+            expect(engLocalization.value).toBe('182500.5');
+        });
+    });
+
+    it('returns toggle to OFF and reports sync error when reporting totals cannot be loaded', async () => {
+        const onSyncErrorChange = jest.fn();
+        FundsExpendituresApi.getSummary.mockRejectedValueOnce(new Error('unavailable'));
+
+        render(
+            <RaisedMetricEditPanel
+                metric={createMetric()}
+                onCancel={jest.fn()}
+                onSyncErrorChange={onSyncErrorChange}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('switch'));
+        fireEvent.click(await screen.findByText('Так'));
+
+        await waitFor(() => {
+            expect(screen.getByRole('switch')).not.toBeChecked();
+            expect(onSyncErrorChange).toHaveBeenCalledWith(true);
+            expect(screen.queryByText(MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.SYNC_CONFIRM_TITLE)).not.toBeInTheDocument();
         });
     });
 

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.tsx
@@ -1,9 +1,13 @@
 import { yupResolver } from '@hookform/resolvers/yup';
+import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
+import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
 import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
 import { Toggle } from '@/components/admin/toggle/Toggle';
 import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
+import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
+import { FundsExpendituresApi } from '@/services/api/admin/reports/funds-expenditures-api';
 import { Metric, MetricLocalization, MetricPrefix } from '@/types/admin/main-page';
 import {
     formatCurrencyInput,
@@ -23,9 +27,14 @@ interface RaisedMetricEditPanelProps {
     metric: Metric;
     onSave?: (updatedMetric: Metric) => void;
     onCancel: () => void;
+    onSyncErrorChange?: (hasError: boolean) => void;
 }
 
-export const RaisedMetricEditPanel = ({ metric, onSave, onCancel }: RaisedMetricEditPanelProps) => {
+export const RaisedMetricEditPanel = ({ metric, onSave, onCancel, onSyncErrorChange }: RaisedMetricEditPanelProps) => {
+    const client = useAdminClient();
+    const [isSyncConfirmOpen, setIsSyncConfirmOpen] = useState(false);
+    const [isFetchingSyncPreview, setIsFetchingSyncPreview] = useState(false);
+
     const defaultNameUa = metric.name || '';
     const usdLocalization = metric.localizations?.find((l) => l.languageId === 2);
     const defaultNameEn = usdLocalization?.name || '';
@@ -40,9 +49,10 @@ export const RaisedMetricEditPanel = ({ metric, onSave, onCancel }: RaisedMetric
         control,
         handleSubmit,
         watch,
+        setValue,
         formState: { errors, isValid },
     } = useForm<RaisedMetricFormValues>({
-        mode: 'onBlur',
+        mode: 'onChange',
         resolver: yupResolver(raisedMetricEditSchema),
         defaultValues: {
             nameUa: defaultNameUa,
@@ -102,6 +112,69 @@ export const RaisedMetricEditPanel = ({ metric, onSave, onCancel }: RaisedMetric
         if (onSave) onSave(updatedMetric);
     };
 
+    const closeSyncConfirm = () => {
+        setIsSyncConfirmOpen(false);
+    };
+
+    const handleSyncToggleChange = (checked: boolean) => {
+        if (!checked) {
+            setValue('isAutoSynced', false, {
+                shouldDirty: true,
+                shouldTouch: true,
+                shouldValidate: true,
+            });
+            onSyncErrorChange?.(false);
+            return;
+        }
+
+        setIsSyncConfirmOpen(true);
+    };
+
+    const handleSyncCancel = () => {
+        setValue('isAutoSynced', false, {
+            shouldDirty: true,
+            shouldTouch: true,
+            shouldValidate: true,
+        });
+        closeSyncConfirm();
+    };
+
+    const handleSyncConfirm = async () => {
+        setIsFetchingSyncPreview(true);
+
+        try {
+            const summary = await FundsExpendituresApi.getSummary(client);
+
+            setValue('isAutoSynced', true, {
+                shouldDirty: true,
+                shouldTouch: true,
+                shouldValidate: true,
+            });
+            setValue('valueUah', formatWithSpaces(summary.totalCollectedUah), {
+                shouldDirty: true,
+                shouldTouch: true,
+                shouldValidate: true,
+            });
+            setValue('valueUsd', formatWithSpaces(summary.totalCollectedUsd), {
+                shouldDirty: true,
+                shouldTouch: true,
+                shouldValidate: true,
+            });
+            onSyncErrorChange?.(false);
+            closeSyncConfirm();
+        } catch (error) {
+            setValue('isAutoSynced', false, {
+                shouldDirty: true,
+                shouldTouch: true,
+                shouldValidate: true,
+            });
+            onSyncErrorChange?.(true);
+            closeSyncConfirm();
+        } finally {
+            setIsFetchingSyncPreview(false);
+        }
+    };
+
     return (
         <div className={styles.panel}>
             <div className={styles.header}>{MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.TITLE}</div>
@@ -122,11 +195,11 @@ export const RaisedMetricEditPanel = ({ metric, onSave, onCancel }: RaisedMetric
                 <Controller
                     name="isAutoSynced"
                     control={control}
-                    render={({ field: { onChange, value } }) => (
+                    render={({ field: { value } }) => (
                         <Toggle
                             id={`sync-toggle-${metric.id}`}
                             checked={value}
-                            onChange={onChange}
+                            onChange={handleSyncToggleChange}
                             ariaLabel="Автоматична синхронізація"
                         />
                     )}
@@ -178,6 +251,15 @@ export const RaisedMetricEditPanel = ({ metric, onSave, onCancel }: RaisedMetric
                 isValid={isValid}
                 onCancel={onCancel}
                 onSave={handleSubmit(onValidSubmit)}
+            />
+
+            <ConfirmationModal
+                isOpen={isSyncConfirmOpen}
+                title={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.SYNC_CONFIRM_TITLE}
+                onConfirm={handleSyncConfirm}
+                onCancel={handleSyncCancel}
+                onClose={handleSyncCancel}
+                isButtonsDisabled={isFetchingSyncPreview}
             />
         </div>
     );

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
@@ -43,13 +43,23 @@ jest.mock('../statistics-metric-edit-panel/StatisticsMetricEditPanel', () => ({
 }));
 
 jest.mock('../raised-metric-edit-panel/RaisedMetricEditPanel', () => ({
-    RaisedMetricEditPanel: ({ metric, onSave, onCancel }: any) => (
+    RaisedMetricEditPanel: ({ metric, onSave, onCancel, onSyncErrorChange }: any) => (
         <div data-testid="raised-edit-panel">
             <button
                 type="button"
                 data-testid="save-raised-edit"
-                onClick={() => onSave({ ...metric, name: 'Updated Raised' })}
+                onClick={() =>
+                    onSave({
+                        ...metric,
+                        name: 'Updated Raised',
+                        isAutoSynced: true,
+                        localizations: metric.localizations?.map((loc: any) =>
+                            loc.languageId === 1 ? { ...loc, name: 'Updated Raised' } : loc,
+                        ),
+                    })
+                }
             />
+            <button type="button" data-testid="trigger-raised-sync-error" onClick={() => onSyncErrorChange?.(true)} />
             <button type="button" data-testid="cancel-raised-edit" onClick={onCancel} />
         </div>
     ),
@@ -73,6 +83,7 @@ describe('StatisticsMetricsList', () => {
         return {
             onToggleVisibility: finalProps.onToggleVisibility,
             onMetricUpdate: finalProps.onMetricUpdate,
+            onRaisedFundsSyncErrorChange: finalProps.onRaisedFundsSyncErrorChange,
         };
     };
 
@@ -151,7 +162,28 @@ describe('StatisticsMetricsList', () => {
         expect(screen.getByTestId('raised-edit-panel')).toBeInTheDocument();
 
         fireEvent.click(screen.getByTestId('save-raised-edit'));
-        expect(onMetricUpdate).toHaveBeenCalledWith([metrics[0], { ...metrics[1], name: 'Updated Raised' }]);
+        expect(screen.queryByTestId('raised-edit-panel')).not.toBeInTheDocument();
+        expect(onMetricUpdate).toHaveBeenCalledWith([
+            metrics[0],
+            {
+                ...metrics[1],
+                name: 'Updated Raised',
+                isAutoSynced: true,
+                localizations: metrics[1].localizations?.map((loc: any) =>
+                    loc.languageId === 1 ? { ...loc, name: 'Updated Raised' } : loc,
+                ),
+            },
+        ]);
+    });
+
+    it('passes raised funds sync error state changes from edit panel to parent', () => {
+        const onRaisedFundsSyncErrorChange = jest.fn();
+        setup({ onRaisedFundsSyncErrorChange });
+
+        fireEvent.click(screen.getAllByTestId('icon-Edit metric')[1]);
+        fireEvent.click(screen.getByTestId('trigger-raised-sync-error'));
+
+        expect(onRaisedFundsSyncErrorChange).toHaveBeenCalledWith(true);
     });
 
     it('closes edit panels on cancel', () => {

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
@@ -17,6 +17,7 @@ interface StatisticsMetricsListProps {
     onToggleVisibility: (id: number) => void;
     onReorder: (items: Metric[]) => void;
     onMetricUpdate: (updatedMetrics: Metric[]) => void;
+    onRaisedFundsSyncErrorChange?: (hasError: boolean) => void;
 }
 
 export const StatisticsMetricsList = ({
@@ -25,6 +26,7 @@ export const StatisticsMetricsList = ({
     onToggleVisibility,
     onReorder,
     onMetricUpdate,
+    onRaisedFundsSyncErrorChange,
 }: StatisticsMetricsListProps) => {
     const [editingMetricId, setEditingMetricId] = useState<number | null>(null);
     const visibleMetricsCount = metrics.length - hiddenMetricIds.length;
@@ -43,6 +45,7 @@ export const StatisticsMetricsList = ({
                         metric={metric}
                         onSave={handleSaveMetric}
                         onCancel={() => setEditingMetricId(null)}
+                        onSyncErrorChange={onRaisedFundsSyncErrorChange}
                     />
                 );
             }

--- a/src/types/admin/main-page.ts
+++ b/src/types/admin/main-page.ts
@@ -64,6 +64,9 @@ export interface Metric extends EntityWithLocalizations<MetricLocalization> {
     type: MetricType;
     prefix?: MetricPrefix | null;
     isAutoSynced?: boolean;
+    isAutoSyncFailed?: boolean;
+    autoSyncError?: string | null;
+    syncError?: string | null;
     isHidden: boolean;
     priority: number;
 }
@@ -135,6 +138,9 @@ export interface MetricDto extends EntityWithDtoLocalizations<MetricLocalization
     type?: MetricType;
     prefix?: MetricPrefix | null;
     isAutoSynced?: boolean;
+    isAutoSyncFailed?: boolean;
+    autoSyncError?: string | null;
+    syncError?: string | null;
     isHidden?: boolean;
     priority?: number;
 }
@@ -181,6 +187,7 @@ export interface CreateMetricDto {
     name: string;
     type: MetricType;
     prefix?: MetricPrefix | null;
+    isAutoSynced?: boolean;
     localization?: CreateMetricLocalizationDto | null;
 }
 


### PR DESCRIPTION
## Github tickets

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2442
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2443
* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2406

## Description

Implemented the frontend flow for auto-syncing the raised funds metric from the Reporting page. The raised funds inline edit panel now supports the `IsAutoSynced` toggle, confirmation before enabling sync, previewing Reporting totals before save, read-only amount fields while sync is enabled, and saving the synced state into the main page payload.

### Note
Changes were tested using local backend since actual changes on backend part are still on review - https://github.com/ita-social-projects/VictoryCenter-Back/pull/2682.
These changes will be merged when backend implementation is reviewed and also successfully merged.

## How it looks

https://github.com/user-attachments/assets/885fce3d-37fd-4abd-901f-1930b94d8894


## Summary of change

- Added `IsAutoSynced` support for the raised funds metric in the Statistics inline edit panel.
- Added confirmation popup when enabling auto-sync: “Оновити суми зібраних коштів відповідно до сторінки "Звітність"?”
- Added preview flow: after confirming, UAH/USD amount fields are filled from Reporting totals, become non-editable, and Save becomes active.
- Updated save flow so saved raised funds changes close the inline panel, update the Statistics block values, and enable Publish.
- Extended main page metric types/DTOs with auto-sync and sync failure fields.
- Added Statistics block error display for failed raised funds sync: “Не вдалося оновити суми зібраних коштів.”
- Updated tests for confirm popup, preview state, save behavior, `IsAutoSynced` payload, dirty/valid state, and publish enablement.

## How to recreate changes

1. Open Admin panel > Main page > Statistics block. (`/admin-panel/main`)
2. Open the raised funds metric inline edit panel.
3. Turn on the auto-sync toggle → the confirm popup appears.
4. Click “Так” > UAH/USD amount fields are filled from Reporting totals, become non-editable, and Save becomes active.
5. Click Save > the panel closes, the Statistics block shows updated values, and Publish becomes active.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [x]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation modal for enabling auto-sync on collected funds metrics with synchronized value preview
  * Added error detection and messaging when collected funds synchronization fails
  * Field values are now locked when auto-sync is enabled to maintain consistency
  * Updated form validation to trigger on field change for improved responsiveness

* **Tests**
  * Expanded test coverage for auto-sync confirmation flows, error state handling, and metric synchronization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ita-social-projects/VictoryCenter-Client/pull/424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->