### PR TITLE
Feature/issue-2185: [Reports] Show the disabled "Програмні" record

### DIFF
--- a/src/assets/sass/variables/colors.scss
+++ b/src/assets/sass/variables/colors.scss
@@ -67,6 +67,9 @@ $main-value-summary-text: #58b1da;
 $green: #059669;
 $orange: #d97706;
 
+$expense-maroon: #8b4459;
+$expense-maroon-dark: #5e1e2f;
+
 $olive-dark: #353428;
 $white: #fff;
 

--- a/src/hooks/admin/use-translate-disclaimer/useTranslateDisclaimer.test.ts
+++ b/src/hooks/admin/use-translate-disclaimer/useTranslateDisclaimer.test.ts
@@ -27,6 +27,7 @@ const settingsMock: ReportFundsExpendituresSettings = {
     id: 1,
     disclaimerTitle: 'Original disclaimer',
     exchangeRate: null,
+    programExpendituresReportingYear: 2025,
 };
 
 const languageMock: LocalizationLanguage = {

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
@@ -220,6 +220,7 @@ jest.mock('./components/funds-expenditures-table/FundsExpendituresTable', () => 
         onSelectAllToggle,
         onToggleRecordSelection,
         onOpenBulkDelete,
+        onProgramYearSave,
     }: any) => {
         const { FUNDS_EXPENDITURES_TEXT: FET } = require('@/const/admin/reports');
         return (
@@ -241,6 +242,9 @@ jest.mock('./components/funds-expenditures-table/FundsExpendituresTable', () => 
                     onClick={() => onRecordSave?.(1, { categoryId: 1, amountUah: '7300', amountUsd: '173.81' })}
                 >
                     Save row
+                </button>
+                <button data-testid="trigger-program-year-save" onClick={() => void onProgramYearSave?.('2024')}>
+                    Save program year
                 </button>
                 <button data-testid="row-edit-on" onClick={() => onRowEditModeChange?.(true)}>
                     Row edit on
@@ -393,6 +397,9 @@ const setupMockDataFetch = (
     let callIndex = 0;
     mockUseDataFetch.mockImplementation(({ initialData }: { initialData: unknown }) => {
         const callOrder = callIndex++;
+        // IMPORTANT: slot order must match the order useDataFetch is called in
+        // FundsExpendituresSection: 0=settings, 1=categories, 2=records, 3=summary, 4=programExpenses
+        // If a new useDataFetch call is added to the component, add a slot here in the same position.
         const slot = callOrder % 5;
         const slotDataMap: Record<number, unknown> = {
             0: settings,
@@ -1201,5 +1208,78 @@ describe('FundsExpenditureSection disclaimer localizations', () => {
         });
 
         expect(mockGetByEntityId).not.toHaveBeenCalled();
+    });
+});
+
+describe('FundsExpenditureSection handleProgramYearSave', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        setupMockDataFetch();
+        mockGetByEntityId.mockResolvedValue([]);
+    });
+
+    it('should call updateSettings with the new year and current settings values', async () => {
+        mockUpdateSettings.mockResolvedValueOnce(MOCK_FUNDS_EXPENDITURES_SETTINGS);
+
+        render(<FundsExpenditureSection />);
+        fireEvent.click(screen.getByTestId('trigger-program-year-save'));
+
+        await waitFor(() => {
+            expect(mockUpdateSettings).toHaveBeenCalledWith(stableAdminClient, {
+                disclaimerTitle: MOCK_FUNDS_EXPENDITURES_SETTINGS.disclaimerTitle,
+                exchangeRate: MOCK_FUNDS_EXPENDITURES_SETTINGS.exchangeRate,
+                programExpendituresReportingYear: 2024,
+            });
+        });
+    });
+
+    it('should show success toast after year is saved', async () => {
+        mockUpdateSettings.mockResolvedValueOnce(MOCK_FUNDS_EXPENDITURES_SETTINGS);
+
+        render(<FundsExpenditureSection />);
+        fireEvent.click(screen.getByTestId('trigger-program-year-save'));
+
+        await waitFor(() => {
+            expect(mockAddToast).toHaveBeenCalledWith(
+                FUNDS_EXPENDITURES_TEXT.MESSAGE.RECORD_UPDATED_SUCCESSFULLY,
+                'success',
+            );
+        });
+    });
+
+    it('should show error toast when year save fails', async () => {
+        mockUpdateSettings.mockRejectedValueOnce(new Error('update failed'));
+
+        render(<FundsExpenditureSection />);
+        fireEvent.click(screen.getByTestId('trigger-program-year-save'));
+
+        await waitFor(() => {
+            expect(mockAddToast).toHaveBeenCalledWith(
+                FUNDS_EXPENDITURES_TEXT.MESSAGE.RECORD_UPDATE_FAILED_RETRY,
+                'error',
+            );
+        });
+    });
+
+    it('should use the newly saved year in handlePublish, not the stale settings value', async () => {
+        // Settings has year 2025; user saves year 2024 via the aggregate row edit.
+        // Without the fix, handlePublish would read the stale settings.programExpendituresReportingYear (2025).
+        // With the fix it reads programYearValue (2024) which was updated immediately on save.
+        mockUpdateSettings.mockResolvedValueOnce(MOCK_FUNDS_EXPENDITURES_SETTINGS); // year save
+        mockUpdateSettings.mockResolvedValueOnce(MOCK_FUNDS_EXPENDITURES_SETTINGS); // publish
+
+        render(<FundsExpenditureSection />);
+
+        fireEvent.click(screen.getByTestId('trigger-program-year-save'));
+        await waitFor(() => expect(mockUpdateSettings).toHaveBeenCalledTimes(1));
+
+        fireEvent.click(screen.getByText(FUNDS_EXPENDITURES_TEXT.BUTTON.EDIT));
+        fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED));
+
+        await waitFor(() => expect(mockUpdateSettings).toHaveBeenCalledTimes(2));
+        expect(mockUpdateSettings).toHaveBeenLastCalledWith(
+            stableAdminClient,
+            expect.objectContaining({ programExpendituresReportingYear: 2024 }),
+        );
     });
 });

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
@@ -333,6 +333,13 @@ jest.mock('@/services/api/admin/reports/funds-expenditures-api', () => ({
     },
 }));
 
+const mockProgramExpensesSummaryGet = jest.fn();
+jest.mock('@/services/api/admin/reports/program-expenses-api', () => ({
+    ProgramExpensesApi: {
+        getSummary: (...args: unknown[]) => mockProgramExpensesSummaryGet(...args),
+    },
+}));
+
 const mockGetByEntityId = jest.fn();
 jest.mock(
     '@/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api',
@@ -1281,5 +1288,32 @@ describe('FundsExpenditureSection handleProgramYearSave', () => {
             stableAdminClient,
             expect.objectContaining({ programExpendituresReportingYear: 2024 }),
         );
+    });
+});
+
+describe('FundsExpenditureSection fetch handler delegation', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        setupMockDataFetch();
+        mockGetByEntityId.mockResolvedValue([]);
+    });
+
+    it('fetchProgramSummary calls ProgramExpensesApi.getSummary with the admin client', async () => {
+        const capturedFetchHandlers: Array<(opts?: object) => unknown> = [];
+        // Wrap the slot-based impl so stable data refs are preserved (avoids infinite re-renders)
+        const slotImpl = mockUseDataFetch.getMockImplementation()!;
+        mockUseDataFetch.mockImplementation((props: any) => {
+            capturedFetchHandlers.push(props.fetchHandler);
+            return slotImpl(props);
+        });
+
+        mockProgramExpensesSummaryGet.mockResolvedValueOnce({ totalAmountUah: 500, totalAmountUsd: 200 });
+        render(<FundsExpenditureSection />);
+
+        // slot 4 = fetchProgramSummary (5th useDataFetch call in the component)
+        const result = await capturedFetchHandlers[4]({});
+
+        expect(mockProgramExpensesSummaryGet).toHaveBeenCalledWith(stableAdminClient, {});
+        expect(result).toEqual({ totalAmountUah: 500, totalAmountUsd: 200 });
     });
 });

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.test.tsx
@@ -14,6 +14,7 @@ import {
     ReportFundsExpendituresRecord,
     ReportFundsExpendituresSettings,
     ReportFundsExpendituresSettingsLocalizationDto,
+    ProgramExpensesSummary,
 } from '@/types/admin/reports';
 import { LocalizationLanguage, TranslationStatus } from '@/types/common/language';
 
@@ -21,6 +22,7 @@ const MOCK_FUNDS_EXPENDITURES_SETTINGS: ReportFundsExpendituresSettings = {
     id: 1,
     disclaimerTitle: 'Фінансовий звіт Victory Center за поточний рік. Ми забезпечуємо прозорість кожної гривні.',
     exchangeRate: '42.18',
+    programExpendituresReportingYear: 2025,
 };
 
 const MOCK_FUNDS_EXPENDITURES_CATEGORIES: ReportFundsExpendituresCategory[] = [
@@ -378,18 +380,27 @@ jest.mock('./components/common/translate-disclaimer-modal/TranslateDisclaimerMod
     },
 }));
 
+const MOCK_EMPTY_PROGRAM_SUMMARY: ProgramExpensesSummary = { totalAmountUah: 0, totalAmountUsd: 0 };
+
 const setupMockDataFetch = (
     settings: ReportFundsExpendituresSettings | null = MOCK_FUNDS_EXPENDITURES_SETTINGS,
     categories: ReportFundsExpendituresCategory[] = MOCK_FUNDS_EXPENDITURES_CATEGORIES,
     records: ReportFundsExpendituresRecord[] = MOCK_FUNDS_EXPENDITURES_RECORDS,
     summary: FundsExpendituresSummary = MOCK_FUNDS_EXPENDITURES_SUMMARY,
     loadingBySlot: Partial<Record<number, boolean>> = {},
+    programExpenses: ProgramExpensesSummary = MOCK_EMPTY_PROGRAM_SUMMARY,
 ) => {
     let callIndex = 0;
     mockUseDataFetch.mockImplementation(({ initialData }: { initialData: unknown }) => {
         const callOrder = callIndex++;
-        const slot = callOrder % 4;
-        const slotDataMap: Record<number, unknown> = { 0: settings, 1: categories, 2: records, 3: summary };
+        const slot = callOrder % 5;
+        const slotDataMap: Record<number, unknown> = {
+            0: settings,
+            1: categories,
+            2: records,
+            3: summary,
+            4: programExpenses,
+        };
         const data = slotDataMap[slot];
         return {
             data: data ?? initialData,
@@ -507,7 +518,12 @@ describe('FundsExpenditureSection', () => {
     });
 
     it('should not render disclaimer if settings have no disclaimerTitle', () => {
-        setupMockDataFetch({ id: 1, disclaimerTitle: null, exchangeRate: '42.18' });
+        setupMockDataFetch({
+            id: 1,
+            disclaimerTitle: null,
+            exchangeRate: '42.18',
+            programExpendituresReportingYear: 2025,
+        });
         render(<FundsExpenditureSection />);
         expect(screen.queryByText(FUNDS_EXPENDITURES_TEXT.DISCLAIMER_LABEL)).not.toBeInTheDocument();
     });
@@ -708,7 +724,12 @@ describe('FundsExpenditureSection', () => {
         });
 
         it('should disable publish button when disclaimer is empty', () => {
-            setupMockDataFetch({ id: 1, disclaimerTitle: null, exchangeRate: '42' });
+            setupMockDataFetch({
+                id: 1,
+                disclaimerTitle: null,
+                exchangeRate: '42',
+                programExpendituresReportingYear: 2025,
+            });
             render(<FundsExpenditureSection />);
             enterEditMode();
             expect(getPublishButton()).toBeDisabled();
@@ -957,7 +978,12 @@ describe('FundsExpenditureSection', () => {
 });
 
 describe('FundsExpenditureSection bulk delete flow', () => {
-    const settingsMock = { id: 1, exchangeRate: '40', disclaimerTitle: 'Disclaimer' };
+    const settingsMock = {
+        id: 1,
+        exchangeRate: '40',
+        disclaimerTitle: 'Disclaimer',
+        programExpendituresReportingYear: 2025,
+    };
     const categoriesMock: ReportFundsExpendituresCategory[] = [
         { id: 1, name: 'A', type: 'income', localizations: [] },
         { id: 2, name: 'B', type: 'income', localizations: [] },

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -102,6 +102,7 @@ export const FundsExpenditureSection = ({
     const [disclaimerError, setDisclaimerError] = useState<string | undefined>(undefined);
     const [exchangeRateValue, setExchangeRateValue] = useState('');
     const [exchangeRateError, setExchangeRateError] = useState<string | undefined>(undefined);
+    const [programYearValue, setProgramYearValue] = useState<number>(new Date().getFullYear());
 
     const [selectedType, setSelectedType] = useState<TypeFilterValue>(undefined);
     const [selectedCategoryId, setSelectedCategoryId] = useState<CategoryFilterValue>(undefined);
@@ -311,6 +312,12 @@ export const FundsExpenditureSection = ({
         }
     }, [draftExchangeRate, settings, isEditing]);
 
+    useEffect(() => {
+        if (settings?.programExpendituresReportingYear != null) {
+            setProgramYearValue(settings.programExpendituresReportingYear);
+        }
+    }, [settings?.programExpendituresReportingYear]);
+
     const enrichedRecords = useMemo(() => enrichRecords(recordsState, categories), [recordsState, categories]);
 
     const filteredCategories = useMemo(
@@ -341,24 +348,24 @@ export const FundsExpenditureSection = ({
     const currentExchangeRate = isEditing ? exchangeRateValue : (settings?.exchangeRate ?? null);
 
     const programAggregateRow = useMemo<ProgramAggregateRow>(() => {
-        const reportingYear = settings?.programExpendituresReportingYear || new Date().getFullYear();
-
         return {
-            reportingYear: String(reportingYear),
+            reportingYear: String(programYearValue),
             categoryName: PROGRAM_EXPENSES_TEXT.TABLE.TYPE_LABEL,
             amountUah: formatNumberDecimalComma(programSummary.totalAmountUah),
             amountUsd: formatNumberDecimalComma(programSummary.totalAmountUsd),
         };
-    }, [programSummary, settings?.programExpendituresReportingYear]);
+    }, [programSummary, programYearValue]);
 
     const handleProgramYearSave = useCallback(
         async (reportingYear: string): Promise<boolean> => {
+            const yearNumber = Number.parseInt(reportingYear, 10);
             try {
                 await FundsExpendituresApi.updateSettings(adminClient, {
                     disclaimerTitle: settings?.disclaimerTitle ?? '',
                     exchangeRate: settings?.exchangeRate ?? null,
-                    programExpendituresReportingYear: Number.parseInt(reportingYear, 10),
+                    programExpendituresReportingYear: yearNumber,
                 });
+                setProgramYearValue(yearNumber);
                 refetchSettings();
                 refetchProgramSummary();
                 addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.RECORD_UPDATED_SUCCESSFULLY, ToastType.Success);
@@ -564,8 +571,7 @@ export const FundsExpenditureSection = ({
             const updatedSettings = await FundsExpendituresApi.updateSettings(adminClient, {
                 disclaimerTitle: disclaimerValue,
                 exchangeRate: exchangeRateValue,
-                programExpendituresReportingYear:
-                    settings?.programExpendituresReportingYear ?? new Date().getFullYear(),
+                programExpendituresReportingYear: programYearValue,
             });
 
             setDisclaimerValue(updatedSettings.disclaimerTitle ?? '');
@@ -590,7 +596,7 @@ export const FundsExpenditureSection = ({
         onEditModeChange,
         onExchangeRateValueChange,
         refetchSettings,
-        settings,
+        programYearValue,
     ]);
 
     if (isInitialLoading) {

--- a/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/FundsExpendituresSection.tsx
@@ -15,6 +15,7 @@ import { Button } from '@/components/admin/button/Button';
 import { LocalizationStatuses } from '@/components/admin/localization-statuses/LocalizationStatuses';
 import { ACTION_ICONS } from '@/const/common/action-icons';
 import { FundsExpendituresApi } from '@/services/api/admin/reports/funds-expenditures-api';
+import { ProgramExpensesApi } from '@/services/api/admin/reports/program-expenses-api';
 import { ReportFundsExpendituresSettingsLocalizationsApi } from '@/services/api/admin/reports/report-funds-expenditures-settings-localizations/report-funds-expenditures-settings-localizations-api';
 import {
     FundsExpendituresTransactionType,
@@ -23,9 +24,11 @@ import {
     ReportFundsExpendituresRecord,
     ReportFundsExpendituresSettings,
     ReportFundsExpendituresSettingsLocalization,
+    ProgramExpensesSummary,
 } from '@/types/admin/reports';
 import { LocalizationLanguage } from '@/types/common/language';
 import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/localization/localization-mappers';
+import { formatNumberDecimalComma } from '@/utils/functions/formatters/format-number';
 import { useDataFetch } from '@/hooks/common/use-data-fetch/useDataFetch';
 import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
 import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextProvider';
@@ -38,7 +41,11 @@ import {
     FundsExpendituresToolbar,
     TypeFilterValue,
 } from './components/funds-expenditures-toolbar/FundsExpendituresToolbar';
-import { EnrichedRecord, FundsExpendituresTable } from './components/funds-expenditures-table/FundsExpendituresTable';
+import {
+    EnrichedRecord,
+    FundsExpendituresTable,
+    ProgramAggregateRow,
+} from './components/funds-expenditures-table/FundsExpendituresTable';
 import { AddFundsExpendituresRecordModal } from './components/common/add-funds-expenditures-record-modal/AddFundsExpendituresRecordModal';
 import { AddFundsExpendituresCategoryModal } from './components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal';
 import { DeleteRecordModal } from './components/common/delete-record-modal/DeleteRecordModal';
@@ -183,6 +190,10 @@ export const FundsExpenditureSection = ({
         (options = {}) => FundsExpendituresApi.getSummary(adminClient, options),
         [adminClient],
     );
+    const fetchProgramSummary = useCallback(
+        (options = {}) => ProgramExpensesApi.getSummary(adminClient, options),
+        [adminClient],
+    );
 
     const {
         data: settings,
@@ -227,6 +238,11 @@ export const FundsExpenditureSection = ({
             expenseCategories: 0,
         },
         fetchHandler: fetchSummary,
+    });
+
+    const { data: programSummary, refetch: refetchProgramSummary } = useDataFetch<ProgramExpensesSummary>({
+        initialData: { totalAmountUah: 0, totalAmountUsd: 0 },
+        fetchHandler: fetchProgramSummary,
     });
 
     const isInitialLoading =
@@ -323,6 +339,37 @@ export const FundsExpenditureSection = ({
         summary.expenseCategories >= FUNDS_EXPENDITURES_VALIDATION.maxCategoriesPerType || hasExchangeRateError;
 
     const currentExchangeRate = isEditing ? exchangeRateValue : (settings?.exchangeRate ?? null);
+
+    const programAggregateRow = useMemo<ProgramAggregateRow>(() => {
+        const reportingYear = settings?.programExpendituresReportingYear || new Date().getFullYear();
+
+        return {
+            reportingYear: String(reportingYear),
+            categoryName: PROGRAM_EXPENSES_TEXT.TABLE.TYPE_LABEL,
+            amountUah: formatNumberDecimalComma(programSummary.totalAmountUah),
+            amountUsd: formatNumberDecimalComma(programSummary.totalAmountUsd),
+        };
+    }, [programSummary, settings?.programExpendituresReportingYear]);
+
+    const handleProgramYearSave = useCallback(
+        async (reportingYear: string): Promise<boolean> => {
+            try {
+                await FundsExpendituresApi.updateSettings(adminClient, {
+                    disclaimerTitle: settings?.disclaimerTitle ?? '',
+                    exchangeRate: settings?.exchangeRate ?? null,
+                    programExpendituresReportingYear: Number.parseInt(reportingYear, 10),
+                });
+                refetchSettings();
+                refetchProgramSummary();
+                addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.RECORD_UPDATED_SUCCESSFULLY, ToastType.Success);
+                return true;
+            } catch {
+                addToast(FUNDS_EXPENDITURES_TEXT.MESSAGE.RECORD_UPDATE_FAILED_RETRY, ToastType.Error);
+                return false;
+            }
+        },
+        [adminClient, settings, refetchSettings, refetchProgramSummary, addToast],
+    );
 
     const handleRecordSave = useCallback(
         async (
@@ -517,6 +564,8 @@ export const FundsExpenditureSection = ({
             const updatedSettings = await FundsExpendituresApi.updateSettings(adminClient, {
                 disclaimerTitle: disclaimerValue,
                 exchangeRate: exchangeRateValue,
+                programExpendituresReportingYear:
+                    settings?.programExpendituresReportingYear ?? new Date().getFullYear(),
             });
 
             setDisclaimerValue(updatedSettings.disclaimerTitle ?? '');
@@ -541,6 +590,7 @@ export const FundsExpenditureSection = ({
         onEditModeChange,
         onExchangeRateValueChange,
         refetchSettings,
+        settings,
     ]);
 
     if (isInitialLoading) {
@@ -665,6 +715,8 @@ export const FundsExpenditureSection = ({
                 isRowActionsDisabled={hasExchangeRateError}
                 onRowEditModeChange={setIsRowEditMode}
                 onRecordSave={handleRecordSave}
+                programAggregateRow={programAggregateRow}
+                onProgramYearSave={handleProgramYearSave}
                 onDeleteRecord={handleDeleteClick}
                 selectedRecordIds={selectedRecordIds}
                 eligibleRecordIds={eligibleRecordIds}

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.module.scss
@@ -96,8 +96,8 @@
 }
 
 .type-chip-expense {
-    background-color: #8b4459;
-    border: 1px solid #5e1e2f;
+    background-color: c.$expense-maroon;
+    border: 1px solid c.$expense-maroon-dark;
     color: c.$white;
 }
 
@@ -292,6 +292,36 @@
             stroke: c.$error;
         }
     }
+}
+
+.program-aggregate-row {
+    background-color: c.$light-blue-25;
+    opacity: 0.65;
+
+    .td {
+        border-top: 1px solid c.$grey-900;
+        border-bottom: 1px solid c.$grey-900;
+    }
+
+    .td:first-child {
+        border-left: 4px solid c.$expense-maroon;
+    }
+
+    &:hover {
+        background-color: c.$light-blue-25;
+    }
+
+    .icon-button:not(:disabled) {
+        opacity: 1;
+    }
+}
+
+.program-aggregate-row:last-child .td {
+    border-bottom: none;
+}
+
+.program-aggregate-row-editing {
+    opacity: 1;
 }
 
 .category-edit-td,

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
@@ -892,3 +892,47 @@ describe('FundsExpendituresTable', () => {
         });
     });
 });
+
+describe('FundsExpendituresTable program aggregate row', () => {
+    const currentYear = new Date().getFullYear();
+    const nextYear = String(currentYear + 1);
+    const programAggregateRow = {
+        reportingYear: String(currentYear),
+        categoryName: 'Програмні',
+        amountUah: '4 200',
+        amountUsd: '4 200',
+    };
+
+    it('renders the disabled aggregate row with an edit control when editing', () => {
+        renderTable({ programAggregateRow, isEditing: true });
+
+        expect(screen.getByTestId('program-aggregate-row')).toBeInTheDocument();
+        expect(screen.getByText('Програмні')).toBeInTheDocument();
+        expect(screen.getByLabelText('Edit program reporting year')).toBeInTheDocument();
+    });
+
+    it('keeps accept disabled until the year changes, then saves the new year', async () => {
+        const onProgramYearSave = jest.fn().mockResolvedValue(true);
+        renderTable({ programAggregateRow, isEditing: true, onProgramYearSave });
+
+        fireEvent.click(screen.getByLabelText('Edit program reporting year'));
+        expect(screen.getByLabelText('Accept program reporting year')).toBeDisabled();
+
+        fireEvent.click(screen.getByTestId(`select-option-${nextYear}-${nextYear}`));
+        expect(screen.getByLabelText('Accept program reporting year')).not.toBeDisabled();
+
+        fireEvent.click(screen.getByLabelText('Accept program reporting year'));
+        await waitFor(() => expect(onProgramYearSave).toHaveBeenCalledWith(nextYear));
+    });
+
+    it('closes the year edit without saving', () => {
+        const onProgramYearSave = jest.fn();
+        renderTable({ programAggregateRow, isEditing: true, onProgramYearSave });
+
+        fireEvent.click(screen.getByLabelText('Edit program reporting year'));
+        fireEvent.click(screen.getByLabelText('Close program reporting year edit'));
+
+        expect(screen.queryByLabelText('Accept program reporting year')).not.toBeInTheDocument();
+        expect(onProgramYearSave).not.toHaveBeenCalled();
+    });
+});

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
@@ -20,6 +20,7 @@ import {
     validateFundsExpendituresCategory,
 } from '@/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema';
 import { updateFundsAmounts } from '@/utils/functions/update-funds-amounts/update-funds-amounts';
+import { getProgramReportingYearOptions } from '@/utils/functions/get-reporting-year-options/get-reporting-year-options';
 import { parseAmount } from '@/utils/functions/parse-amount/parse-amount';
 import { isUsdAmountMismatch } from '@/utils/functions/validate-usd-amount-mismatch/validate-usd-amount-mismatch';
 import { InlineLoader } from '@/components/common/inline-loader/InlineLoader';
@@ -29,6 +30,13 @@ import { Button } from '@/components/admin/button/Button';
 
 export interface EnrichedRecord extends ReportFundsExpendituresRecord {
     categoryName: string;
+}
+
+export interface ProgramAggregateRow {
+    reportingYear: string;
+    categoryName: string;
+    amountUah: string;
+    amountUsd: string;
 }
 
 type SortableColumn = 'type' | 'categoryName' | 'amountUah' | 'amountUsd';
@@ -51,6 +59,8 @@ interface FundsExpendituresTableProps {
         recordId: number,
         data: { categoryId: number; amountUah: string; amountUsd: string },
     ) => boolean | Promise<boolean>;
+    programAggregateRow?: ProgramAggregateRow | null;
+    onProgramYearSave?: (reportingYear: string) => boolean | Promise<boolean>;
     onDeleteRecord?: (record: EnrichedRecord) => void;
     selectedRecordIds?: number[];
     eligibleRecordIds?: number[];
@@ -154,6 +164,8 @@ export const FundsExpendituresTable = ({
     isRowActionsDisabled = false,
     onRowEditModeChange,
     onRecordSave,
+    programAggregateRow,
+    onProgramYearSave,
     onDeleteRecord,
     selectedRecordIds,
     eligibleRecordIds,
@@ -164,6 +176,8 @@ export const FundsExpendituresTable = ({
     const [sort, setSort] = useState<ColumnSort>({ column: null, direction: null });
     const [rowEditState, setRowEditState] = useState<RowEditState | null>(null);
     const [savingRecordId, setSavingRecordId] = useState<number | null>(null);
+    const [programYearEdit, setProgramYearEdit] = useState<{ year: string; originalYear: string } | null>(null);
+    const [isSavingProgramYear, setIsSavingProgramYear] = useState(false);
     const [isMoveToTopVisible, setIsMoveToTopVisible] = useState(false);
     const tableWrapperRef = useRef<HTMLDivElement>(null);
     const headerCheckboxRef = useRef<HTMLInputElement | null>(null);
@@ -248,6 +262,52 @@ export const FundsExpendituresTable = ({
     const handleCloseRowEdit = useCallback(() => {
         setRowEditMode(null);
     }, [setRowEditMode]);
+
+    const handleStartProgramYearEdit = useCallback(() => {
+        if (rowEditState || programYearEdit || isRowActionsDisabled || !programAggregateRow) {
+            return;
+        }
+
+        setProgramYearEdit({
+            year: programAggregateRow.reportingYear,
+            originalYear: programAggregateRow.reportingYear,
+        });
+        onRowEditModeChange?.(true);
+    }, [isRowActionsDisabled, onRowEditModeChange, programAggregateRow, programYearEdit, rowEditState]);
+
+    const handleProgramYearChange = useCallback((year: string) => {
+        setProgramYearEdit((prev) => (prev ? { ...prev, year } : prev));
+    }, []);
+
+    const handleCloseProgramYearEdit = useCallback(() => {
+        setProgramYearEdit(null);
+        onRowEditModeChange?.(false);
+    }, [onRowEditModeChange]);
+
+    const handleAcceptProgramYearEdit = useCallback(async () => {
+        if (!programYearEdit || isSavingProgramYear) {
+            return;
+        }
+
+        if (programYearEdit.year === programYearEdit.originalYear) {
+            return;
+        }
+
+        setIsSavingProgramYear(true);
+
+        try {
+            const isSaved = await onProgramYearSave?.(programYearEdit.year);
+
+            if (isSaved === false) {
+                return;
+            }
+
+            setProgramYearEdit(null);
+            onRowEditModeChange?.(false);
+        } finally {
+            setIsSavingProgramYear(false);
+        }
+    }, [isSavingProgramYear, onProgramYearSave, onRowEditModeChange, programYearEdit]);
 
     const handleRowCategoryChange = useCallback(
         (record: EnrichedRecord, categoryId: number | undefined) => {
@@ -446,7 +506,7 @@ export const FundsExpendituresTable = ({
 
     const handleSort = useCallback(
         (column: SortableColumn) => {
-            if (rowEditState) {
+            if (rowEditState || programYearEdit) {
                 return;
             }
 
@@ -468,13 +528,20 @@ export const FundsExpendituresTable = ({
                 setIsMoveToTopVisible(false);
             }
         },
-        [rowEditState],
+        [rowEditState, programYearEdit],
     );
 
     const isAnyRowEditing = rowEditState !== null;
+    const isProgramYearEditing = programYearEdit !== null;
+    const isAnyEditingActive = isAnyRowEditing || isProgramYearEditing;
     const isSavingInProgress = savingRecordId !== null;
     const sortedRecords = sortRecords(records, sort);
     const colSpan = isEditing ? 7 : 5;
+    const isProgramYearAcceptDisabled =
+        !programYearEdit || programYearEdit.year === programYearEdit.originalYear || isSavingProgramYear;
+    const programYearOptions = getProgramReportingYearOptions(
+        programAggregateRow ? Number(programAggregateRow.reportingYear) : undefined,
+    );
 
     const eligibleIds = eligibleRecordIds ?? [];
     const selectedIds = selectedRecordIds ?? [];
@@ -579,6 +646,97 @@ export const FundsExpendituresTable = ({
                         </tr>
                     </thead>
                     <tbody>
+                        {programAggregateRow && (
+                            <tr
+                                className={cn(styles.tr, styles['program-aggregate-row'], {
+                                    [styles['program-aggregate-row-editing']]: isProgramYearEditing,
+                                })}
+                                data-testid="program-aggregate-row"
+                            >
+                                {isEditing && (
+                                    <td className={cn(styles.td, styles['checkbox-td'])} aria-hidden="true" />
+                                )}
+                                <td className={cn(styles.td, { [styles['category-edit-td']]: isProgramYearEditing })}>
+                                    {isProgramYearEditing ? (
+                                        <div className={styles['category-edit-wrapper']}>
+                                            <Select<string>
+                                                value={programYearEdit?.year}
+                                                onValueChange={handleProgramYearChange}
+                                                placeholder={
+                                                    FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER
+                                                }
+                                                className={styles['category-edit-select']}
+                                                optionClassName={styles['category-edit-option']}
+                                            >
+                                                {programYearOptions.map((year) => (
+                                                    <Select.Option key={year} value={year} name={year} />
+                                                ))}
+                                            </Select>
+                                        </div>
+                                    ) : (
+                                        programAggregateRow.reportingYear
+                                    )}
+                                </td>
+                                <td className={styles.td}>
+                                    <span className={cn(styles['type-chip'], styles['type-chip-expense'])}>
+                                        {FUNDS_EXPENDITURES_TEXT.TABLE.TYPE_LABELS.EXPENSE}
+                                    </span>
+                                </td>
+                                <td className={styles.td}>{programAggregateRow.categoryName}</td>
+                                <td className={styles.td}>{programAggregateRow.amountUah}</td>
+                                <td className={styles.td}>{programAggregateRow.amountUsd}</td>
+                                {isEditing && (
+                                    <td className={cn(styles.td, styles['actions-td'])}>
+                                        <div className={styles['row-actions']}>
+                                            {isProgramYearEditing ? (
+                                                <>
+                                                    <button
+                                                        type="button"
+                                                        className={cn(
+                                                            styles['icon-button'],
+                                                            styles['accept-icon-button'],
+                                                        )}
+                                                        aria-label="Accept program reporting year"
+                                                        onClick={handleAcceptProgramYearEdit}
+                                                        disabled={isProgramYearAcceptDisabled}
+                                                    >
+                                                        {isSavingProgramYear ? (
+                                                            <InlineLoader size={1.2} />
+                                                        ) : (
+                                                            <CheckmarkIcon className={styles['action-icon']} />
+                                                        )}
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        className={cn(
+                                                            styles['icon-button'],
+                                                            styles['close-icon-button'],
+                                                        )}
+                                                        aria-label="Close program reporting year edit"
+                                                        onClick={handleCloseProgramYearEdit}
+                                                        disabled={isSavingProgramYear}
+                                                    >
+                                                        <CrossIcon className={styles['action-icon']} />
+                                                    </button>
+                                                </>
+                                            ) : (
+                                                <IconButton
+                                                    type="button"
+                                                    className={cn(styles['icon-button'], styles['edit-icon-button'])}
+                                                    aria-label="Edit program reporting year"
+                                                    onClick={handleStartProgramYearEdit}
+                                                    disabled={
+                                                        isAnyRowEditing || isSavingInProgress || isRowActionsDisabled
+                                                    }
+                                                    DefaultIcon={ACTION_ICONS.edit.default}
+                                                    FilledIcon={ACTION_ICONS.edit.hover}
+                                                />
+                                            )}
+                                        </div>
+                                    </td>
+                                )}
+                            </tr>
+                        )}
                         {sortedRecords.length === 0 && isEditing ? (
                             <tr>
                                 <td
@@ -598,7 +756,7 @@ export const FundsExpendituresTable = ({
                             sortedRecords.map((record) => {
                                 const isEditedRow = rowEditState?.recordId === record.id;
                                 const isAnotherRowEditing =
-                                    (isAnyRowEditing && !isEditedRow) || isSavingInProgress || isRowActionsDisabled;
+                                    (isAnyEditingActive && !isEditedRow) || isSavingInProgress || isRowActionsDisabled;
                                 const isSavingCurrentRow = savingRecordId === record.id;
                                 const editableCategories = categoriesByType[record.type];
                                 const isAcceptDisabled = !isEditedRow || isAcceptButtonDisabled(rowEditState);

--- a/src/services/api/admin/reports/funds-expenditures-api.test.ts
+++ b/src/services/api/admin/reports/funds-expenditures-api.test.ts
@@ -44,18 +44,27 @@ describe('FundsExpendituresApi', () => {
 
     describe('updateSettings', () => {
         it('should send update payload and map response', async () => {
-            mockClient.put.mockResolvedValueOnce({ data: { id: 1, disclaimerTitle: 'Updated', exchangeRate: 40 } });
+            mockClient.put.mockResolvedValueOnce({
+                data: { id: 1, disclaimerTitle: 'Updated', exchangeRate: 40, programExpendituresReportingYear: 2025 },
+            });
 
             const result = await FundsExpendituresApi.updateSettings(mockClient, {
                 disclaimerTitle: 'Updated',
                 exchangeRate: '40',
+                programExpendituresReportingYear: 2025,
             });
 
             expect(mockClient.put).toHaveBeenCalledWith(API_ROUTES.REPORTS.FUNDS_EXPENDITURES.SETTINGS, {
                 disclaimerTitle: 'Updated',
                 exchangeRate: 40,
+                programExpendituresReportingYear: 2025,
             });
-            expect(result).toEqual({ id: 1, disclaimerTitle: 'Updated', exchangeRate: '40' });
+            expect(result).toEqual({
+                id: 1,
+                disclaimerTitle: 'Updated',
+                exchangeRate: '40',
+                programExpendituresReportingYear: 2025,
+            });
         });
     });
 

--- a/src/services/api/admin/reports/funds-expenditures-api.ts
+++ b/src/services/api/admin/reports/funds-expenditures-api.ts
@@ -40,7 +40,10 @@ export const FundsExpendituresApi = {
 
     updateSettings: async (
         client: AxiosInstance,
-        settings: Pick<ReportFundsExpendituresSettings, 'disclaimerTitle' | 'exchangeRate'>,
+        settings: Pick<
+            ReportFundsExpendituresSettings,
+            'disclaimerTitle' | 'exchangeRate' | 'programExpendituresReportingYear'
+        >,
     ): Promise<ReportFundsExpendituresSettings> => {
         const response = await client.put<ReportFundsExpendituresSettingsDto>(
             API_ROUTES.REPORTS.FUNDS_EXPENDITURES.SETTINGS,

--- a/src/services/api/admin/reports/program-expenses-api.test.ts
+++ b/src/services/api/admin/reports/program-expenses-api.test.ts
@@ -238,4 +238,28 @@ describe('ProgramExpensesApi', () => {
             );
         });
     });
+
+    describe('getSummary', () => {
+        it('should GET summary and map to totals', async () => {
+            mockClient.get.mockResolvedValueOnce({ data: { totalAmountUah: 1500, totalAmountUsd: 1000 } });
+
+            const result = await ProgramExpensesApi.getSummary(mockClient);
+
+            expect(mockClient.get).toHaveBeenCalledWith(`${API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS}/summary`, {
+                signal: undefined,
+            });
+            expect(result).toEqual({ totalAmountUah: 1500, totalAmountUsd: 1000 });
+        });
+
+        it('should pass cancellation signal', async () => {
+            mockClient.get.mockResolvedValueOnce({ data: { totalAmountUah: 0, totalAmountUsd: 0 } });
+            const signal = new AbortController().signal;
+
+            await ProgramExpensesApi.getSummary(mockClient, { cancellationSignal: signal });
+
+            expect(mockClient.get).toHaveBeenCalledWith(`${API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS}/summary`, {
+                signal,
+            });
+        });
+    });
 });

--- a/src/services/api/admin/reports/program-expenses-api.ts
+++ b/src/services/api/admin/reports/program-expenses-api.ts
@@ -76,6 +76,18 @@ export const ProgramExpensesApi = {
         return mapDtoToReadOnlyData(recordsResponse.data, categoriesResponse.data, exchangeRate);
     },
 
+    getSummary: async (client: AxiosInstance, options: RequestOptions = {}): Promise<ProgramExpensesSummary> => {
+        const response = await client.get<{ totalAmountUah: number; totalAmountUsd: number }>(
+            `${API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS}/summary`,
+            { signal: options.cancellationSignal },
+        );
+
+        return {
+            totalAmountUah: response.data.totalAmountUah,
+            totalAmountUsd: response.data.totalAmountUsd,
+        };
+    },
+
     getAll: async (client: AxiosInstance): Promise<ReportProgramExpendituresRecordDto[]> => {
         const response = await client.get<ReportProgramExpendituresRecordDto[]>(
             API_ROUTES.REPORTS.PROGRAM_EXPENDITURES_RECORDS,

--- a/src/types/admin/reports.ts
+++ b/src/types/admin/reports.ts
@@ -89,11 +89,13 @@ export interface ReportFundsExpendituresSettingsDto {
     id: number;
     disclaimerTitle: string;
     exchangeRate: number;
+    programExpendituresReportingYear: number;
 }
 
 export interface UpdateReportFundsExpendituresSettingsDto {
     disclaimerTitle: string;
     exchangeRate: number;
+    programExpendituresReportingYear: number;
 }
 
 export interface ReportFundsExpendituresCategoryDto
@@ -151,6 +153,7 @@ export interface ReportFundsExpendituresSettings {
     id: number;
     disclaimerTitle: string | null;
     exchangeRate: string | null;
+    programExpendituresReportingYear: number | null;
 }
 
 export interface ReportFundsExpendituresCategoryLocalizableFields {

--- a/src/utils/functions/get-reporting-year-options/get-reporting-year-options.test.ts
+++ b/src/utils/functions/get-reporting-year-options/get-reporting-year-options.test.ts
@@ -1,4 +1,7 @@
-import { getReportingYearOptions } from '@/utils/functions/get-reporting-year-options/get-reporting-year-options';
+import {
+    getReportingYearOptions,
+    getProgramReportingYearOptions,
+} from '@/utils/functions/get-reporting-year-options/get-reporting-year-options';
 
 describe('getReportingYearOptions', () => {
     it('should return previous, current, and next year in order', () => {
@@ -7,5 +10,32 @@ describe('getReportingYearOptions', () => {
         expect(getReportingYearOptions()).toEqual(['2025', '2026', '2027']);
 
         jest.useRealTimers();
+    });
+});
+
+describe('getProgramReportingYearOptions', () => {
+    beforeEach(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2026-03-30T00:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('should return the default window sorted descending when no year is provided', () => {
+        expect(getProgramReportingYearOptions()).toEqual(['2027', '2026', '2025']);
+    });
+
+    it('should ignore null and undefined selected years', () => {
+        expect(getProgramReportingYearOptions(null)).toEqual(['2027', '2026', '2025']);
+        expect(getProgramReportingYearOptions(undefined)).toEqual(['2027', '2026', '2025']);
+    });
+
+    it('should include a selected year outside the default window, sorted descending', () => {
+        expect(getProgramReportingYearOptions(2020)).toEqual(['2027', '2026', '2025', '2020']);
+    });
+
+    it('should not duplicate a selected year already inside the window', () => {
+        expect(getProgramReportingYearOptions(2026)).toEqual(['2027', '2026', '2025']);
     });
 });

--- a/src/utils/functions/get-reporting-year-options/get-reporting-year-options.ts
+++ b/src/utils/functions/get-reporting-year-options/get-reporting-year-options.ts
@@ -3,3 +3,13 @@ export const getReportingYearOptions = (): string[] => {
 
     return [String(currentYear - 1), String(currentYear), String(currentYear + 1)];
 };
+
+export const getProgramReportingYearOptions = (selectedYear?: number | null): string[] => {
+    const options = new Set(getReportingYearOptions());
+
+    if (selectedYear !== undefined && selectedYear !== null) {
+        options.add(String(selectedYear));
+    }
+
+    return Array.from(options).sort((a, b) => Number(b) - Number(a));
+};

--- a/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.test.ts
+++ b/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.test.ts
@@ -204,12 +204,14 @@ describe('reports-mapper', () => {
                 id: 1,
                 disclaimerTitle: 'Disclaimer',
                 exchangeRate: 42.18,
+                programExpendituresReportingYear: 2025,
             };
 
             expect(mapReportFundsExpendituresSettingsDtoToSettings(dto)).toEqual({
                 id: 1,
                 disclaimerTitle: 'Disclaimer',
                 exchangeRate: '42,18',
+                programExpendituresReportingYear: 2025,
             });
         });
 

--- a/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.ts
+++ b/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.ts
@@ -72,13 +72,18 @@ export const mapReportFundsExpendituresSettingsDtoToSettings = (
     id: dto.id,
     disclaimerTitle: dto.disclaimerTitle,
     exchangeRate: formatNumberDecimalComma(dto.exchangeRate),
+    programExpendituresReportingYear: dto.programExpendituresReportingYear,
 });
 
 export const mapReportFundsExpendituresSettingsToUpdateDto = (
-    settings: Pick<ReportFundsExpendituresSettings, 'disclaimerTitle' | 'exchangeRate'>,
+    settings: Pick<
+        ReportFundsExpendituresSettings,
+        'disclaimerTitle' | 'exchangeRate' | 'programExpendituresReportingYear'
+    >,
 ): UpdateReportFundsExpendituresSettingsDto => ({
     disclaimerTitle: settings.disclaimerTitle ?? '',
     exchangeRate: Number.parseFloat((settings.exchangeRate ?? '0').replace(',', '.')) || 0,
+    programExpendituresReportingYear: settings.programExpendituresReportingYear ?? new Date().getFullYear(),
 });
 
 export const mapReportFundsExpendituresCategoryDtoToCategory = (


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2185

## Description

This PR implements functionality that allows an Admin to edit the reporting year of the aggregated "Програмні" record in the Funds & Expenditures table.

The record is always displayed as the first, read-only row. Only its reporting year can be edited, while the expenditure totals are retrieved from the backend program expenditures summary.

## How it looks

https://github.com/user-attachments/assets/7395b57a-d787-4965-9d2e-43a5322e99ed

## Summary of change

- Added programExpendituresReportingYear to settings type/DTO/mapper and updateSettings.
- Funds section fetches program totals via ProgramExpensesApi.getSummary and renders a pinned, disabled "Програмні" aggregate row.

## How to recreate changes

1. Go to Reports → Доходи та витрати.
2. Note the first row - the disabled "Програмні" record.

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [x]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable “program expenditures reporting year” to the funds expenditures section, with save/cancel controls and success/error notifications.
  * Display and edit a new program aggregate row in the funds expenditures table, and ensure the saved year is used for publishing.
* **Style**
  * Updated expense styling to use new theme-based maroon color tokens for consistent visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->