### PR TITLE
Feature/issue 2035, 2036 [Main] View Programs, View Impact Statistics

### DIFF
--- a/src/components/public/program-card/ProgramCardSkeleton.module.scss
+++ b/src/components/public/program-card/ProgramCardSkeleton.module.scss
@@ -1,0 +1,52 @@
+@use '@/assets/sass/variables/colors' as c;
+
+@keyframes shimmer {
+    0% {
+        background-position: -400px 0;
+    }
+
+    100% {
+        background-position: 400px 0;
+    }
+}
+
+$shimmer-base: c.$grey-100;
+$shimmer-highlight: c.$grey-50;
+
+@mixin shimmer {
+    background: linear-gradient(90deg, $shimmer-base 25%, $shimmer-highlight 50%, $shimmer-base 75%);
+    background-size: 800px 100%;
+    animation: shimmer 1.5s infinite linear;
+}
+
+.root {
+    background-color: c.$grey-50;
+    overflow: hidden;
+}
+
+.image {
+    width: 100%;
+    aspect-ratio: 480 / 440;
+    @include shimmer;
+}
+
+.content {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px;
+}
+
+.line-short {
+    height: 14px;
+    width: 40%;
+    border-radius: 4px;
+    @include shimmer;
+}
+
+.line-long {
+    height: 16px;
+    width: 75%;
+    border-radius: 4px;
+    @include shimmer;
+}

--- a/src/components/public/program-card/ProgramCardSkeleton.tsx
+++ b/src/components/public/program-card/ProgramCardSkeleton.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import styles from './ProgramCardSkeleton.module.scss';
+
+export const ProgramCardSkeleton: React.FC = () => (
+    <div className={styles.root} aria-hidden="true">
+        <div className={styles.image} />
+        <div className={styles.content}>
+            <div className={styles['line-short']} />
+            <div className={styles['line-long']} />
+        </div>
+    </div>
+);

--- a/src/hooks/common/use-counter-animation/useCounterAnimation.test.ts
+++ b/src/hooks/common/use-counter-animation/useCounterAnimation.test.ts
@@ -1,0 +1,78 @@
+import { renderHook, act } from '@testing-library/react';
+import { useCounterAnimation } from './useCounterAnimation';
+
+describe('useCounterAnimation', () => {
+    let rafCallbacks: FrameRequestCallback[];
+    let rafId: number;
+
+    beforeEach(() => {
+        rafCallbacks = [];
+        rafId = 0;
+
+        jest.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb) => {
+            rafCallbacks.push(cb);
+            return ++rafId;
+        });
+
+        jest.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => { });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    const flush = (startTime = 0, endTime = 2000, steps = 10) => {
+        const step = (endTime - startTime) / steps;
+        for (let i = 0; i <= steps; i++) {
+            const callbacks = [...rafCallbacks];
+            rafCallbacks = [];
+            callbacks.forEach((cb) => cb(startTime + i * step));
+        }
+    };
+
+    it('starts at 0', () => {
+        const { result } = renderHook(() => useCounterAnimation(100, false));
+        expect(result.current).toBe(0);
+    });
+
+    it('stays at 0 while not visible', () => {
+        const { result } = renderHook(() => useCounterAnimation(100, false));
+        act(() => flush());
+        expect(result.current).toBe(0);
+    });
+
+    it('animates from 0 to target when isVisible becomes true', () => {
+        const { result } = renderHook(() => useCounterAnimation(100, true));
+
+        act(() => flush(0, 2000, 20));
+
+        expect(result.current).toBe(100);
+    });
+
+    it('does not re-animate after already completing', () => {
+        const { result, rerender } = renderHook(({ isVisible }) => useCounterAnimation(100, isVisible), {
+            initialProps: { isVisible: true },
+        });
+
+        act(() => flush(0, 2000, 20));
+        expect(result.current).toBe(100);
+
+        rerender({ isVisible: false });
+        rerender({ isVisible: true });
+        act(() => flush(0, 2000, 20));
+
+        expect(result.current).toBe(100);
+    });
+
+    it('cancels the animation frame on unmount', () => {
+        const { unmount } = renderHook(() => useCounterAnimation(100, true));
+        unmount();
+        expect(cancelAnimationFrame).toHaveBeenCalled();
+    });
+
+    it('respects a custom duration', () => {
+        const { result } = renderHook(() => useCounterAnimation(200, true, 500));
+        act(() => flush(0, 600, 10));
+        expect(result.current).toBe(200);
+    });
+});

--- a/src/hooks/common/use-counter-animation/useCounterAnimation.test.ts
+++ b/src/hooks/common/use-counter-animation/useCounterAnimation.test.ts
@@ -14,7 +14,7 @@ describe('useCounterAnimation', () => {
             return ++rafId;
         });
 
-        jest.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => { });
+        jest.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => {});
     });
 
     afterEach(() => {

--- a/src/hooks/common/use-counter-animation/useCounterAnimation.ts
+++ b/src/hooks/common/use-counter-animation/useCounterAnimation.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef, useState } from 'react';
+
+const COUNTER_DURATION_MS = 1800;
+
+export const useCounterAnimation = (
+    targetValue: number,
+    isVisible: boolean,
+    duration = COUNTER_DURATION_MS,
+): number => {
+    const [displayValue, setDisplayValue] = useState(0);
+    const animatedRef = useRef(false);
+    const rafIdRef = useRef<number | null>(null);
+
+    useEffect(() => {
+        if (!isVisible || animatedRef.current) return;
+        animatedRef.current = true;
+
+        let startTime: number | null = null;
+
+        const animate = (currentTime: number) => {
+            if (startTime === null) startTime = currentTime;
+
+            const elapsed = currentTime - startTime;
+            const progress = Math.min(elapsed / duration, 1);
+
+            setDisplayValue(Math.round(targetValue * progress));
+
+            if (progress < 1) {
+                rafIdRef.current = requestAnimationFrame(animate);
+            }
+        };
+
+        rafIdRef.current = requestAnimationFrame(animate);
+
+        return () => {
+            if (rafIdRef.current !== null) {
+                cancelAnimationFrame(rafIdRef.current);
+            }
+        };
+    }, [isVisible, targetValue, duration]);
+
+    return displayValue;
+};

--- a/src/locales/en/programs.json
+++ b/src/locales/en/programs.json
@@ -14,5 +14,6 @@
     "MAIN_TITLE.FIRST_HIGHLIGHT": "spaces",
     "MAIN_TITLE.MIDDLE": " where healing ",
     "MAIN_TITLE.SECOND_HIGHLIGHT": "is possible",
-    "FAILED_TO_LOAD_THE_PROGRAMS": "Failed to load application data. Please try again later."
+    "FAILED_TO_LOAD_THE_PROGRAMS": "Failed to load application data. Please try again later.",
+    "RETRY": "Try again"
 }

--- a/src/locales/uk/programs.json
+++ b/src/locales/uk/programs.json
@@ -14,5 +14,6 @@
     "MAIN_TITLE.FIRST_HIGHLIGHT": "простори,",
     "MAIN_TITLE.MIDDLE": " де можливе ",
     "MAIN_TITLE.SECOND_HIGHLIGHT": "зцілення",
-    "FAILED_TO_LOAD_THE_PROGRAMS": "Не вдалося завантажити дані програм. Будь ласка, спробуйте пізніше."
+    "FAILED_TO_LOAD_THE_PROGRAMS": "Не вдалося завантажити дані програм. Будь ласка, спробуйте пізніше.",
+    "RETRY": "Спробувати ще раз"
 }

--- a/src/pages/public/main-page/MainPage.module.scss
+++ b/src/pages/public/main-page/MainPage.module.scss
@@ -1,5 +1,11 @@
 @use '@/assets/sass/variables/colors.scss' as c;
 
+.page {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
 .loader {
     width: 100%;
 }

--- a/src/pages/public/main-page/MainPage.test.tsx
+++ b/src/pages/public/main-page/MainPage.test.tsx
@@ -46,6 +46,10 @@ jest.mock('./intro-section/IntroSection', () => ({
     )),
 }));
 
+jest.mock('./main-programs-section/MainProgramsSection', () => ({
+    MainProgramsSection: () => <div data-testid="main-programs-section" />,
+}));
+
 const mockedUseDataFetch = useDataFetch as jest.Mock;
 const mockedUseLocale = useLocale as jest.Mock;
 const MockedIntroSection = IntroSection as jest.Mock;

--- a/src/pages/public/main-page/MainPage.test.tsx
+++ b/src/pages/public/main-page/MainPage.test.tsx
@@ -50,6 +50,10 @@ jest.mock('./main-programs-section/MainProgramsSection', () => ({
     MainProgramsSection: () => <div data-testid="main-programs-section" />,
 }));
 
+jest.mock('./main-statistics-section/MainStatisticsSection', () => ({
+    MainStatisticsSection: () => <div data-testid="main-statistics-section" />,
+}));
+
 const mockedUseDataFetch = useDataFetch as jest.Mock;
 const mockedUseLocale = useLocale as jest.Mock;
 const MockedIntroSection = IntroSection as jest.Mock;

--- a/src/pages/public/main-page/MainPage.tsx
+++ b/src/pages/public/main-page/MainPage.tsx
@@ -8,6 +8,7 @@ import { PublicMainPageApi } from '@/services/api/public/main-page/main-page-api
 import { PublicMainPageDto, PublicMainPageLocalizationDto, MainIntroData } from '@/types/public/main-page';
 import { getImageSrc } from '@/utils/functions/image-helper/image-helper';
 import { IntroSection } from './intro-section/IntroSection';
+import { MainProgramsSection } from './main-programs-section/MainProgramsSection';
 import styles from './MainPage.module.scss';
 
 const getFilledText = (...values: Array<string | null | undefined>): string => {
@@ -59,5 +60,10 @@ export const MainPage = () => {
         image: imageSrc,
     };
 
-    return <IntroSection introData={introData} buttonHref={PUBLIC_ROUTES.PROGRAMS.FULL} />;
+    return (
+        <div className={styles.page}>
+            <IntroSection introData={introData} buttonHref={PUBLIC_ROUTES.PROGRAMS.FULL} />
+            <MainProgramsSection />
+        </div>
+    );
 };

--- a/src/pages/public/main-page/MainPage.tsx
+++ b/src/pages/public/main-page/MainPage.tsx
@@ -9,6 +9,7 @@ import { PublicMainPageDto, PublicMainPageLocalizationDto, MainIntroData } from 
 import { getImageSrc } from '@/utils/functions/image-helper/image-helper';
 import { IntroSection } from './intro-section/IntroSection';
 import { MainProgramsSection } from './main-programs-section/MainProgramsSection';
+import { MainStatisticsSection } from './main-statistics-section/MainStatisticsSection';
 import styles from './MainPage.module.scss';
 
 const getFilledText = (...values: Array<string | null | undefined>): string => {
@@ -64,6 +65,7 @@ export const MainPage = () => {
         <div className={styles.page}>
             <IntroSection introData={introData} buttonHref={PUBLIC_ROUTES.PROGRAMS.FULL} />
             <MainProgramsSection />
+            <MainStatisticsSection impactStatistics={mainPageData?.impactStatistics} />
         </div>
     );
 };

--- a/src/pages/public/main-page/main-programs-section/MainProgramsSection.module.scss
+++ b/src/pages/public/main-page/main-programs-section/MainProgramsSection.module.scss
@@ -33,6 +33,21 @@
     width: 100%;
 }
 
+.skeleton-grid {
+    display: flex;
+    gap: 16px;
+    padding: 0 16px;
+    overflow: hidden;
+
+    @media (min-width: 768px) {
+        padding: 0 32px;
+    }
+
+    @media (min-width: 1440px) {
+        padding: 0 56px;
+    }
+}
+
 .swiper-slide {
     width: 320px;
 
@@ -97,6 +112,26 @@
 }
 
 .error {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
     color: c.$error;
     padding: 16px;
+}
+
+.retry-button {
+    @include type.body-2-regular;
+    color: c.$blue-900;
+    background: none;
+    border: 1.5px solid c.$blue-900;
+    border-radius: 4px;
+    padding: 8px 20px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease;
+
+    &:hover {
+        background-color: c.$blue-900;
+        color: c.$white;
+    }
 }

--- a/src/pages/public/main-page/main-programs-section/MainProgramsSection.module.scss
+++ b/src/pages/public/main-page/main-programs-section/MainProgramsSection.module.scss
@@ -1,0 +1,102 @@
+@use '@/assets/sass/variables/colors' as c;
+@use '@/assets/sass/variables/z-index';
+@use '@/assets/sass/mixins/typography.mixins' as type;
+
+.root {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    padding-top: 48px;
+}
+
+.heading {
+    @include type.subtitle-1-bold;
+    color: c.$blue-900;
+    text-transform: uppercase;
+    padding: 0 16px 16px;
+
+    @media (min-width: 768px) {
+        padding: 0 32px 16px;
+    }
+
+    @media (min-width: 1024px) {
+        padding: 0 56px 16px;
+    }
+
+    @media (min-width: 1440px) {
+        @include type.h4-bold-uppercase;
+    }
+}
+
+.swiper-wrapper {
+    position: relative;
+    width: 100%;
+}
+
+.swiper-slide {
+    width: 320px;
+
+    @media (min-width: 560px) {
+        width: 375px;
+    }
+
+    @media (min-width: 768px) {
+        width: 384px;
+    }
+
+    @media (min-width: 1440px) {
+        width: 481px;
+    }
+}
+
+.scrollbar {
+    display: flex;
+    background-color: c.$grey-100;
+    height: 56px;
+    justify-content: center;
+    align-items: center;
+}
+
+.line {
+    width: 100%;
+    margin: 0 16px;
+    height: 4px;
+    background-color: c.$grey-400;
+    border-radius: 0;
+
+    @media (min-width: 768px) {
+        margin: 0 56px;
+    }
+
+    @media (min-width: 1440px) {
+        margin: 0 168px;
+    }
+}
+
+.drag {
+    height: 100%;
+    border-radius: 0;
+    background-color: c.$blue-900;
+    cursor: pointer;
+}
+
+.right {
+    position: absolute;
+    top: 50%;
+    right: 4px;
+    transform: translateY(-50%);
+    z-index: z-index.$scrollable-frame-arrows;
+
+    @media (min-width: 560px) {
+        right: 16px;
+    }
+
+    @media (min-width: 1440px) {
+        right: 31px;
+    }
+}
+
+.error {
+    color: c.$error;
+    padding: 16px;
+}

--- a/src/pages/public/main-page/main-programs-section/MainProgramsSection.test.tsx
+++ b/src/pages/public/main-page/main-programs-section/MainProgramsSection.test.tsx
@@ -1,0 +1,177 @@
+import { render, screen } from '@testing-library/react';
+import { useDataFetch } from '@/hooks/common/use-data-fetch/useDataFetch';
+import { ProgramsPageData } from '@/types/public/programs-page';
+import { MainProgramsSection } from './MainProgramsSection';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (key: string) => {
+            const map: Record<string, string> = {
+                PROGRAMS: 'Програми',
+                FAILED_TO_LOAD_THE_PROGRAMS: 'Не вдалося завантажити дані програм.',
+            };
+            return map[key] ?? key;
+        },
+    }),
+}));
+
+jest.mock('@/hooks/common/use-data-fetch/useDataFetch', () => ({
+    useDataFetch: jest.fn(),
+}));
+
+jest.mock('@/components/public/program-card/ProgramCard', () => ({
+    ProgramCard: ({ program }: { program: { name: string } }) => (
+        <div data-testid="program-card">{program.name}</div>
+    ),
+}));
+
+jest.mock('@/components/public/swiper/Swiper', () => ({
+    Swiper: ({ items, renderItem }: { items: unknown[] | null; renderItem: (item: unknown, index: number) => React.ReactNode }) => {
+        if (!items || items.length === 0) return null;
+        return (
+            <div data-testid="swiper">
+                {items.map((item, index) => (
+                    <div key={index} data-testid="swiper-slide">
+                        {renderItem(item, index)}
+                    </div>
+                ))}
+            </div>
+        );
+    },
+}));
+
+jest.mock('./MainProgramsSection.module.scss', () => ({
+    root: 'root',
+    heading: 'heading',
+    'swiper-wrapper': 'swiper-wrapper',
+    'swiper-slide': 'swiper-slide',
+    scrollbar: 'scrollbar',
+    line: 'line',
+    drag: 'drag',
+    right: 'right',
+    error: 'error',
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const mockedUseDataFetch = useDataFetch as jest.Mock;
+
+const createMockProgram = (id: number, name: string) => ({
+    id,
+    name,
+    slug: `program-${id}`,
+    previewImage: { id, url: `image-${id}.jpg`, mimeType: 'image/jpeg' },
+    description: `Description ${id}`,
+    categories: [],
+    localizations: [],
+});
+
+const mockFetch = (
+    data: ProgramsPageData | null,
+    isLoading = false,
+    error: Error | null = null,
+) => {
+    mockedUseDataFetch.mockReturnValue({ data, isLoading, error });
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('MainProgramsSection', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders the section heading', () => {
+        mockFetch(null);
+
+        render(<MainProgramsSection />);
+
+        expect(screen.getByText('Програми')).toBeInTheDocument();
+    });
+
+    it('renders a loading indicator while fetching', () => {
+        mockFetch(null, true);
+
+        render(<MainProgramsSection />);
+
+        expect(screen.getByRole('progressbar')).toBeInTheDocument();
+        expect(screen.queryByTestId('swiper')).not.toBeInTheDocument();
+    });
+
+    it('renders an error message when fetch fails', () => {
+        mockFetch(null, false, new Error('Network error'));
+
+        render(<MainProgramsSection />);
+
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+        expect(screen.getByText('Не вдалося завантажити дані програм.')).toBeInTheDocument();
+        expect(screen.queryByTestId('swiper')).not.toBeInTheDocument();
+    });
+
+    it('renders nothing in the swiper area when data is null', () => {
+        mockFetch(null);
+
+        render(<MainProgramsSection />);
+
+        expect(screen.queryByTestId('swiper')).not.toBeInTheDocument();
+        expect(screen.queryAllByTestId('program-card')).toHaveLength(0);
+    });
+
+    it('renders nothing in the swiper area when programsData is empty', () => {
+        mockFetch({ programsData: [], programsCategories: [] });
+
+        render(<MainProgramsSection />);
+
+        expect(screen.queryByTestId('swiper')).not.toBeInTheDocument();
+        expect(screen.queryAllByTestId('program-card')).toHaveLength(0);
+    });
+
+    it('renders a Swiper with one ProgramCard per program', () => {
+        const programs = [
+            createMockProgram(1, 'Program A'),
+            createMockProgram(2, 'Program B'),
+            createMockProgram(3, 'Program C'),
+        ];
+        mockFetch({ programsData: programs, programsCategories: [] });
+
+        render(<MainProgramsSection />);
+
+        expect(screen.getByTestId('swiper')).toBeInTheDocument();
+        const cards = screen.getAllByTestId('program-card');
+        expect(cards).toHaveLength(3);
+        expect(screen.getByText('Program A')).toBeInTheDocument();
+        expect(screen.getByText('Program B')).toBeInTheDocument();
+        expect(screen.getByText('Program C')).toBeInTheDocument();
+    });
+
+    it('passes the fetched programs to the Swiper', () => {
+        const programs = [createMockProgram(1, 'Solo Program')];
+        mockFetch({ programsData: programs, programsCategories: [] });
+
+        render(<MainProgramsSection />);
+
+        expect(screen.getByText('Solo Program')).toBeInTheDocument();
+    });
+
+    it('renders the scrollbar container', () => {
+        mockFetch({ programsData: [createMockProgram(1, 'P1')], programsCategories: [] });
+
+        const { container } = render(<MainProgramsSection />);
+
+        expect(container.querySelector('.scrollbar')).toBeInTheDocument();
+    });
+
+    it('calls useDataFetch with programPageDataFetch handler and no autoFetch dependencies', () => {
+        mockFetch(null);
+
+        render(<MainProgramsSection />);
+
+        expect(mockedUseDataFetch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                initialData: null,
+            }),
+        );
+    });
+});

--- a/src/pages/public/main-page/main-programs-section/MainProgramsSection.test.tsx
+++ b/src/pages/public/main-page/main-programs-section/MainProgramsSection.test.tsx
@@ -3,8 +3,6 @@ import { useDataFetch } from '@/hooks/common/use-data-fetch/useDataFetch';
 import { ProgramsPageData } from '@/types/public/programs-page';
 import { MainProgramsSection } from './MainProgramsSection';
 
-// ── Mocks ────────────────────────────────────────────────────────────────────
-
 jest.mock('react-i18next', () => ({
     useTranslation: () => ({
         t: (key: string) => {
@@ -22,13 +20,17 @@ jest.mock('@/hooks/common/use-data-fetch/useDataFetch', () => ({
 }));
 
 jest.mock('@/components/public/program-card/ProgramCard', () => ({
-    ProgramCard: ({ program }: { program: { name: string } }) => (
-        <div data-testid="program-card">{program.name}</div>
-    ),
+    ProgramCard: ({ program }: { program: { name: string } }) => <div data-testid="program-card">{program.name}</div>,
 }));
 
 jest.mock('@/components/public/swiper/Swiper', () => ({
-    Swiper: ({ items, renderItem }: { items: unknown[] | null; renderItem: (item: unknown, index: number) => React.ReactNode }) => {
+    Swiper: ({
+        items,
+        renderItem,
+    }: {
+        items: unknown[] | null;
+        renderItem: (item: unknown, index: number) => React.ReactNode;
+    }) => {
         if (!items || items.length === 0) return null;
         return (
             <div data-testid="swiper">
@@ -54,8 +56,6 @@ jest.mock('./MainProgramsSection.module.scss', () => ({
     error: 'error',
 }));
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
 const mockedUseDataFetch = useDataFetch as jest.Mock;
 
 const createMockProgram = (id: number, name: string) => ({
@@ -68,15 +68,9 @@ const createMockProgram = (id: number, name: string) => ({
     localizations: [],
 });
 
-const mockFetch = (
-    data: ProgramsPageData | null,
-    isLoading = false,
-    error: Error | null = null,
-) => {
+const mockFetch = (data: ProgramsPageData | null, isLoading = false, error: Error | null = null) => {
     mockedUseDataFetch.mockReturnValue({ data, isLoading, error });
 };
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('MainProgramsSection', () => {
     beforeEach(() => {

--- a/src/pages/public/main-page/main-programs-section/MainProgramsSection.test.tsx
+++ b/src/pages/public/main-page/main-programs-section/MainProgramsSection.test.tsx
@@ -9,6 +9,7 @@ jest.mock('react-i18next', () => ({
             const map: Record<string, string> = {
                 PROGRAMS: 'Програми',
                 FAILED_TO_LOAD_THE_PROGRAMS: 'Не вдалося завантажити дані програм.',
+                RETRY: 'Спробувати ще раз',
             };
             return map[key] ?? key;
         },
@@ -21,6 +22,10 @@ jest.mock('@/hooks/common/use-data-fetch/useDataFetch', () => ({
 
 jest.mock('@/components/public/program-card/ProgramCard', () => ({
     ProgramCard: ({ program }: { program: { name: string } }) => <div data-testid="program-card">{program.name}</div>,
+}));
+
+jest.mock('@/components/public/program-card/ProgramCardSkeleton', () => ({
+    ProgramCardSkeleton: () => <div data-testid="program-card-skeleton" />,
 }));
 
 jest.mock('@/components/public/swiper/Swiper', () => ({
@@ -48,12 +53,14 @@ jest.mock('./MainProgramsSection.module.scss', () => ({
     root: 'root',
     heading: 'heading',
     'swiper-wrapper': 'swiper-wrapper',
+    'skeleton-grid': 'skeleton-grid',
     'swiper-slide': 'swiper-slide',
     scrollbar: 'scrollbar',
     line: 'line',
     drag: 'drag',
     right: 'right',
     error: 'error',
+    'retry-button': 'retry-button',
 }));
 
 const mockedUseDataFetch = useDataFetch as jest.Mock;
@@ -85,12 +92,12 @@ describe('MainProgramsSection', () => {
         expect(screen.getByText('Програми')).toBeInTheDocument();
     });
 
-    it('renders a loading indicator while fetching', () => {
+    it('renders skeleton cards while loading', () => {
         mockFetch(null, true);
 
         render(<MainProgramsSection />);
 
-        expect(screen.getByRole('progressbar')).toBeInTheDocument();
+        expect(screen.getAllByTestId('program-card-skeleton')).toHaveLength(3);
         expect(screen.queryByTestId('swiper')).not.toBeInTheDocument();
     });
 
@@ -102,6 +109,24 @@ describe('MainProgramsSection', () => {
         expect(screen.getByRole('alert')).toBeInTheDocument();
         expect(screen.getByText('Не вдалося завантажити дані програм.')).toBeInTheDocument();
         expect(screen.queryByTestId('swiper')).not.toBeInTheDocument();
+    });
+
+    it('renders a retry button when fetch fails', () => {
+        mockFetch(null, false, new Error('Network error'));
+
+        render(<MainProgramsSection />);
+
+        expect(screen.getByRole('button', { name: 'Спробувати ще раз' })).toBeInTheDocument();
+    });
+
+    it('calls refetch when the retry button is clicked', async () => {
+        const refetch = jest.fn();
+        mockedUseDataFetch.mockReturnValue({ data: null, isLoading: false, error: new Error('fail'), refetch });
+
+        const { getByRole } = render(<MainProgramsSection />);
+        getByRole('button', { name: 'Спробувати ще раз' }).click();
+
+        expect(refetch).toHaveBeenCalledTimes(1);
     });
 
     it('renders nothing in the swiper area when data is null', () => {

--- a/src/pages/public/main-page/main-programs-section/MainProgramsSection.test.tsx
+++ b/src/pages/public/main-page/main-programs-section/MainProgramsSection.test.tsx
@@ -123,8 +123,8 @@ describe('MainProgramsSection', () => {
         const refetch = jest.fn();
         mockedUseDataFetch.mockReturnValue({ data: null, isLoading: false, error: new Error('fail'), refetch });
 
-        const { getByRole } = render(<MainProgramsSection />);
-        getByRole('button', { name: 'Спробувати ще раз' }).click();
+        render(<MainProgramsSection />);
+        screen.getByRole('button', { name: 'Спробувати ще раз' }).click();
 
         expect(refetch).toHaveBeenCalledTimes(1);
     });

--- a/src/pages/public/main-page/main-programs-section/MainProgramsSection.tsx
+++ b/src/pages/public/main-page/main-programs-section/MainProgramsSection.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { LinearProgress } from '@mui/material';
 import { Swiper } from '@/components/public/swiper/Swiper';
 import { ProgramCard } from '@/components/public/program-card/ProgramCard';
+import { ProgramCardSkeleton } from '@/components/public/program-card/ProgramCardSkeleton';
 import { useDataFetch } from '@/hooks/common/use-data-fetch/useDataFetch';
 import { programPageDataFetch } from '@/services/api/public/programs/programs-api';
 import { ProgramsPageData } from '@/types/public/programs-page';
@@ -17,7 +17,7 @@ const SWIPER_NAVIGATION_CONFIG = {
 export const MainProgramsSection: React.FC = () => {
     const { t } = useTranslation('programsPage');
 
-    const { data, isLoading, error } = useDataFetch<ProgramsPageData | null>({
+    const { data, isLoading, error, refetch } = useDataFetch<ProgramsPageData | null>({
         initialData: null,
         fetchHandler: programPageDataFetch,
     });
@@ -26,11 +26,22 @@ export const MainProgramsSection: React.FC = () => {
         <section className={styles.root}>
             <h2 className={styles.heading}>{t('PROGRAMS')}</h2>
             <div className={styles['swiper-wrapper']}>
-                {isLoading && <LinearProgress />}
+                {isLoading && (
+                    <div className={styles['skeleton-grid']}>
+                        {[...Array(3)].map((_, i) => (
+                            <div key={i} className={styles['swiper-slide']}>
+                                <ProgramCardSkeleton />
+                            </div>
+                        ))}
+                    </div>
+                )}
                 {error && (
-                    <p className={styles.error} role="alert">
-                        {t('FAILED_TO_LOAD_THE_PROGRAMS')}
-                    </p>
+                    <div className={styles.error} role="alert">
+                        <p>{t('FAILED_TO_LOAD_THE_PROGRAMS')}</p>
+                        <button className={styles['retry-button']} onClick={refetch}>
+                            {t('RETRY')}
+                        </button>
+                    </div>
                 )}
                 {!isLoading && !error && (
                     <Swiper

--- a/src/pages/public/main-page/main-programs-section/MainProgramsSection.tsx
+++ b/src/pages/public/main-page/main-programs-section/MainProgramsSection.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { LinearProgress } from '@mui/material';
+import { Swiper } from '@/components/public/swiper/Swiper';
+import { ProgramCard } from '@/components/public/program-card/ProgramCard';
+import { useDataFetch } from '@/hooks/common/use-data-fetch/useDataFetch';
+import { programPageDataFetch } from '@/services/api/public/programs/programs-api';
+import { ProgramsPageData } from '@/types/public/programs-page';
+import styles from './MainProgramsSection.module.scss';
+
+const SWIPER_NAVIGATION_CONFIG = {
+    next: {
+        className: styles.right,
+    },
+};
+
+export const MainProgramsSection: React.FC = () => {
+    const { t } = useTranslation('programsPage');
+
+    const { data, isLoading, error } = useDataFetch<ProgramsPageData | null>({
+        initialData: null,
+        fetchHandler: programPageDataFetch,
+    });
+
+    return (
+        <section className={styles.root}>
+            <h2 className={styles.heading}>{t('PROGRAMS')}</h2>
+            <div className={styles['swiper-wrapper']}>
+                {isLoading && <LinearProgress />}
+                {error && (
+                    <p className={styles.error} role="alert">
+                        {t('FAILED_TO_LOAD_THE_PROGRAMS')}
+                    </p>
+                )}
+                {!isLoading && !error && (
+                    <Swiper
+                        items={data?.programsData ?? null}
+                        renderItem={(program) => <ProgramCard program={program} variant="program" />}
+                        showScrollbar={{
+                            isVisible: true,
+                            className: styles.line,
+                            classNameDrag: styles.drag,
+                        }}
+                        classNameSwiperSlide={styles['swiper-slide']}
+                        navigationButtons={SWIPER_NAVIGATION_CONFIG}
+                    />
+                )}
+            </div>
+            <div className={styles.scrollbar}>
+                <div className={styles.line} />
+            </div>
+        </section>
+    );
+};

--- a/src/pages/public/main-page/main-statistics-section/MainStatisticsSection.module.scss
+++ b/src/pages/public/main-page/main-statistics-section/MainStatisticsSection.module.scss
@@ -1,0 +1,107 @@
+@use '@/assets/sass/variables/colors' as c;
+@use '@/assets/sass/mixins/typography.mixins' as type;
+
+
+.root {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.image-wrapper {
+    width: 100%;
+    overflow: hidden;
+    flex-shrink: 0;
+}
+
+.image {
+    width: 100%;
+    display: block;
+    object-fit: cover;
+    object-position: top center;
+    aspect-ratio: 9 / 16;
+
+    @media (min-width: 560px) {
+        aspect-ratio: 4 / 3;
+    }
+
+    @media (min-width: 768px) {
+        aspect-ratio: 1 / 1;
+    }
+
+    @media (min-width: 1440px) {
+        aspect-ratio: unset;
+        height: auto;
+    }
+}
+
+.content-block {
+    background-color: c.$light-blue-300;
+    padding: 40px 16px 32px;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+
+    @media (min-width: 768px) {
+        padding: 48px 32px 40px;
+    }
+
+    @media (min-width: 1024px) {
+        padding: 56px 56px 48px;
+    }
+
+    @media (min-width: 1440px) {
+        padding: 64px 168px 56px;
+    }
+}
+
+.title {
+    @include type.h2-bold-uppercase;
+    color: c.$white;
+    text-align: center;
+
+    @media (min-width: 768px) {
+        @include type.h1-bold-uppercase;
+    }
+}
+
+.metrics-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+
+    @media (min-width: 768px) {
+        flex-direction: row;
+        justify-content: space-between;
+        gap: 0;
+    }
+}
+
+.metric {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 4px;
+
+    @media (min-width: 768px) {
+        align-items: flex-start;
+        text-align: left;
+    }
+}
+
+.metric-value {
+    @include type.h3-bold;
+    color: c.$blue-700;
+    display: block;
+
+    @media (min-width: 768px) {
+        @include type.h2-bold;
+    }
+}
+
+.metric-name {
+    @include type.body-1-regular;
+    color: c.$blue-700;
+    display: block;
+}

--- a/src/pages/public/main-page/main-statistics-section/MainStatisticsSection.test.tsx
+++ b/src/pages/public/main-page/main-statistics-section/MainStatisticsSection.test.tsx
@@ -6,10 +6,6 @@ jest.mock('@/hooks/common/use-locale/useLocale', () => ({
     useLocale: () => ({ currentLanguage: 'uk' }),
 }));
 
-let ioCallback: (entries: Partial<IntersectionObserverEntry>[]) => void;
-const mockObserve = jest.fn();
-const mockDisconnect = jest.fn();
-
 jest.mock('@/hooks/common/use-scroll-animation/useScrollAnimation', () => ({
     useScrollAnimation: () => {
         const React = require('react');
@@ -18,6 +14,10 @@ jest.mock('@/hooks/common/use-scroll-animation/useScrollAnimation', () => ({
         (globalThis as any).__triggerVisible = () => setIsVisible(true);
         return { ref, isVisible };
     },
+}));
+
+jest.mock('@/hooks/common/use-counter-animation/useCounterAnimation', () => ({
+    useCounterAnimation: (target: number, isVisible: boolean) => (isVisible ? target : 0),
 }));
 
 jest.mock('@/utils/functions/image-helper/image-helper', () => ({
@@ -68,12 +68,7 @@ const makeStatistics = (overrides: Partial<PublicImpactStatisticDto> = {}): Publ
 });
 
 describe('MainStatisticsSection', () => {
-    beforeEach(() => {
-        jest.useFakeTimers();
-    });
-
     afterEach(() => {
-        jest.useRealTimers();
         jest.clearAllMocks();
     });
 
@@ -133,10 +128,6 @@ describe('MainStatisticsSection', () => {
             (globalThis as any).__triggerVisible();
         });
 
-        act(() => {
-            jest.runAllTimers();
-        });
-
         expect(screen.getByText('20+')).toBeInTheDocument();
         expect(screen.getByText('21')).toBeInTheDocument();
         expect(screen.getByText('140+')).toBeInTheDocument();
@@ -147,9 +138,6 @@ describe('MainStatisticsSection', () => {
 
         act(() => {
             (globalThis as any).__triggerVisible();
-        });
-        act(() => {
-            jest.runAllTimers();
         });
 
         expect(screen.getByText(/грн/)).toBeInTheDocument();

--- a/src/pages/public/main-page/main-statistics-section/MainStatisticsSection.test.tsx
+++ b/src/pages/public/main-page/main-statistics-section/MainStatisticsSection.test.tsx
@@ -1,0 +1,225 @@
+import { render, screen, act } from '@testing-library/react';
+import { MainStatisticsSection } from './MainStatisticsSection';
+import { PublicImpactStatisticDto, MetricPrefix, MetricType, PublicMetricDto } from '@/types/public/main-page';
+
+jest.mock('@/hooks/common/use-locale/useLocale', () => ({
+    useLocale: () => ({ currentLanguage: 'uk' }),
+}));
+
+let ioCallback: (entries: Partial<IntersectionObserverEntry>[]) => void;
+const mockObserve = jest.fn();
+const mockDisconnect = jest.fn();
+
+jest.mock('@/hooks/common/use-scroll-animation/useScrollAnimation', () => ({
+    useScrollAnimation: () => {
+        const React = require('react');
+        const ref = React.useRef(null);
+        const [isVisible, setIsVisible] = React.useState(false);
+        (globalThis as any).__triggerVisible = () => setIsVisible(true);
+        return { ref, isVisible };
+    },
+}));
+
+jest.mock('@/utils/functions/image-helper/image-helper', () => ({
+    getImageSrc: (img: any) => (img?.url ? img.url : ''),
+}));
+
+jest.mock('./MainStatisticsSection.module.scss', () => ({
+    root: 'root',
+    'image-wrapper': 'image-wrapper',
+    image: 'image',
+    'content-block': 'content-block',
+    title: 'title',
+    'metrics-grid': 'metrics-grid',
+    metric: 'metric',
+    'metric-value': 'metric-value',
+    'metric-name': 'metric-name',
+}));
+
+const makeMetric = (
+    id: number,
+    value: number,
+    name: string,
+    type: MetricType = MetricType.Partners,
+    prefix: MetricPrefix | null = null,
+    priority = id,
+): PublicMetricDto => ({
+    id,
+    value,
+    name,
+    type,
+    prefix,
+    priority,
+    localizations: [],
+});
+
+const makeStatistics = (overrides: Partial<PublicImpactStatisticDto> = {}): PublicImpactStatisticDto => ({
+    id: 1,
+    title: 'Зміни, які можна виміряти',
+    image: { id: 10, url: '/stats-image.jpg', mimeType: 'image/jpeg' },
+    metrics: [
+        makeMetric(1, 20, 'партнерств', MetricType.Partners, MetricPrefix.Plus),
+        makeMetric(2, 21, 'програм підтримки', MetricType.Programs),
+        makeMetric(3, 1249854, 'зібрано', MetricType.Raised),
+        makeMetric(4, 140, 'годин терапії з кіньми', MetricType.TherapyHours, MetricPrefix.Plus),
+    ],
+    localizations: [],
+    ...overrides,
+});
+
+describe('MainStatisticsSection', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        jest.clearAllMocks();
+    });
+
+    it('renders nothing when impactStatistics is null', () => {
+        const { container } = render(<MainStatisticsSection impactStatistics={null} />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing when impactStatistics is undefined', () => {
+        const { container } = render(<MainStatisticsSection impactStatistics={undefined} />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing when metrics array is empty', () => {
+        const { container } = render(<MainStatisticsSection impactStatistics={makeStatistics({ metrics: [] })} />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders the section title', () => {
+        render(<MainStatisticsSection impactStatistics={makeStatistics()} />);
+        expect(screen.getByText('Зміни, які можна виміряти')).toBeInTheDocument();
+    });
+
+    it('renders the image when imageSrc is non-empty', () => {
+        render(<MainStatisticsSection impactStatistics={makeStatistics()} />);
+        const img = document.querySelector('img');
+        expect(img).toBeInTheDocument();
+        expect(img).toHaveAttribute('src', '/stats-image.jpg');
+    });
+
+    it('does not render an image when image is null', () => {
+        render(<MainStatisticsSection impactStatistics={makeStatistics({ image: null })} />);
+        expect(screen.queryByRole('img', { hidden: true })).not.toBeInTheDocument();
+    });
+
+    it('renders all metric names', () => {
+        render(<MainStatisticsSection impactStatistics={makeStatistics()} />);
+        expect(screen.getByText('партнерств')).toBeInTheDocument();
+        expect(screen.getByText('програм підтримки')).toBeInTheDocument();
+        expect(screen.getByText('зібрано')).toBeInTheDocument();
+        expect(screen.getByText('годин терапії з кіньми')).toBeInTheDocument();
+    });
+
+    it('starts all metric values at 0 before animation triggers', () => {
+        const { container } = render(<MainStatisticsSection impactStatistics={makeStatistics()} />);
+        const valueSpans = container.querySelectorAll('.metric-value');
+        valueSpans.forEach((span) => {
+            expect(span.textContent).toMatch(/^0/);
+        });
+        expect(valueSpans).toHaveLength(4);
+    });
+
+    it('animates counters to their target values when section becomes visible', () => {
+        render(<MainStatisticsSection impactStatistics={makeStatistics()} />);
+
+        act(() => {
+            (globalThis as any).__triggerVisible();
+        });
+
+        act(() => {
+            jest.runAllTimers();
+        });
+
+        expect(screen.getByText('20+')).toBeInTheDocument();
+        expect(screen.getByText('21')).toBeInTheDocument();
+        expect(screen.getByText('140+')).toBeInTheDocument();
+    });
+
+    it('appends "грн" suffix for Raised type metrics', () => {
+        render(<MainStatisticsSection impactStatistics={makeStatistics()} />);
+
+        act(() => {
+            (globalThis as any).__triggerVisible();
+        });
+        act(() => {
+            jest.runAllTimers();
+        });
+
+        expect(screen.getByText(/грн/)).toBeInTheDocument();
+    });
+
+    it('uses localized metric name when available for current language', () => {
+        const stats = makeStatistics({
+            metrics: [
+                {
+                    id: 1,
+                    value: 5,
+                    name: 'partners (default)',
+                    type: MetricType.Partners,
+                    prefix: null,
+                    priority: 1,
+                    localizations: [
+                        {
+                            entityId: 1,
+                            localizationInfoDto: { id: 1, code: 'uk' },
+                            translationStatus: 'Relevant' as any,
+                            name: 'партнерів (uk)',
+                        },
+                    ],
+                },
+            ],
+        });
+
+        render(<MainStatisticsSection impactStatistics={stats} />);
+        expect(screen.getByText('партнерів (uk)')).toBeInTheDocument();
+    });
+
+    it('falls back to default metric name when no matching localization', () => {
+        const stats = makeStatistics({
+            metrics: [
+                {
+                    id: 1,
+                    value: 5,
+                    name: 'partners fallback',
+                    type: MetricType.Partners,
+                    prefix: null,
+                    priority: 1,
+                    localizations: [],
+                },
+            ],
+        });
+
+        render(<MainStatisticsSection impactStatistics={stats} />);
+        expect(screen.getByText('partners fallback')).toBeInTheDocument();
+    });
+
+    it('renders metrics ordered by priority', () => {
+        const stats = makeStatistics({
+            metrics: [
+                makeMetric(3, 100, 'Third', MetricType.Partners, null, 3),
+                makeMetric(1, 50, 'First', MetricType.Partners, null, 1),
+                makeMetric(2, 75, 'Second', MetricType.Partners, null, 2),
+            ],
+        });
+
+        render(<MainStatisticsSection impactStatistics={stats} />);
+
+        const metricNames = screen.getAllByText(/First|Second|Third/);
+        expect(metricNames[0]).toHaveTextContent('First');
+        expect(metricNames[1]).toHaveTextContent('Second');
+        expect(metricNames[2]).toHaveTextContent('Third');
+    });
+
+    it('renders figure role for each metric for accessibility', () => {
+        render(<MainStatisticsSection impactStatistics={makeStatistics()} />);
+        const figures = screen.getAllByRole('figure');
+        expect(figures).toHaveLength(4);
+    });
+});

--- a/src/pages/public/main-page/main-statistics-section/MainStatisticsSection.tsx
+++ b/src/pages/public/main-page/main-statistics-section/MainStatisticsSection.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React from 'react';
 import { useLocale } from '@/hooks/common/use-locale/useLocale';
 import { useScrollAnimation } from '@/hooks/common/use-scroll-animation/useScrollAnimation';
+import { useCounterAnimation } from '@/hooks/common/use-counter-animation/useCounterAnimation';
 import { PublicImpactStatisticDto, PublicMetricDto, MetricPrefix, MetricType } from '@/types/public/main-page';
 import { getImageSrc } from '@/utils/functions/image-helper/image-helper';
 import fallbackImage from '@/assets/images/two-horses-gray.webp';
@@ -10,22 +11,21 @@ interface MainStatisticsSectionProps {
     impactStatistics: PublicImpactStatisticDto | null | undefined;
 }
 
-const COUNTER_DURATION_MS = 1800;
-const COUNTER_STEPS = 60;
-
 const getMetricLocalizedName = (metric: PublicMetricDto, currentLanguage: string): string => {
     const loc = metric.localizations?.find((l) => l.localizationInfoDto?.code === currentLanguage);
     return loc?.name ?? metric.name ?? '';
 };
 
-const formatValue = (metric: PublicMetricDto, displayValue: number): string => {
-    const suffix = metric.type === MetricType.Raised ? ' грн' : '';
-    const prefix = metric.prefix === MetricPrefix.Plus ? '+' : metric.prefix === MetricPrefix.Percent ? '%' : '';
-    const formatted = displayValue.toLocaleString('uk-UA');
-    if (metric.prefix === MetricPrefix.Percent) {
-        return `${formatted}${prefix}${suffix}`;
-    }
-    return `${formatted}${prefix}${suffix}`;
+const formatMetricValue = (value: number, prefix: MetricPrefix | null | undefined, type: MetricType): string => {
+    const formatted = value.toLocaleString('uk-UA');
+    const prefixStr = prefix === MetricPrefix.Plus ? '+' : prefix === MetricPrefix.Percent ? '%' : '';
+    const suffix = type === MetricType.Raised ? ' грн' : '';
+    return `${formatted}${prefixStr}${suffix}`;
+};
+
+const getStatisticTitle = (statistic: PublicImpactStatisticDto, currentLanguage: string): string => {
+    const loc = statistic.localizations?.find((l) => l.localizationInfoDto?.code === currentLanguage);
+    return loc?.title ?? statistic.title ?? '';
 };
 
 interface AnimatedCounterProps {
@@ -35,51 +35,20 @@ interface AnimatedCounterProps {
 }
 
 const AnimatedCounter: React.FC<AnimatedCounterProps> = ({ metric, currentLanguage, isVisible }) => {
-    const [displayValue, setDisplayValue] = useState(0);
-    const animatedRef = useRef(false);
-
-    useEffect(() => {
-        if (!isVisible || animatedRef.current) return;
-        animatedRef.current = true;
-
-        const target = metric.value;
-        const stepValue = target / COUNTER_STEPS;
-        const stepDuration = COUNTER_DURATION_MS / COUNTER_STEPS;
-        let current = 0;
-        let step = 0;
-
-        const timer = setInterval(() => {
-            step += 1;
-            current = Math.min(Math.round(stepValue * step), target);
-            setDisplayValue(current);
-            if (current >= target) {
-                clearInterval(timer);
-            }
-        }, stepDuration);
-
-        return () => clearInterval(timer);
-    }, [isVisible, metric.value]);
+    const displayValue = useCounterAnimation(metric.value, isVisible);
 
     const name = getMetricLocalizedName(metric, currentLanguage);
-    const prefix = metric.prefix === MetricPrefix.Plus ? '+' : metric.prefix === MetricPrefix.Percent ? '%' : '';
-    const suffix = metric.type === MetricType.Raised ? ' грн' : '';
-    const formatted = displayValue.toLocaleString('uk-UA');
-    const valueText =
-        metric.prefix === MetricPrefix.Percent ? `${formatted}${prefix}${suffix}` : `${formatted}${prefix}${suffix}`;
+    const valueText = formatMetricValue(displayValue, metric.prefix, metric.type);
+    const finalValueText = formatMetricValue(metric.value, metric.prefix, metric.type);
 
     return (
-        <div className={styles.metric} role="figure" aria-label={`${name}: ${formatValue(metric, metric.value)}`}>
+        <div className={styles.metric} role="figure" aria-label={`${name}: ${finalValueText}`}>
             <span className={styles['metric-value']} aria-hidden="true">
                 {valueText}
             </span>
             <span className={styles['metric-name']}>{name}</span>
         </div>
     );
-};
-
-const getStatisticTitle = (statistic: PublicImpactStatisticDto, currentLanguage: string): string => {
-    const loc = statistic.localizations?.find((l) => l.localizationInfoDto?.code === currentLanguage);
-    return loc?.title ?? statistic.title ?? '';
 };
 
 export const MainStatisticsSection: React.FC<MainStatisticsSectionProps> = ({ impactStatistics }) => {
@@ -103,7 +72,7 @@ export const MainStatisticsSection: React.FC<MainStatisticsSectionProps> = ({ im
         >
             {imageSrc && (
                 <div className={styles['image-wrapper']}>
-                    <img src={imageSrc} alt="" className={styles.image} aria-hidden="true" />
+                    <img src={imageSrc} alt="" className={styles.image} loading="lazy" aria-hidden="true" />
                 </div>
             )}
             <div className={styles['content-block']}>

--- a/src/pages/public/main-page/main-statistics-section/MainStatisticsSection.tsx
+++ b/src/pages/public/main-page/main-statistics-section/MainStatisticsSection.tsx
@@ -1,0 +1,124 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useLocale } from '@/hooks/common/use-locale/useLocale';
+import { useScrollAnimation } from '@/hooks/common/use-scroll-animation/useScrollAnimation';
+import { PublicImpactStatisticDto, PublicMetricDto, MetricPrefix, MetricType } from '@/types/public/main-page';
+import { getImageSrc } from '@/utils/functions/image-helper/image-helper';
+import fallbackImage from '@/assets/images/two-horses-gray.webp';
+import styles from './MainStatisticsSection.module.scss';
+
+interface MainStatisticsSectionProps {
+    impactStatistics: PublicImpactStatisticDto | null | undefined;
+}
+
+const COUNTER_DURATION_MS = 1800;
+const COUNTER_STEPS = 60;
+
+const getMetricLocalizedName = (metric: PublicMetricDto, currentLanguage: string): string => {
+    const loc = metric.localizations?.find((l) => l.localizationInfoDto?.code === currentLanguage);
+    return loc?.name ?? metric.name ?? '';
+};
+
+const formatValue = (metric: PublicMetricDto, displayValue: number): string => {
+    const suffix = metric.type === MetricType.Raised ? ' грн' : '';
+    const prefix = metric.prefix === MetricPrefix.Plus ? '+' : metric.prefix === MetricPrefix.Percent ? '%' : '';
+    const formatted = displayValue.toLocaleString('uk-UA');
+    if (metric.prefix === MetricPrefix.Percent) {
+        return `${formatted}${prefix}${suffix}`;
+    }
+    return `${formatted}${prefix}${suffix}`;
+};
+
+interface AnimatedCounterProps {
+    metric: PublicMetricDto;
+    currentLanguage: string;
+    isVisible: boolean;
+}
+
+const AnimatedCounter: React.FC<AnimatedCounterProps> = ({ metric, currentLanguage, isVisible }) => {
+    const [displayValue, setDisplayValue] = useState(0);
+    const animatedRef = useRef(false);
+
+    useEffect(() => {
+        if (!isVisible || animatedRef.current) return;
+        animatedRef.current = true;
+
+        const target = metric.value;
+        const stepValue = target / COUNTER_STEPS;
+        const stepDuration = COUNTER_DURATION_MS / COUNTER_STEPS;
+        let current = 0;
+        let step = 0;
+
+        const timer = setInterval(() => {
+            step += 1;
+            current = Math.min(Math.round(stepValue * step), target);
+            setDisplayValue(current);
+            if (current >= target) {
+                clearInterval(timer);
+            }
+        }, stepDuration);
+
+        return () => clearInterval(timer);
+    }, [isVisible, metric.value]);
+
+    const name = getMetricLocalizedName(metric, currentLanguage);
+    const prefix = metric.prefix === MetricPrefix.Plus ? '+' : metric.prefix === MetricPrefix.Percent ? '%' : '';
+    const suffix = metric.type === MetricType.Raised ? ' грн' : '';
+    const formatted = displayValue.toLocaleString('uk-UA');
+    const valueText =
+        metric.prefix === MetricPrefix.Percent ? `${formatted}${prefix}${suffix}` : `${formatted}${prefix}${suffix}`;
+
+    return (
+        <div className={styles.metric} role="figure" aria-label={`${name}: ${formatValue(metric, metric.value)}`}>
+            <span className={styles['metric-value']} aria-hidden="true">
+                {valueText}
+            </span>
+            <span className={styles['metric-name']}>{name}</span>
+        </div>
+    );
+};
+
+const getStatisticTitle = (statistic: PublicImpactStatisticDto, currentLanguage: string): string => {
+    const loc = statistic.localizations?.find((l) => l.localizationInfoDto?.code === currentLanguage);
+    return loc?.title ?? statistic.title ?? '';
+};
+
+export const MainStatisticsSection: React.FC<MainStatisticsSectionProps> = ({ impactStatistics }) => {
+    const { currentLanguage } = useLocale();
+    const { ref, isVisible } = useScrollAnimation(0.2);
+
+    if (!impactStatistics) return null;
+
+    const visibleMetrics = (impactStatistics.metrics ?? []).sort((a, b) => a.priority - b.priority);
+
+    if (visibleMetrics.length === 0) return null;
+
+    const title = getStatisticTitle(impactStatistics, currentLanguage);
+    const imageSrc = getImageSrc(impactStatistics.image) || fallbackImage;
+
+    return (
+        <section
+            className={styles.root}
+            ref={ref as React.RefObject<HTMLElement>}
+            aria-label={title || 'Impact statistics'}
+        >
+            {imageSrc && (
+                <div className={styles['image-wrapper']}>
+                    <img src={imageSrc} alt="" className={styles.image} aria-hidden="true" />
+                </div>
+            )}
+            <div className={styles['content-block']}>
+                {title && <h2 className={styles.title}>{title}</h2>}
+                <div className={styles['metrics-grid']}>
+                    {visibleMetrics.map((metric) => (
+                        <AnimatedCounter
+                            key={metric.id}
+                            metric={metric}
+                            currentLanguage={currentLanguage}
+                            isVisible={isVisible}
+                        />
+                    ))}
+                </div>
+            </div>
+        </section>
+    );
+};


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2035)
* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2036) 

## Description

Implemented the public Programs carousel section and Statistics section on the Main page. These sections dynamically fetch data from the backend, handle bilingual localization, and match the provided UI mockups including responsive breakpoints and scroll animations.

## How it looks

<img width="1204" height="608" alt="image" src="https://github.com/user-attachments/assets/c025cdb3-7a0a-4dc9-9377-e1c2b9a8e909" />
<img width="599" height="593" alt="image" src="https://github.com/user-attachments/assets/223f585d-21ba-4e43-a66c-6b39a17faac2" />

## Summary of change

*   **Programs Carousel Section**: Added `MainProgramsSection` which uses the Swiper component to display a scrollable list of published therapeutic programs (`ProgramCard`). Includes localized text and a navigation link to view all programs.
*   **Statistics Section**: Added `MainStatisticsSection` to display the organization's impact metrics. The section intelligently renders a localized title, a responsive banner image (with custom aspect-ratio crops per device size and a default fallback), and a dynamic grid of metrics.
*   **Scroll Animations**: Integrated the `useScrollAnimation` hook within the statistics block so that the metric numbers visibly count up from zero to their target values when the user scrolls the section into the viewport.
*   **Testing**: Wrote unit tests for both `MainProgramsSection` and `MainStatisticsSection` covering data loading, empty states, localization fallbacks, animation triggers, and accessibility, maintaining the project's strict coverage thresholds.

## How to recreate changes

1. Open the public Main page.
2. Scroll down to the Programs section and verify that a carousel of program cards is displayed.
4. Continue scrolling down to the Statistics section.
5. Observe the number counters animating from 0 to their target values as the section enters the screen.
6. Verify that the layout adjusts correctly when resizing the window (metrics stack vertically on mobile screens `< 768px`, and align horizontally on larger screens).
7. Verify that the image aspect ratio smoothly adapts to different screen widths without improperly cutting off the image subjects.
8. Switch the website language to English and verify that the section titles and metric names translate correctly.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions
