### PR TITLE
Fix/issue 2812 [Partners] Rich Text Title Editor: Applying Bold Style Automatically Applies Italic Style

### DIFF
--- a/src/pages/public/partners-page/partners-sections/intro-section/IntroSection.module.scss
+++ b/src/pages/public/partners-page/partners-sections/intro-section/IntroSection.module.scss
@@ -51,7 +51,6 @@
 
 .title strong {
     font-weight: 800;
-    font-style: italic;
 }
 
 .subtitle {


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2812)

## Description

This PR fixes a visual bug on the public Partners page banner where any bold text in the Title was inadvertently being displayed as italicized. Previously, the CSS rule for .title strong unconditionally applied font-style: italic;, meaning text formatted purely as bold in the admin panel would still render as italic on the public page. The explicit font-style: italic; property has been removed, ensuring that bold text behaves as expected.

## How it looks


https://github.com/user-attachments/assets/7b6a9c0b-cdce-4772-8377-65e6037643ce

## Summary of change

* **Styling Adjustment (`IntroSection.module.scss`)**: Removed `font-style: italic;` from the `.title strong` rule to prevent bold text from being forced into an italic style on the public Partners page banner.

## How to recreate changes
1. Log in to the Admin panel.
2. Navigate to the Partners page.
3. In the "Title" field for the Partner Banner, enter some text.
4. Select a portion of the text and apply **Bold** formatting using the editor toolbar (do not apply Italic).
5. Click the **"Опублікувати"** (Publish) button and confirm to save the banner.
6. Navigate to the public Partners page (`/partners-page`).
7. Verify that the text you made bold is displayed strictly as bold and is no longer incorrectly italicized.


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions
