### PR TITLE
fix/issue-2699-2700: [Programs] Scrollbar appears on dropdown list on "Видалити категорію" and "Редагувати категорію" pop ups

### DIFF
--- a/src/pages/admin/programs/components/program-category-modals/DeleteCategoryModal.tsx
+++ b/src/pages/admin/programs/components/program-category-modals/DeleteCategoryModal.tsx
@@ -71,7 +71,7 @@ export const DeleteCategoryModal = ({ isOpen, onClose, onDeleteCategory, categor
         <Modal isOpen={isOpen} onClose={handleClose}>
             <Modal.Title>{COMMON_TEXT_ADMIN.CATEGORIES.FORM.TITLE.DELETE_CATEGORY}</Modal.Title>
             <Modal.Content>
-                <div className="program-form-main">
+                <div className="program-form-main hide-scrollbar expandable-dropdown">
                     <SingleSelectInputGroup
                         id="delete-category-select"
                         label={PROGRAM_CATEGORY_TEXT.FORM.LABEL.CATEGORY}

--- a/src/pages/admin/programs/components/program-category-modals/ProgramCategoryModal.scss
+++ b/src/pages/admin/programs/components/program-category-modals/ProgramCategoryModal.scss
@@ -13,3 +13,55 @@
 .w-100 {
     width: 100% !important;
 }
+
+.hide-scrollbar {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+}
+
+    .hide-scrollbar::-webkit-scrollbar {
+        display: none;
+    }
+
+.program-form-main {
+    overflow-y: visible;
+
+    .singleselect-options {
+        max-height: 120px;
+        overflow-y: scroll;
+        scrollbar-color: #a4a49b transparent;
+
+        &::-webkit-scrollbar {
+            width: 8px;
+        }
+
+        &::-webkit-scrollbar-track {
+            background: transparent;
+            border-radius: 8px;
+        }
+
+        &::-webkit-scrollbar-thumb {
+            background-color: #a4a49b;
+            border-radius: 8px;
+
+            &:hover {
+                background-color: #8c8c84;
+            }
+        }
+    }
+
+    &.expandable-dropdown {
+        .singleselect-options {
+            position: absolute;
+            z-index: 100;
+        }
+
+        .input-group:has(.singleselect-options) {
+            margin-bottom: 126px;
+        }
+    }
+
+    .input-group {
+        margin-bottom: 6px;
+    }
+}

--- a/src/pages/admin/programs/components/program-category-modals/ProgramCategoryModal.tsx
+++ b/src/pages/admin/programs/components/program-category-modals/ProgramCategoryModal.tsx
@@ -262,7 +262,11 @@ export const ProgramCategoryModal = (props: ProgramCategoryModalProps) => {
             <Modal isOpen={isOpen} onClose={handleClose}>
                 <Modal.Title>{getTitle()}</Modal.Title>
                 <Modal.Content>
-                    <form onSubmit={(e) => e.preventDefault()} className="program-form-main" id={getFormId()}>
+                    <form
+                        onSubmit={(e) => e.preventDefault()}
+                        className="program-form-main hide-scrollbar"
+                        id={getFormId()}
+                    >
                         {mode === 'edit' && (
                             <SingleSelectInputGroup
                                 id={getFieldId('select')}


### PR DESCRIPTION
## Github ticker

* Resolves [#2699](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2699)
* Resolves [#2700](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2700)

* Initial issue [#2652](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2652)

## Description

This PR resolves the issue with the "Category" dropdown list display on the "Edit category" and "Delete category" modal windows. Previously, opening the dropdown list caused an unnecessary scrollbar to appear on the modal window itself. The main goal is to ensure the form expands correctly when the list is opened and to prevent the general scrollbar from appearing on the form, while maintaining proper focus styling (without stretching the blue input border).

## How it looks

<h3>Edit:</h3>
<img width="636" height="360" alt="image" src="https://github.com/user-attachments/assets/f572a26b-8f63-448a-b994-ce8e9866fe56" />

<h3>Delete:</h3>
<img width="626" height="336" alt="image" src="https://github.com/user-attachments/assets/d484dec1-57d5-4898-84c2-420e6caaa235" />

<img width="616" height="455" alt="image" src="https://github.com/user-attachments/assets/3a61f31a-d999-49f5-8e70-c03c7ecb3ac4" />

## Summary of change

* Limited the maximum height (`max-height`) for the `.singleselect-options` dropdown list and added a stylized custom inner scrollbar for convenient option scrolling.
* Updated `ProgramCategoryModal.scss`: configured absolute positioning for the list so it doesn't stretch the input container (the blue border).
* Added dynamic modal window expansion using the `:has(.singleselect-options)` pseudo-class, which smoothly adds an invisible `margin-bottom` below the input when the list is opened, preventing the general scrollbar from appearing.
* Added the `hide-scrollbar` class to ensure the absence of a native scrollbar at the form level.

## How to recreate changes

1. Login as 'Admin'.
2. Go to the "Programs" page.
3. Ensure the system contains previously created categories.
4. Click on the context menu button next to a category.
5. Click on the "Edit" option (to verify #2700) or "Delete" option (to verify #2699).
6. In the opened modal window, click on the "Category" dropdown.
**Expected result:** The dropdown list expands and has its own neat scrollbar (if there are many items), and the general scrollbar does not appear on the modal window itself.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved scrollbar visibility in program category modals for a cleaner interface.

## Style
* Enhanced dropdown layout and positioning in program category modal components.
* Optimized spacing and visual styling for expandable dropdown options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->