### PR TITLE
Fix/issue-2758 [Partners][Admin panel] 'Опис' field counter shows '50' as total limit instead of '30' in the Title section

### DIFF
--- a/src/const/admin/partners.ts
+++ b/src/const/admin/partners.ts
@@ -62,7 +62,7 @@ export const PARTNER_BANNER_VALIDATION = {
     },
     description: {
         min: 10,
-        max: 50,
+        max: 30,
         getRequiredError: () => `Опис обов'язковий`,
     },
     image: {


### PR DESCRIPTION
## Github ticket

* [ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2758)

## Description

  This PR updates the character validation constraints for the partner banner description. The maximum character
  limit has been reduced to ensure optimal layout presentation and prevent text overflow issues on the user interface.

 ## How it looks

    
<img width="1012" height="355" alt="image" src="https://github.com/user-attachments/assets/357b236f-89fd-472c-86f9-7446749a7ae1" />


 ## Summary of change

 - **Validation Limit Update**: Updated the `max` validation constraint for descriptions inside partners.ts in
  partners.ts from `50` to `30` characters.

 ## How to recreate changes

 1. Navigate to the **Partners Banner** editor in the admin panel.
 2. Attempt to save a description with more than 30 characters (but less than 50).
 3. Verify that the form raises a validation error for descriptions exceeding the 30-character limit.

 ## CHECK LIST

 - [ ] New tests were added or existing were modified
 - [ ] Changes have severe impact on users
 - [ ] Changes have medium impact on users
 - [x] Changes have light impact on users
 - [ ] Test coverage was updated
 - [x] PR meets all conventions