### PR TITLE
Fix/issue 2486 [Team] Pop-up "Hе забудьте налаштувати порядок відображення члена команди на сайті" is not displayed when a new team member is published

### DIFF
--- a/src/const/admin/team.ts
+++ b/src/const/admin/team.ts
@@ -11,7 +11,7 @@ export const TEAM_MEMBERS_TEXT = {
     MESSAGE: {
         FAIL_TO_FETCH_MEMBERS: 'Виникла помилка, не вдалось завантажити учасників команди',
         FAIL_TO_REORDER_MEMBERS: 'Виникла помилка, не вдалось змінити пріоритет учасників команди',
-        DONT_FORGET_TO_ORDER: 'Не забудь встановити порядок відображення',
+        DONT_FORGET_TO_ORDER: 'Не забудьте налаштувати порядок відображення члена команди на сайті',
     },
 
     QUESTION: {

--- a/src/pages/admin/team/components/team-page-content/TeamPageContent.test.tsx
+++ b/src/pages/admin/team/components/team-page-content/TeamPageContent.test.tsx
@@ -305,6 +305,40 @@ jest.mock('../team-page-modals/TeamPageModals', () => ({
                 Simulate Edit Member
             </button>
             <button
+                data-testid="simulate-edit-draft-to-published"
+                onClick={() => {
+                    const updatedMember = {
+                        id: 2,
+                        fullName: 'Jane Smith Published',
+                        description: 'Updated description.',
+                        status: 1,
+                        categoryId: 1,
+                        image: null,
+                        localizations: [],
+                    };
+                    onEditTeamMember(updatedMember);
+                }}
+            >
+                Simulate Edit Draft To Published
+            </button>
+            <button
+                data-testid="simulate-edit-published-to-published"
+                onClick={() => {
+                    const updatedMember = {
+                        id: 1,
+                        fullName: 'John Doe Updated',
+                        description: 'Updated description.',
+                        status: 1,
+                        categoryId: 1,
+                        image: null,
+                        localizations: [],
+                    };
+                    onEditTeamMember(updatedMember);
+                }}
+            >
+                Simulate Edit Published To Published
+            </button>
+            <button
                 data-testid="simulate-translate-member"
                 onClick={() => {
                     const translatedMember = {
@@ -1232,6 +1266,44 @@ describe('TeamPageContent', () => {
                 // Test delete member
                 fireEvent.click(screen.getByTestId('simulate-delete-member'));
                 expect(mockCloseModalActions.closeDeleteItemModal).toHaveBeenCalled();
+            });
+
+            it('shows DONT_FORGET_TO_ORDER toast when editing a Draft member and publishing it', async () => {
+                // Simulate the member being edited was previously a Draft
+                mockModalState.itemToEdit = mockMembers[1]; // status: Draft
+
+                render(<TeamPageContent />);
+
+                await waitFor(() => {
+                    expect(screen.getByTestId('simulate-edit-draft-to-published')).toBeInTheDocument();
+                });
+
+                fireEvent.click(screen.getByTestId('simulate-edit-draft-to-published'));
+
+                expect(mockAddToast).toHaveBeenCalledWith(
+                    TEAM_MEMBERS_TEXT.MESSAGE.DONT_FORGET_TO_ORDER,
+                    ToastType.Info,
+                );
+                expect(mockCloseModalActions.closeEditItemModal).toHaveBeenCalled();
+            });
+
+            it('does NOT show DONT_FORGET_TO_ORDER toast when re-saving an already Published member', async () => {
+                // Simulate the member being edited was already Published
+                mockModalState.itemToEdit = mockMembers[0]; // status: Published
+
+                render(<TeamPageContent />);
+
+                await waitFor(() => {
+                    expect(screen.getByTestId('simulate-edit-published-to-published')).toBeInTheDocument();
+                });
+
+                fireEvent.click(screen.getByTestId('simulate-edit-published-to-published'));
+
+                expect(mockAddToast).not.toHaveBeenCalledWith(
+                    TEAM_MEMBERS_TEXT.MESSAGE.DONT_FORGET_TO_ORDER,
+                    ToastType.Info,
+                );
+                expect(mockCloseModalActions.closeEditItemModal).toHaveBeenCalled();
             });
 
             it('handles category operations through modals', async () => {

--- a/src/pages/admin/team/components/team-page-content/TeamPageContent.tsx
+++ b/src/pages/admin/team/components/team-page-content/TeamPageContent.tsx
@@ -48,7 +48,7 @@ export const TeamPageContent = () => {
     const [statusFilter, setStatusFilter] = useState<VisibilityStatus | undefined>();
     const [error, setError] = useState<ErrorState>({ message: null, type: null });
     const modalsStateControl = useModalsState<TeamMember>();
-    const { isAnyModalOpened, openModalActions, closeModalActions } = modalsStateControl;
+    const { isAnyModalOpened, openModalActions, closeModalActions, modalState } = modalsStateControl;
 
     const [selectedSearchMember, setSelectedSearchMember] = useState<TeamMember | null>(null);
 
@@ -433,20 +433,28 @@ export const TeamPageContent = () => {
             if (mappedMember.image && 'url' in mappedMember.image)
                 mappedMember.image.url = `${mappedMember.image.url}?cb=${Date.now()}`;
 
+            const isPublishingForFirstTime =
+                mappedMember.status === VisibilityStatus.Published &&
+                modalState.itemToEdit?.status !== VisibilityStatus.Published;
+
+            if (isPublishingForFirstTime) {
+                addToast(TEAM_MEMBERS_TEXT.MESSAGE.DONT_FORGET_TO_ORDER, ToastType.Info);
+            }
+
             setMembers((prevMembers) =>
                 prevMembers.map((member) => (member.id === mappedMember.id ? mappedMember : member)),
             );
 
-            if (mappedMember.categoryId !== selectedCategory!.id) {
+            if (selectedCategory && mappedMember.categoryId !== selectedCategory.id) {
                 setMembers((prev) => prev.filter((m) => m.id !== mappedMember.id));
                 setCategories((prevCategories) =>
-                    updateCategoryMemberCounts(prevCategories, selectedCategory!.id, mappedMember),
+                    updateCategoryMemberCounts(prevCategories, selectedCategory.id, mappedMember),
                 );
             }
 
             closeModalActions.closeEditItemModal();
         },
-        [closeModalActions, selectedCategory],
+        [closeModalActions, selectedCategory, addToast, modalState.itemToEdit],
     );
 
     const handleDeleteMember = useCallback(


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2486)

## Description

Fixes a bug where the warning pop-up (toast message) advising the administrator to configure the team member's display order on the website was not shown when updating a team member's status from Draft to Published. This PR ensures the info toast appears only on the initial transition from Draft to Published during a profile edit, keeping state update flows pure and avoiding side-effects inside state updater functions. Additionally, it corrects the Ukrainian translation text of this toast message to align with the expected specification and refactors a non-null category selection check.

## How it looks


https://github.com/user-attachments/assets/171ea5b2-eb9d-450c-a7e9-fa2341a559e9


## Summary of change

*   **`TeamPageContent.tsx`**: Added logic to trigger an info toast when a team member's status changes from **Draft** to **Published**. Refactored `modalState` destructuring to keep setter functions pure and replaced a non-null assertion with safe conditional logic (`if (selectedCategory && ...)`).
*   **`team.ts`**: Corrected the `DONT_FORGET_TO_ORDER` message in `TEAM_MEMBERS_TEXT.MESSAGE`.
*   **`TeamPageContent.test.tsx`**: Extended mocked modals to simulate status transitions and added tests to verify the toast appears *only* when transitioning from Draft to Published.

## How to recreate changes

1. Navigate to the Admin Panel -> **Team** page.
2. Click **Edit** on a team member currently in **Draft** status.
3. Click **"Опублікувати"** (Publish) and accept the confirmation modal.
4. Verify the following toast notification appears: *"Не забудьте налаштувати порядок відображення члена команди на сайті"*.
5. Click **Edit** on an already **Published** team member. 
6. Confirm an edit and verify that the toast notification does **not** appear.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an informational notification displayed when a team member is published for the first time, guiding users through the ordering setup process.

* **Tests**
  * Added test coverage to verify notification behavior in team member publishing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->