### PR TITLE
Fix/issue-2595 [Programs] Partial search by program name does not work for substrings within the title

### DIFF
--- a/src/services/api/admin/programs/programs-api.test.ts
+++ b/src/services/api/admin/programs/programs-api.test.ts
@@ -902,7 +902,7 @@ describe('fetchProgramSearchItems', () => {
 
         mockClient.get.mockResolvedValueOnce({
             data: {
-                items: [...mockPrograms, programWithNameMatch, programWithCategoryMatch],
+                items: [...mockPrograms, programWithCategoryMatch, programWithNameMatch],
                 totalItemsCount: 5,
             },
         });
@@ -917,6 +917,30 @@ describe('fetchProgramSearchItems', () => {
         expect(nameMatchIndex).toBeGreaterThan(-1);
         expect(categoryMatchIndex).toBeGreaterThan(-1);
         expect(nameMatchIndex).toBeLessThan(categoryMatchIndex);
+    });
+
+    it('correctly sorts matches: starts with > includes > alphabetical', async () => {
+        const searchTerm = 'program';
+        const items: HippotherapyProgramDto[] = [
+            { id: 1, name: 'ZZZ program', categories: [] } as any,
+            { id: 2, name: 'program AAA', categories: [] } as any,
+            { id: 3, name: 'AAA program', categories: [] } as any,
+            { id: 4, name: 'program ZZZ', categories: [] } as any,
+        ];
+
+        mockClient.get.mockResolvedValueOnce({
+            data: { items, totalItemsCount: 4 },
+        });
+
+        const result = await ProgramsApi.fetchProgramSearchItems(mockClient, searchTerm, 0, 10);
+        const names = result.items.map((i) => i.name);
+
+        // Expected:
+        // 1. program AAA (starts with, alphabetical)
+        // 2. program ZZZ (starts with, alphabetical)
+        // 3. AAA program (includes, alphabetical)
+        // 4. ZZZ program (includes, alphabetical)
+        expect(names).toEqual(['program AAA', 'program ZZZ', 'AAA program', 'ZZZ program']);
     });
 
     it('handles pagination', async () => {
@@ -1042,7 +1066,7 @@ describe('fetchProgramSearchItems', () => {
         const result = await ProgramsApi.fetchProgramSearchItems(mockClient, searchTerm, 2, 7, signal);
 
         expect(mockClient.get).toHaveBeenCalledWith(`${API_ROUTES.PROGRAMS.SEARCH}`, {
-            params: { SearchQuery: searchTerm, offset: 2, limit: 7 },
+            params: { searchQuery: searchTerm, offset: 2, limit: 7 },
             signal,
         });
 

--- a/src/services/api/admin/programs/programs-api.ts
+++ b/src/services/api/admin/programs/programs-api.ts
@@ -114,7 +114,7 @@ export const ProgramsApi = {
     ): Promise<PaginationResult<ProgramSearchItemData>> => {
         const response = await client.get<PaginationResult<HippotherapyProgramDto>>(`${API_ROUTES.PROGRAMS.SEARCH}`, {
             params: {
-                SearchQuery: searchTerm,
+                searchQuery: searchTerm,
                 offset: offset,
                 limit: limit,
             },
@@ -122,6 +122,26 @@ export const ProgramsApi = {
         });
 
         const suggestions = response.data.items.map(convertProgramToSuggestion);
+
+        const lowerSearchTerm = searchTerm.toLowerCase();
+        suggestions.sort((a, b) => {
+            const aName = a.name.toLowerCase();
+            const bName = b.name.toLowerCase();
+
+            const aStartsWith = aName.startsWith(lowerSearchTerm);
+            const bStartsWith = bName.startsWith(lowerSearchTerm);
+
+            if (aStartsWith && !bStartsWith) return -1;
+            if (!aStartsWith && bStartsWith) return 1;
+
+            const aIncludes = aName.includes(lowerSearchTerm);
+            const bIncludes = bName.includes(lowerSearchTerm);
+
+            if (aIncludes && !bIncludes) return -1;
+            if (!aIncludes && bIncludes) return 1;
+
+            return aName.localeCompare(bName);
+        });
 
         return {
             items: suggestions,


### PR DESCRIPTION
## Github ticket

* [ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2595)

## Description

 This PR fixes a bug in the Programs search functionality where partial matches (substrings) within the program title
  were not returning results. This was primarily caused by an inconsistent API parameter name and a lack of explicit
  client-side prioritization for substring matches.

## How it looks

 - Searching for "лікують" now correctly displays "Коні лікують".
 - Searching for "програ" now correctly displays "Сімейна програма".
 - Results are prioritized: names starting with the search term appear first, followed by substring matches, then
     alphabetically.

## Summary of change

 - API Alignment: Updated the search query parameter name from SearchQuery to searchQuery in fetchProgramSearchItems
     to match backend expectations and other search endpoints (like FAQ).
 - Prioritization Logic: Implemented client-side sorting in the ProgramsApi to ensure optimal result ordering:
       1. Prefix Matches: Titles starting with the search term.
       2. Substring Matches: Titles containing the search term anywhere else.
       3. Alphabetical: Fallback sorting for equal priority matches.
 - Test Coverage: Updated programs-api.test.ts to reflect the parameter change and added a new test suite specifically
     verifying the prioritization logic (Prefix > Substring > Alphabetical).

## How to recreate changes

1. Log in as Admin.
2. Navigate to the Programs ('Програми') section.
4. Ensure you have programs with names like "Коні лікують" and "Сімейна програма".
5. Type "лікують" in the search bar.
    - Before: No results found.
    - After: "Коні лікують" appears in the suggestions.
6. Type "Реаб".
    - Verify prefix matches like "Реабілітація дітей" appear at the top.
7. Run unit tests: npm test src/services/api/admin/programs/programs-api.test.ts to verify the logic
      programmatically.


## CHECK LIST
 - [x]  New tests was added or existing was modified
 - [ ]  Changes has severe impact on users
 - [ ]  Changes has medium impact on users
 - [x]  Changes has light impact on users
 - [x]  Test covetage was updated
 - [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced program search ranking: programs matching at the start of the name now appear first, followed by partial matches, with alphabetical sorting within each tier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->