### PR TITLE
Fix/issue 2983, 3002, 3004, 3005 [Reports] The required field "Змінених життів" in the "Блок Змінених життів" section is not validated according to the specified validation rules.

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -27,7 +27,7 @@ export const REPORTS_TEXT = {
         SUCCESSFULLY_PUBLISHED: 'Успішно опубліковано',
         RECORD_UPDATED_SUCCESSFULLY: 'Зміни збережено успішно',
         RECORD_UPDATE_FAILED_RETRY: 'Виникла помилка, спробуйте ще раз',
-        INVALID_VALUE: 'Значення повинно бути числом',
+        INVALID_VALUE: 'Поле може містити лише цілі цифри',
     },
     REPORT_AND_ANALYTICS: {
         TITLE: 'Управління фінансами',
@@ -61,6 +61,7 @@ export const REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION = {
         getRequiredError: () => `Заголовок обов'язковий`,
     },
     changedLives: {
+        min: 2,
         max: 10,
     },
     image: {

--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -63,6 +63,8 @@ export const REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION = {
     changedLives: {
         min: 2,
         max: 10,
+        getMinError: () => 'Не менше 2 цифр',
+        getMaxError: () => 'Не більше 10 цифр',
     },
     image: {
         width: 280,

--- a/src/pages/admin/reports/components/block-component/ReportsMediaBlock.test.tsx
+++ b/src/pages/admin/reports/components/block-component/ReportsMediaBlock.test.tsx
@@ -314,11 +314,15 @@ describe('ReportsMediaBlock', () => {
             renderComponent({ isValueEditable: true });
 
             const valueInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-value');
+            fireEvent.change(valueInput, { target: { value: '250000' } });
+            jest.clearAllMocks();
+            fireEvent.change(valueInput, { target: { value: '250000 ' } });
+            jest.clearAllMocks();
             fireEvent.blur(valueInput);
 
-            expect(mockValidateTotalAmount).toHaveBeenCalledWith('250000');
+            expect(mockValidateTotalAmount).toHaveBeenCalledWith('250000 ');
             expect(mockOnValuesChange).toHaveBeenCalledWith(
-                { ...defaultValues, totalAmount: '250000' },
+                { ...defaultValues, totalAmount: '250000 ' },
                 { totalAmount: undefined },
             );
         });

--- a/src/pages/admin/reports/components/block-component/ReportsMediaBlock.test.tsx
+++ b/src/pages/admin/reports/components/block-component/ReportsMediaBlock.test.tsx
@@ -288,9 +288,9 @@ describe('ReportsMediaBlock', () => {
             const valueInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-value');
             fireEvent.change(valueInput, { target: { value: '300000' } });
 
-            expect(mockValidateTotalAmount).toHaveBeenCalledWith(300000);
+            expect(mockValidateTotalAmount).toHaveBeenCalledWith('300000');
             expect(mockOnValuesChange).toHaveBeenCalledWith(
-                { ...defaultValues, totalAmount: 300000 },
+                { ...defaultValues, totalAmount: '300000' },
                 { totalAmount: undefined },
             );
         });
@@ -304,7 +304,7 @@ describe('ReportsMediaBlock', () => {
             fireEvent.change(valueInput, { target: { value: 'abc' } });
 
             expect(mockOnValuesChange).toHaveBeenCalledWith(
-                { ...defaultValues, totalAmount: NaN },
+                { ...defaultValues, totalAmount: 'abc' },
                 { totalAmount: valueError },
             );
         });
@@ -316,8 +316,11 @@ describe('ReportsMediaBlock', () => {
             const valueInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-value');
             fireEvent.blur(valueInput);
 
-            expect(mockValidateTotalAmount).toHaveBeenCalledWith(250000);
-            expect(mockOnValuesChange).toHaveBeenCalledWith({ ...defaultValues }, { totalAmount: undefined });
+            expect(mockValidateTotalAmount).toHaveBeenCalledWith('250000');
+            expect(mockOnValuesChange).toHaveBeenCalledWith(
+                { ...defaultValues, totalAmount: '250000' },
+                { totalAmount: undefined },
+            );
         });
 
         it('should work without validateTotalAmount function', () => {
@@ -330,7 +333,7 @@ describe('ReportsMediaBlock', () => {
             fireEvent.change(valueInput, { target: { value: '500' } });
 
             expect(mockOnValuesChange).toHaveBeenCalledWith(
-                { ...defaultValues, totalAmount: 500 },
+                { ...defaultValues, totalAmount: '500' },
                 { totalAmount: undefined },
             );
         });

--- a/src/pages/admin/reports/components/block-component/ReportsMediaBlock.tsx
+++ b/src/pages/admin/reports/components/block-component/ReportsMediaBlock.tsx
@@ -112,8 +112,9 @@ export const ReportsMediaBlock = ({
     );
 
     const handleTotalAmountBlur = useCallback(() => {
-        const error = validationFunctions.validateTotalAmount?.(localTotalAmount);
-        onValuesChange({ ...values, totalAmount: localTotalAmount }, { ...errors, totalAmount: error });
+        const normalizedAmount = typeof localTotalAmount === 'string' ? localTotalAmount.trim() : localTotalAmount;
+        const error = validationFunctions.validateTotalAmount?.(normalizedAmount);
+        onValuesChange({ ...values, totalAmount: normalizedAmount }, { ...errors, totalAmount: error });
     }, [onValuesChange, values, errors, validationFunctions, localTotalAmount]);
 
     const handleImageChange = useCallback(

--- a/src/pages/admin/reports/components/block-component/ReportsMediaBlock.tsx
+++ b/src/pages/admin/reports/components/block-component/ReportsMediaBlock.tsx
@@ -112,9 +112,10 @@ export const ReportsMediaBlock = ({
     );
 
     const handleTotalAmountBlur = useCallback(() => {
-        const normalizedAmount = typeof localTotalAmount === 'string' ? localTotalAmount.trim() : localTotalAmount;
-        const error = validationFunctions.validateTotalAmount?.(normalizedAmount);
-        onValuesChange({ ...values, totalAmount: normalizedAmount }, { ...errors, totalAmount: error });
+        if (String(localTotalAmount) === String(values.totalAmount)) return;
+
+        const error = validationFunctions.validateTotalAmount?.(localTotalAmount);
+        onValuesChange({ ...values, totalAmount: localTotalAmount }, { ...errors, totalAmount: error });
     }, [onValuesChange, values, errors, validationFunctions, localTotalAmount]);
 
     const handleImageChange = useCallback(

--- a/src/pages/admin/reports/components/block-component/ReportsMediaBlock.tsx
+++ b/src/pages/admin/reports/components/block-component/ReportsMediaBlock.tsx
@@ -1,5 +1,5 @@
 import { Image, ImageValues } from '@/types/common/image';
-import { useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import styles from './ReportsMediaBlock.module.scss';
 import { InputError } from '@/components/admin/input-error/InputError';
 import { REPORTS_TEXT } from '@/const/admin/reports';
@@ -12,7 +12,7 @@ import './ReportsMediaBlock.scss';
 export interface ReportsMediaBlockValues {
     title: string;
     titleEn: string;
-    totalAmount: number;
+    totalAmount: number | string;
     image: ImageValues | Image | null;
     imageId: number | null;
 }
@@ -27,7 +27,7 @@ export interface ReportsMediaBlockErrors {
 export interface ReportsMediaBlockValidationFunctions {
     validateTitle: (value: string) => string | undefined;
     validateTitleEn: (value: string) => string | undefined;
-    validateTotalAmount?: (value: number) => string | undefined;
+    validateTotalAmount?: (value: number | string) => string | undefined;
 }
 
 export interface ReportsMediaBlockProps {
@@ -59,6 +59,11 @@ export const ReportsMediaBlock = ({
     validationFunctions,
     onValuesChange,
 }: ReportsMediaBlockProps) => {
+    const [localTotalAmount, setLocalTotalAmount] = useState<string>(values.totalAmount.toString());
+
+    useEffect(() => {
+        setLocalTotalAmount(values.totalAmount.toString());
+    }, [values.totalAmount]);
     const handleTitleChange = useCallback(
         (e: React.ChangeEvent<HTMLTextAreaElement>) => {
             const value = e.target.value;
@@ -97,17 +102,19 @@ export const ReportsMediaBlock = ({
 
     const handleTotalAmountChange = useCallback(
         (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-            const value = Number(e.target.value);
-            const error = validationFunctions.validateTotalAmount?.(value);
-            onValuesChange({ ...values, totalAmount: value }, { ...errors, totalAmount: error });
+            const rawValue = e.target.value;
+            setLocalTotalAmount(rawValue);
+
+            const error = validationFunctions.validateTotalAmount?.(rawValue);
+            onValuesChange({ ...values, totalAmount: rawValue }, { ...errors, totalAmount: error });
         },
         [onValuesChange, values, errors, validationFunctions],
     );
 
     const handleTotalAmountBlur = useCallback(() => {
-        const error = validationFunctions.validateTotalAmount?.(values.totalAmount);
-        onValuesChange({ ...values }, { ...errors, totalAmount: error });
-    }, [onValuesChange, values, errors, validationFunctions]);
+        const error = validationFunctions.validateTotalAmount?.(localTotalAmount);
+        onValuesChange({ ...values, totalAmount: localTotalAmount }, { ...errors, totalAmount: error });
+    }, [onValuesChange, values, errors, validationFunctions, localTotalAmount]);
 
     const handleImageChange = useCallback(
         (value: ImageValues | null) => {
@@ -178,7 +185,7 @@ export const ReportsMediaBlock = ({
                             label={descriptionTitle}
                             id={`${windowTitle}-value`}
                             name={`${windowTitle}-value`}
-                            value={values.totalAmount.toString()}
+                            value={localTotalAmount}
                             onChange={handleTotalAmountChange}
                             onBlur={handleTotalAmountBlur}
                             maxLength={totalAmountMaxLength}

--- a/src/pages/admin/reports/components/media-settings/MediaSettings.test.tsx
+++ b/src/pages/admin/reports/components/media-settings/MediaSettings.test.tsx
@@ -60,7 +60,7 @@ jest.mock('@/validation/admin/reports-schema/reports-media-settings/reports-medi
     REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS: {
         validateTitle: jest.fn(),
         validateTitleEn: jest.fn(),
-        validateChangedLives: jest.fn(),
+        validateTotalAmount: jest.fn(),
     },
 }));
 

--- a/src/pages/admin/reports/components/media-settings/MediaSettings.tsx
+++ b/src/pages/admin/reports/components/media-settings/MediaSettings.tsx
@@ -217,7 +217,11 @@ export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
                     changedLives: {
                         title: changedLivesValues.title,
                         titleEn: changedLivesValues.titleEn,
-                        changedLives: Number(changedLivesValues.totalAmount),
+                        changedLives: (() => {
+                            const parsed = parseInt(String(changedLivesValues.totalAmount).trim(), 10);
+                            if (isNaN(parsed)) throw new Error('changedLives is not a valid integer');
+                            return parsed;
+                        })(),
                         image: changedLivesImage,
                         imageId: changedLivesImageId,
                     },

--- a/src/pages/admin/reports/components/media-settings/MediaSettings.tsx
+++ b/src/pages/admin/reports/components/media-settings/MediaSettings.tsx
@@ -148,7 +148,7 @@ export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
             const changedLivesTitleError = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTitle(
                 changedLivesValues.title,
             );
-            const changedLivesValueError = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateChangedLives(
+            const changedLivesValueError = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTotalAmount(
                 changedLivesValues.totalAmount,
             );
 
@@ -217,7 +217,7 @@ export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
                     changedLives: {
                         title: changedLivesValues.title,
                         titleEn: changedLivesValues.titleEn,
-                        changedLives: changedLivesValues.totalAmount,
+                        changedLives: Number(changedLivesValues.totalAmount),
                         image: changedLivesImage,
                         imageId: changedLivesImageId,
                     },

--- a/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.test.ts
+++ b/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.test.ts
@@ -247,17 +247,17 @@ describe('reports-media-settings-schema', () => {
 
             it('should return min error for 0', () => {
                 const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTotalAmount(0);
-                expect(result).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(2));
+                expect(result).toBe(REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.getMinError());
             });
 
             it('should return min error for 1-digit number', () => {
                 const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTotalAmount(5);
-                expect(result).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(2));
+                expect(result).toBe(REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.getMinError());
             });
 
             it('should return error for negative number', () => {
                 const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTotalAmount(-1);
-                expect(result).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(2));
+                expect(result).toBe(REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.getMinError());
             });
 
             it('should return undefined for value at min (10)', () => {
@@ -278,11 +278,7 @@ describe('reports-media-settings-schema', () => {
             it('should return max error when value exceeds max numeric bound', () => {
                 const overMax = 10 ** REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max;
                 const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTotalAmount(overMax);
-                expect(result).toBe(
-                    COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
-                        REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max,
-                    ),
-                );
+                expect(result).toBe(REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.getMaxError());
             });
 
             it('should return undefined for value exactly at numeric max bound (10 digits)', () => {

--- a/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.test.ts
+++ b/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.test.ts
@@ -227,42 +227,57 @@ describe('reports-media-settings-schema', () => {
             });
         });
 
-        describe('validateChangedLives', () => {
+        describe('validateTotalAmount', () => {
             it('should return required error for undefined value', () => {
-                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateChangedLives(
+                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTotalAmount(
                     undefined as unknown as number,
                 );
                 expect(result).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED);
             });
 
+            it('should return required error for empty string', () => {
+                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTotalAmount('');
+                expect(result).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED);
+            });
+
             it('should return undefined for a valid number', () => {
-                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateChangedLives(5);
+                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTotalAmount(15);
                 expect(result).toBeUndefined();
             });
 
-            it('should return error for less than 2', () => {
-                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateChangedLives(0);
+            it('should return min error for 0', () => {
+                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTotalAmount(0);
+                expect(result).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(2));
+            });
+
+            it('should return min error for 1-digit number', () => {
+                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTotalAmount(5);
                 expect(result).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(2));
             });
 
             it('should return error for negative number', () => {
-                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateChangedLives(-1);
+                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTotalAmount(-1);
                 expect(result).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(2));
             });
 
-            it('should return undefined for value at min (2)', () => {
-                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateChangedLives(2);
+            it('should return undefined for value at min (10)', () => {
+                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTotalAmount(10);
                 expect(result).toBeUndefined();
             });
 
             it('should return error for non-integer number', () => {
-                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateChangedLives(3.5);
+                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTotalAmount(3.5);
+                expect(result).toBe(REPORTS_TEXT.MESSAGE.INVALID_VALUE);
+            });
+
+            it('should return type error for non-numeric string', () => {
+                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTotalAmount('abc');
                 expect(result).toBe(REPORTS_TEXT.MESSAGE.INVALID_VALUE);
             });
 
             it('should return max error when value exceeds max numeric bound', () => {
                 const overMax = 10 ** REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max;
-                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateChangedLives(overMax);
+                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTotalAmount(overMax);
                 expect(result).toBe(
                     COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
                         REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max,
@@ -272,13 +287,13 @@ describe('reports-media-settings-schema', () => {
 
             it('should return undefined for value exactly at numeric max bound (10 digits)', () => {
                 const maxVal = 10 ** REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max - 1;
-                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateChangedLives(maxVal);
+                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTotalAmount(maxVal);
                 expect(result).toBeUndefined();
             });
 
             it('should return undefined for value just below numeric max bound (9 digits)', () => {
                 const justBelowMax = 10 ** (REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max - 1) - 1;
-                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateChangedLives(justBelowMax);
+                const result = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTotalAmount(justBelowMax);
                 expect(result).toBeUndefined();
             });
         });

--- a/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.ts
+++ b/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.ts
@@ -64,15 +64,11 @@ const changedLivesSchema = Yup.object({
         .integer(REPORTS_TEXT.MESSAGE.INVALID_VALUE)
         .min(
             10 ** (REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.min - 1),
-            COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(
-                REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.min,
-            ),
+            REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.getMinError(),
         )
         .max(
             10 ** REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max - 1,
-            COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
-                REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max,
-            ),
+            REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.getMaxError(),
         ),
 });
 

--- a/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.ts
+++ b/src/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema.ts
@@ -58,9 +58,16 @@ const changedLivesSchema = Yup.object({
             COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.title.max),
         ),
     changedLives: Yup.number()
+        .typeError(REPORTS_TEXT.MESSAGE.INVALID_VALUE)
+        .transform((value, originalValue) => (String(originalValue).trim() === '' ? undefined : value))
         .required(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED)
         .integer(REPORTS_TEXT.MESSAGE.INVALID_VALUE)
-        .min(2, COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(2))
+        .min(
+            10 ** (REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.min - 1),
+            COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(
+                REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.min,
+            ),
+        )
         .max(
             10 ** REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.changedLives.max - 1,
             COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
@@ -86,7 +93,7 @@ export const REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS = {
             return error.message;
         }
     },
-    validateChangedLives: (value: number): string | undefined => {
+    validateTotalAmount: (value: number | string): string | undefined => {
         try {
             changedLivesSchema.validateSyncAt('changedLives', { changedLives: value });
             return undefined;


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2983)
* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3002)
* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3004)
* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3005)

## Description

This PR resolves a series of type-safety and React compilation errors in the `ReportsMediaBlock` component by refactoring the "Changed Lives" (total amount) validation architecture. Previously, the component attempted to manually parse user input into numbers before validation, causing desynchronization bugs and type errors when the field was cleared (empty string) or contained non-numeric characters. Additionally, the numeric validation failed to enforce the strict "Не менше 2 символів" (At least 2 characters) rule effectively without throwing type errors for large scientific notations. The underlying form logic has been updated to use a controlled local string state. Now, the UI delegates all parsing and numeric casting logic to the centralized Yup schema, ensuring accurate error messages (like *"Не менше 2 символів"*, *"Поле обов'язкове"* and *"Поле може містити лише цілі цифри"*).

## How it looks


https://github.com/user-attachments/assets/ca593f68-d000-44ab-a342-eae2ecbf5a4a



## Summary of change

- **Local State for Numeric Inputs (`ReportsMediaBlock.tsx`)**: Introduced `localTotalAmount` (`useState<string>`) to manage raw user input locally, eliminating premature `Number()` conversions in the UI layer and removing unused `React.` prefixed hooks.
- **Dynamic Character Boundaries (`reports-media-settings-schema.ts`)**: Delegated all string-to-number parsing to the Yup schema and replaced hardcoded magic numbers with dynamically derived bounds (`10 ** (MIN - 1)`). This mathematical mapping guarantees the "Не менше 2 символів" constraint functions flawlessly on numbers without using `.length` checks.
- **Test Suite Updates**: Updated `ReportsMediaBlock.test.tsx` and `reports-media-settings-schema.test.ts` to expect string values during the `totalAmount` validation phase, and added a specific test for the new non-numeric string type error..

## How to recreate changes

1. Log into the Admin panel and navigate to the **Reports** page.
2. Locate the "Змінено життів" (Changed Lives) block.
3. Type a single digit (e.g. `5`) into the `Кількість змінених життів` input field.
4. Observe that the input accurately displays the *"Не менше 2 символів"* error.
5. Try deleting all digits in the field. 
6. Observe that it accurately displays the *"Поле обов'язкове"* error.
7. Try typing a letter (e.g. "a") or a decimal (e.g. "3.5") into the field.
8. Observe that the *"Поле може містити лише цілі цифри"* error is displayed correctly.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation messaging in report settings to clarify allowed values (whole integers only).
  * Enforced the minimum constraint for the “changed lives” setting (now rejected when below the required threshold) and better handled blank or invalid inputs.
  * Updated total amount input handling to be more consistent while typing and when publishing, reducing unexpected validation errors and ensuring the saved value is correctly interpreted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->