### PR TITLE
Fix/issue 2719 [Partners] the second and outcomed confirmation pop-ups are not displayed in a Published Partner section after clicking 'Видалити секцію' button.

### DIFF
--- a/src/const/admin/partners.ts
+++ b/src/const/admin/partners.ts
@@ -15,6 +15,7 @@ export const PARTNERS_TEXT = {
         },
         MESSAGE: {
             FAIL_TO_DELETE_PARTNER_SECTION: 'Виникла помилка під час видалення секції партнерів',
+            DELETE_SECTION_WARNING: 'Всі партнери в секції будуть видалені. Бажаєте продовжити?',
         },
         IMAGE: {
             ADD_IMAGE_HERE: 'Додайте файл сюди',

--- a/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.test.tsx
+++ b/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.test.tsx
@@ -468,6 +468,12 @@ describe('PartnerSectionsEditor', () => {
         fireEvent.click(screen.getByTestId('confirm-delete'));
 
         await waitFor(() => {
+            expect(screen.getByText(PARTNERS_TEXT.FORM.MESSAGE.DELETE_SECTION_WARNING)).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByTestId('confirm-delete'));
+
+        await waitFor(() => {
             expect(mockedPartnersApi.deleteSection).toHaveBeenCalledWith('mock-client', 5);
         });
 
@@ -500,6 +506,12 @@ describe('PartnerSectionsEditor', () => {
         await act(async () => {
             latestProps.onDelete(latestProps.value.localId);
         });
+        fireEvent.click(screen.getByTestId('confirm-delete'));
+        
+        await waitFor(() => {
+            expect(screen.getByText(PARTNERS_TEXT.FORM.MESSAGE.DELETE_SECTION_WARNING)).toBeInTheDocument();
+        });
+        
         fireEvent.click(screen.getByTestId('confirm-delete'));
 
         expect(mockedPartnersApi.deleteSection).not.toHaveBeenCalled();
@@ -581,6 +593,45 @@ describe('PartnerSectionsEditor', () => {
         expect(mockedPartnersApi.deleteSection).not.toHaveBeenCalled();
     });
 
+    it('closes the second delete modal when cancel is clicked', async () => {
+        mockedUseDataFetch.mockReturnValue({
+            data: [
+                {
+                    id: 7,
+                    title: 'Cancelable Second',
+                    description: 'Desc',
+                    partners: [],
+                },
+            ],
+            isLoading: false,
+            error: null,
+            refetch: jest.fn(),
+            setData: jest.fn(),
+        });
+
+        render(<PartnerSectionsEditor />);
+
+        await waitFor(() => expect(mockPartnerSectionFormRender).toHaveBeenCalled());
+        const props = mockPartnerSectionFormRender.mock.calls[0][0];
+
+        await act(async () => {
+            props.onDelete(props.value.localId);
+        });
+
+        expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByTestId('confirm-delete'));
+
+        await waitFor(() => {
+            expect(screen.getByText(PARTNERS_TEXT.FORM.MESSAGE.DELETE_SECTION_WARNING)).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByTestId('cancel-delete'));
+
+        expect(screen.queryByTestId('confirmation-modal')).not.toBeInTheDocument();
+        expect(mockedPartnersApi.deleteSection).not.toHaveBeenCalled();
+    });
+
     it('shows error toast when deleting section fails', async () => {
         mockedPartnersApi.deleteSection.mockRejectedValueOnce(new Error('delete fail'));
 
@@ -605,6 +656,12 @@ describe('PartnerSectionsEditor', () => {
 
         await act(async () => {
             props.onDelete(props.value.localId);
+        });
+
+        fireEvent.click(screen.getByTestId('confirm-delete'));
+
+        await waitFor(() => {
+            expect(screen.getByText(PARTNERS_TEXT.FORM.MESSAGE.DELETE_SECTION_WARNING)).toBeInTheDocument();
         });
 
         fireEvent.click(screen.getByTestId('confirm-delete'));

--- a/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.test.tsx
+++ b/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.test.tsx
@@ -82,6 +82,37 @@ const mockedUseToast = useToast as jest.Mock;
 const addToastMock = jest.fn();
 const uuidMock = jest.fn();
 
+const mockDataFetch = (data: any[], isLoading = false, error: any = null) => {
+    mockedUseDataFetch.mockReturnValue({
+        data,
+        isLoading,
+        error,
+        refetch: jest.fn(),
+        setData: jest.fn(),
+    });
+};
+
+const getLatestProps = () =>
+    mockPartnerSectionFormRender.mock.calls[mockPartnerSectionFormRender.mock.calls.length - 1][0];
+
+const renderWithSection = async (sectionData: Record<string, any> = {}) => {
+    mockDataFetch([{ id: 1, title: 'Test', description: 'Desc', partners: [], ...sectionData }]);
+    render(<PartnerSectionsEditor />);
+    await waitFor(() => expect(mockPartnerSectionFormRender).toHaveBeenCalled());
+    return getLatestProps();
+};
+
+const performTwoStepDelete = async (props: any) => {
+    await act(async () => {
+        props.onDelete(props.value.localId);
+    });
+    fireEvent.click(screen.getByTestId('confirm-delete'));
+    await waitFor(() =>
+        expect(screen.getByText(PARTNERS_TEXT.FORM.MESSAGE.DELETE_SECTION_WARNING)).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId('confirm-delete'));
+};
+
 beforeAll(() => {
     Object.defineProperty(globalThis, 'crypto', {
         value: {
@@ -134,13 +165,7 @@ beforeEach(() => {
 
 describe('PartnerSectionsEditor', () => {
     it('shows loader when sections are loading and none are rendered yet', () => {
-        mockedUseDataFetch.mockReturnValue({
-            data: [],
-            isLoading: true,
-            error: null,
-            refetch: jest.fn(),
-            setData: jest.fn(),
-        });
+        mockDataFetch([], true);
 
         render(<PartnerSectionsEditor />);
 
@@ -167,30 +192,21 @@ describe('PartnerSectionsEditor', () => {
     });
 
     it('renders partner sections returned from the API', async () => {
-        let counter = 0;
-        uuidMock.mockImplementation(() => `uuid-${++counter}`);
-
-        mockedUseDataFetch.mockReturnValue({
-            data: [
-                {
-                    id: 1,
-                    title: 'API section',
-                    description: 'API description',
-                    partners: [
-                        {
-                            id: 11,
-                            description: 'API partner',
-                            image: { id: 21, url: 'api.jpg', mimeType: 'image/png' },
-                            imageId: 21,
-                        },
-                    ],
-                },
-            ],
-            isLoading: false,
-            error: null,
-            refetch: jest.fn(),
-            setData: jest.fn(),
-        });
+        mockDataFetch([
+            {
+                id: 1,
+                title: 'API section',
+                description: 'API description',
+                partners: [
+                    {
+                        id: 11,
+                        description: 'API partner',
+                        image: { id: 21, url: 'api.jpg', mimeType: 'image/png' },
+                        imageId: 21,
+                    },
+                ],
+            },
+        ]);
 
         render(<PartnerSectionsEditor />);
 
@@ -205,23 +221,7 @@ describe('PartnerSectionsEditor', () => {
     });
 
     it('updates local section state via onChange', async () => {
-        let counter = 0;
-        uuidMock.mockImplementation(() => `uuid-${++counter}`);
-
-        mockedUseDataFetch.mockReturnValue({
-            data: [
-                {
-                    id: 2,
-                    title: 'Initial section',
-                    description: 'Initial description',
-                    partners: [],
-                },
-            ],
-            isLoading: false,
-            error: null,
-            refetch: jest.fn(),
-            setData: jest.fn(),
-        });
+        mockDataFetch([{ id: 2, title: 'Initial section', description: 'Initial description', partners: [] }]);
 
         render(<PartnerSectionsEditor />);
 
@@ -239,21 +239,14 @@ describe('PartnerSectionsEditor', () => {
         });
 
         await waitFor(() => {
-            const lastCall =
-                mockPartnerSectionFormRender.mock.calls[mockPartnerSectionFormRender.mock.calls.length - 1][0];
+            const lastCall = getLatestProps();
             expect(lastCall.value.title).toBe('Changed title');
             expect(lastCall.errors.title).toBe('title error');
         });
     });
 
     it('exposes addSection via ref and prevents duplicate empty sections', async () => {
-        mockedUseDataFetch.mockReturnValue({
-            data: [],
-            isLoading: false,
-            error: null,
-            refetch: jest.fn(),
-            setData: jest.fn(),
-        });
+        mockDataFetch([]);
 
         const ref = createRef<PartnerSectionsEditorRef>();
         render(<PartnerSectionsEditor ref={ref} />);
@@ -272,13 +265,7 @@ describe('PartnerSectionsEditor', () => {
     });
 
     it('publishes a newly created section and refreshes state', async () => {
-        mockedUseDataFetch.mockReturnValue({
-            data: [],
-            isLoading: false,
-            error: null,
-            refetch: jest.fn(),
-            setData: jest.fn(),
-        });
+        mockDataFetch([]);
 
         const ref = createRef<PartnerSectionsEditorRef>();
         render(<PartnerSectionsEditor ref={ref} />);
@@ -312,11 +299,8 @@ describe('PartnerSectionsEditor', () => {
             expect(mockPartnerSectionFormRender).toHaveBeenCalledTimes(2);
         });
 
-        const latestProps =
-            mockPartnerSectionFormRender.mock.calls[mockPartnerSectionFormRender.mock.calls.length - 1][0];
-
         await act(async () => {
-            await latestProps.onPublish(populatedSection.localId);
+            await getLatestProps().onPublish(populatedSection.localId);
         });
 
         expect(mockedPartnersApi.postSection).toHaveBeenCalledWith('mock-client', {
@@ -334,43 +318,26 @@ describe('PartnerSectionsEditor', () => {
         expect(addToastMock).toHaveBeenCalledWith(PARTNERS_TEXT.MESSAGE.SECTION_CREATED, ToastType.Success);
 
         await waitFor(() => {
-            const latestCall =
-                mockPartnerSectionFormRender.mock.calls[mockPartnerSectionFormRender.mock.calls.length - 1][0];
+            const latestCall = getLatestProps();
             expect(latestCall.value.sectionId).toBe(101);
             expect(latestCall.value.partners[0].partnerId).toBe(201);
         });
     });
 
     it('publishes an existing section and handles success toast', async () => {
-        mockedUseDataFetch.mockReturnValue({
-            data: [
+        const props = await renderWithSection({
+            id: 1,
+            title: 'Existing title',
+            description: 'Existing description',
+            partners: [
                 {
-                    id: 1,
-                    title: 'Existing title',
-                    description: 'Existing description',
-                    partners: [
-                        {
-                            id: 10,
-                            description: 'Existing partner',
-                            image: { id: 20, url: 'existing.jpg', mimeType: 'image/png' },
-                            imageId: 20,
-                        },
-                    ],
+                    id: 10,
+                    description: 'Existing partner',
+                    image: { id: 20, url: 'existing.jpg', mimeType: 'image/png' },
+                    imageId: 20,
                 },
             ],
-            isLoading: false,
-            error: null,
-            refetch: jest.fn(),
-            setData: jest.fn(),
         });
-
-        render(<PartnerSectionsEditor />);
-
-        await waitFor(() => {
-            expect(mockPartnerSectionFormRender).toHaveBeenCalled();
-        });
-
-        const props = mockPartnerSectionFormRender.mock.calls[0][0];
 
         await act(async () => {
             await props.onPublish(props.value.localId);
@@ -394,24 +361,7 @@ describe('PartnerSectionsEditor', () => {
     it('handles publish errors: shows toast on failure, no toast on cancellation', async () => {
         const setupAndPublish = async (rejectValue: Error | { name: string }) => {
             mockedPartnersApi.updateSection.mockRejectedValueOnce(rejectValue);
-            mockedUseDataFetch.mockReturnValue({
-                data: [
-                    {
-                        id: 2,
-                        title: 'Test section',
-                        description: 'Test description',
-                        partners: [],
-                    },
-                ],
-                isLoading: false,
-                error: null,
-                refetch: jest.fn(),
-                setData: jest.fn(),
-            });
-
-            render(<PartnerSectionsEditor />);
-            await waitFor(() => expect(mockPartnerSectionFormRender).toHaveBeenCalled());
-            const props = mockPartnerSectionFormRender.mock.calls[0][0];
+            const props = await renderWithSection({ id: 2, title: 'Test section', description: 'Test description' });
 
             await act(async () => {
                 await props.onPublish(props.value.localId);
@@ -421,11 +371,9 @@ describe('PartnerSectionsEditor', () => {
         // Test error toast on regular failure
         await setupAndPublish(new Error('publish failed'));
         expect(addToastMock).toHaveBeenCalledWith(PARTNERS_TEXT.MESSAGE.FAIL_TO_PUBLISH_SECTION, ToastType.Error);
-        const latestCallAfterError =
-            mockPartnerSectionFormRender.mock.calls[mockPartnerSectionFormRender.mock.calls.length - 1][0];
-        expect(latestCallAfterError.disabled).toBe(false);
+        expect(getLatestProps().disabled).toBe(false);
 
-        // Clear mocks for next test
+        // Clear mocks for next sub-test
         jest.clearAllMocks();
         mockPartnerSectionFormRender.mockClear();
 
@@ -435,43 +383,9 @@ describe('PartnerSectionsEditor', () => {
     });
 
     it('deletes a persisted section after confirmation', async () => {
-        mockedUseDataFetch.mockReturnValue({
-            data: [
-                {
-                    id: 5,
-                    title: 'Deletable',
-                    description: 'To delete',
-                    partners: [],
-                },
-            ],
-            isLoading: false,
-            error: null,
-            refetch: jest.fn(),
-            setData: jest.fn(),
-        });
+        const props = await renderWithSection({ id: 5, title: 'Deletable', description: 'To delete' });
 
-        render(<PartnerSectionsEditor />);
-
-        await waitFor(() => {
-            expect(mockPartnerSectionFormRender).toHaveBeenCalled();
-        });
-
-        const latestProps =
-            mockPartnerSectionFormRender.mock.calls[mockPartnerSectionFormRender.mock.calls.length - 1][0];
-
-        await act(async () => {
-            latestProps.onDelete(latestProps.value.localId);
-        });
-
-        expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument();
-
-        fireEvent.click(screen.getByTestId('confirm-delete'));
-
-        await waitFor(() => {
-            expect(screen.getByText(PARTNERS_TEXT.FORM.MESSAGE.DELETE_SECTION_WARNING)).toBeInTheDocument();
-        });
-
-        fireEvent.click(screen.getByTestId('confirm-delete'));
+        await performTwoStepDelete(props);
 
         await waitFor(() => {
             expect(mockedPartnersApi.deleteSection).toHaveBeenCalledWith('mock-client', 5);
@@ -481,13 +395,7 @@ describe('PartnerSectionsEditor', () => {
     });
 
     it('deletes an unsaved section without calling API', async () => {
-        mockedUseDataFetch.mockReturnValue({
-            data: [],
-            isLoading: false,
-            error: null,
-            refetch: jest.fn(),
-            setData: jest.fn(),
-        });
+        mockDataFetch([]);
 
         const ref = createRef<PartnerSectionsEditorRef>();
         render(<PartnerSectionsEditor ref={ref} />);
@@ -500,19 +408,7 @@ describe('PartnerSectionsEditor', () => {
             expect(mockPartnerSectionFormRender).toHaveBeenCalled();
         });
 
-        const latestProps =
-            mockPartnerSectionFormRender.mock.calls[mockPartnerSectionFormRender.mock.calls.length - 1][0];
-
-        await act(async () => {
-            latestProps.onDelete(latestProps.value.localId);
-        });
-        fireEvent.click(screen.getByTestId('confirm-delete'));
-
-        await waitFor(() => {
-            expect(screen.getByText(PARTNERS_TEXT.FORM.MESSAGE.DELETE_SECTION_WARNING)).toBeInTheDocument();
-        });
-
-        fireEvent.click(screen.getByTestId('confirm-delete'));
+        await performTwoStepDelete(getLatestProps());
 
         expect(mockedPartnersApi.deleteSection).not.toHaveBeenCalled();
         expect(addToastMock).toHaveBeenCalledWith(PARTNERS_TEXT.MESSAGE.SECTION_DELETED, ToastType.Success);
@@ -533,20 +429,7 @@ describe('PartnerSectionsEditor', () => {
     });
 
     it('prevents adding a new section when last section has no partners', async () => {
-        mockedUseDataFetch.mockReturnValue({
-            data: [
-                {
-                    id: 1,
-                    title: '',
-                    description: '',
-                    partners: [],
-                },
-            ],
-            isLoading: false,
-            error: null,
-            refetch: jest.fn(),
-            setData: jest.fn(),
-        });
+        mockDataFetch([{ id: 1, title: '', description: '', partners: [] }]);
 
         const ref = createRef<PartnerSectionsEditorRef>();
         render(<PartnerSectionsEditor ref={ref} />);
@@ -561,25 +444,7 @@ describe('PartnerSectionsEditor', () => {
     });
 
     it('closes the delete modal when cancel is clicked', async () => {
-        mockedUseDataFetch.mockReturnValue({
-            data: [
-                {
-                    id: 6,
-                    title: 'Cancelable',
-                    description: 'Desc',
-                    partners: [],
-                },
-            ],
-            isLoading: false,
-            error: null,
-            refetch: jest.fn(),
-            setData: jest.fn(),
-        });
-
-        render(<PartnerSectionsEditor />);
-
-        await waitFor(() => expect(mockPartnerSectionFormRender).toHaveBeenCalled());
-        const props = mockPartnerSectionFormRender.mock.calls[0][0];
+        const props = await renderWithSection({ id: 6, title: 'Cancelable', description: 'Desc' });
 
         await act(async () => {
             props.onDelete(props.value.localId);
@@ -594,25 +459,7 @@ describe('PartnerSectionsEditor', () => {
     });
 
     it('closes the second delete modal when cancel is clicked', async () => {
-        mockedUseDataFetch.mockReturnValue({
-            data: [
-                {
-                    id: 7,
-                    title: 'Cancelable Second',
-                    description: 'Desc',
-                    partners: [],
-                },
-            ],
-            isLoading: false,
-            error: null,
-            refetch: jest.fn(),
-            setData: jest.fn(),
-        });
-
-        render(<PartnerSectionsEditor />);
-
-        await waitFor(() => expect(mockPartnerSectionFormRender).toHaveBeenCalled());
-        const props = mockPartnerSectionFormRender.mock.calls[0][0];
+        const props = await renderWithSection({ id: 7, title: 'Cancelable Second', description: 'Desc' });
 
         await act(async () => {
             props.onDelete(props.value.localId);
@@ -635,36 +482,9 @@ describe('PartnerSectionsEditor', () => {
     it('shows error toast when deleting section fails', async () => {
         mockedPartnersApi.deleteSection.mockRejectedValueOnce(new Error('delete fail'));
 
-        mockedUseDataFetch.mockReturnValue({
-            data: [
-                {
-                    id: 7,
-                    title: 'Delete me',
-                    description: 'Desc',
-                    partners: [],
-                },
-            ],
-            isLoading: false,
-            error: null,
-            refetch: jest.fn(),
-            setData: jest.fn(),
-        });
+        const props = await renderWithSection({ id: 7, title: 'Delete me', description: 'Desc' });
 
-        render(<PartnerSectionsEditor />);
-
-        const props = mockPartnerSectionFormRender.mock.calls[0][0];
-
-        await act(async () => {
-            props.onDelete(props.value.localId);
-        });
-
-        fireEvent.click(screen.getByTestId('confirm-delete'));
-
-        await waitFor(() => {
-            expect(screen.getByText(PARTNERS_TEXT.FORM.MESSAGE.DELETE_SECTION_WARNING)).toBeInTheDocument();
-        });
-
-        fireEvent.click(screen.getByTestId('confirm-delete'));
+        await performTwoStepDelete(props);
 
         await waitFor(() => {
             expect(addToastMock).toHaveBeenCalledWith(PARTNERS_TEXT.MESSAGE.FAIL_TO_DELETE_SECTION, ToastType.Error);
@@ -672,20 +492,7 @@ describe('PartnerSectionsEditor', () => {
     });
 
     it('does not add section while sections are loading', async () => {
-        mockedUseDataFetch.mockReturnValue({
-            data: [
-                {
-                    id: 8,
-                    title: 'Loading title',
-                    description: 'Desc',
-                    partners: [],
-                },
-            ],
-            isLoading: true,
-            error: null,
-            refetch: jest.fn(),
-            setData: jest.fn(),
-        });
+        mockDataFetch([{ id: 8, title: 'Loading title', description: 'Desc', partners: [] }], true);
 
         const ref = createRef<PartnerSectionsEditorRef>();
         render(<PartnerSectionsEditor ref={ref} />);

--- a/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.test.tsx
+++ b/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.test.tsx
@@ -107,9 +107,7 @@ const performTwoStepDelete = async (props: any) => {
         props.onDelete(props.value.localId);
     });
     fireEvent.click(screen.getByTestId('confirm-delete'));
-    await waitFor(() =>
-        expect(screen.getByText(PARTNERS_TEXT.FORM.MESSAGE.DELETE_SECTION_WARNING)).toBeInTheDocument(),
-    );
+    await screen.findByText(PARTNERS_TEXT.FORM.MESSAGE.DELETE_SECTION_WARNING);
     fireEvent.click(screen.getByTestId('confirm-delete'));
 };
 
@@ -325,7 +323,7 @@ describe('PartnerSectionsEditor', () => {
     });
 
     it('publishes an existing section and handles success toast', async () => {
-        const props = await renderWithSection({
+        const view = await renderWithSection({
             id: 1,
             title: 'Existing title',
             description: 'Existing description',
@@ -340,19 +338,19 @@ describe('PartnerSectionsEditor', () => {
         });
 
         await act(async () => {
-            await props.onPublish(props.value.localId);
+            await view.onPublish(view.value.localId);
         });
 
-        expect(mockedPartnersApi.updateSection).toHaveBeenCalledWith('mock-client', props.value.sectionId, {
-            title: props.value.title,
-            description: props.value.description,
-            partnersToUpdate: props.value.partners.map((partner: any) => ({
+        expect(mockedPartnersApi.updateSection).toHaveBeenCalledWith('mock-client', view.value.sectionId, {
+            title: view.value.title,
+            description: view.value.description,
+            partnersToUpdate: view.value.partners.map((partner: any) => ({
                 id: partner.partnerId,
                 description: partner.description,
                 image: partner.image,
                 imageId: partner.imageId,
             })),
-            partnerIdsToDelete: props.value.deletedPartnerIds || [],
+            partnerIdsToDelete: view.value.deletedPartnerIds || [],
         });
 
         expect(addToastMock).toHaveBeenCalledWith(PARTNERS_TEXT.MESSAGE.SECTION_PUBLISHED, ToastType.Success);
@@ -361,10 +359,10 @@ describe('PartnerSectionsEditor', () => {
     it('handles publish errors: shows toast on failure, no toast on cancellation', async () => {
         const setupAndPublish = async (rejectValue: Error | { name: string }) => {
             mockedPartnersApi.updateSection.mockRejectedValueOnce(rejectValue);
-            const props = await renderWithSection({ id: 2, title: 'Test section', description: 'Test description' });
+            const view = await renderWithSection({ id: 2, title: 'Test section', description: 'Test description' });
 
             await act(async () => {
-                await props.onPublish(props.value.localId);
+                await view.onPublish(view.value.localId);
             });
         };
 
@@ -383,9 +381,9 @@ describe('PartnerSectionsEditor', () => {
     });
 
     it('deletes a persisted section after confirmation', async () => {
-        const props = await renderWithSection({ id: 5, title: 'Deletable', description: 'To delete' });
+        const view = await renderWithSection({ id: 5, title: 'Deletable', description: 'To delete' });
 
-        await performTwoStepDelete(props);
+        await performTwoStepDelete(view);
 
         await waitFor(() => {
             expect(mockedPartnersApi.deleteSection).toHaveBeenCalledWith('mock-client', 5);
@@ -444,10 +442,10 @@ describe('PartnerSectionsEditor', () => {
     });
 
     it('closes the delete modal when cancel is clicked', async () => {
-        const props = await renderWithSection({ id: 6, title: 'Cancelable', description: 'Desc' });
+        const view = await renderWithSection({ id: 6, title: 'Cancelable', description: 'Desc' });
 
         await act(async () => {
-            props.onDelete(props.value.localId);
+            view.onDelete(view.value.localId);
         });
 
         expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument();
@@ -459,10 +457,10 @@ describe('PartnerSectionsEditor', () => {
     });
 
     it('closes the second delete modal when cancel is clicked', async () => {
-        const props = await renderWithSection({ id: 7, title: 'Cancelable Second', description: 'Desc' });
+        const view = await renderWithSection({ id: 7, title: 'Cancelable Second', description: 'Desc' });
 
         await act(async () => {
-            props.onDelete(props.value.localId);
+            view.onDelete(view.value.localId);
         });
 
         expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument();
@@ -482,9 +480,9 @@ describe('PartnerSectionsEditor', () => {
     it('shows error toast when deleting section fails', async () => {
         mockedPartnersApi.deleteSection.mockRejectedValueOnce(new Error('delete fail'));
 
-        const props = await renderWithSection({ id: 7, title: 'Delete me', description: 'Desc' });
+        const view = await renderWithSection({ id: 7, title: 'Delete me', description: 'Desc' });
 
-        await performTwoStepDelete(props);
+        await performTwoStepDelete(view);
 
         await waitFor(() => {
             expect(addToastMock).toHaveBeenCalledWith(PARTNERS_TEXT.MESSAGE.FAIL_TO_DELETE_SECTION, ToastType.Error);

--- a/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.test.tsx
+++ b/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.test.tsx
@@ -507,11 +507,11 @@ describe('PartnerSectionsEditor', () => {
             latestProps.onDelete(latestProps.value.localId);
         });
         fireEvent.click(screen.getByTestId('confirm-delete'));
-        
+
         await waitFor(() => {
             expect(screen.getByText(PARTNERS_TEXT.FORM.MESSAGE.DELETE_SECTION_WARNING)).toBeInTheDocument();
         });
-        
+
         fireEvent.click(screen.getByTestId('confirm-delete'));
 
         expect(mockedPartnersApi.deleteSection).not.toHaveBeenCalled();

--- a/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.tsx
+++ b/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.tsx
@@ -42,12 +42,18 @@ export interface PartnerSectionsEditorRef {
     addSection: () => void;
 }
 
+enum DeletePhase {
+    IDLE = 'idle',
+    CONFIRM_SECTION = 'confirm_section',
+    CONFIRM_PARTNERS = 'confirm_partners',
+}
+
 export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef>((_, ref) => {
     const client = useAdminClient();
     const { addToast } = useToast();
     const [errors, setErrors] = useState<PartnerSectionErrors[]>([]);
     const [isPublishing, setIsPublishing] = useState<boolean>(false);
-    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [deletePhase, setDeletePhase] = useState<DeletePhase>(DeletePhase.IDLE);
     const [sectionToDeleteId, setSectionToDeleteId] = useState<string | null>(null);
     const [localSections, setLocalSections] = useState<PartnerSectionFormValues[]>([]);
     const scrollAnchorRef = useRef<HTMLDivElement>(null);
@@ -201,19 +207,23 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef>((_, re
 
     const handleDeleteRequest = useCallback((localId: string) => {
         setSectionToDeleteId(localId);
-        setIsModalOpen(true);
+        setDeletePhase(DeletePhase.CONFIRM_SECTION);
     }, []);
 
     const handleCloseModal = useCallback(() => {
-        setIsModalOpen(false);
+        setDeletePhase(DeletePhase.IDLE);
         setSectionToDeleteId(null);
     }, []);
 
-    const handleConfirmDelete = useCallback(async () => {
+    const handleFirstConfirm = useCallback(() => {
+        setDeletePhase(DeletePhase.CONFIRM_PARTNERS);
+    }, []);
+
+    const handleFinalConfirmDelete = useCallback(async () => {
         if (!sectionToDeleteId) return;
 
         setIsPublishing(true);
-        setIsModalOpen(false);
+        setDeletePhase(DeletePhase.IDLE);
 
         try {
             const sectionToDelete = localSections.find((s) => s.localId === sectionToDeleteId);
@@ -316,10 +326,17 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef>((_, re
             <div ref={scrollAnchorRef} />
 
             <ConfirmationModal
-                isOpen={isModalOpen}
+                isOpen={deletePhase === DeletePhase.CONFIRM_SECTION}
                 onClose={handleCloseModal}
                 title={PARTNERS_TEXT.FORM.TITLE.DELETE_SECTION}
-                onConfirm={handleConfirmDelete}
+                onConfirm={handleFirstConfirm}
+                onCancel={handleCloseModal}
+            />
+            <ConfirmationModal
+                isOpen={deletePhase === DeletePhase.CONFIRM_PARTNERS}
+                onClose={handleCloseModal}
+                title={PARTNERS_TEXT.FORM.MESSAGE.DELETE_SECTION_WARNING}
+                onConfirm={handleFinalConfirmDelete}
                 onCancel={handleCloseModal}
             />
         </div>


### PR DESCRIPTION
## Github ticket

* [ Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2719)

## Description

This PR fixes a bug in the Partner Sections editor where the second confirmation modal during section deletion was missing. It implements a robust DeletePhase state machine to handle the two-step deletion flow and ensures the proper warning message is displayed as the title of the second modal before deletion occurs.

## How it looks


https://github.com/user-attachments/assets/94c57a8f-7994-49d8-92e7-be32a0c5a89f


## Summary of change

**`partners.ts`**: Added the `DELETE_SECTION_WARNING` string constant to `PARTNERS_TEXT.FORM.MESSAGE`.
*   **`PartnerSectionsEditor.tsx`**: 
    *   **State Refactor:** Replaced the `isModalOpen` boolean with a `DeletePhase` enum (`IDLE`, `CONFIRM_SECTION`, `CONFIRM_PARTNERS`) to safely manage the multi-step deletion state without overlapping modals.
    *   **Two-Step Flow:** Split the delete confirmation logic to transition through the new phases.
    *   **UI Update:** Added a second conditional `ConfirmationModal` that displays the warning text directly as its title.
*   **`PartnerSectionsEditor.test.tsx`**: Updated existing deletion tests to simulate clicking through both modals, and added a new test case to verify that cancellation on the second modal works correctly.

## How to recreate changes

1. Open the Admin application and navigate to the **Partners** page.
2. Ensure you have at least one Partner Section created.
3. Click the **"Видалити секцію"** button on that section.
4. Verify the first confirmation modal appears.
5. Click **"Так"** on the first modal.
6. Verify the second confirmation modal appears with the text: *"Всі партнери в секції будуть видалені. Бажаєте продовжити?"*.
7. **Test cancellation:** Click **"Ні"** to verify the modal closes without deleting the section.
8. **Test completion:** Restart the flow and click **"Так"** on the second modal to verify the section deletes successfully and the success toast appears.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the partner section deletion two-step confirmation flow.
  * Added/updated scenarios to verify canceling the second confirmation closes the modal and prevents the deletion call.

* **Refactor**
  * Updated partner section deletion to use a two-step confirmation process with phase-based modals.
  * Improved the deletion flow UI by adding a warning message indicating all partners in the section will be deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->