### PR TITLE
Feature/issue-2667 Hide the following menu items from Header and Footer

### DIFF
--- a/src/components/public/footer/Footer.test.tsx
+++ b/src/components/public/footer/Footer.test.tsx
@@ -61,14 +61,8 @@ describe('Footer', () => {
             PUBLIC_ROUTES.REPORTS.FULL,
         );
 
-        const howToSupportLink = screen.getByRole('link', { name: footerUk['HOW_TO_SUPPORT'] });
-        expect(howToSupportLink).toHaveAttribute('href', PUBLIC_ROUTES.MOCK.FULL);
-        expect(howToSupportLink).toHaveClass('disable');
-
-        expect(screen.getByRole('link', { name: footerUk['STORIES_OF_VICTORIES'] })).toHaveAttribute(
-            'href',
-            PUBLIC_ROUTES.MOCK.FULL,
-        );
+        expect(screen.getByText(footerUk['HOW_TO_SUPPORT'])).not.toBeVisible();
+        expect(screen.getByText(footerUk['STORIES_OF_VICTORIES'])).not.toBeVisible();
     });
 
     it('renders the about us section with correct links', () => {
@@ -112,10 +106,6 @@ describe('Footer', () => {
         expect(screen.getByRole('link', { name: footerUk['PROGRAMS'] })).toHaveAttribute(
             'href',
             PUBLIC_ROUTES.PROGRAMS.FULL,
-        );
-        expect(screen.getByRole('link', { name: footerUk['PROGRAMS_SESSIONS'] })).toHaveAttribute(
-            'href',
-            PUBLIC_ROUTES.MOCK.FULL,
         );
     });
 

--- a/src/components/public/footer/Footer.tsx
+++ b/src/components/public/footer/Footer.tsx
@@ -72,10 +72,10 @@ export const Footer = () => {
                 <div className="menu">
                     <span className="title">{t('MENU')}</span>
                     <Link to={PUBLIC_ROUTES.REPORTS.FULL}>{t('REPORTING')}</Link>
-                    <Link to={PUBLIC_ROUTES.MOCK.FULL} className="disable">
+                    <Link to={PUBLIC_ROUTES.MOCK.FULL} className="disable" style={{ visibility: 'hidden' }}>
                         {t('HOW_TO_SUPPORT')}
                     </Link>
-                    <Link to={PUBLIC_ROUTES.MOCK.FULL} className="disable">
+                    <Link to={PUBLIC_ROUTES.MOCK.FULL} className="disable" style={{ visibility: 'hidden' }}>
                         {t('STORIES_OF_VICTORIES')}
                     </Link>
                 </div>
@@ -93,9 +93,6 @@ export const Footer = () => {
                     <span className="title">{t('HIPPOTHERAPY')}</span>
                     <Link to={PUBLIC_ROUTES.HIPPOTHERAPY.FULL}>{t('WHAT_IS_HIPPOTHERAPY')}</Link>
                     <Link to={PUBLIC_ROUTES.PROGRAMS.FULL}>{t('PROGRAMS')}</Link>
-                    <Link to={PUBLIC_ROUTES.MOCK.FULL} className="disable">
-                        {t('PROGRAMS_SESSIONS')}
-                    </Link>
                 </div>
             </div>
 

--- a/src/components/public/header/Header.test.tsx
+++ b/src/components/public/header/Header.test.tsx
@@ -197,7 +197,6 @@ describe('Header', () => {
             name: headerUk['HIPPOTHERAPY'],
         });
         expect(hippotherapyLink).toHaveAttribute('data-disabled', 'false');
-
     });
 
     it('toggles mobile menu open and closed', () => {

--- a/src/components/public/header/Header.test.tsx
+++ b/src/components/public/header/Header.test.tsx
@@ -114,14 +114,8 @@ describe('Header', () => {
             'href',
             PUBLIC_ROUTES.REPORTS.FULL,
         );
-        expect(screen.getByRole('link', { name: headerUk['HOW_TO_SUPPORT'] })).toHaveAttribute(
-            'href',
-            PUBLIC_ROUTES.MOCK.FULL,
-        );
-        expect(screen.getByRole('link', { name: headerUk['STORIES_OF_VICTORIES'] })).toHaveAttribute(
-            'href',
-            PUBLIC_ROUTES.MOCK.FULL,
-        );
+        expect(screen.getByText(headerUk['HOW_TO_SUPPORT'])).not.toBeVisible();
+        expect(screen.getByText(headerUk['STORIES_OF_VICTORIES'])).not.toBeVisible();
     });
 
     it('renders Contact Us and Donate buttons', () => {
@@ -204,8 +198,6 @@ describe('Header', () => {
         });
         expect(hippotherapyLink).toHaveAttribute('data-disabled', 'false');
 
-        const prorgamsSessionsLink = within(programsDropdown as HTMLElement).getByText(headerUk['PROGRAMS_SESSIONS']);
-        expect(prorgamsSessionsLink).toHaveAttribute('data-disabled', 'true');
     });
 
     it('toggles mobile menu open and closed', () => {

--- a/src/components/public/header/Header.tsx
+++ b/src/components/public/header/Header.tsx
@@ -28,7 +28,6 @@ export const Header = () => {
     const programsLinks: DropdownLink[] = [
         { text: t('HIPPOTHERAPY'), navigateTo: PUBLIC_ROUTES.HIPPOTHERAPY.FULL, isDisabled: false },
         { text: t('PROGRAMS'), navigateTo: PUBLIC_ROUTES.PROGRAMS.FULL, isDisabled: false },
-        { text: t('PROGRAMS_SESSIONS'), navigateTo: '', isDisabled: true },
     ];
 
     return (
@@ -49,11 +48,11 @@ export const Header = () => {
 
                             <Link to={PUBLIC_ROUTES.REPORTS.FULL}>{t('REPORTING')}</Link>
 
-                            <Link to={PUBLIC_ROUTES.MOCK.FULL} className="disable">
+                            <Link to={PUBLIC_ROUTES.MOCK.FULL} className="disable" style={{ visibility: 'hidden' }}>
                                 {t('STORIES_OF_VICTORIES')}
                             </Link>
 
-                            <Link to={PUBLIC_ROUTES.MOCK.FULL} className="disable">
+                            <Link to={PUBLIC_ROUTES.MOCK.FULL} className="disable" style={{ visibility: 'hidden' }}>
                                 {t('HOW_TO_SUPPORT')}
                             </Link>
                         </nav>
@@ -99,11 +98,21 @@ export const Header = () => {
                             {t('REPORTING')}
                         </Link>
 
-                        <Link to={PUBLIC_ROUTES.MOCK.FULL} onClick={toggleMenu} className="disable">
+                        <Link
+                            to={PUBLIC_ROUTES.MOCK.FULL}
+                            onClick={toggleMenu}
+                            className="disable"
+                            style={{ display: 'none' }}
+                        >
                             {t('STORIES_OF_VICTORIES')}
                         </Link>
 
-                        <Link to={PUBLIC_ROUTES.MOCK.FULL} onClick={toggleMenu} className="disable">
+                        <Link
+                            to={PUBLIC_ROUTES.MOCK.FULL}
+                            onClick={toggleMenu}
+                            className="disable"
+                            style={{ display: 'none' }}
+                        >
                             {t('HOW_TO_SUPPORT')}
                         </Link>
 


### PR DESCRIPTION
##Github ticker

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2667)

## Description

Hide unavailable navigation links in Header and Footer.

## How it looks

<img width="1421" height="196" alt="image" src="https://github.com/user-attachments/assets/8c9512a0-6579-495a-80f0-1590e00ad126" />

## Summary of change

-Removed PROGRAMS_SESSIONS from Header dropdown and Footer
-Hidden STORIES_OF_VICTORIES and HOW_TO_SUPPORT links in Header and Footer
-Updated related tests

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions
