### PR TITLE
Fix/issue 2930 [Reports] Unsaved changes to input fields and media elements are lost after switching tabs

### DIFF
--- a/src/pages/admin/reports/components/reports-panel-content/ReportsPanelContent.tsx
+++ b/src/pages/admin/reports/components/reports-panel-content/ReportsPanelContent.tsx
@@ -39,20 +39,17 @@ export const ReportsPanelContent = () => {
                 <ReportsPageToolbar selectedTab={selectedTab} onTabSelect={handleTabSelect} />
             </div>
             <div className={styles.content}>
-                {isMediaSettingsTab ? (
-                    <MediaSettings
-                        ref={mediaSettingsRef}
-                        resetCounter={resetCounter}
-                        onDirtyChange={handleDirtyChange}
-                        onCancel={handleCancel}
-                        onPublish={handlePublish}
-                        isPublishDisabled={!isDirty}
-                        isCancelDisabled={!isDirty}
-                        isActive={isMediaSettingsTab}
-                    />
-                ) : (
-                    <ReportAnalytics />
-                )}
+                <MediaSettings
+                    ref={mediaSettingsRef}
+                    resetCounter={resetCounter}
+                    onDirtyChange={handleDirtyChange}
+                    onCancel={handleCancel}
+                    onPublish={handlePublish}
+                    isPublishDisabled={!isDirty}
+                    isCancelDisabled={!isDirty}
+                    isActive={isMediaSettingsTab}
+                />
+                {!isMediaSettingsTab && <ReportAnalytics />}
             </div>
             <ToastContainer />
         </div>


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2930)

## Description

This PR resolves an issue in the Reports section where unsaved modifications on the "Media Settings" tab were discarded when a user navigated to another tab and returned. The tab switching architecture has been refactored to keep the MediaSettings component mounted in the DOM rather than fully unmounting it. By relying on the component's internal visibility toggle (isActive), the component safely preserves all local state, including unsaved text fields and media elements, while correctly maintaining synchronization with the global "Відмінити" and "Опублікувати" button states.

## How it looks

https://github.com/user-attachments/assets/fedb4117-9946-40a6-a3d0-a1c8035cd743



## Summary of change

*   **UI Integration & State Preservation**: Fixed a state-loss bug in `ReportsPanelContent.tsx`. Changed the conditional rendering logic so that the `MediaSettings` component remains continuously mounted when navigating between tabs. The component now utilizes its `isActive` property to manage its CSS visibility (`display: none` when inactive) rather than being destroyed and removed from the React tree. This guarantees that local component state immediately synchronizes with the user's expected workflow.

## How to recreate changes

1. Log in to the Admin panel.
2. Navigate to the **Reports** page.
3. Ensure you are on the "Media Settings" tab.
4. Modify at least one text field or media element with new unsaved values.
5. Click on a different tab on the Reports page.
6. Switch back to the "Media Settings" tab.
7. Verify that all unsaved modifications to the input fields and media elements remain completely intact (not reverted to published values).
8. Verify that the "Відмінити" and "Опублікувати" buttons maintain their correct active state.


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reports page so the media settings section is always available, while analytics now only appears on the appropriate tab.
  * Tab switching behavior is now more consistent, helping prevent content from disappearing unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->