### PR TITLE
Fix/issue 2765 [Partners] [Admin] The "Опублікувати" button is enabled without pending changes

### DIFF
--- a/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.test.tsx
+++ b/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.test.tsx
@@ -271,6 +271,7 @@ describe('PartnerBanner', () => {
 
         render(<PartnerBanner />);
 
+        changeDescriptionValue('Changed Description');
         const publishButton = getPublishButton();
         expect(publishButton).toBeEnabled();
 
@@ -326,13 +327,14 @@ describe('PartnerBanner', () => {
 
         render(<PartnerBanner />);
 
+        changeDescriptionValue('Changed');
         clickPublish();
         clickConfirmPublish();
 
         await waitFor(() => {
             expect(mockedPartnersApi.updateBanner).toHaveBeenCalledWith('mock-client', {
                 title: defaultBannerData.title,
-                description: defaultBannerData.description,
+                description: 'Changed',
                 image: defaultBannerData.image,
                 imageId: defaultBannerData.imageId,
             });
@@ -372,6 +374,7 @@ describe('PartnerBanner', () => {
 
         render(<PartnerBanner />);
 
+        changeDescriptionValue('Changed');
         clickPublish();
         clickConfirmPublish();
 
@@ -384,13 +387,14 @@ describe('PartnerBanner', () => {
         await waitFor(() => {
             expect(getTitleInput()).toHaveAttribute('contentEditable', 'true');
             expect(getDescriptionInput()).toBeEnabled();
-            expect(getPublishButton()).toBeEnabled();
+            expect(getPublishButton()).toBeDisabled(); // Disabled because form is no longer dirty after publish
         });
     });
 
     it('shows image error and disables publish until resolved', async () => {
         render(<PartnerBanner />);
 
+        changeDescriptionValue('Changed');
         const publishButton = getPublishButton();
         expect(publishButton).toBeEnabled();
 
@@ -521,6 +525,7 @@ describe('PartnerBanner', () => {
 
         render(<PartnerBanner />);
 
+        changeDescriptionValue('Changed');
         clickPublish();
         clickConfirmPublish();
 
@@ -542,6 +547,7 @@ describe('PartnerBanner', () => {
 
         render(<PartnerBanner />);
 
+        changeDescriptionValue('Changed');
         await waitFor(() => {
             expect(getPublishButton()).toBeEnabled();
         });
@@ -602,6 +608,7 @@ describe('PartnerBanner', () => {
 
         render(<PartnerBanner />);
 
+        changeDescriptionValue('Changed');
         clickPublish();
         clickConfirmPublish();
 

--- a/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.tsx
+++ b/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.tsx
@@ -50,11 +50,26 @@ const isFormValid = (values: PartnerBannerValues, errors: PartnerBannerErrorStat
     return !titleError && !descError && !errors.image;
 };
 
+interface FormState {
+    values: PartnerBannerValues | null;
+    savedValues: PartnerBannerValues | null;
+}
+
+const isImageEqual = (img1: ImageValues | Image | null, img2: ImageValues | Image | null) => {
+    if (img1 === img2) return true;
+    if (!img1 || !img2) return false;
+    if ('url' in img1 && 'url' in img2) return img1.url === img2.url;
+    if ('base64' in img1 && 'base64' in img2) return img1.base64 === img2.base64;
+    return false;
+};
+
 export const PartnerBanner = () => {
     const client = useAdminClient();
     const { addToast } = useToast();
-    const [values, setValues] = useState<PartnerBannerValues | null>(null);
-    const [savedValues, setSavedValues] = useState<PartnerBannerValues | null>(null);
+    const [formState, setFormState] = useState<FormState>({
+        values: null,
+        savedValues: null,
+    });
     const [errors, setErrors] = useState<PartnerBannerErrorState>({});
     const [touched, setTouched] = useState<{ title?: boolean; description?: boolean }>({});
     const [isPublishing, setIsPublishing] = useState(false);
@@ -76,20 +91,21 @@ export const PartnerBanner = () => {
         autoFetchDisabled: false,
     });
 
+    const { values, savedValues } = formState;
+
     const isDirty = React.useMemo(() => {
         if (!savedValues || !values) return false;
         return (
             savedValues.title !== values.title ||
             savedValues.description !== values.description ||
             savedValues.imageId !== values.imageId ||
-            savedValues.image !== values.image
+            !isImageEqual(savedValues.image, values.image)
         );
     }, [savedValues, values]);
 
     useEffect(() => {
         if (!isLoadingData && bannerData && bannerData.title) {
-            setValues(bannerData);
-            setSavedValues(bannerData);
+            setFormState({ values: bannerData, savedValues: bannerData });
             setTouched({});
             setErrors({});
             setTitleKey((prev) => prev + 1);
@@ -110,7 +126,10 @@ export const PartnerBanner = () => {
     }, [fetchError, addToast]);
 
     const handleTitleChange = useCallback((newValue: string) => {
-        setValues((prev) => (prev ? { ...prev, title: newValue } : null));
+        setFormState((prev) => ({
+            ...prev,
+            values: prev.values ? { ...prev.values, title: newValue } : null,
+        }));
 
         const plainText = getPlainTextFromHtml(newValue);
 
@@ -126,7 +145,10 @@ export const PartnerBanner = () => {
 
     const handleDescriptionChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         const newValue = e.target.value;
-        setValues((prev) => (prev ? { ...prev, description: newValue } : null));
+        setFormState((prev) => ({
+            ...prev,
+            values: prev.values ? { ...prev.values, description: newValue } : null,
+        }));
         setTouched((prev) => ({ ...prev, description: true }));
         setErrors((prev) => ({
             ...prev,
@@ -135,7 +157,10 @@ export const PartnerBanner = () => {
     }, []);
 
     const handleImageChange = useCallback((value: ImageValues | null) => {
-        setValues((prev) => (prev ? { ...prev, image: value, imageId: value ? prev.imageId : null } : null));
+        setFormState((prev) => ({
+            ...prev,
+            values: prev.values ? { ...prev.values, image: value, imageId: value ? prev.values.imageId : null } : null,
+        }));
     }, []);
 
     const handleImageError = useCallback((error: string | null) => {
@@ -162,8 +187,7 @@ export const PartnerBanner = () => {
                 imageId: values.imageId,
             });
 
-            setValues(updatedBanner);
-            setSavedValues(updatedBanner);
+            setFormState({ values: updatedBanner, savedValues: updatedBanner });
             setTouched({});
             setErrors({});
             addToast(PARTNERS_TEXT.MESSAGE.BANNER_SAVED, ToastType.Success);

--- a/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.tsx
+++ b/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.tsx
@@ -54,6 +54,7 @@ export const PartnerBanner = () => {
     const client = useAdminClient();
     const { addToast } = useToast();
     const [values, setValues] = useState<PartnerBannerValues | null>(null);
+    const [savedValues, setSavedValues] = useState<PartnerBannerValues | null>(null);
     const [errors, setErrors] = useState<PartnerBannerErrorState>({});
     const [touched, setTouched] = useState<{ title?: boolean; description?: boolean }>({});
     const [isPublishing, setIsPublishing] = useState(false);
@@ -75,9 +76,20 @@ export const PartnerBanner = () => {
         autoFetchDisabled: false,
     });
 
+    const isDirty = React.useMemo(() => {
+        if (!savedValues || !values) return false;
+        return (
+            savedValues.title !== values.title ||
+            savedValues.description !== values.description ||
+            savedValues.imageId !== values.imageId ||
+            savedValues.image !== values.image
+        );
+    }, [savedValues, values]);
+
     useEffect(() => {
         if (!isLoadingData && bannerData && bannerData.title) {
             setValues(bannerData);
+            setSavedValues(bannerData);
             setTouched({});
             setErrors({});
             setTitleKey((prev) => prev + 1);
@@ -151,6 +163,7 @@ export const PartnerBanner = () => {
             });
 
             setValues(updatedBanner);
+            setSavedValues(updatedBanner);
             setTouched({});
             setErrors({});
             addToast(PARTNERS_TEXT.MESSAGE.BANNER_SAVED, ToastType.Success);
@@ -270,7 +283,7 @@ export const PartnerBanner = () => {
                                 type="button"
                                 buttonStyle="primary"
                                 onClick={handlePublishClick}
-                                disabled={isDisabled || !isFormValid(values, errors)}
+                                disabled={isDisabled || !isDirty || !isFormValid(values, errors)}
                             >
                                 {COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED}
                             </Button>

--- a/src/pages/admin/partners/components/partner-section/PartnerSectionForm.test.tsx
+++ b/src/pages/admin/partners/components/partner-section/PartnerSectionForm.test.tsx
@@ -139,6 +139,7 @@ describe('PartnerSectionForm', () => {
             <PartnerSectionForm
                 value={defaultSectionValue}
                 errors={defaultSectionErrors}
+                isDirty={true}
                 disabled={false}
                 onChange={jest.fn()}
                 onDelete={jest.fn()}
@@ -164,6 +165,7 @@ describe('PartnerSectionForm', () => {
             <PartnerSectionForm
                 value={defaultSectionValue}
                 errors={defaultSectionErrors}
+                isDirty={true}
                 disabled={false}
                 onChange={onChange}
                 onDelete={jest.fn()}
@@ -190,6 +192,7 @@ describe('PartnerSectionForm', () => {
             <PartnerSectionForm
                 value={defaultSectionValue}
                 errors={defaultSectionErrors}
+                isDirty={true}
                 disabled={false}
                 onChange={onChange}
                 onDelete={jest.fn()}
@@ -215,6 +218,7 @@ describe('PartnerSectionForm', () => {
             <PartnerSectionForm
                 value={defaultSectionValue}
                 errors={defaultSectionErrors}
+                isDirty={true}
                 disabled={false}
                 onChange={onChange}
                 onDelete={jest.fn()}
@@ -250,6 +254,7 @@ describe('PartnerSectionForm', () => {
             <PartnerSectionForm
                 value={defaultSectionValue}
                 errors={defaultSectionErrors}
+                isDirty={true}
                 disabled={false}
                 onChange={onChange}
                 onDelete={jest.fn()}
@@ -283,6 +288,7 @@ describe('PartnerSectionForm', () => {
             <PartnerSectionForm
                 value={defaultSectionValue}
                 errors={defaultSectionErrors}
+                isDirty={true}
                 disabled={false}
                 onChange={onChange}
                 onDelete={jest.fn()}
@@ -309,6 +315,7 @@ describe('PartnerSectionForm', () => {
             <PartnerSectionForm
                 value={defaultSectionValue}
                 errors={defaultSectionErrors}
+                isDirty={true}
                 disabled={false}
                 onChange={jest.fn()}
                 onDelete={jest.fn()}
@@ -324,6 +331,7 @@ describe('PartnerSectionForm', () => {
             <PartnerSectionForm
                 value={defaultSectionValue}
                 errors={defaultSectionErrors}
+                isDirty={true}
                 disabled={false}
                 onChange={jest.fn()}
                 onDelete={jest.fn()}
@@ -341,6 +349,7 @@ describe('PartnerSectionForm', () => {
             <PartnerSectionForm
                 value={defaultSectionValue}
                 errors={defaultSectionErrors}
+                isDirty={true}
                 disabled={false}
                 onChange={jest.fn()}
                 onDelete={jest.fn()}
@@ -362,6 +371,7 @@ describe('PartnerSectionForm', () => {
             <PartnerSectionForm
                 value={valueWithoutImage}
                 errors={errorsWithImageIssue}
+                isDirty={true}
                 disabled={false}
                 onChange={jest.fn()}
                 onDelete={jest.fn()}
@@ -379,6 +389,7 @@ describe('PartnerSectionForm', () => {
             <PartnerSectionForm
                 value={defaultSectionValue}
                 errors={errorsWithImageIssue}
+                isDirty={true}
                 disabled={false}
                 onChange={jest.fn()}
                 onDelete={jest.fn()}
@@ -394,6 +405,7 @@ describe('PartnerSectionForm', () => {
             <PartnerSectionForm
                 value={defaultSectionValue}
                 errors={defaultSectionErrors}
+                isDirty={true}
                 disabled={true}
                 onChange={jest.fn()}
                 onDelete={jest.fn()}
@@ -414,6 +426,7 @@ describe('PartnerSectionForm', () => {
             <PartnerSectionForm
                 value={defaultSectionValue}
                 errors={defaultSectionErrors}
+                isDirty={true}
                 disabled={false}
                 onChange={jest.fn()}
                 onDelete={onDelete}
@@ -436,6 +449,7 @@ describe('PartnerSectionForm', () => {
             <PartnerSectionForm
                 value={{ ...defaultSectionValue, partners: [partnerWithoutId] }}
                 errors={defaultSectionErrors}
+                isDirty={true}
                 disabled={false}
                 onChange={onChange}
                 onDelete={jest.fn()}

--- a/src/pages/admin/partners/components/partner-section/PartnerSectionForm.test.tsx
+++ b/src/pages/admin/partners/components/partner-section/PartnerSectionForm.test.tsx
@@ -438,7 +438,7 @@ describe('PartnerSectionForm', () => {
         fireEvent.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED }));
 
         expect(onDelete).toHaveBeenCalledWith(defaultSectionValue.localId);
-        expect(onPublish).toHaveBeenCalledWith(defaultSectionValue.localId);
+        expect(onPublish).toHaveBeenCalledWith(defaultSectionValue.localId, defaultSectionValue);
     });
 
     it('does not push deleted id when partner has no persisted id', () => {
@@ -460,5 +460,48 @@ describe('PartnerSectionForm', () => {
         fireEvent.click(screen.getByTestId(`partner-delete-${partnerWithoutId.localId}`));
 
         expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ deletedPartnerIds: [] }), expect.anything());
+    });
+
+    it('disables publish button when not dirty', () => {
+        render(
+            <PartnerSectionForm
+                value={defaultSectionValue}
+                errors={defaultSectionErrors}
+                isDirty={false}
+                disabled={false}
+                onChange={jest.fn()}
+                onDelete={jest.fn()}
+                onPublish={jest.fn()}
+            />,
+        );
+        expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED })).toBeDisabled();
+    });
+
+    it('enables publish button only when dirty and valid', () => {
+        const { rerender } = render(
+            <PartnerSectionForm
+                value={defaultSectionValue}
+                errors={defaultSectionErrors}
+                isDirty={false}
+                disabled={false}
+                onChange={jest.fn()}
+                onDelete={jest.fn()}
+                onPublish={jest.fn()}
+            />,
+        );
+        expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED })).toBeDisabled();
+
+        rerender(
+            <PartnerSectionForm
+                value={defaultSectionValue}
+                errors={defaultSectionErrors}
+                isDirty={true}
+                disabled={false}
+                onChange={jest.fn()}
+                onDelete={jest.fn()}
+                onPublish={jest.fn()}
+            />,
+        );
+        expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED })).toBeEnabled();
     });
 });

--- a/src/pages/admin/partners/components/partner-section/PartnerSectionForm.tsx
+++ b/src/pages/admin/partners/components/partner-section/PartnerSectionForm.tsx
@@ -34,6 +34,7 @@ export interface PartnerSectionProps {
     onChange: (value: PartnerSectionFormValues, errors: PartnerSectionErrors) => void;
     onDelete: (localId: string) => void;
     onPublish: (localId: string) => void;
+    isDirty: boolean;
 }
 
 const PartnerSectionComponent = ({
@@ -43,6 +44,7 @@ const PartnerSectionComponent = ({
     onPublish,
     disabled = false,
     errors,
+    isDirty,
 }: PartnerSectionProps) => {
     const handleTitleChange = useCallback(
         (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -218,7 +220,7 @@ const PartnerSectionComponent = ({
                 <Button buttonStyle="secondary" onClick={handleDelete} disabled={disabled}>
                     {PARTNERS_TEXT.SECTION.DELETE_SECTION}
                 </Button>
-                <Button buttonStyle="primary" onClick={handlePublish} disabled={disabled || !isFormValid()}>
+                <Button buttonStyle="primary" onClick={handlePublish} disabled={disabled || !isDirty || !isFormValid()}>
                     {COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED}
                 </Button>
             </div>

--- a/src/pages/admin/partners/components/partner-section/PartnerSectionForm.tsx
+++ b/src/pages/admin/partners/components/partner-section/PartnerSectionForm.tsx
@@ -33,7 +33,7 @@ export interface PartnerSectionProps {
     disabled: boolean;
     onChange: (value: PartnerSectionFormValues, errors: PartnerSectionErrors) => void;
     onDelete: (localId: string) => void;
-    onPublish: (localId: string) => void;
+    onPublish: (localId: string, sectionData: PartnerSectionFormValues) => void;
     isDirty: boolean;
 }
 
@@ -129,8 +129,8 @@ const PartnerSectionComponent = ({
     }, [onDelete, value.localId]);
 
     const handlePublish = useCallback(() => {
-        onPublish(value.localId);
-    }, [onPublish, value.localId]);
+        onPublish(value.localId, value);
+    }, [onPublish, value]);
 
     const isFormValid = (): boolean => {
         if (PARTNER_SECTION_VALIDATION_FUNCTIONS.validateTitle(value.title)) {

--- a/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.test.tsx
+++ b/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.test.tsx
@@ -33,7 +33,7 @@ const mockPartnerSectionFormRender = jest.fn((props: any) => {
             <button
                 type="button"
                 data-testid={`section-publish-${value.localId}`}
-                onClick={() => onPublish(value.localId)}
+                onClick={() => onPublish(value.localId, value)}
                 disabled={disabled}
             >
                 Publish Section
@@ -154,7 +154,7 @@ function getLatestFormProps() {
 
 function openPublishModal(props: any) {
     act(() => {
-        props.onPublish(props.value.localId);
+        props.onPublish(props.value.localId, props.value);
     });
     expect(screen.getByTestId(`confirm-${PARTNERS_TEXT.FORM.TITLE.PUBLISH_SECTION}`)).toBeInTheDocument();
 }

--- a/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.tsx
+++ b/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.tsx
@@ -38,6 +38,31 @@ const isSectionEmpty = (section: PartnerSectionFormValues): boolean => {
     return titleEmpty && descriptionEmpty && allPartnersEmpty;
 };
 
+const isSectionDirty = (section: PartnerSectionFormValues, fetchedSections: PartnerSection[]): boolean => {
+    if (section.sectionId === null) return true;
+
+    const originalSection = fetchedSections.find((s) => s.id === section.sectionId);
+    if (!originalSection) return true;
+
+    if (section.title !== originalSection.title) return true;
+    if (section.description !== originalSection.description) return true;
+    if (section.deletedPartnerIds && section.deletedPartnerIds.length > 0) return true;
+    if (section.partners.length !== originalSection.partners.length) return true;
+
+    for (const partner of section.partners) {
+        if (partner.partnerId === null) return true;
+
+        const originalPartner = originalSection.partners.find((p) => p.id === partner.partnerId);
+        if (!originalPartner) return true;
+
+        if (partner.description !== originalPartner.description) return true;
+        if (partner.imageId !== originalPartner.imageId) return true;
+        if (partner.image !== originalPartner.image) return true;
+    }
+
+    return false;
+};
+
 export interface PartnerSectionsEditorRef {
     addSection: () => void;
 }
@@ -72,6 +97,7 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef>((_, re
         isLoading: isSectionsLoading,
         error: sectionsFetchError,
         refetch: refetchSections,
+        setData: setFetchedSections,
     } = useDataFetch<PartnerSection[]>({
         initialData: [],
         fetchHandler: fetchSectionsHandler,
@@ -207,6 +233,16 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef>((_, re
             };
 
             setLocalSections((currentSections) => currentSections.map(updateSectionInList));
+            setFetchedSections((current) => {
+                const currentArray = current || [];
+                const existingIndex = currentArray.findIndex((s) => s.id === savedSection.id);
+                if (existingIndex >= 0) {
+                    const newArray = [...currentArray];
+                    newArray[existingIndex] = savedSection;
+                    return newArray;
+                }
+                return [...currentArray, savedSection];
+            });
         } catch (error: any) {
             if (axios.isCancel?.(error) || error.name === 'CanceledError' || error.name === 'AbortError') {
                 return;
@@ -216,7 +252,7 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef>((_, re
             setIsPublishing(false);
             setSectionToPublishId(null);
         }
-    }, [localSections, addToast, client, setLocalSections, sectionToPublishId]);
+    }, [localSections, addToast, client, setLocalSections, sectionToPublishId, setFetchedSections]);
 
     const handleDeleteRequest = useCallback((localId: string) => {
         setSectionToDeleteId(localId);
@@ -249,6 +285,10 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef>((_, re
             setLocalSections((current) => current.filter((s) => s.localId !== sectionToDeleteId));
             setErrors((current) => current.filter((_, i) => i !== indexToDelete));
 
+            if (sectionToDelete && sectionToDelete.sectionId) {
+                setFetchedSections((current) => (current || []).filter((s) => s.id !== sectionToDelete.sectionId));
+            }
+
             addToast(PARTNERS_TEXT.MESSAGE.SECTION_DELETED, ToastType.Success);
         } catch (error: any) {
             if (axios.isCancel?.(error) || error.name === 'CanceledError' || error.name === 'AbortError') {
@@ -259,7 +299,7 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef>((_, re
             setIsPublishing(false);
             setSectionToDeleteId(null);
         }
-    }, [localSections, client, setLocalSections, sectionToDeleteId, addToast]);
+    }, [localSections, client, setLocalSections, sectionToDeleteId, addToast, setFetchedSections]);
 
     const addSection = useCallback(() => {
         if (isPublishing || isSectionsLoading) {
@@ -331,6 +371,7 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef>((_, re
                     value={section}
                     errors={errors[index] || { partners: [] }}
                     disabled={isSectionsLoading || isPublishing}
+                    isDirty={isSectionDirty(section, fetchedSections)}
                     onChange={handleChange}
                     onDelete={handleDeleteRequest}
                     onPublish={handlePublishRequest}

--- a/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.tsx
+++ b/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.tsx
@@ -38,6 +38,14 @@ const isSectionEmpty = (section: PartnerSectionFormValues): boolean => {
     return titleEmpty && descriptionEmpty && allPartnersEmpty;
 };
 
+const isImageEqual = (img1: any, img2: any) => {
+    if (img1 === img2) return true;
+    if (!img1 || !img2) return false;
+    if ('url' in img1 && 'url' in img2) return img1.url === img2.url;
+    if ('base64' in img1 && 'base64' in img2) return img1.base64 === img2.base64;
+    return false;
+};
+
 const isSectionDirty = (section: PartnerSectionFormValues, fetchedSections: PartnerSection[]): boolean => {
     if (section.sectionId === null) return true;
 
@@ -49,15 +57,17 @@ const isSectionDirty = (section: PartnerSectionFormValues, fetchedSections: Part
     if (section.deletedPartnerIds && section.deletedPartnerIds.length > 0) return true;
     if (section.partners.length !== originalSection.partners.length) return true;
 
+    const originalPartnersMap = new Map(originalSection.partners.map((p) => [p.id, p]));
+
     for (const partner of section.partners) {
         if (partner.partnerId === null) return true;
 
-        const originalPartner = originalSection.partners.find((p) => p.id === partner.partnerId);
+        const originalPartner = originalPartnersMap.get(partner.partnerId);
         if (!originalPartner) return true;
 
         if (partner.description !== originalPartner.description) return true;
         if (partner.imageId !== originalPartner.imageId) return true;
-        if (partner.image !== originalPartner.image) return true;
+        if (!isImageEqual(partner.image, originalPartner.image)) return true;
     }
 
     return false;
@@ -82,6 +92,7 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef>((_, re
     const [sectionToDeleteId, setSectionToDeleteId] = useState<string | null>(null);
     const [isPublishModalOpen, setIsPublishModalOpen] = useState(false);
     const [sectionToPublishId, setSectionToPublishId] = useState<string | null>(null);
+    const [sectionToPublishData, setSectionToPublishData] = useState<PartnerSectionFormValues | null>(null);
     const [localSections, setLocalSections] = useState<PartnerSectionFormValues[]>([]);
     const scrollAnchorRef = useRef<HTMLDivElement>(null);
 
@@ -159,24 +170,25 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef>((_, re
         [localSections, setLocalSections],
     );
 
-    const handlePublishRequest = useCallback((localId: string) => {
+    const handlePublishRequest = useCallback((localId: string, sectionData: PartnerSectionFormValues) => {
         setSectionToPublishId(localId);
+        setSectionToPublishData(sectionData);
         setIsPublishModalOpen(true);
     }, []);
 
     const handleClosePublishModal = useCallback(() => {
         setIsPublishModalOpen(false);
         setSectionToPublishId(null);
+        setSectionToPublishData(null);
     }, []);
 
     const handleConfirmPublish = useCallback(async () => {
-        if (!sectionToPublishId) return;
+        if (!sectionToPublishId || !sectionToPublishData) return;
 
         setIsPublishing(true);
         setIsPublishModalOpen(false);
         try {
-            const sectionToPublish = localSections.find((s) => s.localId === sectionToPublishId);
-            if (!sectionToPublish) return;
+            const sectionToPublish = sectionToPublishData;
 
             let savedSection: PartnerSection;
 
@@ -251,8 +263,9 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef>((_, re
         } finally {
             setIsPublishing(false);
             setSectionToPublishId(null);
+            setSectionToPublishData(null);
         }
-    }, [localSections, addToast, client, setLocalSections, sectionToPublishId, setFetchedSections]);
+    }, [sectionToPublishData, addToast, client, setLocalSections, sectionToPublishId, setFetchedSections]);
 
     const handleDeleteRequest = useCallback((localId: string) => {
         setSectionToDeleteId(localId);
@@ -344,6 +357,11 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef>((_, re
         [addSection],
     );
 
+    const sectionDirtyStates = React.useMemo(
+        () => localSections.map((section) => isSectionDirty(section, fetchedSections)),
+        [localSections, fetchedSections],
+    );
+
     if (isSectionsLoading && localSections.length === 0) {
         return (
             <div className={styles.loader}>
@@ -371,7 +389,7 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef>((_, re
                     value={section}
                     errors={errors[index] || { partners: [] }}
                     disabled={isSectionsLoading || isPublishing}
-                    isDirty={isSectionDirty(section, fetchedSections)}
+                    isDirty={sectionDirtyStates[index]}
                     onChange={handleChange}
                     onDelete={handleDeleteRequest}
                     onPublish={handlePublishRequest}


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2765)

## Description

This PR resolves an issue in the Admin Panel's Partners page where the "Опублікувати" (Publish) buttons for the main Banner (Title) and individual Partner sections were incorrectly enabled by default. The underlying form logic has been updated to implement comprehensive "dirty-state" tracking. Now, the publish buttons remain disabled upon loading and will only become active when the user makes actual modifications to the form fields (e.g., editing text, changing images, or adding/removing partners).

## How it looks


https://github.com/user-attachments/assets/a6e616de-6b93-4e26-9a4f-1a783e58c987


## Summary of change

*   **Dirty State Tracking for Banner (`PartnerBannerForm.tsx`)**: Added a `savedValues` state and an `isDirty` calculation hook to compare current form values against the originally loaded data, disabling the publish button when unmodified.
*   **Deep Comparison for Sections (`PartnerSectionsEditor.tsx`)**: Implemented the `isSectionDirty` helper function to perform a deep comparison between local section forms (including nested partner data) and the original `fetchedSections` API response.
*   **Component Prop Updates (`PartnerSectionForm.tsx`)**: Extended `PartnerSectionProps` to accept an `isDirty` boolean, allowing the component to conditionally disable its publish button.
*   **Test Suite Updates**: Modified unit tests in `PartnerBannerForm.test.tsx` and `PartnerSectionForm.test.tsx` to simulate user changes prior to publishing, successfully testing the new disabled-by-default behavior.

## How to recreate changes

1. Log into the Admin panel and navigate to the **"Партнери"** page.
2. Locate the **"Опублікувати"** (Publish) buttons for both the main Title/Banner section and any individual Partner sections. Observe that they are disabled by default.
3. Make a change to any field (e.g., add a character to a description, change an image, or add a new partner).
4. Observe that the corresponding **"Опублікувати"** button immediately becomes enabled.
5. Click the **"Опублікувати"** button and confirm the publication in the popup modal.
6. Verify that after the success toast appears, the **"Опублікувати"** button immediately becomes disabled again until further changes are made.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Publish actions in partner banners and sections now require actual changes before becoming available.
  * The editor now better reflects whether a section has unsaved changes.

* **Bug Fixes**
  * Improved publish behavior so saved content is tracked correctly after successful updates.
  * Deleting a section now keeps the displayed list in sync with the latest state.
  * Updated form handling to ensure publish button states match validation and change status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->