### PR TITLE
Feature/issue 2617 [Main] Disable the ability to translate

### DIFF
--- a/src/pages/admin/main/components/main-page-content/MainPageContent.test.tsx
+++ b/src/pages/admin/main/components/main-page-content/MainPageContent.test.tsx
@@ -1263,4 +1263,19 @@ describe('MainPageContent', () => {
 
         await waitFor(() => expect(screen.queryByText('Додати переклад')).not.toBeInTheDocument());
     });
+
+    it('disables the translation icon when text input fields have unpublished changes', async () => {
+        mockLocalizationToolkitState.translationLanguages = [{ id: 2, code: 'en', name: 'Англійська' }];
+
+        await renderAndLoadContent();
+
+        const translateIcon = screen.getByLabelText('Додати переклад');
+        expect(translateIcon).not.toBeDisabled();
+
+        fireEvent.click(screen.getByTestId('publish-btn-dirty'));
+
+        await waitFor(() => {
+            expect(translateIcon).toBeDisabled();
+        });
+    });
 });

--- a/src/pages/admin/main/components/main-page-content/MainPageContent.test.tsx
+++ b/src/pages/admin/main/components/main-page-content/MainPageContent.test.tsx
@@ -114,6 +114,14 @@ const MockFormBlock = ({ testId, btnTestId, onPublish, isPublishDisabled, isRead
             >
                 Normalize Dirty
             </button>
+            <button
+                data-testid={`${btnTestId}-clean-text`}
+                onClick={() => {
+                    setValue('titleUa', 'Test Title', { shouldDirty: true, shouldValidate: true });
+                }}
+            >
+                Clean Text
+            </button>
             <button data-testid={btnTestId} onClick={onPublish} disabled={isPublishDisabled}>
                 Publish
             </button>
@@ -1276,6 +1284,24 @@ describe('MainPageContent', () => {
 
         await waitFor(() => {
             expect(translateIcon).toBeDisabled();
+        });
+    });
+
+    it('re-enables translation icon when changes are reverted', async () => {
+        mockLocalizationToolkitState.translationLanguages = [{ id: 2, code: 'en', name: 'Англійська' }];
+
+        await renderAndLoadContent();
+
+        const translateIcon = screen.getByLabelText('Додати переклад');
+
+        fireEvent.click(screen.getByTestId('publish-btn-dirty'));
+        await waitFor(() => {
+            expect(translateIcon).toBeDisabled();
+        });
+
+        fireEvent.click(screen.getByTestId('publish-btn-clean-text'));
+        await waitFor(() => {
+            expect(translateIcon).not.toBeDisabled();
         });
     });
 });

--- a/src/pages/admin/main/components/main-page-content/MainPageContent.tsx
+++ b/src/pages/admin/main/components/main-page-content/MainPageContent.tsx
@@ -80,13 +80,6 @@ const TABS: TabItem[] = [
     { id: 'partners', label: MAIN_PAGE_TEXT.TABS.PARTNERS, localizationBlock: MainPageLocalizationBlock.Partners },
 ];
 
-const TRANSLATABLE_BLOCKS = new Set<MainPageLocalizationBlock>([
-    MainPageLocalizationBlock.Title,
-    MainPageLocalizationBlock.AboutUs,
-    MainPageLocalizationBlock.Donations,
-    MainPageLocalizationBlock.Partners,
-]);
-
 const sanitizeMainPageFormValues = (values: MainPageFormValues): MainPageFormValues => ({
     ...values,
     statisticsTitleUa: values.statisticsTitleUa ?? '',
@@ -126,7 +119,16 @@ const areRichTextFieldValuesEqual = (
     normalizeRichTextHtmlForComparison(String(currentValues[field] ?? '')) ===
     normalizeRichTextHtmlForComparison(String(savedValues[field] ?? ''));
 
-const BLOCK_TEXT_FIELDS: Partial<Record<MainPageLocalizationBlock, Array<keyof MainPageFormValues>>> = {
+const TRANSLATABLE_BLOCKS_ARRAY = [
+    MainPageLocalizationBlock.Title,
+    MainPageLocalizationBlock.AboutUs,
+    MainPageLocalizationBlock.Donations,
+    MainPageLocalizationBlock.Partners,
+] as const;
+
+type TranslatableBlock = (typeof TRANSLATABLE_BLOCKS_ARRAY)[number];
+
+const BLOCK_TEXT_FIELDS: Record<TranslatableBlock, Array<keyof MainPageFormValues>> = {
     [MainPageLocalizationBlock.Title]: ['titleUa', 'titleEn', 'descriptionUa', 'descriptionEn'],
     [MainPageLocalizationBlock.AboutUs]: [
         'aboutUsTitleUa',
@@ -148,6 +150,8 @@ const BLOCK_TEXT_FIELDS: Partial<Record<MainPageLocalizationBlock, Array<keyof M
     ],
 };
 
+const TRANSLATABLE_BLOCKS = new Set<MainPageLocalizationBlock>(TRANSLATABLE_BLOCKS_ARRAY);
+
 const hasBlockDirtyTextFields = (
     block: MainPageLocalizationBlock | undefined,
     dirtyFields: Partial<Record<keyof MainPageFormValues, unknown>>,
@@ -156,7 +160,7 @@ const hasBlockDirtyTextFields = (
 ) => {
     if (block == null) return false;
 
-    const blockFields = BLOCK_TEXT_FIELDS[block];
+    const blockFields = BLOCK_TEXT_FIELDS[block as TranslatableBlock];
     if (!blockFields) return false;
 
     return blockFields.some((fieldName) => {
@@ -518,12 +522,7 @@ export const MainPageContent = () => {
         );
 
     const handleOpenTranslationModal = () => {
-        if (
-            isTranslateButtonDisabled ||
-            translationLanguages.length === 0 ||
-            selectedTab.localizationBlock == null ||
-            !TRANSLATABLE_BLOCKS.has(selectedTab.localizationBlock)
-        ) {
+        if (isTranslateButtonDisabled || !canTranslateActiveBlock || selectedTab.localizationBlock == null) {
             return;
         }
 

--- a/src/pages/admin/main/components/main-page-content/MainPageContent.tsx
+++ b/src/pages/admin/main/components/main-page-content/MainPageContent.tsx
@@ -126,6 +126,50 @@ const areRichTextFieldValuesEqual = (
     normalizeRichTextHtmlForComparison(String(currentValues[field] ?? '')) ===
     normalizeRichTextHtmlForComparison(String(savedValues[field] ?? ''));
 
+const BLOCK_TEXT_FIELDS: Partial<Record<MainPageLocalizationBlock, Array<keyof MainPageFormValues>>> = {
+    [MainPageLocalizationBlock.Title]: ['titleUa', 'titleEn', 'descriptionUa', 'descriptionEn'],
+    [MainPageLocalizationBlock.AboutUs]: [
+        'aboutUsTitleUa',
+        'aboutUsTitleEn',
+        'aboutUsDescriptionUa',
+        'aboutUsDescriptionEn',
+    ],
+    [MainPageLocalizationBlock.Donations]: [
+        'donationsTitleUa',
+        'donationsTitleEn',
+        'donationsDescriptionUa',
+        'donationsDescriptionEn',
+    ],
+    [MainPageLocalizationBlock.Partners]: [
+        'partnersTitleUa',
+        'partnersTitleEn',
+        'partnersDescriptionUa',
+        'partnersDescriptionEn',
+    ],
+};
+
+const hasBlockDirtyTextFields = (
+    block: MainPageLocalizationBlock | undefined,
+    dirtyFields: Partial<Record<keyof MainPageFormValues, unknown>>,
+    currentValues: MainPageFormValues,
+    savedValues: MainPageFormValues,
+) => {
+    if (block == null) return false;
+
+    const blockFields = BLOCK_TEXT_FIELDS[block];
+    if (!blockFields) return false;
+
+    return blockFields.some((fieldName) => {
+        if (!dirtyFields[fieldName]) return false;
+
+        if (RICH_TEXT_FORM_FIELD_SET.has(fieldName)) {
+            return !areRichTextFieldValuesEqual(fieldName, currentValues, savedValues);
+        }
+
+        return currentValues[fieldName] !== savedValues[fieldName];
+    });
+};
+
 const hasRelevantMainPageDirtyFields = (
     dirtyFields: Partial<Record<keyof MainPageFormValues, unknown>>,
     currentValues: MainPageFormValues,
@@ -464,8 +508,18 @@ export const MainPageContent = () => {
         selectedTab.localizationBlock != null &&
         TRANSLATABLE_BLOCKS.has(selectedTab.localizationBlock);
 
+    const isTranslateButtonDisabled =
+        canTranslateActiveBlock &&
+        hasBlockDirtyTextFields(
+            selectedTab.localizationBlock,
+            methods.formState.dirtyFields,
+            methods.getValues(),
+            savedValuesRef.current,
+        );
+
     const handleOpenTranslationModal = () => {
         if (
+            isTranslateButtonDisabled ||
             translationLanguages.length === 0 ||
             selectedTab.localizationBlock == null ||
             !TRANSLATABLE_BLOCKS.has(selectedTab.localizationBlock)
@@ -578,6 +632,7 @@ export const MainPageContent = () => {
                             type="button"
                             onClick={handleOpenTranslationModal}
                             DefaultIcon={ACTION_ICONS.translate.default}
+                            disabled={isTranslateButtonDisabled}
                         />
                     </div>
                 )}


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2617)

## Description

This PR implements logic to prevent inconsistent translations on the Admin Main Page by disabling the translation icon when a block contains unpublished changes in its text input fields. It introduces an dirty-field checking mechanism that accurately compares current rich text field inputs against saved data to guarantee translations are only performed on published content.

## How it looks
<img width="1280" height="503" alt="image" src="https://github.com/user-attachments/assets/f6ef3d2d-3fde-4a37-b821-72539875dace" />

## Summary of change

- **State Management (`MainPageContent.tsx`)**: Added the `BLOCK_TEXT_FIELDS` mapping to precisely identify and track the translatable text input fields for each specific block.
- **Dirty Checking Logic**: Introduced the `hasBlockDirtyTextFields` helper function to evaluate if any text fields within the active block differ from their published state, utilizing the existing rich text HTML normalization (`areRichTextFieldValuesEqual`) to avoid false positives.
- **UI Interaction**: Bound the `disabled` property of the translation `IconButton` to the new dirty state logic. Updated `handleOpenTranslationModal` to exit early to cover edge cases.
- **Testing (`MainPageContent.test.tsx`)**: Added a new test case to assert that the translation icon correctly becomes disabled when modifying text input fields in a translatable block.

## How to recreate changes

1. Log in as an Admin and navigate to the **Головна** page.
2. Select any tab with translatable content (e.g., Title, About Us, Donations, Partners).
3. Observe that the translation icon is visible and enabled in the top right corner of the content area.
4. Modify any text input field within the active block (e.g., type into the title or description field).
5. Observe that the translation icon immediately becomes disabled, preventing you from adding a translation to unpublished content.
6. Either revert the text back to its original state or save the changes by clicking **"Опублікувати" (Publish)**.
7. Observe that the translation icon becomes enabled again once the state is consistent.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The translation action is now disabled only when the currently selected content block has unsaved text changes, preventing translation while edits are pending.
  * The translation action is re-enabled after the dirty text is cleaned back to an equal/rich-text value.

* **Tests**
  * Updated and expanded coverage to verify the translation icon’s enabled/disabled state across dirty and clean text transitions using UI state assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->