### PR TITLE
Feature/issue 2335,2366 [Main] Edit standard metric value Statistics block, Save standard metrics changes

### DIFF
--- a/src/const/admin/main-page.ts
+++ b/src/const/admin/main-page.ts
@@ -148,6 +148,10 @@ export const MAIN_PAGE_VALIDATION = {
             getMinError: () => COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(2),
             getMaxError: () => COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(20),
         },
+        value: {
+            ONLY_NUMBERS: 'Лише цифри',
+            ONLY_POSITIVE: 'Лише позитивні значення',
+        },
     },
 
     raisedFunds: {

--- a/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/raised-metric-edit-panel/RaisedMetricEditPanel.tsx
@@ -52,7 +52,7 @@ export const RaisedMetricEditPanel = ({ metric, onSave, onCancel, onSyncErrorCha
         setValue,
         formState: { errors, isValid },
     } = useForm<RaisedMetricFormValues>({
-        mode: 'onChange',
+        mode: 'onTouched',
         resolver: yupResolver(raisedMetricEditSchema),
         defaultValues: {
             nameUa: defaultNameUa,

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.test.tsx
@@ -111,18 +111,6 @@ describe('StatisticsMetricEditPanel', () => {
         ]);
     });
 
-    it('preserves decimal value when saving', async () => {
-        const onSave = jest.fn();
-        render(<StatisticsMetricEditPanel metric={createMetric()} onSave={onSave} onCancel={jest.fn()} />);
-
-        fireEvent.change(screen.getByTestId('metric-val-1'), { target: { value: '2 345.75' } });
-        fireEvent.change(screen.getByTestId('metric-ua-1'), { target: { value: 'Нова UA' } });
-
-        const updatedMetric = await submitForm(onSave);
-
-        expect(updatedMetric.value).toBe(2345.75);
-    });
-
     it('uses fallback defaults when name and localizations are missing', () => {
         render(
             <StatisticsMetricEditPanel

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
@@ -39,7 +39,7 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
         watch,
         formState: { errors, isValid },
     } = useForm<MetricFormValues>({
-        mode: 'all',
+        mode: 'onTouched',
         resolver: yupResolver(metricEditSchema),
         defaultValues: {
             nameUa: defaultNameUa,
@@ -60,14 +60,13 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
         currentValue !== defaultValueStr ||
         currentPrefix !== defaultPrefix;
 
-    const handleValueChange = (raw: string) => {
+    const handleValueChange = (raw: string, currentValue: string) => {
         if (!raw) return '';
         const stripped = raw.replace(/\s/g, '');
-        if (stripped === '-') return '-';
-        if (/^-?\d+$/.test(stripped)) {
+        if (/^\d+$/.test(stripped)) {
             return formatWithSpaces(stripped);
         }
-        return raw;
+        return currentValue;
     };
 
     const onValidSubmit = (data: MetricFormValues) => {
@@ -116,7 +115,7 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
                             name={name}
                             label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.VALUE_LABEL}
                             value={value}
-                            onChange={(e) => onChange(handleValueChange(e.target.value))}
+                            onChange={(e) => onChange(handleValueChange(e.target.value, value))}
                             onBlur={onBlur}
                             error={errors.value?.message}
                             maxLength={15}

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metric-edit-panel/StatisticsMetricEditPanel.tsx
@@ -5,11 +5,7 @@ import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/in
 import { MultiSelectInput } from '@/components/admin/multi-select-input/MultiSelectInput';
 import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
 import { Metric, MetricLocalization, MetricPrefix } from '@/types/admin/main-page';
-import {
-    formatCurrencyInput,
-    formatWithSpaces,
-    parseFormattedNumber,
-} from '@/utils/functions/formatters/format-number';
+import { formatWithSpaces, parseFormattedNumber } from '@/utils/functions/formatters/format-number';
 import {
     MetricFormValues,
     metricEditSchema,
@@ -43,7 +39,7 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
         watch,
         formState: { errors, isValid },
     } = useForm<MetricFormValues>({
-        mode: 'onBlur',
+        mode: 'all',
         resolver: yupResolver(metricEditSchema),
         defaultValues: {
             nameUa: defaultNameUa,
@@ -63,6 +59,16 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
         currentNameEn.trim() !== defaultNameEn.trim() ||
         currentValue !== defaultValueStr ||
         currentPrefix !== defaultPrefix;
+
+    const handleValueChange = (raw: string) => {
+        if (!raw) return '';
+        const stripped = raw.replace(/\s/g, '');
+        if (stripped === '-') return '-';
+        if (/^-?\d+$/.test(stripped)) {
+            return formatWithSpaces(stripped);
+        }
+        return raw;
+    };
 
     const onValidSubmit = (data: MetricFormValues) => {
         const parsedValue = parseFormattedNumber(data.value) ?? 0;
@@ -110,7 +116,7 @@ export const StatisticsMetricEditPanel = ({ metric, onSave, onCancel }: Statisti
                             name={name}
                             label={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.VALUE_LABEL}
                             value={value}
-                            onChange={(e) => onChange(formatCurrencyInput(e.target.value))}
+                            onChange={(e) => onChange(handleValueChange(e.target.value))}
                             onBlur={onBlur}
                             error={errors.value?.message}
                             maxLength={15}

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
@@ -78,7 +78,7 @@ describe('StatisticsMetricsList', () => {
     const setup = (propsOverrides: Partial<React.ComponentProps<typeof StatisticsMetricsList>> = {}) => {
         (useAdminClient as jest.Mock).mockReturnValue({});
         (useToast as jest.Mock).mockReturnValue({ addToast: jest.fn() });
-        MainPageApi.updateMetric = jest.fn().mockResolvedValue(undefined);
+        MainPageApi.updateMetric = jest.fn().mockResolvedValue({ wasModified: true, updatedFields: [] });
 
         const defaultProps = {
             metrics,

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.test.tsx
@@ -1,8 +1,11 @@
 import { Metric } from '@/types/admin/main-page';
 import { metricPartners, metricRaised } from '@/utils/test-mocks/statistics-block-mocks';
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { StatisticsMetricsList } from './StatisticsMetricsList';
+import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
+import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextProvider';
+import { MainPageApi } from '@/services/api/admin/main-page/main-page-api';
 
 const normalizeSpaces = (value: string) => value.replace(/\u00a0/g, ' ');
 
@@ -16,6 +19,10 @@ jest.mock('@/components/admin/draggable-list-item/DraggableListItem', () => ({
         );
     },
 }));
+
+jest.mock('@/hooks/admin/use-admin-client/useAdminClient');
+jest.mock('@/contexts/admin/toast-context-provider/ToastContextProvider');
+jest.mock('@/services/api/admin/main-page/main-page-api');
 
 jest.mock('@/components/admin/icon-button/IconButton', () => ({
     IconButton: ({ onClick, disabled, 'aria-label': ariaLabel }: any) => (
@@ -69,6 +76,10 @@ const metrics: Metric[] = [metricPartners, metricRaised];
 
 describe('StatisticsMetricsList', () => {
     const setup = (propsOverrides: Partial<React.ComponentProps<typeof StatisticsMetricsList>> = {}) => {
+        (useAdminClient as jest.Mock).mockReturnValue({});
+        (useToast as jest.Mock).mockReturnValue({ addToast: jest.fn() });
+        MainPageApi.updateMetric = jest.fn().mockResolvedValue(undefined);
+
         const defaultProps = {
             metrics,
             hiddenMetricIds: [],
@@ -145,35 +156,39 @@ describe('StatisticsMetricsList', () => {
         expect(onToggleVisibility).not.toHaveBeenCalled();
     });
 
-    it('renders standard edit panel and saves updated metric', () => {
+    it('renders standard edit panel and saves updated metric', async () => {
         const { onMetricUpdate } = setup();
 
         fireEvent.click(screen.getAllByTestId('icon-Edit metric')[0]);
         expect(screen.getByTestId('metric-edit-panel')).toBeInTheDocument();
 
         fireEvent.click(screen.getByTestId('save-edit'));
-        expect(onMetricUpdate).toHaveBeenCalledWith([{ ...metrics[0], name: 'Updated Metric' }, metrics[1]]);
+        await waitFor(() => {
+            expect(onMetricUpdate).toHaveBeenCalledWith([{ ...metrics[0], name: 'Updated Metric' }, metrics[1]]);
+        });
     });
 
-    it('renders raised edit panel and saves updated metric', () => {
+    it('renders raised edit panel and saves updated metric', async () => {
         const { onMetricUpdate } = setup();
 
         fireEvent.click(screen.getAllByTestId('icon-Edit metric')[1]);
         expect(screen.getByTestId('raised-edit-panel')).toBeInTheDocument();
 
         fireEvent.click(screen.getByTestId('save-raised-edit'));
-        expect(screen.queryByTestId('raised-edit-panel')).not.toBeInTheDocument();
-        expect(onMetricUpdate).toHaveBeenCalledWith([
-            metrics[0],
-            {
-                ...metrics[1],
-                name: 'Updated Raised',
-                isAutoSynced: true,
-                localizations: metrics[1].localizations?.map((loc: any) =>
-                    loc.languageId === 1 ? { ...loc, name: 'Updated Raised' } : loc,
-                ),
-            },
-        ]);
+        await waitFor(() => {
+            expect(screen.queryByTestId('raised-edit-panel')).not.toBeInTheDocument();
+            expect(onMetricUpdate).toHaveBeenCalledWith([
+                metrics[0],
+                {
+                    ...metrics[1],
+                    name: 'Updated Raised',
+                    isAutoSynced: true,
+                    localizations: metrics[1].localizations?.map((loc: any) =>
+                        loc.languageId === 1 ? { ...loc, name: 'Updated Raised' } : loc,
+                    ),
+                },
+            ]);
+        });
     });
 
     it('passes raised funds sync error state changes from edit panel to parent', () => {

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
@@ -4,7 +4,11 @@ import { ReactComponent as EyeOpenedIcon } from '@/assets/icons/eye-opened.svg';
 import { DraggableListItem } from '@/components/admin/draggable-list-item/DraggableListItem';
 import { IconButton } from '@/components/admin/icon-button/IconButton';
 import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
-import { Metric, MetricType } from '@/types/admin/main-page';
+import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextProvider';
+import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
+import { MainPageApi } from '@/services/api/admin/main-page/main-page-api';
+import { ToastType } from '@/types/admin/toast';
+import { Metric, MetricType, UpdateSingleMetricDto } from '@/types/admin/main-page';
 import { formatMetricValue, getMetricName } from '@/utils/functions/formatters/metric-formatters';
 import { useState } from 'react';
 import { RaisedMetricEditPanel } from '../raised-metric-edit-panel/RaisedMetricEditPanel';
@@ -28,13 +32,55 @@ export const StatisticsMetricsList = ({
     onMetricUpdate,
     onRaisedFundsSyncErrorChange,
 }: StatisticsMetricsListProps) => {
+    const client = useAdminClient();
+    const { addToast } = useToast();
     const [editingMetricId, setEditingMetricId] = useState<number | null>(null);
     const visibleMetricsCount = metrics.length - hiddenMetricIds.length;
 
-    const handleSaveMetric = (updatedMetric: Metric) => {
-        const newMetrics = metrics.map((m) => (m.id === updatedMetric.id ? updatedMetric : m));
-        onMetricUpdate(newMetrics);
-        setEditingMetricId(null);
+    const getMetricDiff = (original: Metric, updated: Metric): UpdateSingleMetricDto => {
+        const patch: UpdateSingleMetricDto = {};
+        if (original.value !== updated.value) patch.value = updated.value;
+        if (original.name !== updated.name) patch.name = updated.name;
+        if (original.prefix !== updated.prefix) patch.prefix = updated.prefix;
+        if (original.isAutoSynced !== updated.isAutoSynced) patch.isAutoSynced = updated.isAutoSynced;
+
+        const origEn = original.localizations?.find((l) => l.languageId === 2);
+        const updatedEn = updated.localizations?.find((l) => l.languageId === 2);
+
+        if (origEn?.name !== updatedEn?.name || origEn?.value !== updatedEn?.value) {
+            patch.localization = {
+                languageId: 2,
+                name: updatedEn?.name,
+                value: updatedEn?.value,
+            };
+        }
+
+        return patch;
+    };
+
+    const handleSaveMetric = async (updatedMetric: Metric) => {
+        const originalMetric = metrics.find((m) => m.id === updatedMetric.id);
+        if (!originalMetric || !updatedMetric.id) {
+            setEditingMetricId(null);
+            return;
+        }
+
+        const patch = getMetricDiff(originalMetric, updatedMetric);
+        if (Object.keys(patch).length === 0) {
+            setEditingMetricId(null);
+            return;
+        }
+
+        try {
+            await MainPageApi.updateMetric(client, updatedMetric.id, patch);
+
+            const newMetrics = metrics.map((m) => (m.id === updatedMetric.id ? updatedMetric : m));
+            onMetricUpdate(newMetrics);
+            setEditingMetricId(null);
+            addToast('Зміни збережено успішно', ToastType.Success, 3000);
+        } catch (error) {
+            addToast('Виникла помилка, спробуйте ще раз', ToastType.Error, 3000);
+        }
     };
 
     const renderRow = (metric: Metric) => {

--- a/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
+++ b/src/pages/admin/main/components/statistics-block/components/statistics-metrics-list/StatisticsMetricsList.tsx
@@ -1,6 +1,8 @@
+import axios from 'axios';
 import { ReactComponent as EditIcon } from '@/assets/icons/edit.svg';
 import { ReactComponent as EyeClosedIcon } from '@/assets/icons/eye-closed.svg';
 import { ReactComponent as EyeOpenedIcon } from '@/assets/icons/eye-opened.svg';
+import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
 import { DraggableListItem } from '@/components/admin/draggable-list-item/DraggableListItem';
 import { IconButton } from '@/components/admin/icon-button/IconButton';
 import { MAIN_PAGE_TEXT } from '@/const/admin/main-page';
@@ -35,10 +37,12 @@ export const StatisticsMetricsList = ({
     const client = useAdminClient();
     const { addToast } = useToast();
     const [editingMetricId, setEditingMetricId] = useState<number | null>(null);
+    const [pendingMetric, setPendingMetric] = useState<Metric | null>(null);
+    const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
     const visibleMetricsCount = metrics.length - hiddenMetricIds.length;
 
-    const getMetricDiff = (original: Metric, updated: Metric): UpdateSingleMetricDto => {
-        const patch: UpdateSingleMetricDto = {};
+    const getMetricDiff = (original: Metric, updated: Metric): Partial<UpdateSingleMetricDto> => {
+        const patch: Partial<UpdateSingleMetricDto> = {};
         if (original.value !== updated.value) patch.value = updated.value;
         if (original.name !== updated.name) patch.name = updated.name;
         if (original.prefix !== updated.prefix) patch.prefix = updated.prefix;
@@ -47,12 +51,23 @@ export const StatisticsMetricsList = ({
         const origEn = original.localizations?.find((l) => l.languageId === 2);
         const updatedEn = updated.localizations?.find((l) => l.languageId === 2);
 
-        if (origEn?.name !== updatedEn?.name || origEn?.value !== updatedEn?.value) {
-            patch.localization = {
-                languageId: 2,
-                name: updatedEn?.name,
-                value: updatedEn?.value,
-            };
+        const origEnName = origEn?.name ?? null;
+        const updatedEnName = updatedEn?.name ?? null;
+        const origEnValue = origEn?.value ?? null;
+        const updatedEnValue = updatedEn?.value ?? null;
+
+        if (origEnName !== updatedEnName || origEnValue !== updatedEnValue) {
+            if (updatedEnName !== null || updatedEnValue !== null) {
+                patch.localization = {
+                    languageId: 2,
+                    name: updatedEnName ?? undefined,
+                    value: updatedEnValue ?? undefined,
+                };
+            }
+        }
+
+        if (Object.keys(patch).length > 0 && original.rowVersion) {
+            patch.expectedVersion = original.rowVersion;
         }
 
         return patch;
@@ -62,35 +77,65 @@ export const StatisticsMetricsList = ({
         const originalMetric = metrics.find((m) => m.id === updatedMetric.id);
         if (!originalMetric || !updatedMetric.id) {
             setEditingMetricId(null);
+            setPendingMetric(null);
             return;
         }
 
         const patch = getMetricDiff(originalMetric, updatedMetric);
         if (Object.keys(patch).length === 0) {
+            addToast('Немає змін для збереження', ToastType.Info, 2000);
             setEditingMetricId(null);
+            setPendingMetric(null);
             return;
         }
 
         try {
-            await MainPageApi.updateMetric(client, updatedMetric.id, patch);
+            setPendingMetric(updatedMetric);
+            const response = await MainPageApi.updateMetric(client, updatedMetric.id, patch as UpdateSingleMetricDto);
 
-            const newMetrics = metrics.map((m) => (m.id === updatedMetric.id ? updatedMetric : m));
-            onMetricUpdate(newMetrics);
-            setEditingMetricId(null);
-            addToast('Зміни збережено успішно', ToastType.Success, 3000);
+            if (response.wasModified) {
+                const newMetrics = metrics.map((m) => (m.id === updatedMetric.id ? updatedMetric : m));
+                onMetricUpdate(newMetrics);
+                setEditingMetricId(null);
+                setPendingMetric(null);
+                addToast('Зміни збережено успішно', ToastType.Success, 3000);
+            } else {
+                setEditingMetricId(null);
+                setPendingMetric(null);
+                addToast('Змін не виявлено', ToastType.Info, 3000);
+            }
         } catch (error) {
-            addToast('Виникла помилка, спробуйте ще раз', ToastType.Error, 3000);
+            if (axios.isAxiosError(error) && error.response?.status === 409) {
+                addToast('Дані змінено іншим користувачем. Перезавантажте сторінку', ToastType.Warning, 3000);
+            } else {
+                addToast('Виникла помилка, спробуйте ще раз', ToastType.Error, 3000);
+            }
         }
+    };
+
+    const handleCancelEdit = () => {
+        if (pendingMetric) {
+            setIsCancelModalOpen(true);
+        } else {
+            setEditingMetricId(null);
+        }
+    };
+
+    const confirmCancelEdit = () => {
+        setIsCancelModalOpen(false);
+        setPendingMetric(null);
+        setEditingMetricId(null);
     };
 
     const renderRow = (metric: Metric) => {
         if (editingMetricId === metric.id) {
+            const currentMetric = pendingMetric?.id === metric.id ? pendingMetric : metric;
             if (metric.type === MetricType.Raised) {
                 return (
                     <RaisedMetricEditPanel
-                        metric={metric}
+                        metric={currentMetric}
                         onSave={handleSaveMetric}
-                        onCancel={() => setEditingMetricId(null)}
+                        onCancel={handleCancelEdit}
                         onSyncErrorChange={onRaisedFundsSyncErrorChange}
                     />
                 );
@@ -98,9 +143,9 @@ export const StatisticsMetricsList = ({
 
             return (
                 <StatisticsMetricEditPanel
-                    metric={metric}
+                    metric={currentMetric}
                     onSave={handleSaveMetric}
-                    onCancel={() => setEditingMetricId(null)}
+                    onCancel={handleCancelEdit}
                 />
             );
         }
@@ -176,6 +221,14 @@ export const StatisticsMetricsList = ({
                     />
                 ))}
             </div>
+
+            <ConfirmationModal
+                isOpen={isCancelModalOpen}
+                onClose={() => setIsCancelModalOpen(false)}
+                title={MAIN_PAGE_TEXT.BLOCKS.EDIT_PANEL.CANCEL_MODAL_TITLE}
+                onConfirm={confirmCancelEdit}
+                onCancel={() => setIsCancelModalOpen(false)}
+            />
         </div>
     );
 };

--- a/src/services/api/admin/main-page/main-page-api.ts
+++ b/src/services/api/admin/main-page/main-page-api.ts
@@ -6,6 +6,7 @@ import {
     UpdateMainPageDto,
     UpdateMetricVisibilityDto,
     UpdateSingleMetricDto,
+    UpdateMetricResult,
 } from '@/types/admin/main-page';
 import type { LocalizationLanguage } from '@/types/common/language';
 import { mapEntityWithLocalizations } from '@/utils/functions/mappers/common/localization/localization-mappers';
@@ -65,8 +66,13 @@ export const MainPageApi = {
         await client.put(`${API_ROUTES.MAIN_PAGE.BASE}/metrics/${id}/visibility`, dto);
     },
 
-    updateMetric: async (client: AxiosInstance, id: number, dto: UpdateSingleMetricDto): Promise<void> => {
-        await client.patch(`${API_ROUTES.MAIN_PAGE.BASE}/metrics/${id}`, dto);
+    updateMetric: async (
+        client: AxiosInstance,
+        id: number,
+        dto: UpdateSingleMetricDto,
+    ): Promise<UpdateMetricResult> => {
+        const response = await client.patch<UpdateMetricResult>(`${API_ROUTES.MAIN_PAGE.BASE}/metrics/${id}`, dto);
+        return response.data;
     },
 
     reorderMetrics: async (client: AxiosInstance, dto: ReorderMetricsDto): Promise<void> => {

--- a/src/services/api/admin/main-page/main-page-api.ts
+++ b/src/services/api/admin/main-page/main-page-api.ts
@@ -5,6 +5,7 @@ import {
     ReorderMetricsDto,
     UpdateMainPageDto,
     UpdateMetricVisibilityDto,
+    UpdateSingleMetricDto,
 } from '@/types/admin/main-page';
 import type { LocalizationLanguage } from '@/types/common/language';
 import { mapEntityWithLocalizations } from '@/utils/functions/mappers/common/localization/localization-mappers';
@@ -62,6 +63,10 @@ export const MainPageApi = {
         dto: UpdateMetricVisibilityDto,
     ): Promise<void> => {
         await client.put(`${API_ROUTES.MAIN_PAGE.BASE}/metrics/${id}/visibility`, dto);
+    },
+
+    updateMetric: async (client: AxiosInstance, id: number, dto: UpdateSingleMetricDto): Promise<void> => {
+        await client.patch(`${API_ROUTES.MAIN_PAGE.BASE}/metrics/${id}`, dto);
     },
 
     reorderMetrics: async (client: AxiosInstance, dto: ReorderMetricsDto): Promise<void> => {

--- a/src/types/admin/main-page.ts
+++ b/src/types/admin/main-page.ts
@@ -443,6 +443,14 @@ export interface UpdateMetricVisibilityDto {
     isHidden: boolean;
 }
 
+export interface UpdateSingleMetricDto {
+    value?: number;
+    name?: string;
+    prefix?: MetricPrefix | null;
+    isAutoSynced?: boolean;
+    localization?: UpdateMetricLocalizationDto | null;
+}
+
 // Form Values & Defaults
 
 export interface MainPageFormValues {

--- a/src/types/admin/main-page.ts
+++ b/src/types/admin/main-page.ts
@@ -89,6 +89,7 @@ export interface Metric extends EntityWithLocalizations<MetricLocalization> {
     autoSyncError?: string | null;
     syncError?: string | null;
     isHidden: boolean;
+    rowVersion?: string;
     priority: number;
 }
 
@@ -443,12 +444,24 @@ export interface UpdateMetricVisibilityDto {
     isHidden: boolean;
 }
 
-export interface UpdateSingleMetricDto {
+export type UpdateSingleMetricDto = (
+    | { value: number }
+    | { name: string }
+    | { prefix: MetricPrefix | null }
+    | { isAutoSynced: boolean }
+    | { localization: UpdateMetricLocalizationDto | null }
+) & {
     value?: number;
     name?: string;
     prefix?: MetricPrefix | null;
     isAutoSynced?: boolean;
     localization?: UpdateMetricLocalizationDto | null;
+    expectedVersion?: string;
+};
+
+export interface UpdateMetricResult {
+    wasModified: boolean;
+    updatedFields: string[];
 }
 
 // Form Values & Defaults

--- a/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.test.ts
+++ b/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.test.ts
@@ -42,7 +42,13 @@ describe('metricEditSchema', () => {
 
     it('requires positive value', async () => {
         await expect(metricEditSchema.validate({ ...validPayload, value: '0' })).rejects.toThrow(
-            MAIN_PAGE_VALIDATION.common.REQUIRED,
+            MAIN_PAGE_VALIDATION.editPanel.value.ONLY_POSITIVE,
+        );
+    });
+
+    it('rejects non-numeric value', async () => {
+        await expect(metricEditSchema.validate({ ...validPayload, value: 'abc' })).rejects.toThrow(
+            MAIN_PAGE_VALIDATION.editPanel.value.ONLY_NUMBERS,
         );
     });
 

--- a/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.ts
+++ b/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.ts
@@ -3,10 +3,6 @@ import { MetricPrefix } from '@/types/admin/main-page';
 import { normalizeFormattedNumber, parseFormattedNumber } from '@/utils/functions/formatters/format-number';
 import * as Yup from 'yup';
 
-const parseThousands = (value: string): number => {
-    return parseFormattedNumber(value || '') ?? 0;
-};
-
 const raisedFundsValidator = Yup.string()
     .required(MAIN_PAGE_VALIDATION.raisedFunds.REQUIRED)
     .test('not-empty', MAIN_PAGE_VALIDATION.raisedFunds.REQUIRED, (val) => {
@@ -46,7 +42,17 @@ export const metricEditSchema = Yup.object({
         .max(MAIN_PAGE_VALIDATION.editPanel.name.max, MAIN_PAGE_VALIDATION.editPanel.name.getMaxError()),
     value: Yup.string()
         .required(MAIN_PAGE_VALIDATION.common.REQUIRED)
-        .test('is-positive', MAIN_PAGE_VALIDATION.common.REQUIRED, (val) => parseThousands(val || '') > 0),
+        .test('only-numbers', MAIN_PAGE_VALIDATION.editPanel.value.ONLY_NUMBERS, (val) => {
+            if (!val) return false;
+            const stripped = val.replace(/\s/g, '');
+            return /^-?\d+$/.test(stripped);
+        })
+        .test('is-positive', MAIN_PAGE_VALIDATION.editPanel.value.ONLY_POSITIVE, (val) => {
+            if (!val) return false;
+            const stripped = val.replace(/\s/g, '');
+            const num = Number(stripped);
+            return !Number.isNaN(num) && num > 0;
+        }),
     prefix: Yup.mixed<MetricPrefix>().required(MAIN_PAGE_VALIDATION.common.REQUIRED),
 });
 

--- a/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.ts
+++ b/src/validation/admin/main-page-schema/metric-edit-schema/metric-edit-schema.ts
@@ -45,7 +45,7 @@ export const metricEditSchema = Yup.object({
         .test('only-numbers', MAIN_PAGE_VALIDATION.editPanel.value.ONLY_NUMBERS, (val) => {
             if (!val) return false;
             const stripped = val.replace(/\s/g, '');
-            return /^-?\d+$/.test(stripped);
+            return /^[1-9]\d*$/.test(stripped) || stripped === '0';
         })
         .test('is-positive', MAIN_PAGE_VALIDATION.editPanel.value.ONLY_POSITIVE, (val) => {
             if (!val) return false;


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2335)
* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2366)

## Description

This PR implements the inline saving and specific field validation for standard metrics in the Admin Main Page management section. It introduces a specific PATCH endpoint integration to ensure only modified fields are transmitted, preserving unchanged data. It also refines the numeric validation schema to provide precise, on-the-fly user feedback for invalid inputs.

### Note
Backend PR with PATCH endpoint implementation:
https://github.com/ita-social-projects/VictoryCenter-Back/pull/2996


## Summary of change

*   **Validation & Constants**: Added specific numeric validation constants (`main-page.ts`). Updated `metric-edit-schema.ts` to trigger "Лише позитивні значення" and "Лише цифри" errors.
*   **Types & API**: Defined the `UpdateSingleMetricDto` interface to support partial updates and introduced the `updateMetric` PATCH method in `main-page-api.ts`.
*   **Edit Panel (`StatisticsMetricEditPanel.tsx`)**: Enabled real-time validation feedback by setting `react-hook-form` mode to `'all'`. Relaxed `handleValueChange` to let the Yup schema naturally catch invalid intermediate states (like minus signs or empty strings).
*   **Metrics List (`StatisticsMetricsList.tsx`)**: Refactored save logic to calculate and send only modified properties using `getMetricDiff`. Integrated the update API with success and error snackbars. Improved error handling so the edit panel remains open if a save fails.

## How to recreate changes

1. Log in as an Admin and navigate to the **Main Page** (Титульна сторінка) -> **Statistics** (Статистика) tab.
2. Click the Edit icon on one of the standard metrics (e.g., Partners, Programs, or Therapy hours).
3. Type a negative number (e.g., `-5`) or attempt to type non-numeric characters into the "Значення" field to observe the new on-the-fly validation errors.
4. Correct the value, change the prefix, and click **"Зберегти"** (Save).
5. Observe the green success snackbar and the immediately updated values in both the list and preview sections without a page reload.

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin metric editing now updates values through the server and supports clearer feedback on successful saves, unchanged data, and concurrent edits.
  * Metric value validation now distinguishes between non-numeric input and values that must be greater than zero.

* **Bug Fixes**
  * Improved editing behavior for metric values, including better formatting while typing.
  * Canceling an in-progress metric edit now asks for confirmation when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->