### PR TITLE
Fix/issue 2907 [Reports] "Кількість змінених життів" field validation incorrectly blocks publishing

### DIFF
--- a/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.test.ts
+++ b/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.test.ts
@@ -152,8 +152,10 @@ describe('reports-media-settings-schema', () => {
                 expect(result).toBe(REPORTS_TEXT.MESSAGE.INVALID_VALUE);
             });
 
-            it('should return max error when value exceeds max', () => {
-                const overMax = REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max + 1;
+            it('should return max error when value length exceeds max', () => {
+                const overMax = Number(
+                    '1'.repeat(REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max + 1),
+                );
                 const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateChangedLives(overMax);
                 expect(result).toBe(
                     COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
@@ -162,10 +164,9 @@ describe('reports-media-settings-schema', () => {
                 );
             });
 
-            it('should return undefined for value at max', () => {
-                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateChangedLives(
-                    REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max,
-                );
+            it('should return undefined for value length at max', () => {
+                const maxVal = Number('1'.repeat(REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max));
+                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateChangedLives(maxVal);
                 expect(result).toBeUndefined();
             });
         });

--- a/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.test.ts
+++ b/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.test.ts
@@ -152,10 +152,8 @@ describe('reports-media-settings-schema', () => {
                 expect(result).toBe(REPORTS_TEXT.MESSAGE.INVALID_VALUE);
             });
 
-            it('should return max error when value length exceeds max', () => {
-                const overMax = Number(
-                    '1'.repeat(REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max + 1),
-                );
+            it('should return max error when value exceeds max numeric bound', () => {
+                const overMax = 10 ** REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max;
                 const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateChangedLives(overMax);
                 expect(result).toBe(
                     COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
@@ -164,9 +162,15 @@ describe('reports-media-settings-schema', () => {
                 );
             });
 
-            it('should return undefined for value length at max', () => {
-                const maxVal = Number('1'.repeat(REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max));
+            it('should return undefined for value exactly at numeric max bound (10 digits)', () => {
+                const maxVal = 10 ** REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max - 1;
                 const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateChangedLives(maxVal);
+                expect(result).toBeUndefined();
+            });
+
+            it('should return undefined for value just below numeric max bound (9 digits)', () => {
+                const justBelowMax = 10 ** (REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max - 1) - 1;
+                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateChangedLives(justBelowMax);
                 expect(result).toBeUndefined();
             });
         });

--- a/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.ts
+++ b/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.ts
@@ -61,11 +61,15 @@ const changedLivesSchema = Yup.object({
         .required(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED)
         .integer(REPORTS_TEXT.MESSAGE.INVALID_VALUE)
         .min(2, COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(2))
-        .max(
-            REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max,
+        .test(
+            'max-length',
             COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
                 REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max,
             ),
+            (value) =>
+                value === undefined ||
+                value === null ||
+                String(value).length <= REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max,
         ),
 });
 

--- a/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.ts
+++ b/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.ts
@@ -61,15 +61,11 @@ const changedLivesSchema = Yup.object({
         .required(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED)
         .integer(REPORTS_TEXT.MESSAGE.INVALID_VALUE)
         .min(2, COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(2))
-        .test(
-            'max-length',
+        .max(
+            10 ** REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max - 1,
             COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
                 REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max,
             ),
-            (value) =>
-                value === undefined ||
-                value === null ||
-                String(value).length <= REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max,
         ),
 });
 


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2907)

## Description

This PR resolves a validation issue in the Admin Panel's Media Settings tab where the "Кількість змінених життів" input field was incorrectly preventing publication. Valid numbers (e.g., 205) were triggering a "Не більше 10 символів" error. The underlying validation schema has been updated to correctly enforce a character length limit (max 10 characters) rather than a strict mathematical value limit (max value of 10).

## How it looks


https://github.com/user-attachments/assets/a2d6021c-5dd0-40d0-927a-62b2fa02a110



## Summary of change

*   **Schema Validation Fix**: Replaced the `.max()` value constraint with a custom `.test('max-length')` constraint in `reports-media-settings-schema.ts` to evaluate the character length of the input instead of its numerical size.
*   **Test Suite Updates**: Updated the unit tests in `reports-media-settings-schema.test.ts` to properly assert against string length limits (e.g., testing an 11-digit number) rather than mathematical upper bounds.


## How to recreate changes
1. Log into the Admin panel and navigate to the **"Налаштування медіа"** tab under **"Звітність"**.
2. Locate the **"Кількість змінених життів"** input field.
3. Type a number greater than 10 but fewer than 11 digits (e.g., `205`).
4. Observe that the *"Не більше 10 символів"* error is no longer displayed beneath the input.
5. Click the **"Опублікувати"** (Publish) button.
6. Verify that the confirmation popup *"Опублікувати зміни?"* successfully appears with the **"ТАК"** and **"НІ"** buttons.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for the “changed lives” field in report media settings, with corrected handling of numeric upper-bound (“max”) scenarios while keeping the same error messaging.
- **Tests**
  - Updated and strengthened unit tests to cover “at max” and “exceeds max” boundary cases more precisely using adjusted numeric inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->