### PR TITLE
Fix/issue-2623: [Programs] The layout and components of the Programs page impacts its functionality, is not adaptive to Mobile (< 768px), Tablet(768px – 1024px).

### DIFF
--- a/src/components/common/tabs/Tabs.scss
+++ b/src/components/common/tabs/Tabs.scss
@@ -15,7 +15,8 @@
         font-size: 1.125rem;
         font-weight: 600;
         color: colors.$tab-color;
-        min-width: 12rem;
+        flex: 1;
+        min-width: 0;
         min-height: 2.68rem;
         border: none;
         cursor: pointer;
@@ -30,5 +31,27 @@
     .tab.active {
         border-bottom: 0.125rem solid colors.$light-blue-500;
         color: black;
+    }
+
+    .tooltip-container {
+        flex: 1;
+        display: flex;
+
+        .tab {
+            flex: 1;
+            width: 100%;
+        }
+    }
+}
+
+@media (max-width: 900px) {
+    .tabsContainer {
+        overflow: hidden;
+        padding-left: 0;
+        padding-right: 0;
+
+        .tab {
+            font-size: 0.9rem;
+        }
     }
 }

--- a/src/components/common/tabs/Tabs.scss
+++ b/src/components/common/tabs/Tabs.scss
@@ -46,7 +46,6 @@
 
 @media (max-width: 900px) {
     .tabsContainer {
-        overflow: hidden;
         padding-left: 0;
         padding-right: 0;
 

--- a/src/components/public/header/Header.scss
+++ b/src/components/public/header/Header.scss
@@ -15,6 +15,7 @@ $header-height: 4rem;
     backdrop-filter: blur(10.375rem);
     box-sizing: border-box;
     max-width: 1440px;
+    overflow: visible;
 
     .header-content-container {
         display: flex;
@@ -69,11 +70,13 @@ $header-height: 4rem;
     display: none;
     align-self: center;
     color: black;
+
     &.button {
         width: 3.5rem !important;
         height: 3.5rem !important;
         padding: 0 !important;
     }
+
     svg {
         width: 2.5rem !important;
         height: 2.5rem !important;

--- a/src/index.css
+++ b/src/index.css
@@ -12,4 +12,5 @@ body {
         'Droid Sans', 'Helvetica Neue', sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    overflow-x: hidden;
 }

--- a/src/layouts/public-layout/PublicLayout.scss
+++ b/src/layouts/public-layout/PublicLayout.scss
@@ -4,4 +4,5 @@
     background-color: colors.$grey-50;
     max-width: 1440px;
     margin-inline: auto;
+    overflow-x: clip;
 }

--- a/src/pages/public/donate-page/DonatePage.scss
+++ b/src/pages/public/donate-page/DonatePage.scss
@@ -2,6 +2,8 @@
 
 .donatePage {
     background-color: colors.$light-blue-50;
+    width: 100%;
+    min-height: 100vh;
     padding-top: 1rem;
 
     &-loader {
@@ -30,5 +32,30 @@
         position: sticky;
         top: 21rem;
         height: fit-content;
+    }
+}
+
+@media (max-width: 900px) {
+    .donatePageContent {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 3rem;
+        padding: 4rem 2rem;
+
+        .stickyBlock {
+            position: static;
+            width: 100%;
+        }
+
+        .rightSectionContainer {
+            width: 100%;
+        }
+    }
+}
+
+@media (max-width: 568px) {
+    .donatePageContent {
+        padding: 3rem 1rem;
+        gap: 2rem;
     }
 }

--- a/src/pages/public/donate-page/donate-page-intro/DonatePageIntro.scss
+++ b/src/pages/public/donate-page/donate-page-intro/DonatePageIntro.scss
@@ -9,5 +9,9 @@
         font-weight: 700;
         font-size: 4rem;
         text-align: center;
+
+        @media (max-width: 900px) {
+            font-size: 2rem;
+        }
     }
 }

--- a/src/pages/public/donate-page/donate-section/DonateSection.scss
+++ b/src/pages/public/donate-page/donate-section/DonateSection.scss
@@ -4,11 +4,12 @@
 .donateSection {
     background-color: white;
     max-width: 27rem;
-    height: 21.125rem;
+    height: auto;
     display: flex;
     flex-direction: column;
     align-content: center;
     box-shadow: 0 1rem 1.5rem -1rem rgba(colors.$donate-box-shadow, 0.75);
+    padding-bottom: 1.5rem;
 
     .donateTabsContainer {
         display: flex;
@@ -24,7 +25,8 @@
             font-size: 1.125rem;
             font-weight: 600;
             color: colors.$grey-700;
-            min-width: 12rem;
+            flex: 1;
+            min-width: 0;
             min-height: 2.68rem;
             border: none;
             cursor: pointer;
@@ -50,10 +52,13 @@
         flex-direction: row;
         align-items: flex-end;
         border-bottom: 0.125rem solid colors.$grey-900;
+        overflow: hidden;
 
         .donateAmountInput {
             padding-left: 1rem;
             border: none;
+            flex: 1;
+            min-width: 0;
             max-width: 16rem;
             min-height: 5rem;
             font-size: 4rem;
@@ -75,6 +80,7 @@
             color: colors.$grey-700;
             cursor: pointer;
             margin-bottom: 0.75rem;
+            flex-shrink: 0;
         }
 
         .currencySelector select {
@@ -124,11 +130,14 @@
         justify-content: center;
         gap: 0.5rem;
         margin-top: 1.5rem;
+        padding-left: 1.5rem;
+        padding-right: 1.5rem;
 
         .donateFastOptionButton {
             background-color: white;
             border-radius: 2.69rem;
-            width: 7.67rem;
+            flex: 1;
+            min-width: 0;
             height: 3.19rem;
             font-family: fonts.$mulish-regular-font;
             font-size: 1.125rem;
@@ -201,4 +210,11 @@
 .tooltip-container:hover .tooltip-text {
     visibility: visible;
     opacity: 1;
+}
+
+@media (max-width: 900px) {
+    .donateSection {
+        width: 100%;
+        overflow: hidden;
+    }
 }

--- a/src/pages/public/donate-page/donate-section/DonateSection.scss
+++ b/src/pages/public/donate-page/donate-section/DonateSection.scss
@@ -215,6 +215,5 @@
 @media (max-width: 900px) {
     .donateSection {
         width: 100%;
-        overflow: hidden;
     }
 }

--- a/src/pages/public/donate-page/right-section/RightSection.scss
+++ b/src/pages/public/donate-page/right-section/RightSection.scss
@@ -3,6 +3,7 @@
 
 .rightSection {
     width: 33.1rem;
+    max-width: 33.1rem;
     overflow-wrap: anywhere;
     word-break: normal;
 
@@ -51,15 +52,15 @@
     border-radius: 50%;
 }
 
-.switch input:checked + .slider {
+.switch input:checked+.slider {
     background-color: colors.$light-blue-500;
 }
 
-.switch input:checked + .slider::before {
+.switch input:checked+.slider::before {
     transform: translateX(1.375rem);
 }
 
-.switch input:focus + .slider {
+.switch input:focus+.slider {
     box-shadow: 0 0 1px colors.$slider-blue;
 }
 
@@ -80,4 +81,21 @@
 
 .donate-error-message {
     color: colors.$error;
+}
+
+@media (max-width: 900px) {
+    .rightSection {
+        width: 100%;
+        max-width: none;
+    }
+
+    .locationToggleContainer {
+        width: 100%;
+    }
+
+    .switch {
+        margin-left: 0;
+        display: block;
+        width: 100%;
+    }
 }


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2623)

## Description

The Donate page had several responsive layout defects affecting viewports below ~900 px (iPhone SE 375×667, 560×910, 768×1024, 1024×1366). The white donation form card and the bank-details section were rendered side by side in all viewports instead of stacking into a single column, causing horizontal overflow, a horizontal scrollbar, clipped/truncated UI elements, and an incorrect background colour. The "Донатити" button in the header was also not clickable at 560 px because the page's horizontal overflow inflated document.scrollWidth, shifting the fixed header's hit-test area. This PR fixes all reported issues with CSS-only changes.

## How it looks

**Before**
<img width="456" height="811" alt="image" src="https://github.com/user-attachments/assets/c827ff57-a852-4de1-90dd-3e8325c3541f" />
**After**
<img width="455" height="809" alt="image" src="https://github.com/user-attachments/assets/227445ac-68c0-4382-9f9a-ba6d360465ac" />

### Summary of change

*   **Global & Layout (`index.css`, `PublicLayout.scss`)**: Added overflow clipping to the document body and public layout to prevent horizontal scrolling without breaking sticky positioning.
*   **Header (`Header.scss`)**: Fixed accidental clipping of the **Donate** button hit target.
*   **Donate Page (`DonatePage.scss`)**: Ensured the light-blue background fills the entire container. Added breakpoints (≤900px, ≤568px) to stack content vertically and adjust padding for smaller devices.
*   **Donate Section (`DonateSection.scss`)**: Removed fixed height that clipped content. Prevented input elements from forcing viewport overflow (`min-width: 0`). Clipped tooltip text that inflated `scrollWidth`, and adjusted flex behaviors for the currency selector and fast donate options.
*   **Right Section (`RightSection.scss`)**: Made elements full-width on screens ≤900px and fixed a layout bug that left empty space next to the currency tabs.
*   **Tabs (`Tabs.scss`)**: Replaced fixed minimum widths with dynamic flex-sharing (`flex: 1; min-width: 0`) to prevent overflow on very small viewports (<400px), including fixes for the disabled tab tooltip wrapper. Adjusted responsive padding and font sizes.

### How to recreate changes

1. Open the site and navigate to the Programs page.
2. Select the layout 375 x 667 px (iPhone SE) in Devtools;
3. Click the **Донатити** button in the header
4. Verufy that the donation form and bank details stack vertically, all content is visible, there is no horizontal scrollbar, the background fills the full viewport, and the **Донатити** button is clickable.


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced tab layout to use flexible sizing so tabs distribute evenly and tooltips fill available space
  * Reduced tab font size and removed side padding for narrower screens to improve responsiveness
  * Improved horizontal overflow handling site-wide to prevent unintended sideways scrolling or content cutoff
<!-- end of auto-generated comment: release notes by coderabbit.ai -->