### PR TITLE
Fix/issue-2270: [Single Program] [UI] Modal window design does not match Figma mock-up (confirmation pop-up layout mismatch)

### DIFF
--- a/src/components/admin/confirmation-modal/ConfirmationModal.tsx
+++ b/src/components/admin/confirmation-modal/ConfirmationModal.tsx
@@ -30,7 +30,9 @@ export const ConfirmationModal = ({
 }: ConfirmationModalProps) => {
     return (
         <Modal isOpen={isOpen} onClose={onClose} className={className}>
-            <Modal.Title>{title}</Modal.Title>
+            <Modal.Title>
+                <span style={{ whiteSpace: 'pre-line' }}>{title}</span>
+            </Modal.Title>
             <Modal.Content>{content && <p>{content}</p>}</Modal.Content>
             <Modal.Actions>
                 <Button

--- a/src/const/admin/common.ts
+++ b/src/const/admin/common.ts
@@ -54,7 +54,7 @@ export const COMMON_TEXT_ADMIN = {
 
     QUESTION: {
         SAVE_CHANGES: 'Зберегти зміни?',
-        CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE: 'Зміни будуть втрачені. Бажаєте продовжити?',
+        CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE: 'Зміни будуть втрачені\nБажаєте продовжити?',
         REMOVE_FROM_PUBLICATION: 'Зняти з публікації?',
         PUBLISH_CHANGES: 'Опублікувати зміни?',
     },

--- a/src/pages/admin/donate/components/generic-form/GenericForm.test.tsx
+++ b/src/pages/admin/donate/components/generic-form/GenericForm.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable testing-library/render-result-naming-convention */
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, getDefaultNormalizer } from '@testing-library/react';
 import { createGenericForm, GenericFormField, GenericFormMode, GenericFormProps } from './GenericForm';
 import { DONATE_TEXT } from '@/const/admin/donate';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
@@ -99,11 +99,19 @@ const confirmModal = async () => clickButton(getYesButton());
 const cancelModal = () => clickButton(getNoButton());
 
 const expectModalVisible = (text: string) => {
-    expect(screen.getByText(text)).toBeInTheDocument();
+    expect(
+        screen.getByText(text, {
+            normalizer: getDefaultNormalizer({ collapseWhitespace: false }),
+        }),
+    ).toBeInTheDocument();
 };
 
 const expectModalNotVisible = (text: string) => {
-    expect(screen.queryByText(text)).not.toBeInTheDocument();
+    expect(
+        screen.queryByText(text, {
+            normalizer: getDefaultNormalizer({ collapseWhitespace: false }),
+        }),
+    ).not.toBeInTheDocument();
 };
 
 const expectButtonDisabled = (button: HTMLButtonElement, disabled: boolean = true) => {

--- a/src/pages/admin/donate/components/support-options/support-option-item/SupportOptionItem.test.tsx
+++ b/src/pages/admin/donate/components/support-options/support-option-item/SupportOptionItem.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, getDefaultNormalizer } from '@testing-library/react';
 import { SupportOptionItem, SupportOptionItemMode } from './SupportOptionItem';
 import { DONATE_TEXT } from '@/const/admin/donate';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
@@ -390,7 +390,9 @@ describe('SupportOptionItem', () => {
             clickButton(getCancelButton());
 
             expect(
-                screen.getByText(COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE),
+                screen.getByText(COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE, {
+                    normalizer: getDefaultNormalizer({ collapseWhitespace: false }),
+                }),
             ).toBeInTheDocument();
 
             cancelModal();

--- a/src/pages/admin/faq/components/faq-modals/faq-modal/FaqModal.test.tsx
+++ b/src/pages/admin/faq/components/faq-modals/faq-modal/FaqModal.test.tsx
@@ -241,6 +241,7 @@ describe('FaqModal', () => {
             expect(getQuestionModal()).toBeInTheDocument();
             expect(getQuestionTitle()).toHaveTextContent(
                 COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE,
+                { normalizeWhitespace: false },
             );
         });
 

--- a/src/pages/admin/history/components/history-page-content/HistoryPageContent.test.tsx
+++ b/src/pages/admin/history/components/history-page-content/HistoryPageContent.test.tsx
@@ -452,6 +452,7 @@ describe('HistoryPageContent', () => {
 
         expect(screen.getByTestId('question-title')).toHaveTextContent(
             COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE,
+            { normalizeWhitespace: false },
         );
 
         await user.click(screen.getByTestId('question-cancel'));

--- a/src/pages/admin/programs/components/program-category-modals/ProgramCategoryModal.test.tsx
+++ b/src/pages/admin/programs/components/program-category-modals/ProgramCategoryModal.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act, getDefaultNormalizer } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ProgramCategoryModal, ProgramCategoryModalProps } from './ProgramCategoryModal';
 import { ProgramsCategoriesApi } from '@/services/api/admin/programs/programs-api';
@@ -228,11 +228,17 @@ describe('ProgramCategoryModal - Add Mode', () => {
         typeName('Dirty name');
         fireEvent.click(screen.getByTestId('modal-close-btn'));
 
-        expect(screen.getByText(COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE)).toBeInTheDocument();
+        expect(
+            screen.getByText(COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE, {
+                normalizer: getDefaultNormalizer({ collapseWhitespace: false }),
+            }),
+        ).toBeInTheDocument();
 
         fireEvent.click(screen.getByText('No'));
         expect(
-            screen.queryByText(COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE),
+            screen.queryByText(COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE, {
+                normalizer: getDefaultNormalizer({ collapseWhitespace: false }),
+            }),
         ).not.toBeInTheDocument();
         expect(onClose).not.toHaveBeenCalled();
 
@@ -397,6 +403,9 @@ describe('ProgramCategoryModal - Closing Behavior', () => {
         expect(screen.getByTestId('confirm-modal')).toBeInTheDocument();
         expect(screen.getByTestId('confirm-title')).toHaveTextContent(
             COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE,
+            {
+                normalizeWhitespace: false,
+            },
         );
     });
 

--- a/src/pages/admin/programs/components/programs-page-modals/program-modal/ProgramModal.test.tsx
+++ b/src/pages/admin/programs/components/programs-page-modals/program-modal/ProgramModal.test.tsx
@@ -368,6 +368,7 @@ describe('ProgramModal', () => {
             expect(screen.getByTestId('question-modal')).toBeInTheDocument();
             expect(screen.getByTestId('question-title')).toHaveTextContent(
                 COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE,
+                { normalizeWhitespace: false },
             );
 
             fireEvent.click(screen.getByTestId('question-confirm'));
@@ -443,6 +444,7 @@ describe('ProgramModal', () => {
 
             expect(screen.getByTestId('question-title')).toHaveTextContent(
                 COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE,
+                { normalizeWhitespace: false },
             );
         });
 
@@ -475,6 +477,7 @@ describe('ProgramModal', () => {
             expect(screen.getByTestId('question-modal')).toBeInTheDocument();
             expect(screen.getByTestId('question-title')).toHaveTextContent(
                 COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE,
+                { normalizeWhitespace: false },
             );
             expect(mockDiscardCallback).not.toHaveBeenCalled();
 
@@ -549,6 +552,7 @@ describe('ProgramModal', () => {
             expect(getQuestionModal()).toBeInTheDocument();
             expect(getQuestionTitle()).toHaveTextContent(
                 COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE,
+                { normalizeWhitespace: false },
             );
         });
 

--- a/src/pages/admin/programs/components/translate-program-modal/TranslateProgramModal.test.tsx
+++ b/src/pages/admin/programs/components/translate-program-modal/TranslateProgramModal.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, getDefaultNormalizer } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { TranslateProgramModal } from './TranslateProgramModal';
 import { HippotherapyProgram } from '@/types/admin/programs';
@@ -307,7 +307,9 @@ describe('TranslateProgramModal', () => {
 
         await waitFor(() => {
             expect(
-                screen.getByText(COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE),
+                screen.getByText(COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE, {
+                    normalizer: getDefaultNormalizer({ collapseWhitespace: false }),
+                }),
             ).toBeInTheDocument();
         });
     });
@@ -322,7 +324,9 @@ describe('TranslateProgramModal', () => {
 
         expect(onClose).toHaveBeenCalledTimes(1);
         expect(
-            screen.queryByText(COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE),
+            screen.queryByText(COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE, {
+                normalizer: getDefaultNormalizer({ collapseWhitespace: false }),
+            }),
         ).not.toBeInTheDocument();
     });
 
@@ -335,7 +339,9 @@ describe('TranslateProgramModal', () => {
 
         await waitFor(() => {
             expect(
-                screen.getByText(COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE),
+                screen.getByText(COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE, {
+                    normalizer: getDefaultNormalizer({ collapseWhitespace: false }),
+                }),
             ).toBeInTheDocument();
         });
 
@@ -345,7 +351,9 @@ describe('TranslateProgramModal', () => {
         fireEvent.click(screen.getByLabelText('Close modal'));
         await waitFor(() => {
             expect(
-                screen.getByText(COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE),
+                screen.getByText(COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE, {
+                    normalizer: getDefaultNormalizer({ collapseWhitespace: false }),
+                }),
             ).toBeInTheDocument();
         });
 

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-section-content-block/PdfSectionContentBlock.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, getDefaultNormalizer } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PdfSectionContentBlock } from './PdfSectionContentBlock';
 import { PDF_FILES_SECTION_TEXT } from '@/const/admin/reports';
@@ -237,7 +237,9 @@ describe('PdfSectionContentBlock', () => {
             await utils.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.CANCEL }));
             expect(await screen.findByTestId('confirmation-modal')).toBeInTheDocument();
             expect(
-                screen.getByText(COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE),
+                screen.getByText(COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE, {
+                    normalizer: getDefaultNormalizer({ collapseWhitespace: false }),
+                }),
             ).toBeInTheDocument();
         });
 

--- a/src/pages/admin/team/components/team-category-modal/TeamCategoryModal.test.tsx
+++ b/src/pages/admin/team/components/team-category-modal/TeamCategoryModal.test.tsx
@@ -497,6 +497,7 @@ describe('TeamCategoryModal', () => {
             expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument();
             expect(screen.getByTestId('confirmation-title')).toHaveTextContent(
                 COMMON_TEXT_ADMIN.QUESTION.CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE,
+                { normalizeWhitespace: false },
             );
         });
 


### PR DESCRIPTION
## Github ticker

* [2270](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2270)

## Description

The main goal of this PR is to fix the text formatting of the confirmation modal that appears when a user attempts to close a modal window with unsaved changes. The update ensures the title text is properly broken into two lines, matching the intended Figma design layout.

## How it looks

<img width="521" height="192" alt="image" src="https://github.com/user-attachments/assets/27ba5ee2-c0cd-4922-be1c-61a79eb03fc5" />

## Summary of change

**Updated Text Constant:** Modified the `CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE` string in the `QUESTION` constants object. Removed the period and added a newline character (`\n`) to split the text: `'Зміни будуть втрачені\nБажаєте продовжити?'`.

**Updated Modal Component:** Wrapped the `{title}` variable inside `<Modal.Title>` with a `<span>` element and applied the CSS property `style={{ whiteSpace: 'pre-line' }}`. This allows the component to properly recognize and render the `\n` character as a visible line break in the UI.

## How to recreate changes

**Preconditions**

1. User is logged in as Admin
2. Add new Program modal window is open.
3. X button is visible and active

**Steps to reproduce**

1. Enter some data in at least one field in the modal window .
2. Click on the "X" button

**Expected result**

1. The confirmation pop-up with the message "Зміни будуть втрачені. Бажаєте продовжити?" is displayed
2. The "Так", "Ні" and "X" buttons are displayed and are active (clickable)
3. The design of the modal window matches the Figma layout on the website


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated admin confirmation modal titles to render multi-line text correctly when newline characters are present.
  * Adjusted the Ukrainian “changes will be lost” prompt to include an explicit newline for clearer readability.

* **Tests**
  * Improved admin modal text assertions to avoid over-collapsing whitespace, ensuring confirmations match exactly as displayed in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->