### PR TITLE
Fix/issue  2888 [Reports] The "Налаштування медіа" tab does not match the mock-up. The "Заголовок" input field is missing.  

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -3,7 +3,8 @@ import { COMMON_TEXT_ADMIN } from './common';
 export const REPORTS_TEXT = {
     FORM: {
         LABEL: {
-            TITLE: 'Заголовок/EN',
+            TITLE: 'Заголовок',
+            TITLE_EN: 'Заголовок/EN',
             COLLECTED_FUNDS_WINDOW: 'Вікно 1: Зібрано коштів',
             CHANGED_LIVES_WINDOW: 'Вікно 2: Змінено життів',
             COLLECTED_FUNDS: 'Зібрані кошти',

--- a/src/pages/admin/reports/components/block-component/ReportsMediaBlock.module.scss
+++ b/src/pages/admin/reports/components/block-component/ReportsMediaBlock.module.scss
@@ -20,7 +20,7 @@
 
 .content {
     width: 650px;
-    height: 877px;
+    height: 993px;
 }
 
 .image-wrapper {
@@ -59,7 +59,7 @@
 
 .inputs {
     width: 650px;
-    height: 323px;
+    height: 439px;
 }
 
 .header {

--- a/src/pages/admin/reports/components/block-component/ReportsMediaBlock.test.tsx
+++ b/src/pages/admin/reports/components/block-component/ReportsMediaBlock.test.tsx
@@ -119,10 +119,12 @@ jest.mock('./ReportsMediaBlock.module.scss', () => ({
 describe('ReportsMediaBlock', () => {
     const mockOnValuesChange = jest.fn();
     const mockValidateTitle = jest.fn();
+    const mockValidateTitleEn = jest.fn();
     const mockValidateTotalAmount = jest.fn();
 
     const defaultValues: ReportsMediaBlockValues = {
         title: 'Test Title',
+        titleEn: 'Test Title UK',
         totalAmount: 250000,
         image: null,
         imageId: null,
@@ -132,6 +134,7 @@ describe('ReportsMediaBlock', () => {
 
     const defaultValidationFunctions: ReportsMediaBlockValidationFunctions = {
         validateTitle: mockValidateTitle,
+        validateTitleEn: mockValidateTitleEn,
         validateTotalAmount: mockValidateTotalAmount,
     };
 
@@ -320,7 +323,7 @@ describe('ReportsMediaBlock', () => {
         it('should work without validateTotalAmount function', () => {
             renderComponent({
                 isValueEditable: true,
-                validationFunctions: { validateTitle: mockValidateTitle },
+                validationFunctions: { validateTitle: mockValidateTitle, validateTitleEn: mockValidateTitleEn },
             });
 
             const valueInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-value');

--- a/src/pages/admin/reports/components/block-component/ReportsMediaBlock.tsx
+++ b/src/pages/admin/reports/components/block-component/ReportsMediaBlock.tsx
@@ -11,6 +11,7 @@ import './ReportsMediaBlock.scss';
 
 export interface ReportsMediaBlockValues {
     title: string;
+    titleEn: string;
     totalAmount: number;
     image: ImageValues | Image | null;
     imageId: number | null;
@@ -18,12 +19,14 @@ export interface ReportsMediaBlockValues {
 
 export interface ReportsMediaBlockErrors {
     title?: string;
+    titleEn?: string;
     totalAmount?: string;
     image?: string;
 }
 
 export interface ReportsMediaBlockValidationFunctions {
     validateTitle: (value: string) => string | undefined;
+    validateTitleEn: (value: string) => string | undefined;
     validateTotalAmount?: (value: number) => string | undefined;
 }
 
@@ -70,6 +73,24 @@ export const ReportsMediaBlock = ({
             const normalizedTitle = getNormalizedInputText(values.title);
             const error = validationFunctions.validateTitle(normalizedTitle);
             onValuesChange({ ...values, title: normalizedTitle }, { ...errors, title: error });
+        },
+        [onValuesChange, values, errors, validationFunctions],
+    );
+
+    const handleTitleEnChange = useCallback(
+        (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+            const value = e.target.value;
+            const error = validationFunctions.validateTitleEn(value);
+            onValuesChange({ ...values, titleEn: value }, { ...errors, titleEn: error });
+        },
+        [onValuesChange, values, errors, validationFunctions],
+    );
+
+    const handleTitleEnBlur = useCallback(
+        (_e: React.FocusEvent<HTMLTextAreaElement>) => {
+            const normalizedTitle = getNormalizedInputText(values.titleEn);
+            const error = validationFunctions.validateTitleEn(normalizedTitle);
+            onValuesChange({ ...values, titleEn: normalizedTitle }, { ...errors, titleEn: error });
         },
         [onValuesChange, values, errors, validationFunctions],
     );
@@ -127,6 +148,25 @@ export const ReportsMediaBlock = ({
                                 REPORTS_TEXT.FORM.MAX_LENGTH.TITLE,
                             )}
                             error={errors.title}
+                            rows={1}
+                            isRequired={true}
+                            errorCounterContainerClassName={styles['error-counter']}
+                        />
+                    </div>
+
+                    <div className={styles['title-input']}>
+                        <TextAreaWithCharacterLimitGroup
+                            label={REPORTS_TEXT.FORM.LABEL.TITLE_EN}
+                            id={`${windowTitle}-title-en`}
+                            name={`${windowTitle}-title-en`}
+                            value={values.titleEn}
+                            onChange={handleTitleEnChange}
+                            onBlur={handleTitleEnBlur}
+                            maxLength={REPORTS_TEXT.FORM.MAX_LENGTH.TITLE}
+                            maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
+                                REPORTS_TEXT.FORM.MAX_LENGTH.TITLE,
+                            )}
+                            error={errors.titleEn}
                             rows={1}
                             isRequired={true}
                             errorCounterContainerClassName={styles['error-counter']}

--- a/src/pages/admin/reports/components/media-settings/MediaSettings.test.tsx
+++ b/src/pages/admin/reports/components/media-settings/MediaSettings.test.tsx
@@ -55,9 +55,11 @@ jest.mock('@/utils/functions/fetch-default-image/fetch-default-image');
 jest.mock('@/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema', () => ({
     REPORTS_COLLECTED_FUNDS_VALIDATION_FUNCTIONS: {
         validateTitle: jest.fn(),
+        validateTitleEn: jest.fn(),
     },
     REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS: {
         validateTitle: jest.fn(),
+        validateTitleEn: jest.fn(),
         validateChangedLives: jest.fn(),
     },
 }));
@@ -87,11 +89,13 @@ describe('MediaSettings', () => {
     const defaultMediaSettingsData = {
         collectedFunds: {
             title: 'Зібрано коштів',
+            titleEn: 'Зібрано коштів УК',
             image: { id: 1, url: 'collected-image.jpg', mimeType: 'image/jpeg' },
             imageId: 1,
         },
         changedLives: {
             title: 'Змінено життів',
+            titleEn: 'Змінено життів УК',
             changedLives: 56,
             image: { id: 2, url: 'changed-lives-image.jpg', mimeType: 'image/jpeg' },
             imageId: 2,
@@ -278,7 +282,13 @@ describe('MediaSettings', () => {
         it('should call onDirtyChange(true) when collected funds values change', () => {
             renderComponent();
 
-            const newValues = { title: 'New Title', totalAmount: 300000, image: null, imageId: null };
+            const newValues = {
+                title: 'New Title',
+                titleEn: 'New Title UK',
+                totalAmount: 300000,
+                image: null,
+                imageId: null,
+            };
             const newErrors = {};
 
             act(() => {
@@ -291,7 +301,13 @@ describe('MediaSettings', () => {
         it('should call onDirtyChange(true) when changed lives values change', () => {
             renderComponent();
 
-            const newValues = { title: 'New Title', totalAmount: 100, image: null, imageId: null };
+            const newValues = {
+                title: 'New Title',
+                titleEn: 'New Title UK',
+                totalAmount: 100,
+                image: null,
+                imageId: null,
+            };
             const newErrors = {};
 
             act(() => {
@@ -317,7 +333,13 @@ describe('MediaSettings', () => {
         it('should update collected funds block values after change', () => {
             renderComponent();
 
-            const newValues = { title: 'Updated Title', totalAmount: 500000, image: null, imageId: null };
+            const newValues = {
+                title: 'Updated Title',
+                titleEn: 'Updated Title UK',
+                totalAmount: 500000,
+                image: null,
+                imageId: null,
+            };
             const newErrors = { title: 'Some error' };
 
             act(() => {
@@ -331,7 +353,13 @@ describe('MediaSettings', () => {
         it('should update changed lives block values after change', () => {
             renderComponent();
 
-            const newValues = { title: 'Updated Lives', totalAmount: 99, image: null, imageId: null };
+            const newValues = {
+                title: 'Updated Lives',
+                titleEn: 'Updated Lives UK',
+                totalAmount: 99,
+                image: null,
+                imageId: null,
+            };
             const newErrors = { totalAmount: 'Invalid' };
 
             act(() => {
@@ -550,11 +578,13 @@ describe('MediaSettings', () => {
             const updatedData = {
                 collectedFunds: {
                     title: 'Updated CF Title',
+                    titleEn: 'Updated CF Title UK',
                     image: { id: 3, url: 'new-cf.jpg', mimeType: 'image/jpeg' },
                     imageId: 3,
                 },
                 changedLives: {
                     title: 'Updated CL Title',
+                    titleEn: 'Updated CL Title UK',
                     changedLives: 100,
                     image: { id: 4, url: 'new-cl.jpg', mimeType: 'image/jpeg' },
                     imageId: 4,

--- a/src/pages/admin/reports/components/media-settings/MediaSettings.tsx
+++ b/src/pages/admin/reports/components/media-settings/MediaSettings.tsx
@@ -44,6 +44,7 @@ export interface MediaSettingsRef {
 
 const INITIAL_BLOCK_VALUES: ReportsMediaBlockValues = {
     title: '',
+    titleEn: '',
     totalAmount: 0,
     image: null,
     imageId: null,
@@ -54,12 +55,14 @@ const INITIAL_BLOCK_ERRORS: ReportsMediaBlockErrors = {};
 const syncValuesFromData = (data: ReportsMediaSettings) => ({
     collectedFunds: {
         title: data.collectedFunds.title ?? '',
+        titleEn: data.collectedFunds.titleEn ?? '',
         totalAmount: 0,
         image: data.collectedFunds.image ?? null,
         imageId: data.collectedFunds.imageId ?? null,
     } satisfies ReportsMediaBlockValues,
     changedLives: {
         title: data.changedLives.title ?? '',
+        titleEn: data.changedLives.titleEn ?? '',
         totalAmount: data.changedLives.changedLives ?? 0,
         image: data.changedLives.image ?? null,
         imageId: data.changedLives.imageId ?? null,
@@ -86,8 +89,8 @@ export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
             refetch,
         } = useDataFetch<ReportsMediaSettings>({
             initialData: {
-                collectedFunds: { title: '', image: null, imageId: null },
-                changedLives: { title: '', changedLives: 0, image: null, imageId: null },
+                collectedFunds: { title: '', titleEn: '', image: null, imageId: null },
+                changedLives: { title: '', titleEn: '', changedLives: 0, image: null, imageId: null },
             },
             fetchHandler: fetchMediaSettingsHandler,
             autoFetchDisabled: false,
@@ -133,8 +136,14 @@ export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
         );
 
         const validateCurrentValues = useCallback((): boolean => {
+            const collectedFundsTitleEnError = REPORTS_COLLECTED_FUNDS_VALIDATION_FUNCTIONS.validateTitleEn(
+                collectedFundsValues.titleEn,
+            );
             const collectedFundsTitleError = REPORTS_COLLECTED_FUNDS_VALIDATION_FUNCTIONS.validateTitle(
                 collectedFundsValues.title,
+            );
+            const changedLivesTitleEnError = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTitleEn(
+                changedLivesValues.titleEn,
             );
             const changedLivesTitleError = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTitle(
                 changedLivesValues.title,
@@ -144,16 +153,25 @@ export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
             );
 
             const hasValidationErrors = Boolean(
-                collectedFundsTitleError || changedLivesTitleError || changedLivesValueError,
+                collectedFundsTitleEnError ||
+                    collectedFundsTitleError ||
+                    changedLivesTitleEnError ||
+                    changedLivesTitleError ||
+                    changedLivesValueError,
             );
 
             if (!hasValidationErrors) {
                 return true;
             }
 
-            setCollectedFundsErrors((prev) => ({ ...prev, title: collectedFundsTitleError }));
+            setCollectedFundsErrors((prev) => ({
+                ...prev,
+                titleEn: collectedFundsTitleEnError,
+                title: collectedFundsTitleError,
+            }));
             setChangedLivesErrors((prev) => ({
                 ...prev,
+                titleEn: changedLivesTitleEnError,
                 title: changedLivesTitleError,
                 totalAmount: changedLivesValueError,
             }));
@@ -192,11 +210,13 @@ export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
                 const updated = await ReportsApi.updateMediaSettings(client, {
                     collectedFunds: {
                         title: collectedFundsValues.title,
+                        titleEn: collectedFundsValues.titleEn,
                         image: collectedFundsImage,
                         imageId: collectedFundsImageId,
                     },
                     changedLives: {
                         title: changedLivesValues.title,
+                        titleEn: changedLivesValues.titleEn,
                         changedLives: changedLivesValues.totalAmount,
                         image: changedLivesImage,
                         imageId: changedLivesImageId,

--- a/src/services/api/admin/reports/reports-api.test.ts
+++ b/src/services/api/admin/reports/reports-api.test.ts
@@ -12,6 +12,7 @@ jest.mock('../image/image-api');
 
 const createCollectedFundsBlockDto = (overrides: Partial<ReportsMediaSettingsDto['collectedFundsBlock']> = {}) => ({
     title: 'CF Title',
+    titleEn: 'CF Title UK',
     image: { id: 10, url: 'https://img/cf.png', mimeType: 'image/png' } as Image,
     imageId: 10,
     ...overrides,
@@ -19,6 +20,7 @@ const createCollectedFundsBlockDto = (overrides: Partial<ReportsMediaSettingsDto
 
 const createChangedLivesBlockDto = (overrides: Partial<ReportsMediaSettingsDto['changedLivesBlock']> = {}) => ({
     title: 'CL Title',
+    titleEn: 'CL Title UK',
     changedLives: 56,
     image: { id: 20, url: 'https://img/cl.png', mimeType: 'image/png' } as Image,
     imageId: 20,
@@ -59,11 +61,13 @@ describe('ReportsApi', () => {
             const expected: ReportsMediaSettings = {
                 collectedFunds: {
                     title: 'CF Title',
+                    titleEn: 'CF Title UK',
                     image: dto.collectedFundsBlock.image,
                     imageId: 10,
                 },
                 changedLives: {
                     title: 'CL Title',
+                    titleEn: 'CL Title UK',
                     changedLives: 56,
                     image: dto.changedLivesBlock.image,
                     imageId: 20,
@@ -74,16 +78,16 @@ describe('ReportsApi', () => {
 
         it('should handle null images in response', async () => {
             const dto = createResponseDto(
-                { title: 'Title', image: null, imageId: null },
-                { title: 'Title 2', changedLives: 0, image: null, imageId: null },
+                { title: 'Title', titleEn: '', image: null, imageId: null },
+                { title: 'Title 2', titleEn: '', changedLives: 0, image: null, imageId: null },
             );
             mockClient.get.mockResolvedValueOnce({ data: dto });
 
             const result = await ReportsApi.getMediaSettings(mockClient);
 
             expect(result).toEqual({
-                collectedFunds: { title: 'Title', image: null, imageId: null },
-                changedLives: { title: 'Title 2', changedLives: 0, image: null, imageId: null },
+                collectedFunds: { title: 'Title', titleEn: '', image: null, imageId: null },
+                changedLives: { title: 'Title 2', titleEn: '', changedLives: 0, image: null, imageId: null },
             });
         });
     });
@@ -93,11 +97,13 @@ describe('ReportsApi', () => {
             const request: ReportsMediaSettingsUpdateRequest = {
                 collectedFunds: {
                     title: 'New CF Title',
+                    titleEn: 'New CF Title UK',
                     image: { base64: 'cf-base64', mimeType: 'image/png' },
                     imageId: 10,
                 },
                 changedLives: {
                     title: 'New CL Title',
+                    titleEn: 'New CL Title UK',
                     changedLives: 100,
                     image: { base64: 'cl-base64', mimeType: 'image/jpeg' },
                     imageId: 20,
@@ -111,11 +117,13 @@ describe('ReportsApi', () => {
             const responseDto = createResponseDto(
                 {
                     title: 'New CF Title',
+                    titleEn: 'New CF Title UK',
                     image: { id: 11, url: 'https://img/cf-new.png', mimeType: 'image/png' },
                     imageId: 11,
                 },
                 {
                     title: 'New CL Title',
+                    titleEn: 'New CL Title UK',
                     changedLives: 100,
                     image: { id: 21, url: 'https://img/cl-new.png', mimeType: 'image/jpeg' },
                     imageId: 21,
@@ -138,8 +146,13 @@ describe('ReportsApi', () => {
             );
 
             expect(mockClient.put).toHaveBeenCalledWith(API_ROUTES.REPORTS.MEDIA_SETTINGS, {
-                collectedFundsBlock: { title: 'New CF Title', imageId: 11 },
-                changedLivesBlock: { title: 'New CL Title', changedLives: 100, imageId: 21 },
+                collectedFundsBlock: { title: 'New CF Title', titleEn: 'New CF Title UK', imageId: 11 },
+                changedLivesBlock: {
+                    title: 'New CL Title',
+                    titleEn: 'New CL Title UK',
+                    changedLives: 100,
+                    imageId: 21,
+                },
             });
 
             expect(mockedImageApi.delete).toHaveBeenCalledWith(mockClient, 10);
@@ -148,11 +161,13 @@ describe('ReportsApi', () => {
             expect(result).toEqual({
                 collectedFunds: {
                     title: 'New CF Title',
+                    titleEn: 'New CF Title UK',
                     image: responseDto.collectedFundsBlock.image,
                     imageId: 11,
                 },
                 changedLives: {
                     title: 'New CL Title',
+                    titleEn: 'New CL Title UK',
                     changedLives: 100,
                     image: responseDto.changedLivesBlock.image,
                     imageId: 21,
@@ -162,8 +177,8 @@ describe('ReportsApi', () => {
 
         it('should not delete images when there is nothing to remove', async () => {
             const request: ReportsMediaSettingsUpdateRequest = {
-                collectedFunds: { title: 'Keep Title', image: null, imageId: null },
-                changedLives: { title: 'Keep CL', changedLives: 10, image: null, imageId: null },
+                collectedFunds: { title: 'Keep Title', titleEn: 'Keep Title UK', image: null, imageId: null },
+                changedLives: { title: 'Keep CL', titleEn: 'Keep CL UK', changedLives: 10, image: null, imageId: null },
             };
 
             mockedImageApi.getUpdateImageId
@@ -185,11 +200,13 @@ describe('ReportsApi', () => {
             const request: ReportsMediaSettingsUpdateRequest = {
                 collectedFunds: {
                     title: 'CF Title',
+                    titleEn: 'CF Title UK',
                     image: { base64: 'new-cf', mimeType: 'image/png' },
                     imageId: 5,
                 },
                 changedLives: {
                     title: 'CL Title',
+                    titleEn: 'CL Title UK',
                     changedLives: 30,
                     image: { id: 20, url: 'https://img/cl.png', mimeType: 'image/png' },
                     imageId: 20,
@@ -218,8 +235,8 @@ describe('ReportsApi', () => {
 
         it('should send null imageId when finalImageId is null', async () => {
             const request: ReportsMediaSettingsUpdateRequest = {
-                collectedFunds: { title: 'Title', image: null, imageId: 7 },
-                changedLives: { title: 'Title 2', changedLives: 0, image: null, imageId: 8 },
+                collectedFunds: { title: 'Title', titleEn: 'Title UK', image: null, imageId: 7 },
+                changedLives: { title: 'Title 2', titleEn: 'Title 2 UK', changedLives: 0, image: null, imageId: 8 },
             };
 
             mockedImageApi.getUpdateImageId
@@ -235,8 +252,8 @@ describe('ReportsApi', () => {
             await ReportsApi.updateMediaSettings(mockClient, request);
 
             expect(mockClient.put).toHaveBeenCalledWith(API_ROUTES.REPORTS.MEDIA_SETTINGS, {
-                collectedFundsBlock: { title: 'Title', imageId: null },
-                changedLivesBlock: { title: 'Title 2', changedLives: 0, imageId: null },
+                collectedFundsBlock: { title: 'Title', titleEn: 'Title UK', imageId: null },
+                changedLivesBlock: { title: 'Title 2', titleEn: 'Title 2 UK', changedLives: 0, imageId: null },
             });
         });
     });

--- a/src/services/api/admin/reports/reports-api.ts
+++ b/src/services/api/admin/reports/reports-api.ts
@@ -30,10 +30,12 @@ export const ReportsApi = {
         const dto: UpdateReportsMediaSettingsDto = {
             collectedFundsBlock: {
                 title: request.collectedFunds.title,
+                titleEn: request.collectedFunds.titleEn,
                 imageId: finalImageIdCollectedFunds ?? null,
             },
             changedLivesBlock: {
                 title: request.changedLives.title,
+                titleEn: request.changedLives.titleEn,
                 changedLives: request.changedLives.changedLives,
                 imageId: finalImageIdChangedLives ?? null,
             },

--- a/src/types/admin/reports.ts
+++ b/src/types/admin/reports.ts
@@ -8,6 +8,7 @@ import { Image, ImageValues } from '../common/image';
 
 export interface ReportsMediaSettingsCollectedFundsDto {
     title: string;
+    titleEn: string;
     collectedAmount?: number;
     image: Image | null;
     imageId: number | null;
@@ -15,6 +16,7 @@ export interface ReportsMediaSettingsCollectedFundsDto {
 
 export interface ReportsMediaSettingsChangedLivesDto {
     title: string;
+    titleEn: string;
     changedLives: number;
     image: Image | null;
     imageId: number | null;
@@ -27,12 +29,14 @@ export interface ReportsMediaSettingsDto {
 
 export type ReportsMediaSettingsCollectedFunds = {
     title: string;
+    titleEn: string;
     image: Image | ImageValues | null;
     imageId: number | null;
 };
 
 export type ReportsMediaSettingsChangedLives = {
     title: string;
+    titleEn: string;
     changedLives: number;
     image: Image | ImageValues | null;
     imageId: number | null;
@@ -46,11 +50,13 @@ export type ReportsMediaSettings = {
 // Update DTOs
 export interface UpdateReportsMediaSettingsCollectedFundsDto {
     title: string;
+    titleEn: string;
     imageId: number | null;
 }
 
 export interface UpdateReportsMediaSettingsChangedLivesDto {
     title: string;
+    titleEn: string;
     changedLives: number;
     imageId: number | null;
 }
@@ -63,12 +69,14 @@ export interface UpdateReportsMediaSettingsDto {
 // Update Request
 export interface ReportsMediaSettingsCollectedFundsUpdateRequest {
     title: string;
+    titleEn: string;
     imageId: number | null;
     image: Image | ImageValues | null;
 }
 
 export interface ReportsMediaSettingsChangedLivesUpdateRequest {
     title: string;
+    titleEn: string;
     changedLives: number;
     imageId: number | null;
     image: Image | ImageValues | null;

--- a/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.test.ts
+++ b/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.test.ts
@@ -26,6 +26,7 @@ describe('reports-mapper', () => {
         it('should map dto with image correctly (without collected amount from API)', () => {
             const dto: ReportsMediaSettingsCollectedFundsDto = {
                 title: 'Зібрані кошти',
+                titleEn: 'Зібрані кошти УК',
                 image: { id: 10, url: 'https://img/cf.png', mimeType: 'image/png' },
                 imageId: 10,
             };
@@ -34,6 +35,7 @@ describe('reports-mapper', () => {
 
             expect(result).toEqual({
                 title: 'Зібрані кошти',
+                titleEn: 'Зібрані кошти УК',
                 image: dto.image,
                 imageId: 10,
             });
@@ -42,6 +44,7 @@ describe('reports-mapper', () => {
         it('should ignore legacy collectedAmount when present', () => {
             const dto: ReportsMediaSettingsCollectedFundsDto = {
                 title: 'Title',
+                titleEn: 'Title UK',
                 collectedAmount: 999,
                 image: { id: 5, url: 'https://img/5.png', mimeType: 'image/jpeg' },
                 imageId: 5,
@@ -51,6 +54,7 @@ describe('reports-mapper', () => {
 
             expect(result).toEqual({
                 title: 'Title',
+                titleEn: 'Title UK',
                 image: dto.image,
                 imageId: 5,
             });
@@ -59,6 +63,7 @@ describe('reports-mapper', () => {
         it('should set imageId from image.id when image is present', () => {
             const dto: ReportsMediaSettingsCollectedFundsDto = {
                 title: 'Title',
+                titleEn: 'Title UK',
                 image: { id: 42, url: 'https://img/42.png', mimeType: 'image/png' },
                 imageId: 99,
             };
@@ -71,6 +76,7 @@ describe('reports-mapper', () => {
         it('should set imageId to null when image is null', () => {
             const dto: ReportsMediaSettingsCollectedFundsDto = {
                 title: 'Title',
+                titleEn: 'Title UK',
                 image: null,
                 imageId: null,
             };
@@ -86,6 +92,7 @@ describe('reports-mapper', () => {
         it('should map dto with image correctly', () => {
             const dto: ReportsMediaSettingsChangedLivesDto = {
                 title: 'Змінені життя',
+                titleEn: 'Змінені життя УК',
                 changedLives: 56,
                 image: { id: 20, url: 'https://img/cl.png', mimeType: 'image/png' },
                 imageId: 20,
@@ -95,6 +102,7 @@ describe('reports-mapper', () => {
 
             expect(result).toEqual({
                 title: 'Змінені життя',
+                titleEn: 'Змінені життя УК',
                 changedLives: 56,
                 image: dto.image,
                 imageId: 20,
@@ -104,6 +112,7 @@ describe('reports-mapper', () => {
         it('should set imageId from image.id when image is present', () => {
             const dto: ReportsMediaSettingsChangedLivesDto = {
                 title: 'Title',
+                titleEn: 'Title UK',
                 changedLives: 10,
                 image: { id: 33, url: 'https://img/33.png', mimeType: 'image/jpeg' },
                 imageId: 50,
@@ -117,6 +126,7 @@ describe('reports-mapper', () => {
         it('should set imageId to null when image is null', () => {
             const dto: ReportsMediaSettingsChangedLivesDto = {
                 title: 'Title',
+                titleEn: 'Title UK',
                 changedLives: 0,
                 image: null,
                 imageId: null,
@@ -134,11 +144,13 @@ describe('reports-mapper', () => {
             const dto: ReportsMediaSettingsDto = {
                 collectedFundsBlock: {
                     title: 'CF Title',
+                    titleEn: 'CF Title UK',
                     image: { id: 1, url: 'https://img/1.png', mimeType: 'image/png' },
                     imageId: 1,
                 },
                 changedLivesBlock: {
                     title: 'CL Title',
+                    titleEn: 'CL Title UK',
                     changedLives: 100,
                     image: { id: 2, url: 'https://img/2.png', mimeType: 'image/jpeg' },
                     imageId: 2,
@@ -150,11 +162,13 @@ describe('reports-mapper', () => {
             expect(result).toEqual({
                 collectedFunds: {
                     title: 'CF Title',
+                    titleEn: 'CF Title UK',
                     image: dto.collectedFundsBlock.image,
                     imageId: 1,
                 },
                 changedLives: {
                     title: 'CL Title',
+                    titleEn: 'CL Title UK',
                     changedLives: 100,
                     image: dto.changedLivesBlock.image,
                     imageId: 2,
@@ -166,11 +180,13 @@ describe('reports-mapper', () => {
             const dto: ReportsMediaSettingsDto = {
                 collectedFundsBlock: {
                     title: 'Empty CF',
+                    titleEn: 'Empty CF UK',
                     image: null,
                     imageId: null,
                 },
                 changedLivesBlock: {
                     title: 'Empty CL',
+                    titleEn: 'Empty CL UK',
                     changedLives: 0,
                     image: null,
                     imageId: null,

--- a/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.ts
+++ b/src/utils/functions/mappers/admin/reports-mapper/reports-mapper.ts
@@ -35,6 +35,7 @@ export const mapReportsMediaSettingsCollectedFundsDtoToCollectedFunds = (
     dto: ReportsMediaSettingsCollectedFundsDto,
 ): ReportsMediaSettingsCollectedFunds => ({
     title: dto.title,
+    titleEn: dto.titleEn,
     image: dto.image,
     imageId: dto.image?.id ?? null,
 });
@@ -43,6 +44,7 @@ export const mapReportsMediaSettingsChangedLivesDtoToChangedLives = (
     dto: ReportsMediaSettingsChangedLivesDto,
 ): ReportsMediaSettingsChangedLives => ({
     title: dto.title,
+    titleEn: dto.titleEn,
     changedLives: dto.changedLives,
     image: dto.image,
     imageId: dto.image?.id ?? null,

--- a/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.ts
+++ b/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.ts
@@ -35,6 +35,14 @@ export const REPORTS_COLLECTED_FUNDS_VALIDATION_FUNCTIONS = {
             return error.message;
         }
     },
+    validateTitleEn: (value: string): string | undefined => {
+        try {
+            collectedFundsSchema.validateSyncAt('title', { title: value });
+            return undefined;
+        } catch (error: any) {
+            return error.message;
+        }
+    },
 };
 
 const changedLivesSchema = Yup.object({
@@ -63,6 +71,14 @@ const changedLivesSchema = Yup.object({
 
 export const REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS = {
     validateTitle: (value: string): string | undefined => {
+        try {
+            changedLivesSchema.validateSyncAt('title', { title: value });
+            return undefined;
+        } catch (error: any) {
+            return error.message;
+        }
+    },
+    validateTitleEn: (value: string): string | undefined => {
         try {
             changedLivesSchema.validateSyncAt('title', { title: value });
             return undefined;


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2888)

## Description

This PR resolves a UI bug in the Reports Media Settings tab where the Ukrainian version of the title field was entirely missing. Previously, the implementation only rendered a single title input labeled "Заголовок/EN". The architecture has been refactored to support bilingual titles correctly: the default title field has been repurposed to store the Ukrainian version, while a newly introduced titleEn field has been added to handle the English translation.

## How it looks

<img width="1905" height="922" alt="image" src="https://github.com/user-attachments/assets/86b59e6a-ca32-4e74-bbba-2252571d52f7" />

## Summary of change

*   **Data Models & API**: Added the `titleEn` property to the `ReportsMediaSettingsCollectedFundsDto` and `ReportsMediaSettingsChangedLivesDto` interfaces in `reports.ts`. Updated the `reports-api.ts` PUT payload and `reports-mapper.ts` to map and persist `titleEn`.
*   **Localization**: Updated `REPORTS_TEXT.FORM.LABEL.TITLE` to "Заголовок" and added `TITLE_EN` as "Заголовок/EN" in `const/admin/reports.ts`.
*   **UI Integration**: Refactored `ReportsMediaBlock.tsx` to display an additional `TextAreaWithCharacterLimitGroup` input field. Swapped the input bindings so the top field maps to the Ukrainian title and the bottom field maps to the English title.
*   **State Management & Validation**: Updated initial form states in `MediaSettings.tsx` to handle `titleEn`. Extended Yup validation schemas in `reports-media-settings-schema.ts` to include `validateTitleEn`, enforcing the same character limits as the default title.
*   **Testing**: Updated fixtures and mock responses across `MediaSettings.test.tsx`, `ReportsMediaBlock.test.tsx`, `reports-mapper.test.ts`, and `reports-api.test.ts` to validate the new `titleEn` payload. 

## How to recreate changes

1. Log in to the Admin panel.
2. Navigate to the **Reports** page.
3. Click on the **"Налаштування медіа"** tab.
4. Verify that both the "Заголовок" and "Заголовок/EN" input fields are correctly rendered for both media blocks.

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions
