### PR TITLE
Feature/issue 1836: [Reports} Bulk deletion of records in the 'Програмні витрати' tab

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -374,4 +374,11 @@ export const PROGRAM_EXPENSES_TEXT = {
             ACTIONS: 'Дії',
         },
     },
+    BULK: {
+        getSelectedLabel: (selected: number, total: number) => `Вибрано ${selected} з ${total}`,
+        DELETE_BUTTON: 'Видалити вибрані',
+        DELETE_CONFIRM_TITLE: 'Видалити обрані записи?',
+        DELETE_SUCCESS: 'Записи видалені успішно',
+        DELETE_FAILED: 'Помилка при видаленні записів. Спробуйте ще раз.',
+    },
 };

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
@@ -63,6 +63,7 @@ jest.mock('@/services/api/admin/reports/program-expenses-api', () => ({
     ProgramExpensesApi: {
         getReadOnlyData: (...args: unknown[]) => mockGetReadOnlyData(...args),
         delete: jest.fn(),
+        bulkDelete: jest.fn(),
     },
 }));
 
@@ -477,5 +478,58 @@ describe('ProgramExpensesSection', () => {
         });
 
         resolveDelete();
+    });
+
+    it('should open bulk delete modal when delete selected button is clicked', () => {
+        render(<ProgramExpensesSection isEditing />);
+
+        fireEvent.click(screen.getByRole('checkbox', { name: 'Select record 1' }));
+        fireEvent.click(screen.getByText(PROGRAM_EXPENSES_TEXT.BULK.DELETE_BUTTON));
+
+        expect(screen.getByTestId('delete-record-modal')).toBeInTheDocument();
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.BULK.DELETE_CONFIRM_TITLE)).toBeInTheDocument();
+    });
+
+    it('should close bulk delete modal and clear selection when cancel is clicked', () => {
+        render(<ProgramExpensesSection isEditing />);
+
+        fireEvent.click(screen.getByRole('checkbox', { name: 'Select record 1' }));
+        fireEvent.click(screen.getByText(PROGRAM_EXPENSES_TEXT.BULK.DELETE_BUTTON));
+        fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.NO));
+
+        expect(screen.queryByTestId('delete-record-modal')).not.toBeInTheDocument();
+        expect(ProgramExpensesApi.bulkDelete).not.toHaveBeenCalled();
+    });
+
+    it('should bulk delete selected records and show success toast', async () => {
+        (ProgramExpensesApi.bulkDelete as jest.Mock).mockResolvedValueOnce(undefined);
+
+        render(<ProgramExpensesSection isEditing />);
+
+        fireEvent.click(screen.getByRole('checkbox', { name: 'Select record 1' }));
+        fireEvent.click(screen.getByText(PROGRAM_EXPENSES_TEXT.BULK.DELETE_BUTTON));
+        fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.YES));
+
+        await waitFor(() => {
+            expect(ProgramExpensesApi.bulkDelete).toHaveBeenCalledWith('mock-client', [1]);
+            expect(mockAddToast).toHaveBeenCalledWith(PROGRAM_EXPENSES_TEXT.BULK.DELETE_SUCCESS, 'success');
+            expect(mockRefetch).toHaveBeenCalled();
+            expect(screen.queryByTestId('delete-record-modal')).not.toBeInTheDocument();
+        });
+    });
+
+    it('should show error toast when bulk delete fails', async () => {
+        (ProgramExpensesApi.bulkDelete as jest.Mock).mockRejectedValueOnce(new Error('failed'));
+
+        render(<ProgramExpensesSection isEditing />);
+
+        fireEvent.click(screen.getByRole('checkbox', { name: 'Select record 1' }));
+        fireEvent.click(screen.getByText(PROGRAM_EXPENSES_TEXT.BULK.DELETE_BUTTON));
+        fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.YES));
+
+        await waitFor(() => {
+            expect(mockAddToast).toHaveBeenCalledWith(PROGRAM_EXPENSES_TEXT.BULK.DELETE_FAILED, 'error', 5000);
+            expect(screen.queryByTestId('delete-record-modal')).not.toBeInTheDocument();
+        });
     });
 });

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
@@ -39,6 +39,9 @@ export const ProgramExpensesSection = ({ isEditing = false }: ProgramExpensesSec
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
     const [recordToDelete, setRecordToDelete] = useState<ProgramExpensesRecord | null>(null);
     const [isDeletingRecord, setIsDeletingRecord] = useState(false);
+    const [selectedRecordIds, setSelectedRecordIds] = useState<number[]>([]);
+    const [isBulkDeleteModalOpen, setIsBulkDeleteModalOpen] = useState(false);
+    const [isBulkDeleting, setIsBulkDeleting] = useState(false);
 
     const fetchReadOnlyData = useCallback(
         (options = {}) => ProgramExpensesApi.getReadOnlyData(adminClient, options),
@@ -68,6 +71,7 @@ export const ProgramExpensesSection = ({ isEditing = false }: ProgramExpensesSec
     useEffect(() => {
         if (!isEditing) {
             setIsAddProgramExpenseModalOpen(false);
+            setSelectedRecordIds([]);
         }
     }, [isEditing]);
 
@@ -121,6 +125,49 @@ export const ProgramExpensesSection = ({ isEditing = false }: ProgramExpensesSec
         setRecordToDelete(null);
     }, []);
 
+    const toggleRecordSelection = useCallback((id: number) => {
+        setSelectedRecordIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
+    }, []);
+
+    const handleSelectAllToggle = useCallback(
+        (checked: boolean) => {
+            if (checked) {
+                setSelectedRecordIds(filteredRecords.map((record) => record.id));
+            } else {
+                setSelectedRecordIds([]);
+            }
+        },
+        [filteredRecords],
+    );
+
+    const handleOpenBulkDeleteModal = useCallback(() => setIsBulkDeleteModalOpen(true), []);
+
+    const handleBulkDeleteCancel = useCallback(() => {
+        setIsBulkDeleteModalOpen(false);
+        setSelectedRecordIds([]);
+    }, []);
+
+    const handleConfirmBulkDelete = useCallback(async () => {
+        if (selectedRecordIds.length === 0) {
+            setIsBulkDeleteModalOpen(false);
+            return;
+        }
+        setIsBulkDeleting(true);
+
+        try {
+            await ProgramExpensesApi.bulkDelete(adminClient, selectedRecordIds);
+            setSelectedRecordIds([]);
+            setIsBulkDeleteModalOpen(false);
+            refetchReadOnlyData();
+            addToast(PROGRAM_EXPENSES_TEXT.BULK.DELETE_SUCCESS, ToastType.Success);
+        } catch {
+            setIsBulkDeleteModalOpen(false);
+            addToast(PROGRAM_EXPENSES_TEXT.BULK.DELETE_FAILED, ToastType.Error, 5000);
+        } finally {
+            setIsBulkDeleting(false);
+        }
+    }, [adminClient, selectedRecordIds, refetchReadOnlyData, addToast]);
+
     if (isInitialLoading) {
         return (
             <div className={styles.section}>
@@ -152,6 +199,10 @@ export const ProgramExpensesSection = ({ isEditing = false }: ProgramExpensesSec
                     isAddProgramExpenseDisabled={isAddProgramExpenseDisabled || !isEditing}
                     onAddProgramExpense={isEditing ? handleOpenAddProgramExpenseModal : undefined}
                     onDeleteRecord={isEditing ? handleDeleteClick : undefined}
+                    selectedRecordIds={selectedRecordIds}
+                    onToggleRecordSelection={toggleRecordSelection}
+                    onSelectAllToggle={handleSelectAllToggle}
+                    onOpenBulkDelete={handleOpenBulkDeleteModal}
                 />
             </div>
 
@@ -172,6 +223,17 @@ export const ProgramExpensesSection = ({ isEditing = false }: ProgramExpensesSec
                 onConfirm={handleConfirmDelete}
                 onCancel={handleCancelDelete}
                 onClose={handleCancelDelete}
+            />
+
+            <DeleteRecordModal
+                isOpen={isBulkDeleteModalOpen}
+                title={PROGRAM_EXPENSES_TEXT.BULK.DELETE_CONFIRM_TITLE}
+                confirmText={COMMON_TEXT_ADMIN.BUTTON.YES}
+                cancelText={COMMON_TEXT_ADMIN.BUTTON.NO}
+                isButtonsDisabled={isBulkDeleting}
+                onConfirm={handleConfirmBulkDelete}
+                onCancel={handleBulkDeleteCancel}
+                onClose={handleBulkDeleteCancel}
             />
         </div>
     );

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.module.scss
@@ -2,6 +2,11 @@
 @use '@/assets/sass/mixins/typography.mixins' as type;
 @use '@/assets/sass/variables/typography' as t;
 
+.table-container {
+    display: flex;
+    flex-direction: column;
+}
+
 .table-wrapper {
     box-sizing: border-box;
     width: 100%;
@@ -152,6 +157,49 @@
 .delete-icon-button {
     --icon-btn-color: #{c.$blue-500};
     --icon-btn-hover-color: #{c.$error};
+}
+
+.selection-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin: 12px 0;
+}
+
+.selection-row-hidden {
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
+}
+
+.selection-pill {
+    background-color: rgba(c.$light-blue-100, 0.63);
+    padding: 10px 14px;
+    border-radius: 24px;
+    font-weight: 600;
+    border: 1px solid c.$light-blue-200;
+    box-shadow: 0px 4px 6px rgba(c.$light-blue-200, 0.25);
+    color: c.$dropdown-text;
+}
+
+.selection-actions {
+    margin-left: 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.delete-selected-button {
+    height: 40px;
+    padding: 8px 16px;
+    background-color: c.$red-50;
+    border: 1px solid rgba(c.$error, 0.12);
+    color: c.$error;
+    border-radius: 24px;
+    font-weight: 600;
+    box-shadow: none;
 }
 
 @media (max-width: 1200px) {

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { ProgramExpensesTable } from './ProgramExpensesTable';
 import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
+import { ProgramExpensesTable, ProgramExpensesTableProps } from './ProgramExpensesTable';
 
 jest.mock(
     '@/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState',
@@ -63,6 +63,10 @@ describe('ProgramExpensesTable', () => {
 
     const normalizeText = (value: string) => value.replaceAll('\u00A0', ' ').replaceAll(/\s+/g, ' ').trim();
 
+    const renderTable = (props: Partial<ProgramExpensesTableProps> = {}) => {
+        return render(<ProgramExpensesTable records={records} hasAnyProgramExpenseRecords isEditing {...props} />);
+    };
+
     it('should render table headers', () => {
         render(<ProgramExpensesTable records={records} hasAnyProgramExpenseRecords />);
 
@@ -101,7 +105,7 @@ describe('ProgramExpensesTable', () => {
     });
 
     it('should render checkboxes and action column in edit mode', () => {
-        render(<ProgramExpensesTable records={records} hasAnyProgramExpenseRecords isEditing />);
+        renderTable();
 
         expect(screen.getByText(PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.ACTIONS)).toBeInTheDocument();
         expect(screen.getAllByRole('checkbox')).toHaveLength(3);
@@ -109,37 +113,31 @@ describe('ProgramExpensesTable', () => {
         expect(screen.getByRole('button', { name: 'Delete record 1' })).toBeEnabled();
     });
 
-    it('should select all visible records from the header checkbox', () => {
-        render(<ProgramExpensesTable records={records} hasAnyProgramExpenseRecords isEditing />);
+    it('should call onSelectAllToggle when header checkbox is clicked', () => {
+        const onSelectAllToggle = jest.fn();
+
+        renderTable({ onSelectAllToggle });
 
         fireEvent.click(screen.getByRole('checkbox', { name: 'Select all program expense records' }));
 
-        expect(screen.getByRole('checkbox', { name: 'Select record 1' })).toBeChecked();
-        expect(screen.getByRole('checkbox', { name: 'Select record 2' })).toBeChecked();
+        expect(onSelectAllToggle).toHaveBeenCalledWith(true);
     });
 
-    it('should toggle a single record checkbox in edit mode', () => {
-        render(<ProgramExpensesTable records={records} hasAnyProgramExpenseRecords isEditing />);
+    it('should call onToggleRecordSelection when row checkbox is clicked', () => {
+        const onToggleRecordSelection = jest.fn();
+
+        renderTable({ onToggleRecordSelection });
 
         fireEvent.click(screen.getByRole('checkbox', { name: 'Select record 1' }));
 
-        expect(screen.getByRole('checkbox', { name: 'Select record 1' })).toBeChecked();
-        expect(screen.getByRole('checkbox', { name: 'Select record 2' })).not.toBeChecked();
+        expect(onToggleRecordSelection).toHaveBeenCalledWith(1);
     });
 
     it('should call edit and delete callbacks from row action icons', () => {
         const onEditRecord = jest.fn();
         const onDeleteRecord = jest.fn();
 
-        render(
-            <ProgramExpensesTable
-                records={records}
-                hasAnyProgramExpenseRecords
-                isEditing
-                onEditRecord={onEditRecord}
-                onDeleteRecord={onDeleteRecord}
-            />,
-        );
+        renderTable({ onEditRecord, onDeleteRecord });
 
         fireEvent.click(screen.getByRole('button', { name: 'Edit record 1' }));
         fireEvent.click(screen.getByRole('button', { name: 'Delete record 1' }));
@@ -152,5 +150,17 @@ describe('ProgramExpensesTable', () => {
         render(<ProgramExpensesTable records={[]} hasAnyProgramExpenseRecords={false} isEditing />);
 
         expectEmptyState('program-expenses', '7');
+    });
+
+    it('should show selection bar with count and delete button when records are selected', () => {
+        const onOpenBulkDelete = jest.fn();
+
+        renderTable({ selectedRecordIds: [1], onOpenBulkDelete });
+
+        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.BULK.getSelectedLabel(1, 2))).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText(PROGRAM_EXPENSES_TEXT.BULK.DELETE_BUTTON));
+
+        expect(onOpenBulkDelete).toHaveBeenCalled();
     });
 });

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { ProgramExpensesEmptyState } from '@/pages/admin/reports/components/program-expenses-section/components/program-expenses-empty-state/ProgramExpensesEmptyState';
 import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
 import { ProgramExpensesRecord } from '@/types/admin/reports';
@@ -6,6 +6,7 @@ import { formatSummaryAmount } from '@/utils/functions/format-summary-amount/for
 import { parseAmount } from '@/utils/functions/parse-amount/parse-amount';
 import { IconButton } from '@/components/admin/icon-button/IconButton';
 import { ACTION_ICONS } from '@/const/common/action-icons';
+import { Button } from '@/components/admin/button/Button';
 import cn from 'classnames';
 import styles from './ProgramExpensesTable.module.scss';
 
@@ -17,6 +18,10 @@ interface ProgramExpensesTableProps {
     onAddProgramExpense?: () => void;
     onEditRecord?: (record: ProgramExpensesRecord) => void;
     onDeleteRecord?: (record: ProgramExpensesRecord) => void;
+    selectedRecordIds?: number[];
+    onToggleRecordSelection?: (id: number) => void;
+    onSelectAllToggle?: (checked: boolean) => void;
+    onOpenBulkDelete?: () => void;
 }
 
 const READ_ONLY_TABLE_COLUMNS_COUNT = 5;
@@ -30,8 +35,11 @@ export const ProgramExpensesTable = ({
     onAddProgramExpense,
     onEditRecord,
     onDeleteRecord,
+    selectedRecordIds = [],
+    onToggleRecordSelection,
+    onSelectAllToggle,
+    onOpenBulkDelete,
 }: ProgramExpensesTableProps) => {
-    const [selectedRecordIds, setSelectedRecordIds] = useState<number[]>([]);
     const headerCheckboxRef = useRef<HTMLInputElement>(null);
     const hasNoRecords = records.length === 0;
     const visibleRecordIds = records.map((record) => record.id);
@@ -46,129 +54,124 @@ export const ProgramExpensesTable = ({
         }
     }, [areAllVisibleRecordsSelected, hasSelectedVisibleRecords]);
 
-    useEffect(() => {
-        if (!isEditing) {
-            setSelectedRecordIds([]);
-        }
-    }, [isEditing]);
-
-    const handleSelectAllVisibleRecords = (isChecked: boolean) => {
-        const visibleRecordIdsSet = new Set(visibleRecordIds);
-
-        if (isChecked) {
-            setSelectedRecordIds(Array.from(new Set([...selectedRecordIds, ...visibleRecordIds])));
-            return;
-        }
-
-        setSelectedRecordIds(selectedRecordIds.filter((id) => !visibleRecordIdsSet.has(id)));
-    };
-
-    const handleSelectRecord = (recordId: number, isChecked: boolean) => {
-        if (isChecked) {
-            setSelectedRecordIds(Array.from(new Set([...selectedRecordIds, recordId])));
-            return;
-        }
-
-        setSelectedRecordIds(selectedRecordIds.filter((id) => id !== recordId));
-    };
-
     return (
-        <div className={styles['table-wrapper']}>
-            <table className={styles.table}>
-                <colgroup>
-                    {isEditing && <col className={styles['column-checkbox']} />}
-                    <col className={styles['column-year']} />
-                    <col className={styles['column-type']} />
-                    <col className={styles['column-program']} />
-                    <col className={styles['column-amount']} />
-                    <col className={styles['column-amount']} />
-                    {isEditing && <col className={styles['column-actions']} />}
-                </colgroup>
-                <thead>
-                    <tr>
-                        {isEditing && (
-                            <th className={cn(styles.th, styles['checkbox-th'])}>
-                                <input
-                                    ref={headerCheckboxRef}
-                                    type="checkbox"
-                                    className={styles['row-checkbox']}
-                                    aria-label="Select all program expense records"
-                                    checked={areAllVisibleRecordsSelected}
-                                    disabled={records.length === 0}
-                                    onChange={(event) => handleSelectAllVisibleRecords(event.target.checked)}
-                                />
-                            </th>
-                        )}
-                        <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.REPORTING_YEAR}</th>
-                        <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.TYPE}</th>
-                        <th className={styles.th}>{PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.PROGRAM}</th>
-                        <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_UAH}</th>
-                        <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_USD}</th>
-                        {isEditing && (
-                            <th className={cn(styles.th, styles['actions-th'])}>
-                                {PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.ACTIONS}
-                            </th>
-                        )}
-                    </tr>
-                </thead>
-                <tbody>
-                    {hasNoRecords ? (
-                        <ProgramExpensesEmptyState
-                            colSpan={tableColumnsCount}
-                            variant={hasAnyProgramExpenseRecords ? 'filtered' : 'program-expenses'}
-                            isAddProgramExpenseDisabled={isAddProgramExpenseDisabled}
-                            onAddProgramExpense={onAddProgramExpense}
-                        />
-                    ) : (
-                        records.map((record) => (
-                            <tr key={record.id} className={styles.tr}>
-                                {isEditing && (
-                                    <td className={cn(styles.td, styles['checkbox-td'])}>
-                                        <input
-                                            type="checkbox"
-                                            className={styles['row-checkbox']}
-                                            aria-label={`Select record ${record.id}`}
-                                            checked={selectedRecordIds.includes(record.id)}
-                                            onChange={(event) => handleSelectRecord(record.id, event.target.checked)}
-                                        />
-                                    </td>
-                                )}
-                                <td className={styles.td}>{record.reportingYear}</td>
-                                <td className={styles.td}>
-                                    <span className={styles['type-chip']}>
-                                        {PROGRAM_EXPENSES_TEXT.TABLE.TYPE_LABEL}
-                                    </span>
-                                </td>
-                                <td className={styles.td}>{record.programName}</td>
-                                <td className={styles.td}>{formatSummaryAmount(parseAmount(record.amountUah))}</td>
-                                <td className={styles.td}>{formatSummaryAmount(parseAmount(record.amountUsd))}</td>
-                                {isEditing && (
-                                    <td className={cn(styles.td, styles['actions-td'])}>
-                                        <div className={styles['row-actions']}>
-                                            <IconButton
-                                                type="button"
-                                                className={cn(styles['icon-button'], styles['edit-icon-button'])}
-                                                aria-label={`Edit record ${record.id}`}
-                                                onClick={() => onEditRecord?.(record)}
-                                                DefaultIcon={ACTION_ICONS.edit.default}
-                                                FilledIcon={ACTION_ICONS.edit.hover}
+        <div className={styles['table-container']}>
+            <div
+                className={cn(styles['selection-row'], {
+                    [styles['selection-row-hidden']]: selectedRecordIds.length === 0,
+                })}
+                aria-hidden={selectedRecordIds.length === 0}
+            >
+                <div className={styles['selection-pill']}>
+                    {PROGRAM_EXPENSES_TEXT.BULK.getSelectedLabel(selectedRecordIds.length, records.length)}
+                </div>
+                <div className={styles['selection-actions']}>
+                    <Button
+                        buttonStyle="secondary"
+                        className={styles['delete-selected-button']}
+                        onClick={() => onOpenBulkDelete?.()}
+                    >
+                        {PROGRAM_EXPENSES_TEXT.BULK.DELETE_BUTTON}
+                    </Button>
+                </div>
+            </div>
+
+            <div className={styles['table-wrapper']}>
+                <table className={styles.table}>
+                    <colgroup>
+                        {isEditing && <col className={styles['column-checkbox']} />}
+                        <col className={styles['column-year']} />
+                        <col className={styles['column-type']} />
+                        <col className={styles['column-program']} />
+                        <col className={styles['column-amount']} />
+                        <col className={styles['column-amount']} />
+                        {isEditing && <col className={styles['column-actions']} />}
+                    </colgroup>
+                    <thead>
+                        <tr>
+                            {isEditing && (
+                                <th className={cn(styles.th, styles['checkbox-th'])}>
+                                    <input
+                                        ref={headerCheckboxRef}
+                                        type="checkbox"
+                                        className={styles['row-checkbox']}
+                                        aria-label="Select all program expense records"
+                                        checked={areAllVisibleRecordsSelected}
+                                        onChange={(event) => onSelectAllToggle?.(event.target.checked)}
+                                    />
+                                </th>
+                            )}
+                            <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.REPORTING_YEAR}</th>
+                            <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.TYPE}</th>
+                            <th className={styles.th}>{PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.PROGRAM}</th>
+                            <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_UAH}</th>
+                            <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.AMOUNT_USD}</th>
+                            {isEditing && (
+                                <th className={cn(styles.th, styles['actions-th'])}>
+                                    {PROGRAM_EXPENSES_TEXT.TABLE.COLUMNS.ACTIONS}
+                                </th>
+                            )}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {hasNoRecords ? (
+                            <ProgramExpensesEmptyState
+                                colSpan={tableColumnsCount}
+                                variant={hasAnyProgramExpenseRecords ? 'filtered' : 'program-expenses'}
+                                isAddProgramExpenseDisabled={isAddProgramExpenseDisabled}
+                                onAddProgramExpense={onAddProgramExpense}
+                            />
+                        ) : (
+                            records.map((record) => (
+                                <tr key={record.id} className={styles.tr}>
+                                    {isEditing && (
+                                        <td className={cn(styles.td, styles['checkbox-td'])}>
+                                            <input
+                                                type="checkbox"
+                                                className={styles['row-checkbox']}
+                                                aria-label={`Select record ${record.id}`}
+                                                checked={selectedRecordIds.includes(record.id)}
+                                                onChange={() => onToggleRecordSelection?.(record.id)}
                                             />
-                                            <IconButton
-                                                type="button"
-                                                className={cn(styles['icon-button'], styles['delete-icon-button'])}
-                                                aria-label={`Delete record ${record.id}`}
-                                                onClick={() => onDeleteRecord?.(record)}
-                                                DefaultIcon={ACTION_ICONS.delete.default}
-                                                FilledIcon={ACTION_ICONS.delete.hover}
-                                            />
-                                        </div>
+                                        </td>
+                                    )}
+                                    <td className={styles.td}>{record.reportingYear}</td>
+                                    <td className={styles.td}>
+                                        <span className={styles['type-chip']}>
+                                            {PROGRAM_EXPENSES_TEXT.TABLE.TYPE_LABEL}
+                                        </span>
                                     </td>
-                                )}
-                            </tr>
-                        ))
-                    )}
-                </tbody>
-            </table>
+                                    <td className={styles.td}>{record.programName}</td>
+                                    <td className={styles.td}>{formatSummaryAmount(parseAmount(record.amountUah))}</td>
+                                    <td className={styles.td}>{formatSummaryAmount(parseAmount(record.amountUsd))}</td>
+                                    {isEditing && (
+                                        <td className={cn(styles.td, styles['actions-td'])}>
+                                            <div className={styles['row-actions']}>
+                                                <IconButton
+                                                    type="button"
+                                                    className={cn(styles['icon-button'], styles['edit-icon-button'])}
+                                                    aria-label={`Edit record ${record.id}`}
+                                                    onClick={() => onEditRecord?.(record)}
+                                                    DefaultIcon={ACTION_ICONS.edit.default}
+                                                    FilledIcon={ACTION_ICONS.edit.hover}
+                                                />
+                                                <IconButton
+                                                    type="button"
+                                                    className={cn(styles['icon-button'], styles['delete-icon-button'])}
+                                                    aria-label={`Delete record ${record.id}`}
+                                                    onClick={() => onDeleteRecord?.(record)}
+                                                    DefaultIcon={ACTION_ICONS.delete.default}
+                                                    FilledIcon={ACTION_ICONS.delete.hover}
+                                                />
+                                            </div>
+                                        </td>
+                                    )}
+                                </tr>
+                            ))
+                        )}
+                    </tbody>
+                </table>
+            </div>
         </div>
     );
 };

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.tsx
@@ -10,7 +10,7 @@ import { Button } from '@/components/admin/button/Button';
 import cn from 'classnames';
 import styles from './ProgramExpensesTable.module.scss';
 
-interface ProgramExpensesTableProps {
+export interface ProgramExpensesTableProps {
     records: ProgramExpensesRecord[];
     hasAnyProgramExpenseRecords: boolean;
     isEditing?: boolean;


### PR DESCRIPTION
## Github Ticket
* [#1836](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1836)

## Description
Add bulk deletion UI for the **Програмні витрати** tab in the admin reports page. This PR mirrors the existing bulk deletion pattern from the **Доходи та витрати** (Funds Expenditures) tab and applies it to Program Expenses.

## How it looks
<img width="1277" height="367" alt="image" src="https://github.com/user-attachments/assets/ab2c8d76-18f5-4262-8e79-237f9b4473ed" />

## Summary of change
- `src/const/admin/reports.ts` — added `BULK` constants block to `PROGRAM_EXPENSES_TEXT`
- `ProgramExpensesTable.tsx` — moved selected records state out of the table into the parent section, added selection-row bar with selected count label and delete button, added new props: `selectedRecordIds`, `onToggleRecordSelection`, `onSelectAllToggle`, `onOpenBulkDelete`
- `ProgramExpensesSection.tsx` — added states (`selectedRecordIds`, `isBulkDeleteModalOpen`, `isBulkDeleting`), selection and bulk delete handlers, bulk delete confirmation modal, data and totals refetch after successful deletion
- `ProgramExpensesTable.module.scss` — added styles for `table-container`, `selection-row`, `selection-row-hidden`, `selection-pill`, `selection-actions`, `delete-selected-button`

## How to recreate changes
1. Go to Admin Panel, Reports, **Програмні витрати** tab
2. Enter edit mode
3. Select one or more records using checkboxes
4. Verify the selection bar appears with the counter "Вибрано X з Y" and the "Видалити вибрані" button
5. Click "Видалити вибрані" confirmation modal should appear
6. Confirm deletion records are deleted, totals card recalculates, success toast appears
7. Repeat and click "Ні" in the modal, records are not deleted, selection is cleared

## CHECK LIST
- [x] New tests was added or existing was modified
- [ ] Changes has severe impact on users
- [ ] Changes has medium impact on users
- [x] Changes has light impact on users
- [x] Test coverage was updated
- [x] PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-select checkboxes for program expense records
  * Selection counter displays the number of selected items
  * Bulk delete button appears when records are selected
  * Confirmation modal prevents accidental bulk deletion
  * Success and error notifications provide operation feedback
  * Select all functionality for quick bulk selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->