### PR TITLE
fix/issue-2900 [Reports] The system displays an error message that does not comply with the specifications.

### DIFF
--- a/src/const/admin/image.ts
+++ b/src/const/admin/image.ts
@@ -9,7 +9,7 @@ export const IMAGE_VALIDATION = {
     allowedFormats: ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'],
     ImageDimensionsTooSmallError: 'Розмір зображення менший за рекомендований',
     ImageDimensionsTooLargeError: 'Зображення завелике. Це може вплинути на якість. Обріжте до рекомендованого.',
-    UnexpectedError: () => 'Невідома помилка валідації фото',
-    getFormatError: () => 'Невірний формат фото, дозволено jpeg, jpg, png, webp',
-    getSizeError: (maxSizeMB: number) => `Фото не більше ${maxSizeMB} MB`,
+    UnexpectedError: () => 'Невідома помилка валідації зображення',
+    getFormatError: () => 'Невірний формат зображення, дозволено jpeg, jpg, png, webp',
+    getSizeError: (maxSizeMB: number) => `Зображення не більше ${maxSizeMB} MB`,
 };


### PR DESCRIPTION
## JIRA or Github ticker

* [2900](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2900)

## Description

The main goal of this PR is to update the terminology used in image validation error messages. It replaces the specific word "фото" (photo) with the more accurate and general term "зображення" (image) for better consistency across the application.

## How it looks

<img width="392" height="526" alt="image" src="https://github.com/user-attachments/assets/e51aa43a-729d-4bd7-8f5c-8535119a9bb1" />

<img width="425" height="537" alt="image" src="https://github.com/user-attachments/assets/3ed9721e-d017-44a5-b47a-c38691f8d1ff" />

## Summary of change

- Updated the string returned by UnexpectedError from "помилка валідації фото" to "помилка валідації зображення".
- Updated the string returned by getFormatError from "Невірний формат фото..." to "Невірний формат зображення...".
- Updated the string returned by getSizeError from "Фото не більше..." to "Зображення не більше...".

## How to recreate changes

1. Click on the image upload input field
2. Select an image file with size greater than 5 MB (e.g., 6 MB)
3. Observe the system response
4. Click on the file upload button
5. Select an image file in unsupported bmp format
6. Click "Upload" or confirm upload


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated image validation error messages to use clearer, consistent wording.
  - Error text now references “image” instead of “photo” in format, size, and unexpected error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->