### PR TITLE
Fixed frontend for current API

### DIFF
--- a/src/const/common/api-routes/main-api.ts
+++ b/src/const/common/api-routes/main-api.ts
@@ -112,6 +112,7 @@ export const API_ROUTES = {
     },
     PDF_REPORTS: {
         BASE: 'PdfReports',
+        BY_LANGUAGE_ID: 'PdfReports/languageId',
     },
     FAQ_LOCALIZATIONS: {
         BASE: 'FaqQuestionLocalizations',

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
@@ -136,9 +136,9 @@ describe('PdfFilesSection', () => {
         (useAdminClient as jest.Mock).mockReturnValue(mockClient);
         (useToast as jest.Mock).mockReturnValue({ addToast: mockAddToast });
         const { useLocalizationToolkit } = require('@/hooks/admin/use-localization-toolkit/useLocalizationToolkit');
-        (useLocalizationToolkit as jest.Mock).mockReturnValue({ translationLanguages: [] });
+        (useLocalizationToolkit as jest.Mock).mockReturnValue({ translationLanguages: [], allLanguages: [{ id: 1, code: 'uk', name: 'Ukrainian' }, { id: 2, code: 'en', name: 'English' }] });
         mockCreateObjectURL.mockReturnValue('blob:http://localhost/mock-blob-url');
-        (useLocalizationToolkit as jest.Mock).mockReturnValue({ translationLanguages: [] });
+        (useLocalizationToolkit as jest.Mock).mockReturnValue({ translationLanguages: [], allLanguages: [{ id: 1, code: 'uk', name: 'Ukrainian' }, { id: 2, code: 'en', name: 'English' }] });
     });
 
     afterEach(() => {
@@ -190,7 +190,7 @@ describe('PdfFilesSection', () => {
         (PdfReportsApi.getAll as jest.Mock).mockResolvedValueOnce(mockFilesResponse);
         const filesResult = await capturedFetchFiles();
 
-        expect(PdfReportsApi.getAll).toHaveBeenCalledWith(mockClient, { offset: 0, limit: 1000 });
+        expect(PdfReportsApi.getAll).toHaveBeenCalledWith(mockClient, { offset: 0, limit: 1000, languageId: 1 });
         expect(filesResult).toEqual(mockFilesResponse.items);
     });
 

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
@@ -136,9 +136,14 @@ describe('PdfFilesSection', () => {
         (useAdminClient as jest.Mock).mockReturnValue(mockClient);
         (useToast as jest.Mock).mockReturnValue({ addToast: mockAddToast });
         const { useLocalizationToolkit } = require('@/hooks/admin/use-localization-toolkit/useLocalizationToolkit');
-        (useLocalizationToolkit as jest.Mock).mockReturnValue({ translationLanguages: [], allLanguages: [{ id: 1, code: 'uk', name: 'Ukrainian' }, { id: 2, code: 'en', name: 'English' }] });
+        (useLocalizationToolkit as jest.Mock).mockReturnValue({
+            translationLanguages: [],
+            allLanguages: [
+                { id: 1, code: 'uk', name: 'Ukrainian' },
+                { id: 2, code: 'en', name: 'English' },
+            ],
+        });
         mockCreateObjectURL.mockReturnValue('blob:http://localhost/mock-blob-url');
-        (useLocalizationToolkit as jest.Mock).mockReturnValue({ translationLanguages: [], allLanguages: [{ id: 1, code: 'uk', name: 'Ukrainian' }, { id: 2, code: 'en', name: 'English' }] });
     });
 
     afterEach(() => {

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
@@ -28,7 +28,7 @@ export const PdfFilesSection = () => {
     const [isRenaming, setIsRenaming] = useState(false);
     const [isTranslateModalOpen, setIsTranslateModalOpen] = useState(false);
 
-    const { translationLanguages } = useLocalizationToolkit({
+    const { translationLanguages, allLanguages } = useLocalizationToolkit({
         setErrorState: useCallback(
             (message: string) => {
                 addToast(message, ToastType.Error);
@@ -37,14 +37,17 @@ export const PdfFilesSection = () => {
         ),
     });
 
+    const activeLanguageId = allLanguages.find((l) => l.code === currentLanguage)?.id;
+
     const fetchSection = useCallback(async () => {
         return PdfSectionApi.getPdfSection(client);
     }, [client]);
 
     const fetchFiles = useCallback(async () => {
-        const data = await PdfReportsApi.getAll(client, { offset: 0, limit: 1000 });
+        if (!activeLanguageId) return [];
+        const data = await PdfReportsApi.getAll(client, { offset: 0, limit: 1000, languageId: activeLanguageId });
         return data.items;
-    }, [client]);
+    }, [client, activeLanguageId]);
 
     const {
         data: sectionData,
@@ -147,7 +150,7 @@ export const PdfFilesSection = () => {
         [client, addToast, refetchFiles],
     );
 
-    if (isSectionLoading || isFilesLoading) {
+    if (isSectionLoading || isFilesLoading || !activeLanguageId) {
         return (
             <div className={styles.loader}>
                 <InlineLoader size={3} />
@@ -172,7 +175,7 @@ export const PdfFilesSection = () => {
             <div className={styles['language-switcher-container']}>
                 <LanguageSwitcherButtons currentLanguage={currentLanguage} onLanguageChange={setCurrentLanguage} />
             </div>
-            <PdfDropzone onUploaded={handleUploaded} />
+            <PdfDropzone onUploaded={handleUploaded} languageId={activeLanguageId} />
             <PdfFilesTable
                 files={mergedDedupedFiles}
                 onViewFile={handleViewFile}

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-dropzone/PdfDropzone.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-dropzone/PdfDropzone.test.tsx
@@ -22,7 +22,7 @@ describe('PdfDropzone', () => {
     let mockOnUploaded: jest.Mock;
 
     const setup = () => {
-        const utils = render(<PdfDropzone onUploaded={mockOnUploaded} />);
+        const utils = render(<PdfDropzone onUploaded={mockOnUploaded} languageId={1} />);
         const input = utils.container.querySelector('input[type="file"]') as HTMLInputElement;
 
         return {
@@ -84,7 +84,7 @@ describe('PdfDropzone', () => {
         uploadFile(input, mockFile);
 
         await waitFor(() => {
-            expect(PdfReportsApi.create).toHaveBeenCalledWith(mockClient, mockFile);
+            expect(PdfReportsApi.create).toHaveBeenCalledWith(mockClient, mockFile, 1);
         });
     });
 
@@ -95,7 +95,7 @@ describe('PdfDropzone', () => {
         dropFile(mockFile);
 
         await waitFor(() => {
-            expect(PdfReportsApi.create).toHaveBeenCalledWith(mockClient, mockFile);
+            expect(PdfReportsApi.create).toHaveBeenCalledWith(mockClient, mockFile, 1);
         });
     });
 

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-dropzone/PdfDropzone.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-dropzone/PdfDropzone.tsx
@@ -9,6 +9,7 @@ import { PDF_FILES_SECTION_TEXT, PDF_FILES_SECTION_VALIDATION } from '@/const/ad
 
 interface PdfDropzoneProps {
     onUploaded: (file: PdfReportDto) => void;
+    languageId: number;
 }
 
 const extractErrorMessage = (error: unknown): string => {
@@ -27,7 +28,7 @@ const extractErrorMessage = (error: unknown): string => {
     return PDF_FILES_SECTION_TEXT.DROPZONE.ERROR_UPLOAD_FAILED;
 };
 
-export const PdfDropzone = ({ onUploaded }: PdfDropzoneProps) => {
+export const PdfDropzone = ({ onUploaded, languageId }: PdfDropzoneProps) => {
     const client = useAdminClient();
     const [isDragging, setIsDragging] = useState(false);
     const [isUploading, setIsUploading] = useState(false);
@@ -50,7 +51,7 @@ export const PdfDropzone = ({ onUploaded }: PdfDropzoneProps) => {
             setError(null);
             setIsUploading(true);
             try {
-                const result = await PdfReportsApi.create(client, file);
+                const result = await PdfReportsApi.create(client, file, languageId);
                 onUploaded(result);
             } catch (err) {
                 const errorMessage = extractErrorMessage(err);

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-dropzone/PdfDropzone.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-dropzone/PdfDropzone.tsx
@@ -61,7 +61,7 @@ export const PdfDropzone = ({ onUploaded, languageId }: PdfDropzoneProps) => {
                 setIsUploading(false);
             }
         },
-        [client, onUploaded],
+        [client, onUploaded, languageId],
     );
 
     const handleDrop = useCallback(

--- a/src/pages/public/reports-page/components/reports-section/ReportsSection.test.tsx
+++ b/src/pages/public/reports-page/components/reports-section/ReportsSection.test.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ReportsSection } from './ReportsSection';
+import { PdfReportsApi } from '@/services/api/admin/reports/pdf-reports/pdf-reports-api';
+import { localizationLanguagesDataFetch } from '@/services/api/public/localization/languages/languages-api';
 
 jest.mock('./ReportsSection.module.scss', () => ({
     root: 'root-class',
@@ -14,54 +15,76 @@ jest.mock('./ReportsSection.module.scss', () => ({
 
 jest.mock('react-i18next', () => ({
     useTranslation: () => ({
-        t: (key: string, options?: { year?: number }) => (options?.year ? `${key}:${options.year}` : key),
+        t: (key: string) => key,
     }),
+}));
+
+jest.mock('@/hooks/common/use-locale/useLocale', () => ({
+    useLocale: () => ({ currentLanguage: 'uk' }),
+}));
+
+jest.mock('@/services/api/public/localization/languages/languages-api', () => ({
+    localizationLanguagesDataFetch: jest.fn(),
+}));
+
+jest.mock('@/services/api/admin/reports/pdf-reports/pdf-reports-api', () => ({
+    PdfReportsApi: {
+        getAllByLanguageId: jest.fn(),
+        getPublicFileUrl: (id: number) => `/api/PdfReports/${id}/file`,
+    },
 }));
 
 jest.mock('./report-item', () => ({
     ReportItem: ({ label }: any) => <div data-testid="report-item-mock">{label}</div>,
 }));
 
-const mockReportsData: Array<{ year: number; fileUrl: string }> = [];
-
-jest.mock('@/utils/mock-data/public/reports-page', () => ({
-    get REPORTS_DATA() {
-        return mockReportsData;
-    },
-}));
+const makeReport = (id: number) => ({
+    id,
+    name: `Звіт ${id}.pdf`,
+    blobName: `blob-${id}`,
+    fileSizeBytes: 1024,
+    createdAt: '2024-01-01',
+    priority: id,
+});
 
 describe('ReportsSection', () => {
     beforeEach(() => {
-        mockReportsData.length = 0;
+        jest.clearAllMocks();
+        (localizationLanguagesDataFetch as jest.Mock).mockResolvedValue([{ id: 1, code: 'uk', name: 'Ukrainian' }]);
     });
 
     describe('without overflow (<= 2 items)', () => {
-        it('renders all items and no toggle button', () => {
-            mockReportsData.push({ year: 2024, fileUrl: 'r1.pdf' }, { year: 2023, fileUrl: 'r2.pdf' });
+        it('renders all items and no toggle button', async () => {
+            (PdfReportsApi.getAllByLanguageId as jest.Mock).mockResolvedValueOnce({
+                items: [makeReport(1), makeReport(2)],
+                total: 2,
+            });
 
             render(<ReportsSection />);
 
-            expect(screen.getAllByTestId('report-item-mock')).toHaveLength(2);
+            await waitFor(() => {
+                expect(screen.getAllByTestId('report-item-mock')).toHaveLength(2);
+            });
             expect(screen.queryByText('reports.showMore')).not.toBeInTheDocument();
         });
     });
 
     describe('with overflow (> 2 items)', () => {
+        const manyReports = [1, 2, 3, 4, 5, 6].map(makeReport);
+
         beforeEach(() => {
-            mockReportsData.push(
-                { year: 2025, fileUrl: 'r1.pdf' },
-                { year: 2024, fileUrl: 'r2.pdf' },
-                { year: 2023, fileUrl: 'r3.pdf' },
-                { year: 2022, fileUrl: 'r4.pdf' },
-                { year: 2021, fileUrl: 'r5.pdf' },
-                { year: 2020, fileUrl: 'r6.pdf' },
-            );
+            (PdfReportsApi.getAllByLanguageId as jest.Mock).mockResolvedValue({
+                items: manyReports,
+                total: manyReports.length,
+            });
         });
 
-        it('renders only first 2 items initially and shows toggle button', () => {
+        it('renders only first 2 items initially and shows toggle button', async () => {
             render(<ReportsSection />);
 
-            expect(screen.getAllByTestId('report-item-mock')).toHaveLength(2);
+            await waitFor(() => {
+                expect(screen.getAllByTestId('report-item-mock')).toHaveLength(2);
+            });
             expect(screen.getByText('reports.showMore')).toBeInTheDocument();
         });
 
@@ -69,14 +92,15 @@ describe('ReportsSection', () => {
             const user = userEvent.setup();
             render(<ReportsSection />);
 
-            const toggleButton = screen.getByText('reports.showMore');
-            await user.click(toggleButton);
+            await waitFor(() => {
+                expect(screen.getByText('reports.showMore')).toBeInTheDocument();
+            });
 
+            await user.click(screen.getByText('reports.showMore'));
             expect(screen.getAllByTestId('report-item-mock')).toHaveLength(6);
             expect(screen.getByText('reports.showLess')).toBeInTheDocument();
 
             await user.click(screen.getByText('reports.showLess'));
-
             expect(screen.getAllByTestId('report-item-mock')).toHaveLength(2);
             expect(screen.getByText('reports.showMore')).toBeInTheDocument();
         });

--- a/src/pages/public/reports-page/components/reports-section/ReportsSection.tsx
+++ b/src/pages/public/reports-page/components/reports-section/ReportsSection.tsx
@@ -1,22 +1,41 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { REPORTS_DATA } from '@/utils/mock-data/public/reports-page';
 import { ReportItem } from './report-item';
 import { Button } from '@/components/public/ui/button';
+import { useLocale } from '@/hooks/common/use-locale/useLocale';
+import { localizationLanguagesDataFetch } from '@/services/api/public/localization/languages/languages-api';
+import { PdfReportsApi } from '@/services/api/admin/reports/pdf-reports/pdf-reports-api';
+import { PdfReportDto } from '@/types/admin/pdf-section';
 import styles from './ReportsSection.module.scss';
 
 const INITIAL_VISIBLE_COUNT = 2;
 
 export const ReportsSection = () => {
     const { t } = useTranslation('reportsPage');
+    const { currentLanguage } = useLocale();
     const [isExpanded, setIsExpanded] = useState(false);
+    const [reports, setReports] = useState<PdfReportDto[]>([]);
 
-    const hasOverflow = REPORTS_DATA.length > INITIAL_VISIBLE_COUNT;
-    const visibleReports = hasOverflow && !isExpanded ? REPORTS_DATA.slice(0, INITIAL_VISIBLE_COUNT) : REPORTS_DATA;
+    useEffect(() => {
+        let mounted = true;
+        const fetchReports = async () => {
+            try {
+                const languages = await localizationLanguagesDataFetch();
+                const langCode = currentLanguage?.startsWith('en') ? 'en' : 'uk';
+                const language = languages.find((l) => l.code === langCode);
+                if (!language || !mounted) return;
+                const result = await PdfReportsApi.getAllByLanguageId(language.id, { offset: 0, limit: 1000 });
+                if (mounted) setReports(result.items);
+            } catch {}
+        };
+        fetchReports();
+        return () => {
+            mounted = false;
+        };
+    }, [currentLanguage]);
 
-    const handleToggle = () => {
-        setIsExpanded((prev) => !prev);
-    };
+    const hasOverflow = reports.length > INITIAL_VISIBLE_COUNT;
+    const visibleReports = hasOverflow && !isExpanded ? reports.slice(0, INITIAL_VISIBLE_COUNT) : reports;
 
     return (
         <section className={styles.root}>
@@ -26,18 +45,18 @@ export const ReportsSection = () => {
             </div>
 
             <div className={styles.list}>
-                {visibleReports.map(({ year, fileUrl }) => (
+                {visibleReports.map((report) => (
                     <ReportItem
-                        key={year}
-                        fileUrl={fileUrl}
-                        label={t('reports.itemLabel', { year })}
+                        key={report.id}
+                        fileUrl={PdfReportsApi.getPublicFileUrl(report.id)}
+                        label={report.name.replace(/\.pdf$/i, '')}
                         buttonLabel={t('actions.downloadPdf')}
                     />
                 ))}
 
                 {hasOverflow && (
                     <div className={styles.toggle}>
-                        <Button variant="primary-dark" onClick={handleToggle}>
+                        <Button variant="primary-dark" onClick={() => setIsExpanded((prev) => !prev)}>
                             {isExpanded ? t('reports.showLess') : t('reports.showMore')}
                         </Button>
                     </div>

--- a/src/services/api/admin/reports/pdf-reports/pdf-reports-api.test.ts
+++ b/src/services/api/admin/reports/pdf-reports/pdf-reports-api.test.ts
@@ -161,7 +161,7 @@ describe('PdfReportsApi', () => {
             const createdReport = mockPdfReports[0];
             mockClient.post = jest.fn().mockResolvedValueOnce({ data: createdReport });
 
-            const result = await PdfReportsApi.create(mockClient, mockFile);
+            const result = await PdfReportsApi.create(mockClient, mockFile, 1);
 
             expect(mockClient.post).toHaveBeenCalledWith(API_ROUTES.PDF_REPORTS.BASE, expect.any(FormData), {
                 headers: { 'Content-Type': 'multipart/form-data' },
@@ -173,17 +173,17 @@ describe('PdfReportsApi', () => {
             const mockFile = new File(['content'], 'test.pdf', { type: 'application/pdf' });
             mockClient.post = jest.fn().mockResolvedValueOnce({ data: mockPdfReports[0] });
 
-            await PdfReportsApi.create(mockClient, mockFile);
+            await PdfReportsApi.create(mockClient, mockFile, 1);
 
             const formData = (mockClient.post as jest.Mock).mock.calls[0][1] as FormData;
-            expect(formData.get('file')).toEqual(mockFile);
+            expect(formData.get('File')).toEqual(mockFile);
         });
 
         it('should return created dto', async () => {
             const mockFile = new File(['content'], 'test.pdf', { type: 'application/pdf' });
             mockClient.post = jest.fn().mockResolvedValueOnce({ data: mockPdfReports[0] });
 
-            const result = await PdfReportsApi.create(mockClient, mockFile);
+            const result = await PdfReportsApi.create(mockClient, mockFile, 1);
 
             expect(result.id).toBe(mockPdfReports[0].id);
             expect(result.name).toBe(mockPdfReports[0].name);
@@ -193,7 +193,7 @@ describe('PdfReportsApi', () => {
             const mockFile = new File(['content'], 'test.pdf', { type: 'application/pdf' });
             mockClient.post = jest.fn().mockRejectedValueOnce(new Error('Upload failed'));
 
-            await expect(PdfReportsApi.create(mockClient, mockFile)).rejects.toThrow('Upload failed');
+            await expect(PdfReportsApi.create(mockClient, mockFile, 1)).rejects.toThrow('Upload failed');
         });
     });
 

--- a/src/services/api/admin/reports/pdf-reports/pdf-reports-api.ts
+++ b/src/services/api/admin/reports/pdf-reports/pdf-reports-api.ts
@@ -2,11 +2,13 @@ import { AxiosInstance } from 'axios';
 import { PdfReportDto } from '@/types/admin/pdf-section';
 import { API_ROUTES } from '@/const/common/api-routes/main-api';
 import { PaginationResult } from '@/types/admin/common';
+import { axiosInstance } from '@/services/api/axios';
 
 export const PdfReportsApi = {
-    create: async (client: AxiosInstance, file: File): Promise<PdfReportDto> => {
+    create: async (client: AxiosInstance, file: File, languageId: number): Promise<PdfReportDto> => {
         const formData = new FormData();
-        formData.append('file', file);
+        formData.append('File', file);
+        formData.append('LanguageId', String(languageId));
 
         const response = await client.post<PdfReportDto>(API_ROUTES.PDF_REPORTS.BASE, formData, {
             headers: { 'Content-Type': 'multipart/form-data' },
@@ -27,7 +29,7 @@ export const PdfReportsApi = {
 
     getAll: async (
         client: AxiosInstance,
-        filter: { offset: number; limit: number },
+        filter: { offset: number; limit: number; languageId?: number },
     ): Promise<PaginationResult<PdfReportDto>> => {
         const response = await client.get<PaginationResult<PdfReportDto>>(API_ROUTES.PDF_REPORTS.BASE, {
             params: filter,
@@ -40,5 +42,20 @@ export const PdfReportsApi = {
             responseType: 'blob',
         });
         return response.data;
+    },
+
+    getAllByLanguageId: async (
+        languageId: number,
+        filter: { offset: number; limit: number },
+    ): Promise<PaginationResult<PdfReportDto>> => {
+        const response = await axiosInstance.get<PaginationResult<PdfReportDto>>(
+            `${API_ROUTES.PDF_REPORTS.BY_LANGUAGE_ID}/${languageId}`,
+            { params: filter },
+        );
+        return response.data;
+    },
+
+    getPublicFileUrl: (id: number): string => {
+        return `${API_ROUTES.BASE}/${API_ROUTES.PDF_REPORTS.BASE}/${id}/file`;
     },
 };

--- a/src/types/admin/pdf-section.ts
+++ b/src/types/admin/pdf-section.ts
@@ -30,4 +30,6 @@ export interface PdfReportDto {
     fileSizeBytes: number;
     createdAt: string;
     priority: number;
+    languageId?: number;
+    languageCode?: string;
 }


### PR DESCRIPTION
## GitHub

* [GitHub ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1399)
* 
## Description
-Update the frontend to work with the new PDF Reports API that requires LanguageId for upload and supports ----filtering by language. Wire up the public Reports page to fetch real data instead of mocks.

## Summary of change
-Added LanguageId to POST /api/PdfReports multipart form
-Added ?LanguageId= filter to GET /api/PdfReports based on active EN/UK tab in admin
-Added getAllByLanguageId for GET /api/PdfReports/languageId/{id} and getPublicFileUrl for GET /api/PdfReports/{id}/file
-Admin panel now resolves language ID from LocalizationLanguage API and re-fetches file list on tab switch
-Public Reports page replaced mock data with real API filtered by current site language
-Updated all affected tests

## How to recreate changes
Go to Admin Panel → Reports → PDF-файли
Switch between EN and UK tabs — each should show only files for that language
Upload a PDF on the EN tab — it should be saved with the English LanguageId
Open the public /reports page — PDFs should load from the API filtered by current site language (UA/EN)

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added language-specific PDF report management, so uploaded PDF files are stored and organized by the selected language.
  * PDF report retrieval now supports filtering by language for more targeted results.
  * Added public file URL generation to make PDFs easier to access and share.
* **Bug Fixes**
  * Improved PDF files loading behavior to avoid errors when no active language is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->