### PR TITLE
Fix/issue 2850 Reports][Додати витрати]The Сума (UAH) field allows you to enter 10 characters after the decimal point instead of the maximum 2

### DIFF
--- a/src/components/admin/input-with-character-limit/InputWithCharacterLimit.test.tsx
+++ b/src/components/admin/input-with-character-limit/InputWithCharacterLimit.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, createEvent } from '@testing-library/react';
+import { act, render, screen, fireEvent, createEvent } from '@testing-library/react';
 import { InputWithCharacterLimit, InputWithCharacterLimitProps } from './InputWithCharacterLimit';
 
 describe('InputWithCharacterLimit', () => {
@@ -199,5 +199,34 @@ describe('InputWithCharacterLimit', () => {
     it('sets aria-invalid on textarea when rows provided and length exceeds maxLength', () => {
         renderInputWithCharacterLimit({ rows: 3, value: 'abcd', maxLength: 3 });
         expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('resets localValue to the value prop via microtask when parent onChange does not update state', async () => {
+        const cappedValue = '100,12';
+        const onChange = jest.fn();
+
+        render(
+            <InputWithCharacterLimit
+                value={cappedValue}
+                onChange={onChange}
+                name="amountUah"
+                id="amount-uah"
+                maxLength={20}
+                showCounter={false}
+            />,
+        );
+
+        const input = screen.getByRole('textbox') as HTMLInputElement;
+        expect(input.value).toBe(cappedValue);
+
+        fireEvent.change(input, { target: { value: '100,123' } });
+
+        expect(input.value).toBe('100,123');
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(input.value).toBe(cappedValue);
     });
 });

--- a/src/components/admin/input-with-character-limit/InputWithCharacterLimit.tsx
+++ b/src/components/admin/input-with-character-limit/InputWithCharacterLimit.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState } from 'react';
+import React, { useRef, useEffect, useState, useLayoutEffect } from 'react';
 import cn from 'classnames';
 import { ReactComponent as RemoveIcon } from '@/assets/icons/remove-query.svg';
 import { useInputWithCharacterLimit } from '@/hooks/admin/use-input-with-character-limit/useInputWithCharacterLimit';
@@ -46,6 +46,11 @@ export const InputWithCharacterLimit = ({
     maxRows,
 }: InputWithCharacterLimitProps) => {
     const [localValue, setLocalValue] = useState(value ?? '');
+    const valueRef = useRef(value);
+
+    useLayoutEffect(() => {
+        valueRef.current = value;
+    });
 
     useEffect(() => {
         setLocalValue(value ?? '');
@@ -76,6 +81,9 @@ export const InputWithCharacterLimit = ({
     const onInternalChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setLocalValue(e.target.value);
         handleChange(e);
+        Promise.resolve().then(() => {
+            setLocalValue(valueRef.current ?? '');
+        });
     };
 
     const textareaRef = useRef<HTMLTextAreaElement>(null);

--- a/src/components/admin/input-with-character-limit/InputWithCharacterLimit.tsx
+++ b/src/components/admin/input-with-character-limit/InputWithCharacterLimit.tsx
@@ -50,7 +50,7 @@ export const InputWithCharacterLimit = ({
 
     useLayoutEffect(() => {
         valueRef.current = value;
-    });
+    }, [value]);
 
     useEffect(() => {
         setLocalValue(value ?? '');

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -316,6 +316,7 @@ export const FUNDS_EXPENDITURES_TEXT = {
         CATEGORY_UNIQUE_EXPENSE: 'Категорія вже додана до витрат',
         AMOUNT_ONLY_NUMBER: 'Дозволено лише цифри',
         AMOUNT_MAX_DIGITS: 'Не більше 9 цифр до коми',
+        AMOUNT_MAX_DECIMALS: 'Не більше 2 цифр після коми',
         AMOUNT_NOT_NEGATIVE: "Сума не може бути від'ємною",
         AMOUNT_NOT_ZERO: 'Сума не може дорівнювати 0',
         EXCHANGE_RATE_ONLY_NUMERIC: 'Дозволено тільки числові значення десяткові та цілі',

--- a/src/hooks/admin/use-funds-expenditures-record-form/useFundsExpendituresRecordForm.ts
+++ b/src/hooks/admin/use-funds-expenditures-record-form/useFundsExpendituresRecordForm.ts
@@ -197,7 +197,9 @@ export const useFundsExpendituresRecordForm = ({
         !formState.categoryId ||
         Boolean(amountUahValidationError) ||
         Boolean(amountUsdValidationError) ||
-        Boolean(categoryValidationError);
+        Boolean(categoryValidationError) ||
+        Boolean(formState.errors.amountUah) ||
+        Boolean(formState.errors.amountUsd);
 
     const handleOpenAddConfirmation = useCallback(() => {
         setIsAddConfirmationOpen(true);

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
@@ -637,8 +637,8 @@ describe('FundsExpendituresTable', () => {
                     categoryName: 'Грантові кошти',
                     type: 'income',
                     reportingYear: '2025',
-                    amountUah: '7 265,123',
-                    amountUsd: '173,221',
+                    amountUah: '7 265,12',
+                    amountUsd: '173,22',
                 },
             ];
 
@@ -650,8 +650,8 @@ describe('FundsExpendituresTable', () => {
 
             expect(onRecordSave).toHaveBeenCalledWith(1, {
                 categoryId: 2,
-                amountUah: '7 265,123',
-                amountUsd: '173,221',
+                amountUah: '7 265,12',
+                amountUsd: '173,22',
             });
         });
 

--- a/src/utils/functions/update-funds-amounts/update-funds-amounts.ts
+++ b/src/utils/functions/update-funds-amounts/update-funds-amounts.ts
@@ -22,7 +22,7 @@ export const updateFundsAmounts = (
     return (prev: FundsAmountsState) => {
         const shouldNormalize = trigger === 'blur';
         const normalized = normalizeFundsExpendituresAmountInput(value, shouldNormalize);
-        const currentFieldError = validateFundsExpendituresAmount(normalized, trigger);
+        const currentFieldError = validateFundsExpendituresAmount(value, trigger);
 
         let nextAmountUah = field === 'amountUah' ? normalized : prev.amountUah;
         let nextAmountUsd = field === 'amountUsd' ? normalized : prev.amountUsd;

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
@@ -77,6 +77,11 @@ describe('FUNDS_EXPENDITURES_RECORD_VALIDATION_FUNCTIONS', () => {
             );
         });
 
+        it('should ignore spaces when counting fractional digits', () => {
+            expect(validateFundsExpendituresAmount('1 200, 12', 'change')).toBeUndefined();
+            expect(validateFundsExpendituresAmount('1 200 , 12', 'change')).toBeUndefined();
+        });
+
         it('should support dot input by normalizing it to comma', () => {
             expect(validateFundsExpendituresAmount('1 200.50', 'save')).toBeUndefined();
         });

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
@@ -71,8 +71,10 @@ describe('FUNDS_EXPENDITURES_RECORD_VALIDATION_FUNCTIONS', () => {
             expect(validateFundsExpendituresAmount('1 200,50', 'save')).toBeUndefined();
         });
 
-        it('should not return an error when user types more than two decimal digits', () => {
-            expect(validateFundsExpendituresAmount('1 200,123', 'change')).toBeUndefined();
+        it('should return error when user types more than two decimal digits', () => {
+            expect(validateFundsExpendituresAmount('1 200,123', 'change')).toBe(
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DECIMALS,
+            );
         });
 
         it('should support dot input by normalizing it to comma', () => {

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
@@ -40,6 +40,17 @@ export const validateFundsExpendituresAmount = (
     value: string,
     trigger: FundsExpendituresAmountValidationTrigger = 'change',
 ): string | undefined => {
+    if (value) {
+        const withCommaSeparator = value.replaceAll(/\s+/g, ' ').trimStart().replaceAll('.', ',');
+        const firstCommaIndex = withCommaSeparator.indexOf(',');
+        if (firstCommaIndex !== -1) {
+            const rawDecimalPart = withCommaSeparator.slice(firstCommaIndex + 1).replaceAll(',', '');
+            if (rawDecimalPart.length > 2) {
+                return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DECIMALS;
+            }
+        }
+    }
+
     const normalized = normalizeFundsExpendituresAmountInput(value, true);
 
     if (!normalized) {

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
@@ -29,7 +29,7 @@ export const normalizeFundsExpendituresAmountInput = (value: string | undefined 
     const integerPart = withCommaSeparator.slice(0, firstCommaIndex);
     const decimalPart = withCommaSeparator
         .slice(firstCommaIndex + 1)
-        .replaceAll(',', '')
+        .replaceAll(/[\s,]/g, '')
         .slice(0, 2);
     const normalized = `${integerPart},${decimalPart}`;
 
@@ -44,7 +44,7 @@ export const validateFundsExpendituresAmount = (
         const withCommaSeparator = value.replaceAll(/\s+/g, ' ').trimStart().replaceAll('.', ',');
         const firstCommaIndex = withCommaSeparator.indexOf(',');
         if (firstCommaIndex !== -1) {
-            const rawDecimalPart = withCommaSeparator.slice(firstCommaIndex + 1).replaceAll(',', '');
+            const rawDecimalPart = withCommaSeparator.slice(firstCommaIndex + 1).replaceAll(/[\s,]/g, '');
             if (rawDecimalPart.length > 2) {
                 return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DECIMALS;
             }

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
@@ -44,7 +44,7 @@ export const validateFundsExpendituresAmount = (
         const withCommaSeparator = value.replaceAll(/\s+/g, ' ').trimStart().replaceAll('.', ',');
         const firstCommaIndex = withCommaSeparator.indexOf(',');
         if (firstCommaIndex !== -1) {
-            const rawDecimalPart = withCommaSeparator.slice(firstCommaIndex + 1).replaceAll(/[\s,]/g, '');
+            const rawDecimalPart = withCommaSeparator.slice(firstCommaIndex + 1).replace(/[^\d]/g, '');
             if (rawDecimalPart.length > 2) {
                 return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DECIMALS;
             }


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2850)

## Description

This PR resolves an issue in the Reports section where the "Сума (UAH)" and "Сума (USD)" input fields physically allowed users to type and temporarily view more than 2 characters after the decimal point. The input component synchronization architecture has been refactored to securely cap user input at 2 decimal places. Additionally, the validation flow has been enhanced to actively intercept invalid decimal inputs and display an explicit new validation error message ("Не більше 2 цифр після коми") when users attempt to exceed the limit.

## How it looks

<img width="611" height="782" alt="image" src="https://github.com/user-attachments/assets/ec3d0988-91a7-4189-b33c-23ff9a79f1d8" />

## Summary of change

*   **Validation & Constants**: Added the `AMOUNT_MAX_DECIMALS` error message constant to `src/const/admin/reports.ts`.
*   **State Management & Validation**: Refactored `validateFundsExpendituresAmount` in `funds-expenditures-record-schema.ts` to intercept the raw input data and explicitly return the `AMOUNT_MAX_DECIMALS` error if a user attempts to enter more than 2 decimal digits.
*   **Data Flow**: Updated `updateFundsAmounts.ts` to ensure raw values are passed to the validation layer before truncation occurs.
*   **UI Integration**: Fixed a controlled-input state divergence bug in the globally shared `InputWithCharacterLimit.tsx`. Implemented a `useLayoutEffect` alongside microtask queueing to guarantee that the input's local state immediately synchronizes with the parent's normalized/truncated form state. This resolves the issue where truncated inputs wouldn't visually reset.
*   **Testing**: Added a regression test to `InputWithCharacterLimit.test.tsx` to verify the microtask re-sync behavior. Updated unit tests in `funds-expenditures-record-schema.test.ts` to assert the new explicit decimal error. Refactored mock values in `FundsExpendituresTable.test.tsx` to satisfy the new strict decimal validation constraints.

## How to recreate changes

1. Log in to the Admin panel.
2. Navigate to the **Reports** page.
3. Click the **"Додати витрату"** button or edit an existing record in the table.
4. In the "Сума (UAH)" field, enter a valid decimal number (e.g., `123,12`).
5. Attempt to type a third digit after the decimal point (e.g., `123,123`).
6. Verify that the input physically truncates the entry (preventing the third digit) and immediately displays the red error text *"Не більше 2 цифр після коми"* below the field.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Amount inputs now stay aligned with the saved form value, avoiding brief display of unsaved typed text.
  * Funds expenditures amount validation now correctly rejects entries with more than 2 decimal places and surfaces the updated max-decimals message.
  * Table row saves now store amounts in consistent 2-decimal format.
  * Submissions are now blocked when amount fields contain validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->