### PR TITLE
Fix/issue-2806 [Partners] Displays the wrong image size inside the media icon

### DIFF
--- a/src/const/admin/partners.ts
+++ b/src/const/admin/partners.ts
@@ -97,7 +97,7 @@ export const PARTNER_VALIDATION = {
         getRequiredError: () => `Опис обов'язковий`,
     },
     image: {
-        width: 208,
-        height: 208,
+        width: 200,
+        height: 200,
     },
 };


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2806

## Description
  This PR resolves the incorrect image size validation rules and helper text displayed inside the partner image
  upload area in the admin panel, aligning the requirements to 200x200 pixels.

 ## Summary of Changes

 ### 1. Correct Partner Image Validation Dimensions

 • **Issue**: The partner image validation configuration used `208x208` pixels instead of the expected `200x200`
  pixels. This caused the media icon's subtext helper to display `Розмір: 208x208` and reject `200x200` image uploads
  as too small.
  • **Fix**: Updated `PARTNER_VALIDATION.image` dimensions to `200` (width and height) in
  `src/const/admin/partners.ts`. This dynamically updates the helper text to `Розмір: 200x200` and configures the
  cropper and size validators to accept `200x200` images.

 ## How to recreate changes

 1. Log in to the **Admin Panel**.
 2. Open the **Partners** page.
 3. Open a partner profile in **edit mode**.
 4. In the partner image upload area, observe the helper text below the placeholder icon:
    * **Observe**: The text displays `"Розмір: 200x200"`.
 5. Upload an image with pixel size `200x200`.
    * **Observe**: The image is successfully uploaded and validated according to the rules.

 ## CHECK LIST 
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test coverage was updated
- [x]  PR meets all conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated partner image size validation to accept the current required dimensions, helping prevent image upload or display validation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->