### PR TITLE
Fix/issue-3020 [Partners][Admin panel][Frontend] Title with valid length (≤30 chars) is rejected with 400 Bad Request

### DIFF
--- a/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.tsx
+++ b/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.tsx
@@ -181,8 +181,8 @@ export const PartnerBanner = () => {
         setIsPublishing(true);
         try {
             const updatedBanner = await PartnersApi.updateBanner(client, {
-                title: values.title,
-                description: values.description,
+                title: getPlainTextFromHtml(values.title),
+                description: getPlainTextFromHtml(values.description),
                 image: values.image,
                 imageId: values.imageId,
             });


### PR DESCRIPTION
## Github ticker
* [#3020](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3020)

## Summary of issue
When editing the partner banner in the admin panel, saving changes to the "Заголовок" field failed with a 400 Bad Request ("Title field must have a maximum length of 30 characters"), even though the character counter showed the text was within the limit.

## Root cause
The title field is edited via a rich-text editor (`RichTextInputGroup`), which stores the value as HTML (e.g. `"<p>Дякуємо тим, хто разом із нами</p>"`). Frontend length validation stripped the tags via `getPlainTextFromHtml()` before counting characters, so the form appeared valid. However, `PartnersApi.updateBanner` sent the raw HTML string as-is, and the backend validated the raw string length including tags, exceeding the 30-character limit and returning 400.

## Summary of change
- Convert `values.title` to plain text with `getPlainTextFromHtml()` before sending it in `handlePublishConfirm`, so the validated value and the sent value match

## Testing approach
1. Login as Admin
2. Go to "Partners" section
3. Open the partner banner edit form
4. Enter a title and description 28–30 characters long
5. Click "Опублікувати" → in "Опублікувати зміни?" popup click "Так"
6. Verify the banner saves successfully without a 400 error
7. Reload the page and verify the title is displayed correctly

## CHECK LIST
- [ ]  CI passed
- [ ]  Code coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions