### PR TITLE
Fix/issue-1874: [Who we are] Publish button incorrectly enabled after applying markup to a whitespace character

### DIFF
--- a/src/components/admin/rich-text-input/plugins/htmlSanitizer.ts
+++ b/src/components/admin/rich-text-input/plugins/htmlSanitizer.ts
@@ -1,5 +1,21 @@
 import DOMPurify from 'dompurify';
 
+const removeEmptyTags = (container: Element): void => {
+    container.querySelectorAll('strong, em, b, i').forEach((el) => {
+        const text = el.textContent ?? '';
+        if (!text.trim()) {
+            el.replaceWith(document.createTextNode(text));
+        }
+    });
+
+    container.querySelectorAll('p').forEach((p) => {
+        const text = p.textContent ?? '';
+        if (!text.trim()) {
+            p.remove();
+        }
+    });
+};
+
 export const sanitizeHtml = (html: string): string => {
     if (!html) return '';
 
@@ -53,5 +69,9 @@ export const sanitizeHtml = (html: string): string => {
         ALLOWED_ATTR: [],
     });
 
-    return cleanHtml;
+    const resultDiv = document.createElement('div');
+    resultDiv.innerHTML = cleanHtml;
+    removeEmptyTags(resultDiv);
+
+    return resultDiv.innerHTML;
 };


### PR DESCRIPTION
## Github ticker
* [#1874](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1874)

## Description
The "Опублікувати" button on the Admin panel, Who We Are page was incorrectly becoming active when an admin applied markup (bold, italic) to a whitespace character. This PR fixes the issue by stripping whitespace-only formatting tags inside the HTML sanitizer before the content is compared.

## How it looks
<img width="596" height="557" alt="image" src="https://github.com/user-attachments/assets/3077c9ed-7c40-43fa-bec8-4316ec652ef7" />

## Summary of change
- Added `removeEmptyTags` function in `htmlSanitizer.ts` that:
  - Replaces whitespace-only inline tags (`strong`, `em`, `b`, `i`) with a plain
    text node, preserving the space but removing the formatting
  - Removes `<p>` tags that contain only whitespace after inline tag cleanup

## How to recreate changes
1. Go to Admin panel → Who We Are
2. Click into the text editor
3. Select a space between two words
4. Apply **Bold** or *Italic* formatting to that space
5. Before fix: "Опублікувати" button becomes active 
6. After fix: "Опублікувати" button stays disabled 

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x] Changes has light impact on users
- [ ] Test coverage was updated
- [x] PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML content cleanup to remove empty paragraph elements and empty formatting tags, resulting in cleaner text output in the rich text editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->