### PR TITLE
Feature/issue-1403 [Reports] Order pdf files to present in a section on public web-page

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -139,6 +139,8 @@ export const PDF_FILES_SECTION_TEXT = {
         VIEW_ERROR: 'Не вдалося завантажити файл для перегляду. Спробуйте ще раз.',
         FAIL_TO_CREATE_TRANSLATION: 'Виникла помилка під час додавання перекладу для PDF секції',
         FAIL_TO_UPDATE_TRANSLATION: 'Виникла помилка під час оновлення перекладу для PDF секції',
+        REORDER_SUCCESS: 'Порядок файлів успішно змінено',
+        REORDER_ERROR: 'Не вдалося змінити порядок файлів. Спробуйте ще раз.',
     },
     DELETE_CONFIRMATION: {
         TITLE: 'Файл буде видалено. Бажаєте продовжити?',

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
@@ -489,6 +489,7 @@ describe('PdfFilesSection', () => {
                 PDF_FILES_SECTION_TEXT.MESSAGE.REORDER_SUCCESS,
                 ToastType.Success,
             );
+            expect(mockRefetch).toHaveBeenCalled();
         });
     });
 

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
@@ -31,7 +31,7 @@ jest.mock('./components/pdf-section-content-block/PdfSectionContentBlock', () =>
 }));
 
 jest.mock('./components/pdf-files-table/PdfFilesTable', () => ({
-    PdfFilesTable: ({ files, onDeleteFile, onViewFile, onRenameFile, isDeleting, isRenaming }: any) => (
+    PdfFilesTable: ({ files, onDeleteFile, onViewFile, onRenameFile, onReorderFiles, isDeleting, isRenaming }: any) => (
         <div data-testid="files-table">
             Files Count: {files?.length ?? 0}
             {isDeleting && <span data-testid="is-deleting">Deleting...</span>}
@@ -44,6 +44,9 @@ jest.mock('./components/pdf-files-table/PdfFilesTable', () => ({
             </button>
             <button onClick={() => onRenameFile && onRenameFile(1, 'New Name')} data-testid="rename-btn">
                 Rename
+            </button>
+            <button onClick={() => onReorderFiles && onReorderFiles(files)} data-testid="reorder-btn">
+                Reorder
             </button>
         </div>
     ),
@@ -113,7 +116,7 @@ describe('PdfFilesSection', () => {
     let originalCreateObjectURL: any;
     let originalWindowOpen: any;
 
-    const setupDataFetchMock = (options: { setData?: jest.Mock; filesData?: any[] } = {}) => {
+    const setupDataFetchMock = (options: { setData?: jest.Mock; filesData?: any[]; setFilesData?: jest.Mock } = {}) => {
         (useDataFetch as jest.Mock).mockImplementation(({ initialData }) => {
             if (initialData === null) {
                 return {
@@ -123,7 +126,12 @@ describe('PdfFilesSection', () => {
                     setData: options.setData ?? jest.fn(),
                 };
             }
-            return { data: options.filesData ?? mockFilesResponse.items, isLoading: false, refetch: mockRefetch };
+            return {
+                data: options.filesData ?? mockFilesResponse.items,
+                isLoading: false,
+                refetch: mockRefetch,
+                setData: options.setFilesData ?? jest.fn(),
+            };
         });
     };
 
@@ -158,6 +166,7 @@ describe('PdfFilesSection', () => {
             data: null,
             isLoading: true,
             refetch: mockRefetch,
+            setData: jest.fn(),
         });
 
         render(<PdfFilesSection />);
@@ -166,8 +175,13 @@ describe('PdfFilesSection', () => {
 
     it('should render all components when data is loaded', () => {
         (useDataFetch as jest.Mock)
-            .mockReturnValueOnce({ data: mockSectionData, isLoading: false, refetch: mockRefetch })
-            .mockReturnValueOnce({ data: mockFilesResponse.items, isLoading: false, refetch: mockRefetch });
+            .mockReturnValueOnce({ data: mockSectionData, isLoading: false, refetch: mockRefetch, setData: jest.fn() })
+            .mockReturnValueOnce({
+                data: mockFilesResponse.items,
+                isLoading: false,
+                refetch: mockRefetch,
+                setData: jest.fn(),
+            });
 
         render(<PdfFilesSection />);
 
@@ -184,7 +198,7 @@ describe('PdfFilesSection', () => {
         (useDataFetch as jest.Mock).mockImplementation(({ fetchHandler }) => {
             if (!capturedFetchSection) capturedFetchSection = fetchHandler;
             else capturedFetchFiles = fetchHandler;
-            return { data: [], isLoading: false, refetch: mockRefetch };
+            return { data: [], isLoading: false, refetch: mockRefetch, setData: jest.fn() };
         });
 
         render(<PdfFilesSection />);
@@ -201,8 +215,8 @@ describe('PdfFilesSection', () => {
 
     it('should provide default empty content if sectionData is null', () => {
         (useDataFetch as jest.Mock)
-            .mockReturnValueOnce({ data: null, isLoading: false, refetch: mockRefetch })
-            .mockReturnValueOnce({ data: [], isLoading: false, refetch: mockRefetch });
+            .mockReturnValueOnce({ data: null, isLoading: false, refetch: mockRefetch, setData: jest.fn() })
+            .mockReturnValueOnce({ data: [], isLoading: false, refetch: mockRefetch, setData: jest.fn() });
 
         render(<PdfFilesSection />);
 
@@ -401,7 +415,7 @@ describe('PdfFilesSection', () => {
                 if (initialData === null) {
                     return { data: mockSectionData, isLoading: false, refetch: mockRefetch, setData: mockSetData };
                 }
-                return { data: mockFilesResponse.items, isLoading: false, refetch: mockRefetch };
+                return { data: mockFilesResponse.items, isLoading: false, refetch: mockRefetch, setData: jest.fn() };
             });
 
             render(<PdfFilesSection />);
@@ -455,5 +469,38 @@ describe('PdfFilesSection', () => {
 
         jest.advanceTimersByTime(1500);
         expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:http://localhost/mock-blob-url');
+    });
+
+    it('should call reorder API and toast success on successful reorder', async () => {
+        setupDataFetchMock();
+        (PdfReportsApi.reorder as jest.Mock).mockResolvedValueOnce(undefined);
+
+        render(<PdfFilesSection />);
+
+        const reorderBtn = screen.getByTestId('reorder-btn');
+        fireEvent.click(reorderBtn);
+
+        await waitFor(() => {
+            expect(PdfReportsApi.reorder).toHaveBeenCalledWith(mockClient, 1, [1, 2]);
+            expect(mockAddToast).toHaveBeenCalledWith(
+                PDF_FILES_SECTION_TEXT.MESSAGE.REORDER_SUCCESS,
+                ToastType.Success,
+            );
+        });
+    });
+
+    it('should show error toast and revert on reorder failure', async () => {
+        setupDataFetchMock();
+        (PdfReportsApi.reorder as jest.Mock).mockRejectedValueOnce(new Error('Reorder failed'));
+
+        render(<PdfFilesSection />);
+
+        const reorderBtn = screen.getByTestId('reorder-btn');
+        fireEvent.click(reorderBtn);
+
+        await waitFor(() => {
+            expect(PdfReportsApi.reorder).toHaveBeenCalled();
+            expect(mockAddToast).toHaveBeenCalledWith(PDF_FILES_SECTION_TEXT.MESSAGE.REORDER_ERROR, ToastType.Error);
+        });
     });
 });

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
@@ -30,26 +30,31 @@ jest.mock('./components/pdf-section-content-block/PdfSectionContentBlock', () =>
     ),
 }));
 
+let capturedOnReorderFiles: ((reordered: any[]) => void) | undefined;
+
 jest.mock('./components/pdf-files-table/PdfFilesTable', () => ({
-    PdfFilesTable: ({ files, onDeleteFile, onViewFile, onRenameFile, onReorderFiles, isDeleting, isRenaming }: any) => (
-        <div data-testid="files-table">
-            Files Count: {files?.length ?? 0}
-            {isDeleting && <span data-testid="is-deleting">Deleting...</span>}
-            {isRenaming && <span data-testid="is-renaming">Renaming...</span>}
-            <button onClick={() => onDeleteFile && onDeleteFile(1)} data-testid="delete-btn">
-                Delete
-            </button>
-            <button onClick={() => onViewFile && onViewFile(files?.[0])} data-testid="view-btn">
-                View
-            </button>
-            <button onClick={() => onRenameFile && onRenameFile(1, 'New Name')} data-testid="rename-btn">
-                Rename
-            </button>
-            <button onClick={() => onReorderFiles && onReorderFiles(files)} data-testid="reorder-btn">
-                Reorder
-            </button>
-        </div>
-    ),
+    PdfFilesTable: ({ files, onDeleteFile, onViewFile, onRenameFile, onReorderFiles, isDeleting, isRenaming }: any) => {
+        capturedOnReorderFiles = onReorderFiles;
+        return (
+            <div data-testid="files-table">
+                Files Count: {files?.length ?? 0}
+                {isDeleting && <span data-testid="is-deleting">Deleting...</span>}
+                {isRenaming && <span data-testid="is-renaming">Renaming...</span>}
+                <button onClick={() => onDeleteFile && onDeleteFile(1)} data-testid="delete-btn">
+                    Delete
+                </button>
+                <button onClick={() => onViewFile && onViewFile(files?.[0])} data-testid="view-btn">
+                    View
+                </button>
+                <button onClick={() => onRenameFile && onRenameFile(1, 'New Name')} data-testid="rename-btn">
+                    Rename
+                </button>
+                <button onClick={() => onReorderFiles && onReorderFiles(files)} data-testid="reorder-btn">
+                    Reorder
+                </button>
+            </div>
+        );
+    },
 }));
 
 jest.mock('./components/language-switcher-buttons/LanguageSwitcherButtons', () => ({
@@ -494,16 +499,37 @@ describe('PdfFilesSection', () => {
     });
 
     it('should show error toast and revert on reorder failure', async () => {
-        setupDataFetchMock();
-        (PdfReportsApi.reorder as jest.Mock).mockRejectedValueOnce(new Error('Reorder failed'));
+        const mockSetFilesData = jest.fn();
+        setupDataFetchMock({ setFilesData: mockSetFilesData });
+
+        let rejectReorder: (reason: any) => void = () => {};
+        const reorderPromise = new Promise((_, reject) => {
+            rejectReorder = reject;
+        });
+        (PdfReportsApi.reorder as jest.Mock).mockReturnValueOnce(reorderPromise);
 
         render(<PdfFilesSection />);
 
-        const reorderBtn = screen.getByTestId('reorder-btn');
-        fireEvent.click(reorderBtn);
+        const reordered = [mockFilesResponse.items[1], mockFilesResponse.items[0]];
+
+        // Call the reorder handler with the reversed files list
+        await act(async () => {
+            capturedOnReorderFiles!(reordered);
+        });
+
+        // Verify optimistic update is applied first
+        expect(mockSetFilesData).toHaveBeenCalledWith(reordered);
+        expect(mockSetFilesData).toHaveBeenCalledTimes(1);
+
+        // Reject the API call
+        await act(async () => {
+            rejectReorder(new Error('Reorder failed'));
+        });
 
         await waitFor(() => {
-            expect(PdfReportsApi.reorder).toHaveBeenCalled();
+            // Verify original order is restored
+            expect(mockSetFilesData).toHaveBeenLastCalledWith(mockFilesResponse.items);
+            expect(mockSetFilesData).toHaveBeenCalledTimes(2);
             expect(mockAddToast).toHaveBeenCalledWith(PDF_FILES_SECTION_TEXT.MESSAGE.REORDER_ERROR, ToastType.Error);
         });
     });

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
@@ -26,6 +26,7 @@ export const PdfFilesSection = () => {
     const [currentLanguage, setCurrentLanguage] = useState<'uk' | 'en'>('uk');
     const [isDeleting, setIsDeleting] = useState(false);
     const [isRenaming, setIsRenaming] = useState(false);
+    const [isReordering, setIsReordering] = useState(false);
     const [isTranslateModalOpen, setIsTranslateModalOpen] = useState(false);
 
     const { translationLanguages, allLanguages } = useLocalizationToolkit({
@@ -48,6 +49,7 @@ export const PdfFilesSection = () => {
     const LIMIT = 20;
 
     const fetchedFilesRef = useRef<PdfReportDto[]>([]);
+    const uploadedFilesRef = useRef<PdfReportDto[]>([]);
     const loadMoreAbortControllerRef = useRef<AbortController | null>(null);
 
     const {
@@ -87,6 +89,10 @@ export const PdfFilesSection = () => {
     useEffect(() => {
         fetchedFilesRef.current = fetchedFiles;
     }, [fetchedFiles]);
+
+    useEffect(() => {
+        uploadedFilesRef.current = uploadedFiles;
+    }, [uploadedFiles]);
 
     useEffect(() => {
         return () => {
@@ -241,20 +247,34 @@ export const PdfFilesSection = () => {
 
     const handleReorderFiles = useCallback(
         async (reorderedFiles: PdfReportDto[]) => {
-            if (!activeLanguageId) return;
-            const previousState = fetchedFiles;
+            if (!activeLanguageId || isReordering) return;
+
+            if (!reorderedFiles || reorderedFiles.length === 0) return;
+
+            const currentFiles = fetchedFilesRef.current;
+            const currentDedupedCount = new Set([...currentFiles, ...uploadedFilesRef.current].map((f) => f.id)).size;
+            if (reorderedFiles.length !== currentDedupedCount) {
+                console.error('File count mismatch during reorder');
+                return;
+            }
+
+            const previousState = fetchedFilesRef.current;
+            setIsReordering(true);
 
             try {
                 setFetchedFiles(reorderedFiles);
                 const orderedIds = reorderedFiles.map((f) => f.id);
                 await PdfReportsApi.reorder(client, activeLanguageId, orderedIds);
+                await refetchFiles();
                 addToast(PDF_FILES_SECTION_TEXT.MESSAGE.REORDER_SUCCESS, ToastType.Success);
             } catch {
                 setFetchedFiles(previousState ?? []);
                 addToast(PDF_FILES_SECTION_TEXT.MESSAGE.REORDER_ERROR, ToastType.Error);
+            } finally {
+                setIsReordering(false);
             }
         },
-        [client, activeLanguageId, fetchedFiles, setFetchedFiles, addToast],
+        [client, activeLanguageId, isReordering, setFetchedFiles, refetchFiles, addToast],
     );
 
     if (isSectionLoading || isFilesLoading || !activeLanguageId) {
@@ -291,6 +311,7 @@ export const PdfFilesSection = () => {
                 onReorderFiles={handleReorderFiles}
                 isDeleting={isDeleting}
                 isRenaming={isRenaming}
+                isReordering={isReordering}
                 isLoadingMore={isLoadingMore}
                 onLoadMore={handleLoadMore}
             />

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
@@ -64,6 +64,7 @@ export const PdfFilesSection = () => {
         data: fetchedFiles,
         isLoading: isFilesLoading,
         refetch: refetchFiles,
+        setData: setFetchedFiles,
     } = useDataFetch<PdfReportDto[]>({
         initialData: [],
         fetchHandler: fetchFiles,
@@ -150,6 +151,24 @@ export const PdfFilesSection = () => {
         [client, addToast, refetchFiles],
     );
 
+    const handleReorderFiles = useCallback(
+        async (reorderedFiles: PdfReportDto[]) => {
+            if (!activeLanguageId) return;
+            const previousState = fetchedFiles;
+
+            try {
+                setFetchedFiles(reorderedFiles);
+                const orderedIds = reorderedFiles.map((f) => f.id);
+                await PdfReportsApi.reorder(client, activeLanguageId, orderedIds);
+                addToast(PDF_FILES_SECTION_TEXT.MESSAGE.REORDER_SUCCESS, ToastType.Success);
+            } catch {
+                setFetchedFiles(previousState ?? []);
+                addToast(PDF_FILES_SECTION_TEXT.MESSAGE.REORDER_ERROR, ToastType.Error);
+            }
+        },
+        [client, activeLanguageId, fetchedFiles, setFetchedFiles, addToast],
+    );
+
     if (isSectionLoading || isFilesLoading || !activeLanguageId) {
         return (
             <div className={styles.loader}>
@@ -181,6 +200,7 @@ export const PdfFilesSection = () => {
                 onViewFile={handleViewFile}
                 onDeleteFile={handleDeleteFile}
                 onRenameFile={handleRenameFile}
+                onReorderFiles={handleReorderFiles}
                 isDeleting={isDeleting}
                 isRenaming={isRenaming}
             />

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
@@ -254,6 +254,7 @@ export const PdfFilesSection = () => {
             const currentFiles = fetchedFilesRef.current;
             const currentDedupedCount = new Set([...currentFiles, ...uploadedFilesRef.current].map((f) => f.id)).size;
             if (reorderedFiles.length !== currentDedupedCount) {
+                // eslint-disable-next-line no-console
                 console.error('File count mismatch during reorder');
                 return;
             }

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.module.scss
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.module.scss
@@ -250,6 +250,10 @@
     background-color: c.$grey-500;
 }
 
+.row-drop-target {
+    border-top: 2px solid c.$blue-500 !important;
+}
+
 .container {
     display: flex;
     flex-direction: column;

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.module.scss
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.module.scss
@@ -212,3 +212,39 @@
     color: c.$error;
     font-weight: 400;
 }
+
+.drag-header-cell {
+    width: 50px;
+    padding: 0 !important;
+}
+
+.drag-cell {
+    width: 50px;
+    padding: 0 !important;
+    text-align: center;
+    vertical-align: middle;
+}
+
+.drag-handle-wrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    cursor: grab;
+    width: 100%;
+    height: 100%;
+
+    &:active {
+        cursor: grabbing;
+    }
+}
+
+.drag-handle-icon {
+    width: 24px;
+    height: 24px;
+    fill: c.$grey-600;
+}
+
+.row-dragging {
+    opacity: 0.4;
+    background-color: c.$grey-500;
+}

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.test.tsx
@@ -451,6 +451,13 @@ describe('PdfFilesTable', () => {
             expect(screen.queryByTestId('drag-icon')).not.toBeInTheDocument();
         });
 
+        it('should disable dragging when isReordering is true', () => {
+            render(<PdfFilesTable {...defaultProps} isReordering={true} />);
+            const rows = screen.getAllByRole('row');
+            const fileRow = rows[1];
+            expect(fileRow.getAttribute('draggable')).toBe('false');
+        });
+
         it('should handle dragstart, dragover, drop, and dragend events correctly', () => {
             const onReorderFilesMock = jest.fn();
             render(<PdfFilesTable {...defaultProps} onReorderFiles={onReorderFilesMock} />);
@@ -481,6 +488,66 @@ describe('PdfFilesTable', () => {
 
             // Trigger dragend
             fireEvent.dragEnd(dragRow);
+        });
+
+        it('should highlight drop target row on dragover and clear on dragleave/drop', () => {
+            render(<PdfFilesTable {...defaultProps} />);
+            const rows = screen.getAllByRole('row');
+            const dragRow = rows[1];
+            const dropRow = rows[2];
+
+            const mockDataTransfer = {
+                setData: jest.fn(),
+                getData: jest.fn().mockReturnValue('1'),
+                effectAllowed: '',
+                dropEffect: '',
+            };
+
+            // Start drag on row 1
+            fireEvent.dragStart(dragRow, { dataTransfer: mockDataTransfer });
+            expect(dragRow).toHaveClass('row-dragging');
+
+            // Drag over row 2
+            fireEvent.dragOver(dropRow, { dataTransfer: mockDataTransfer });
+            expect(dropRow).toHaveClass('row-drop-target');
+
+            // Drag leave row 2
+            fireEvent.dragLeave(dropRow);
+            expect(dropRow).not.toHaveClass('row-drop-target');
+
+            // Drag over row 2 again
+            fireEvent.dragOver(dropRow, { dataTransfer: mockDataTransfer });
+            expect(dropRow).toHaveClass('row-drop-target');
+
+            // Drop on row 2
+            fireEvent.drop(dropRow, { dataTransfer: mockDataTransfer });
+            expect(dropRow).not.toHaveClass('row-drop-target');
+        });
+
+        it('should reset dragging state if the dragged file is removed from files list', () => {
+            const { rerender } = render(<PdfFilesTable {...defaultProps} />);
+            const rows = screen.getAllByRole('row');
+            const dragRow = rows[1];
+
+            const mockDataTransfer = {
+                setData: jest.fn(),
+                getData: jest.fn(),
+                effectAllowed: '',
+                dropEffect: '',
+            };
+
+            // Start dragging
+            fireEvent.dragStart(dragRow, { dataTransfer: mockDataTransfer });
+            expect(dragRow).toHaveClass('row-dragging');
+
+            // Rerender with the file removed
+            rerender(<PdfFilesTable {...defaultProps} files={[mockFiles[1]]} />);
+            
+            // Check that it's no longer marked as dragging
+            const newRows = screen.getAllByRole('row');
+            // Since mockFiles[0] was removed, the only file is mockFiles[1] (which corresponds to row index 1)
+            const remainingRow = newRows[1];
+            expect(remainingRow).not.toHaveClass('row-dragging');
         });
     });
 

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PdfFilesTable } from './PdfFilesTable';
 import { PDF_FILES_SECTION_TEXT } from '@/const/admin/reports';
@@ -37,6 +37,9 @@ jest.mock('@/assets/icons/checkmark.svg', () => ({
 }));
 jest.mock('@/assets/icons/cross.svg', () => ({
     ReactComponent: () => <svg data-testid="cross-icon" />,
+}));
+jest.mock('@/assets/icons/dragger.svg', () => ({
+    ReactComponent: () => <svg data-testid="drag-icon" />,
 }));
 jest.mock('@/components/admin/icon-button/IconButton', () => ({
     IconButton: ({ onClick, disabled, 'aria-label': ariaLabel }: any) => (
@@ -429,6 +432,51 @@ describe('PdfFilesTable', () => {
                 PDF_FILES_SECTION_TEXT.ACTIONS.FILE.ACCEPT_RENAME,
             ) as HTMLButtonElement;
             expect(acceptButton).toBeDisabled();
+        });
+    });
+
+    describe('Drag and Drop Reordering', () => {
+        it('should display the drag-and-drop icons when files.length > 1', () => {
+            render(<PdfFilesTable {...defaultProps} />);
+            const dragIcons = screen.getAllByTestId('drag-icon');
+            expect(dragIcons.length).toBe(mockFiles.length);
+        });
+
+        it('should not display the drag-and-drop icon when files.length <= 1', () => {
+            render(<PdfFilesTable {...defaultProps} files={[mockFiles[0]]} />);
+            expect(screen.queryByTestId('drag-icon')).not.toBeInTheDocument();
+        });
+
+        it('should handle dragstart, dragover, drop, and dragend events correctly', () => {
+            const onReorderFilesMock = jest.fn();
+            render(<PdfFilesTable {...defaultProps} onReorderFiles={onReorderFilesMock} />);
+
+            const rows = screen.getAllByRole('row');
+            // rows[0] is table header, rows[1] is file 1, rows[2] is file 2
+            const dragRow = rows[1];
+            const dropRow = rows[2];
+
+            const mockDataTransfer = {
+                setData: jest.fn(),
+                getData: jest.fn().mockReturnValue('1'),
+                effectAllowed: '',
+                dropEffect: '',
+            };
+
+            // Trigger dragstart
+            fireEvent.dragStart(dragRow, { dataTransfer: mockDataTransfer });
+            expect(mockDataTransfer.setData).toHaveBeenCalledWith('text/plain', '1');
+
+            // Trigger dragover
+            fireEvent.dragOver(dropRow, { dataTransfer: mockDataTransfer });
+            expect(mockDataTransfer.dropEffect).toBe('move');
+
+            // Trigger drop
+            fireEvent.drop(dropRow, { dataTransfer: mockDataTransfer });
+            expect(onReorderFilesMock).toHaveBeenCalledWith([mockFiles[1], mockFiles[0]]);
+
+            // Trigger dragend
+            fireEvent.dragEnd(dragRow);
         });
     });
 });

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.test.tsx
@@ -542,7 +542,7 @@ describe('PdfFilesTable', () => {
 
             // Rerender with the file removed
             rerender(<PdfFilesTable {...defaultProps} files={[mockFiles[1]]} />);
-            
+
             // Check that it's no longer marked as dragging
             const newRows = screen.getAllByRole('row');
             // Since mockFiles[0] was removed, the only file is mockFiles[1] (which corresponds to row index 1)

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.tsx
@@ -12,7 +12,7 @@ import cn from 'classnames';
 import styles from './PdfFilesTable.module.scss';
 import './PdfFilesTable.scss';
 import { PdfReportDto } from '@/types/admin/pdf-section';
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
 import { PDF_FILE_RENAME_VALIDATION_FUNCTIONS } from '@/validation/admin/reports-schema/pdf-file-rename-schema/pdf-file-rename-schema';
 import { useTableScrollToTop } from '@/hooks/admin/use-table-scroll-to-top/useTableScrollToTop';
@@ -25,6 +25,7 @@ interface PdfFilesTableProps {
     onReorderFiles?: (reorderedFiles: PdfReportDto[]) => void;
     isDeleting?: boolean;
     isRenaming?: boolean;
+    isReordering?: boolean;
     isLoadingMore?: boolean;
     onLoadMore?: () => void;
 }
@@ -41,10 +42,18 @@ export const PdfFilesTable: React.FC<PdfFilesTableProps> = ({
     onReorderFiles,
     isDeleting = false,
     isRenaming = false,
+    isReordering = false,
     isLoadingMore = false,
     onLoadMore,
 }) => {
     const [draggingId, setDraggingId] = useState<number | null>(null);
+    const [dropTargetId, setDropTargetId] = useState<number | null>(null);
+
+    useEffect(() => {
+        if (draggingId && !files.some((f) => f.id === draggingId)) {
+            setDraggingId(null);
+        }
+    }, [files, draggingId]);
 
     const handleDragStart = useCallback((e: React.DragEvent<HTMLTableRowElement>, id: number) => {
         setDraggingId(id);
@@ -52,14 +61,20 @@ export const PdfFilesTable: React.FC<PdfFilesTableProps> = ({
         e.dataTransfer.effectAllowed = 'move';
     }, []);
 
-    const handleDragOver = useCallback((e: React.DragEvent<HTMLTableRowElement>) => {
+    const handleDragOver = useCallback((e: React.DragEvent<HTMLTableRowElement>, id: number) => {
         e.preventDefault();
+        setDropTargetId(id);
         e.dataTransfer.dropEffect = 'move';
+    }, []);
+
+    const handleDragLeave = useCallback(() => {
+        setDropTargetId(null);
     }, []);
 
     const handleDrop = useCallback(
         (e: React.DragEvent<HTMLTableRowElement>, targetId: number) => {
             e.preventDefault();
+            setDropTargetId(null);
             const sourceIdStr = e.dataTransfer.getData('text/plain');
             if (!sourceIdStr) return;
             const sourceId = Number(sourceIdStr);
@@ -80,6 +95,7 @@ export const PdfFilesTable: React.FC<PdfFilesTableProps> = ({
 
     const handleDragEnd = useCallback(() => {
         setDraggingId(null);
+        setDropTargetId(null);
     }, []);
 
     const { tableWrapperRef, isMoveToTopVisible, handleTableScroll, moveToTop } = useTableScrollToTop(files.length);
@@ -224,10 +240,12 @@ export const PdfFilesTable: React.FC<PdfFilesTableProps> = ({
                                         key={file.id}
                                         className={cn(styles.row, {
                                             [styles['row-dragging']]: draggingId === file.id,
+                                            [styles['row-drop-target']]: dropTargetId === file.id && draggingId !== file.id,
                                         })}
-                                        draggable={files.length > 1}
+                                        draggable={files.length > 1 && !isDeleting && !isRenaming && !isReordering}
                                         onDragStart={(e) => handleDragStart(e, file.id)}
-                                        onDragOver={handleDragOver}
+                                        onDragOver={(e) => handleDragOver(e, file.id)}
+                                        onDragLeave={handleDragLeave}
                                         onDrop={(e) => handleDrop(e, file.id)}
                                         onDragEnd={handleDragEnd}
                                     >

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.tsx
@@ -4,6 +4,7 @@ import { ReactComponent as FileIcon } from '@/assets/icons/file.svg';
 import { ReactComponent as NotFoundIcon } from '@/assets/icons/not-found.svg';
 import { ReactComponent as CheckmarkIcon } from '@/assets/icons/checkmark.svg';
 import { ReactComponent as CrossIcon } from '@/assets/icons/cross.svg';
+import { ReactComponent as DragIcon } from '@/assets/icons/dragger.svg';
 import { PDF_FILES_SECTION_TEXT } from '@/const/admin/reports';
 import cn from 'classnames';
 import styles from './PdfFilesTable.module.scss';
@@ -18,6 +19,7 @@ interface PdfFilesTableProps {
     onViewFile: (file: PdfReportDto) => void;
     onDeleteFile: (id: number) => Promise<void>;
     onRenameFile: (id: number, newName: string) => Promise<void>;
+    onReorderFiles?: (reorderedFiles: PdfReportDto[]) => void;
     isDeleting?: boolean;
     isRenaming?: boolean;
 }
@@ -31,9 +33,48 @@ export const PdfFilesTable: React.FC<PdfFilesTableProps> = ({
     onDeleteFile,
     onViewFile,
     onRenameFile,
+    onReorderFiles,
     isDeleting = false,
     isRenaming = false,
 }) => {
+    const [draggingId, setDraggingId] = useState<number | null>(null);
+
+    const handleDragStart = useCallback((e: React.DragEvent<HTMLTableRowElement>, id: number) => {
+        setDraggingId(id);
+        e.dataTransfer.setData('text/plain', id.toString());
+        e.dataTransfer.effectAllowed = 'move';
+    }, []);
+
+    const handleDragOver = useCallback((e: React.DragEvent<HTMLTableRowElement>) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+    }, []);
+
+    const handleDrop = useCallback(
+        (e: React.DragEvent<HTMLTableRowElement>, targetId: number) => {
+            e.preventDefault();
+            const sourceIdStr = e.dataTransfer.getData('text/plain');
+            if (!sourceIdStr) return;
+            const sourceId = Number(sourceIdStr);
+            if (sourceId === targetId) return;
+
+            const updatedFiles = [...files];
+            const fromIndex = updatedFiles.findIndex((f) => f.id === sourceId);
+            const toIndex = updatedFiles.findIndex((f) => f.id === targetId);
+
+            if (fromIndex !== -1 && toIndex !== -1) {
+                const [draggedItem] = updatedFiles.splice(fromIndex, 1);
+                updatedFiles.splice(toIndex, 0, draggedItem);
+                onReorderFiles?.(updatedFiles);
+            }
+        },
+        [files, onReorderFiles],
+    );
+
+    const handleDragEnd = useCallback(() => {
+        setDraggingId(null);
+    }, []);
+
     const [deleteConfirmation, setDeleteConfirmation] = useState<{ isOpen: boolean; fileId: number | null }>({
         isOpen: false,
         fileId: null,
@@ -123,6 +164,7 @@ export const PdfFilesTable: React.FC<PdfFilesTableProps> = ({
                 <table className={styles.table}>
                     <thead>
                         <tr className={styles['header-row']}>
+                            {files.length > 1 && <th className={cn(styles.cell, styles['drag-header-cell'])} />}
                             <th className={cn(styles.cell, styles['name-cell'])}>
                                 {PDF_FILES_SECTION_TEXT.TABLE.HEADER.NAME}
                             </th>
@@ -149,7 +191,24 @@ export const PdfFilesTable: React.FC<PdfFilesTableProps> = ({
                             </tr>
                         ) : (
                             files.map((file) => (
-                                <tr key={file.id} className={styles.row}>
+                                <tr
+                                    key={file.id}
+                                    className={cn(styles.row, {
+                                        [styles['row-dragging']]: draggingId === file.id,
+                                    })}
+                                    draggable={files.length > 1}
+                                    onDragStart={(e) => handleDragStart(e, file.id)}
+                                    onDragOver={handleDragOver}
+                                    onDrop={(e) => handleDrop(e, file.id)}
+                                    onDragEnd={handleDragEnd}
+                                >
+                                    {files.length > 1 && (
+                                        <td className={cn(styles.cell, styles['drag-cell'])}>
+                                            <div className={styles['drag-handle-wrapper']}>
+                                                <DragIcon className={styles['drag-handle-icon']} />
+                                            </div>
+                                        </td>
+                                    )}
                                     <td className={cn(styles.cell, styles['name-cell'])}>
                                         {editingFileId === file.id ? (
                                             <div className={styles['rename-input-container']}>

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.tsx
@@ -240,7 +240,8 @@ export const PdfFilesTable: React.FC<PdfFilesTableProps> = ({
                                         key={file.id}
                                         className={cn(styles.row, {
                                             [styles['row-dragging']]: draggingId === file.id,
-                                            [styles['row-drop-target']]: dropTargetId === file.id && draggingId !== file.id,
+                                            [styles['row-drop-target']]:
+                                                dropTargetId === file.id && draggingId !== file.id,
                                         })}
                                         draggable={files.length > 1 && !isDeleting && !isRenaming && !isReordering}
                                         onDragStart={(e) => handleDragStart(e, file.id)}

--- a/src/pages/public/main-page/main-programs-section/MainProgramsSection.module.scss
+++ b/src/pages/public/main-page/main-programs-section/MainProgramsSection.module.scss
@@ -128,7 +128,9 @@
     border-radius: 4px;
     padding: 8px 20px;
     cursor: pointer;
-    transition: background-color 0.2s ease, color 0.2s ease;
+    transition:
+        background-color 0.2s ease,
+        color 0.2s ease;
 
     &:hover {
         background-color: c.$blue-900;

--- a/src/pages/public/main-page/main-statistics-section/MainStatisticsSection.module.scss
+++ b/src/pages/public/main-page/main-statistics-section/MainStatisticsSection.module.scss
@@ -1,7 +1,6 @@
 @use '@/assets/sass/variables/colors' as c;
 @use '@/assets/sass/mixins/typography.mixins' as type;
 
-
 .root {
     width: 100%;
     display: flex;

--- a/src/services/api/admin/reports/pdf-reports/pdf-reports-api.ts
+++ b/src/services/api/admin/reports/pdf-reports/pdf-reports-api.ts
@@ -27,6 +27,13 @@ export const PdfReportsApi = {
         return response.data;
     },
 
+    reorder: async (client: AxiosInstance, languageId: number, orderedIds: number[]): Promise<void> => {
+        await client.put(`${API_ROUTES.PDF_REPORTS.BASE}/reorder`, {
+            languageId,
+            orderedIds,
+        });
+    },
+
     getAll: async (
         client: AxiosInstance,
         filter: { offset: number; limit: number; languageId?: number },


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1403

## Description

  This PR implements manual drag-and-drop file reordering in the Admin PDF Reports management section (both Ukrainian
  and English tabs) so that administrators can control the sequence in which files are displayed on the public page
  (#1403). It includes frontend visual indicators, drag handle columns, optimistic state updates, API integration,
  and corresponding unit tests for both client and backend layers.                                                 

  ## Summary of change

  ### Frontend ( client )

  • API Integration: Added the  reorder  function to  PdfReportsApi  to make  PUT  requests to
  /api/PdfReports/reorder .
  • Drag-and-Drop Implementation:
      • Incorporated native HTML5 Drag and Drop events ( onDragStart ,  onDragOver ,  onDrop ,  onDragEnd ) on table
      <tr>  rows.
      • Added a dedicated drag handle column on the left containing a draggable grab handle icon ( DragIcon ).
      • Conditioned row draggability and handle visibility: they automatically hide/disable when  files.length <= 1 .
      • Styled the drag indicators, margins, active drag opacity, and cursors inside  PdfFilesTable.module.scss .
  • State Management:
      • Implemented optimistic UI updates in  handleReorderFiles  within  PdfFilesSection .
      • Added toast messages to show status and automatic state rollback in case of API failure.
  • Testing:
      • Added test cases to  PdfFilesSection.test.tsx  verifying successful and failing API reorder integrations.
      • Added test cases to  PdfFilesTable.test.tsx  checking that drag handles hide correctly when only one file is
      present, and drag events trigger callbacks.


  ### Backend ( api )

  • Entity: Implemented  IOrderableEntity  on the  PdfReport  model to add a  Priority  field for sorting.
  • Commands & Validators:
      • Created  ReorderPdfReportsCommand  and  ReorderPdfReportsDto .
      • Created  ReorderPdfReportsCommandValidator  guarding against null or empty arrays, duplicate IDs, and maximum
      swap counts.
      • Implemented  ReorderPdfReportsHandler  calling the database reorder utility  IReorderService.
      SwapElementsAsync  and validating request integrity.
  • Controller: Exposed  PUT /api/PdfReports/reorder  endpoint under Admin area.
  • Testing: Created  ReorderPdfReportsTests  covering database priority updates, duplicate key exceptions, null
  parameters, and payload mismatches.

  ## How to recreate changes


  1. Log in as an Admin, navigate to the Reports (Звітність) section, and click on the PDF Files tab.
  2. Upload at least 2 files (verify that the grab handle icon is shown on the left of each row).
  3. Drag and drop any file to a new position. Verify that the order changes instantly, a success toast is shown, and
  the new sequence remains correct upon refreshing.
  4. Remove all files except 1. Verify that the grab handle icon disappears.


  ## CHECK LIST

- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop reordering for PDF files in the admin reports view (enabled when more than one file is present).
  * Reordering updates the UI immediately and shows success/failure toasts.

* **Bug Fixes**
  * Added localization for reordering success and failure messaging.
  * Ensures the displayed order is reverted if the reordering request fails.

* **Tests**
  * Expanded unit tests to cover drag-and-drop interactions, optimistic updates, and success/failure reorder flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->