### PR TITLE
Fix/issue 2623 [Programs] The layout and components of the Programs page impacts its functionality, is not adaptive to Mobile (< 768px), Tablet(768px – 1024px). (followup)

### DIFF
--- a/src/components/public/header/Header.scss
+++ b/src/components/public/header/Header.scss
@@ -144,7 +144,7 @@ $header-height: 4rem;
     }
 }
 
-@media (max-width: 568px) {
+@media (max-width: 559px) {
     .header-block {
         .header-content-container {
             padding-left: 0.75rem;
@@ -154,15 +154,23 @@ $header-height: 4rem;
                 gap: 0.25rem;
 
                 .language-switcher {
-                    margin-right: 0.25rem;
+                    display: none;
+                }
+
+                .contact-us-button {
+                    display: none;
                 }
             }
         }
     }
 
     .mobile-menu {
+        width: 100%;
+
         .mobile-language-switcher {
-            display: none;
+            display: flex;
+            padding: 1rem;
+            border-top: 1px solid colors.$blue-50;
         }
     }
 }


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2623)

## Description

This PR resolves a layout issue in the public Header component where the "Донатити" button was being cut off on narrow mobile screens (e.g., iPhone SE at 375px width). The responsive styling has been updated to hide the Language Switcher ("UA" dropdown) and "Зв'язатись" button from the main header bar on screens up to 559px wide. To ensure functionality is not lost, the language switcher is now displayed inside the mobile burger menu, and the mobile menu itself has been adjusted to take up the full screen width.

## How it looks
**Before**
<img width="556" height="572" alt="image" src="https://github.com/user-attachments/assets/9a0ae834-fe07-4c61-a5a2-a33790450595" />

**After**
<img width="642" height="897" alt="image" src="https://github.com/user-attachments/assets/78fe448d-a906-4bf5-ae96-31851b07667c" />

## Summary of change

*   **UI Responsiveness & Layout Fix**: Fixed a layout overflow bug in `Header.scss`. Updated the mobile media query breakpoint to `max-width: 559px` to specifically target smaller devices without affecting intermediate layouts (like 560x910).
*   **Header Adjustments**: Applied `display: none` to the `.language-switcher` and `.contact-us-button` within the header block for narrow screens.
*   **Mobile Menu**: Updated the `.mobile-menu` to `width: 100%` and enabled `display: flex` for the `.mobile-language-switcher` to ensure users can still change the site language from the menu.

## How to recreate changes

1. Open the public website.
2. Open your browser's Developer Tools and set the viewport layout to 375 x 667 px (iPhone SE).
3. Observe the header: Verify that the **"Донатити"** button and the burger menu icon are fully visible, while the "UA" dropdown and **"Зв'язатись"** button are hidden.
4. Click the burger menu icon to open the mobile menu.
5. Verify that the mobile menu takes up the full width of the screen.
6. Verify that the "UA" language switcher is successfully rendered inside the expanded mobile menu.
7. Change the viewport layout to 560 x 910 px.
8. Verify that the header correctly displays the Logo, "UA" dropdown, **"Зв'язатись"** button, **"Донатити"** button, and burger menu without any elements being cut off.


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions
