### PR TITLE
fix: code review fixes for PR #462 (issue-2749)

### DIFF
--- a/src/pages/public/stories-of-victory-page/StoriesOfVictoryPage.test.tsx
+++ b/src/pages/public/stories-of-victory-page/StoriesOfVictoryPage.test.tsx
@@ -59,18 +59,16 @@ describe('StoriesOfVictoryPage', () => {
         expect(container.querySelector('section')).toBeInTheDocument();
     });
 
-    it('should render VideoReviewsSection component', () => {
+    it('should render multiple section elements', () => {
         const { container } = render(<StoriesOfVictoryPage />);
-        // VideoReviewsSection renders a section
         const sections = container.querySelectorAll('section');
         expect(sections.length).toBeGreaterThan(0);
     });
 
     it('should render ReviewsSection component', () => {
         const { container } = render(<StoriesOfVictoryPage />);
-        // ReviewsSection renders section with h4 title and Swiper
-        const h4Elements = container.querySelectorAll('h4');
-        expect(h4Elements.length).toBe(0);
+        const h3Elements = container.querySelectorAll('h3');
+        expect(h3Elements.length).toBeGreaterThan(0);
     });
 
     it('should render all section children within LoadableContent', () => {

--- a/src/pages/public/stories-of-victory-page/StoriesOfVictoryPage.tsx
+++ b/src/pages/public/stories-of-victory-page/StoriesOfVictoryPage.tsx
@@ -56,14 +56,6 @@ const reviewArticles: StoriesOfVictoryReviewArticle[] = [
     },
 ];
 
-// const reviewVideos: StoriesOfVictoryReviewVideo[] = [
-//     { id: 1, title: 'Коні лікують 2025', link: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
-//     { id: 2, title: 'Коні лікують 2025', link: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
-//     { id: 3, title: 'Коні лікують 2025', link: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
-//     { id: 4, title: 'Коні лікують 2025', link: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
-//     { id: 5, title: 'Коні лікують 2025', link: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
-// ];
-
 export const StoriesOfVictoryPage: React.FC<StoriesOfVictoryPageProps> = () => {
     return (
         <LoadableContent isLoading={false} error={false}>
@@ -71,7 +63,6 @@ export const StoriesOfVictoryPage: React.FC<StoriesOfVictoryPageProps> = () => {
                 <>
                     <SloganSection />
                     <ReviewArticlesSection content={reviewArticles} />
-                    {/* <VideoReviewsSection content={reviewVideos} /> */}
                     <ReviewsSection content={reviews} />
                 </>
             }

--- a/src/pages/public/stories-of-victory-page/components/review-articles/ReviewArticlesSection.module.scss
+++ b/src/pages/public/stories-of-victory-page/components/review-articles/ReviewArticlesSection.module.scss
@@ -3,10 +3,10 @@
 
 @keyframes expandHeight {
     from {
-        height: 0%;
+        max-height: 0;
     }
     to {
-        height: 50%;
+        max-height: 50vh;
     }
 }
 
@@ -23,19 +23,6 @@
     margin-bottom: 32px;
 }
 
-.articleLink {
-    @include type.body-2-medium;
-    color: colors.$blue-900;
-    display: flex;
-    border-bottom: 1px solid colors.$blue-900;
-    width: fit-content;
-    cursor: pointer;
-
-    span {
-        margin-right: 8px;
-        margin-bottom: 8px;
-    }
-}
 .articles {
     display: grid;
     grid-template-columns: 1fr;
@@ -81,7 +68,7 @@
 .articleTitle {
     @include type.subtitle-2-semibold;
     color: colors.$blue-900;
-    transition: all 0.3s ease;
+    transition: max-height 0.3s ease;
 
     &:not(.hovered) {
         padding: 12px 0;
@@ -93,8 +80,8 @@
         bottom: 0;
         left: 0;
         right: 0;
-        height: 50%;
-        background: #ffffffe6;
+        max-height: 50vh;
+        background: rgba(colors.$white, 0.9);
         display: flex;
         overflow-y: auto;
         box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.1);
@@ -107,7 +94,6 @@
             word-break: break-word;
         }
 
-        /* Custom scrollbar styling */
         &::-webkit-scrollbar {
             width: 8px;
         }

--- a/src/pages/public/stories-of-victory-page/components/review-articles/ReviewArticlesSection.test.tsx
+++ b/src/pages/public/stories-of-victory-page/components/review-articles/ReviewArticlesSection.test.tsx
@@ -1,19 +1,9 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { ReviewArticlesSection } from './ReviewArticlesSection';
 import { StoriesOfVictoryReviewArticle } from '@/types/public/stories-of-victory';
-
-// Mock SVG icon FIRST
-jest.mock('@/assets/icons/square-arrow-out-up-right.svg', () => ({
-    ReactComponent: () => <svg data-testid="arrow-icon" />,
-}));
-
-// Mock react-i18next BEFORE importing components
-jest.mock('react-i18next', () => ({
-    useTranslation: jest.fn(),
-}));
 
 const article1: StoriesOfVictoryReviewArticle = {
     id: 1,
@@ -32,14 +22,6 @@ const article3: StoriesOfVictoryReviewArticle = {
 };
 
 describe('ReviewArticlesSection', () => {
-    beforeEach(() => {
-        const { useTranslation } = require('react-i18next');
-        (useTranslation as jest.Mock).mockReturnValue({
-            t: (key: string) => (key === 'ARTICLES.READ_STORY' ? 'Read Story' : key),
-            i18n: { changeLanguage: jest.fn() },
-        });
-    });
-
     it('should render section when content is null', () => {
         const { container } = render(<ReviewArticlesSection content={null} />);
         expect(container.querySelector('section')).toBeInTheDocument();
@@ -82,26 +64,35 @@ describe('ReviewArticlesSection', () => {
         expect(title.tagName).toBe('DIV');
     });
 
-    // it('should render article link with read story text', () => {
-    //     render(<ReviewArticlesSection content={[article1]} />);
-    //     expect(screen.getByText('Read Story')).toBeInTheDocument();
-    // });
-
-    // it('should render arrow icon for each article', () => {
-    //     render(<ReviewArticlesSection content={[article1, article2]} />);
-    //     const icons = screen.getAllByTestId('arrow-icon');
-    //     expect(icons).toHaveLength(2);
-    // });
-
-    // it('should call useTranslation with successPage namespace', () => {
-    //     const { useTranslation } = require('react-i18next');
-    //     render(<ReviewArticlesSection content={[article1]} />);
-    //     expect(useTranslation).toHaveBeenCalledWith('successPage');
-    // });
-
     it('should use article id as key for each article', () => {
         const { container } = render(<ReviewArticlesSection content={[article1, article2]} />);
         const articles = container.querySelectorAll('.article');
         expect(articles).toHaveLength(2);
+    });
+
+    it('should show truncated text by default when title exceeds 100 characters', () => {
+        const longTitle = 'A'.repeat(150);
+        render(<ReviewArticlesSection content={[{ id: 1, title: longTitle, image: 'img.jpg' }]} />);
+        expect(screen.getByText(`"${'A'.repeat(100)}..."`)).toBeInTheDocument();
+    });
+
+    it('should show full text on mouse enter', () => {
+        const longTitle = 'A'.repeat(150);
+        const { container } = render(
+            <ReviewArticlesSection content={[{ id: 1, title: longTitle, image: 'img.jpg' }]} />,
+        );
+        fireEvent.mouseEnter(container.querySelector('.article')!);
+        expect(screen.getByText(`"${longTitle}"`)).toBeInTheDocument();
+    });
+
+    it('should revert to truncated text on mouse leave', () => {
+        const longTitle = 'A'.repeat(150);
+        const { container } = render(
+            <ReviewArticlesSection content={[{ id: 1, title: longTitle, image: 'img.jpg' }]} />,
+        );
+        const article = container.querySelector('.article')!;
+        fireEvent.mouseEnter(article);
+        fireEvent.mouseLeave(article);
+        expect(screen.getByText(`"${'A'.repeat(100)}..."`)).toBeInTheDocument();
     });
 });

--- a/src/pages/public/stories-of-victory-page/components/review-articles/ReviewArticlesSection.tsx
+++ b/src/pages/public/stories-of-victory-page/components/review-articles/ReviewArticlesSection.tsx
@@ -8,12 +8,8 @@ interface ReviewArticlesSectionProps {
 
 const TRUNCATE_LENGTH = 100;
 
-const truncateText = (text: string, length: number): { truncated: string; isTruncated: boolean } => {
-    if (text.length > length) {
-        return { truncated: text.substring(0, length) + '...', isTruncated: true };
-    }
-    return { truncated: text, isTruncated: false };
-};
+const truncateText = (text: string, length: number): string =>
+    text.length > length ? text.substring(0, length) + '...' : text;
 
 export const ReviewArticlesSection: React.FC<ReviewArticlesSectionProps> = ({ content }) => {
     const [hoveredArticleId, setHoveredArticleId] = useState<number | null>(null);
@@ -23,7 +19,7 @@ export const ReviewArticlesSection: React.FC<ReviewArticlesSectionProps> = ({ co
             {content && content.length > 0 && (
                 <div className={styles.articles}>
                     {content.map((article) => {
-                        const { truncated } = truncateText(article.title, TRUNCATE_LENGTH);
+                        const truncated = truncateText(article.title, TRUNCATE_LENGTH);
                         const isHovered = hoveredArticleId === article.id;
 
                         return (


### PR DESCRIPTION
## JIRA or Github ticket

- [GitHub ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2749)
- Fixes review findings on [PR #462](https://github.com/ita-social-projects/VictoryCenter-Client/pull/462)

## Description

This PR addresses all medium and minor issues found during the code review of PR #462 (feature/issue-2749 — feedback cards on the Stories of Victory page). No functional changes are made; all user-visible behaviour is preserved. The base branch is `feature/issue-2749` so this merges cleanly into the original PR branch.

## How it looks

No visual change. The hover expand animation now works correctly in browsers (the previous `height: 50%` keyframe was broken because the parent flex container had no explicit height). All other changes are test/code quality fixes.

## Summary of change

**chore** — Delete commented-out `VideoReviewsSection` and `reviewVideos` from `StoriesOfVictoryPage.tsx`. The video reviews feature belongs to a separate open issue ([#2751](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2751)); the component file is left on disk for that future PR.

**fix** — Repair `expandHeight` CSS animation in `ReviewArticlesSection.module.scss`:
- Changed keyframe from `height: 0% → 50%` to `max-height: 0 → 50vh` — the overlay is `position: absolute` inside a flex container with no explicit height, so percentage heights resolved incorrectly
- Replaced hardcoded `#ffffffe6` with `rgba(colors.$white, 0.9)` (uses project SCSS variable)
- Narrowed `transition: all` → `transition: max-height` (performance anti-pattern)
- Removed dead `.articleLink` class (Read Story link was removed in #462)
- Removed explanatory scrollbar comment (violates project no-comment convention)

**refactor** — Simplified `truncateText` in `ReviewArticlesSection.tsx` to return `string` directly; the `isTruncated` boolean was returned but never used at the call site.

**test** — `ReviewArticlesSection.test.tsx`:
- Removed `jest.mock` for the SVG icon and `react-i18next` — both are no longer imported by the component after #462
- Removed stale `beforeEach` block that only configured the removed translation mock
- Deleted 3 tests that were commented out for removed features (Read Story link, arrow icon, `useTranslation`)
- Added 3 new tests covering the hover interaction (default truncation, full text on `mouseEnter`, revert on `mouseLeave`) — SonarQube reported 0% new code coverage on #462

**test** — `StoriesOfVictoryPage.test.tsx`:
- Renamed test `"should render VideoReviewsSection component"` — the component is no longer rendered
- Fixed `"should render ReviewsSection component"` assertion: `ReviewsSection` renders `<h3>`, not `<h4>`

## How to recreate changes

1. Check out `feature/issue-2749-claude-fix`
2. Run `npm start` and navigate to `/` → click through to the Stories of Victory page
3. Hover over a testimonial card — the overlay should animate upward from the bottom of the image
4. Mouse away — overlay should retract and truncated text appears below the image

## CHECK LIST

- [x] New tests were added or existing were modified
- [ ] Changes have severe impact on users
- [ ] Changes have medium impact on users
- [x] Changes have light impact on users
- [x] Test coverage was updated
- [x] PR meets all conventions