### PR TITLE
Fix/issue-1834 [Reports] Edit the sum of expenses of a program allocated

### DIFF
--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
@@ -494,6 +494,12 @@ describe('ProgramExpensesSection', () => {
         expect(screen.getByText(PROGRAM_EXPENSES_TEXT.MODAL.DELETE.TITLE)).toBeInTheDocument();
     });
 
+    it('should not show delete icons when not in edit mode', () => {
+        render(<ProgramExpensesSection isEditing={false} />);
+
+        expect(screen.queryByLabelText('Delete record 1')).not.toBeInTheDocument();
+    });
+
     it('should close delete modal when Cancel is clicked without calling API', () => {
         render(<ProgramExpensesSection />);
 
@@ -684,6 +690,16 @@ describe('ProgramExpensesSection', () => {
                 expect(mockAddToast).toHaveBeenCalledWith(REPORTS_TEXT.MESSAGE.RECORD_UPDATED_SUCCESSFULLY, 'success');
                 expect(mockRefetch).toHaveBeenCalled();
             });
+        });
+
+        it('should cancel inline edit when isEditing turns off', () => {
+            const { rerender } = render(<ProgramExpensesSection isEditing />);
+
+            fireEvent.click(screen.getByLabelText('Edit record 1'));
+            expect(screen.getByLabelText('Accept record 1')).toBeInTheDocument();
+
+            rerender(<ProgramExpensesSection isEditing={false} />);
+            expect(screen.queryByLabelText('Accept record 1')).not.toBeInTheDocument();
         });
 
         it('should clear bulk selection and hide bulk selection bar when row edit starts', async () => {

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
@@ -403,7 +403,11 @@ describe('ProgramExpensesSection', () => {
         fireEvent.click(screen.getByTestId('program-select-no-records'));
 
         expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.MESSAGE)).toBeInTheDocument();
-        expect(screen.queryByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE })).toBeNull();
+
+        const table = screen.getByTestId('program-expenses-table');
+        expect(
+            within(table).queryByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE }),
+        ).toBeNull();
     });
 
     it('should render program expenses empty state when records are missing', () => {
@@ -417,7 +421,10 @@ describe('ProgramExpensesSection', () => {
 
         expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.TABLE.EMPTY_STATE.TITLE)).toBeInTheDocument();
         expect(screen.getByText(PROGRAM_EXPENSES_TEXT.EMPTY_STATE.ADD_RECORD)).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE })).toBeDisabled();
+
+        const addButtons = screen.getAllByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE });
+        expect(addButtons[0]).toBeEnabled();
+        expect(addButtons[1]).toBeEnabled();
     });
 
     it('should pass fetch handler that calls ProgramExpensesApi.getReadOnlyData with client', async () => {
@@ -438,7 +445,7 @@ describe('ProgramExpensesSection', () => {
     });
 
     it('should render edit mode controls when edit mode is active', () => {
-        render(<ProgramExpensesSection isEditing />);
+        render(<ProgramExpensesSection />);
 
         expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE })).toBeEnabled();
         expect(screen.getByRole('checkbox', { name: 'Select all program expense records' })).toBeEnabled();
@@ -446,7 +453,7 @@ describe('ProgramExpensesSection', () => {
     });
 
     it('should display mock exchange rate in edit mode', () => {
-        render(<ProgramExpensesSection isEditing />);
+        render(<ProgramExpensesSection />);
 
         expect(screen.getByText('41.25')).toBeInTheDocument();
         expect(screen.getByTestId('add-program-expense-modal')).toHaveAttribute('data-exchange-rate', '41.25');
@@ -473,13 +480,13 @@ describe('ProgramExpensesSection', () => {
             refetch: mockRefetch,
         };
 
-        render(<ProgramExpensesSection isEditing />);
+        render(<ProgramExpensesSection />);
 
         expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE })).toBeDisabled();
     });
 
     it('should open delete confirmation modal when delete icon is clicked', () => {
-        render(<ProgramExpensesSection isEditing />);
+        render(<ProgramExpensesSection />);
 
         fireEvent.click(screen.getByLabelText('Delete record 1'));
 
@@ -487,14 +494,8 @@ describe('ProgramExpensesSection', () => {
         expect(screen.getByText(PROGRAM_EXPENSES_TEXT.MODAL.DELETE.TITLE)).toBeInTheDocument();
     });
 
-    it('should not show delete icons when not in edit mode', () => {
-        render(<ProgramExpensesSection />);
-
-        expect(screen.queryByLabelText('Delete record 1')).not.toBeInTheDocument();
-    });
-
     it('should close delete modal when Cancel is clicked without calling API', () => {
-        render(<ProgramExpensesSection isEditing />);
+        render(<ProgramExpensesSection />);
 
         fireEvent.click(screen.getByLabelText('Delete record 1'));
         expect(screen.getByTestId('delete-record-modal')).toBeInTheDocument();
@@ -508,7 +509,7 @@ describe('ProgramExpensesSection', () => {
     it('should delete record after confirmation and show success toast', async () => {
         (ProgramExpensesApi.delete as jest.Mock).mockResolvedValueOnce(undefined);
 
-        render(<ProgramExpensesSection isEditing />);
+        render(<ProgramExpensesSection />);
 
         fireEvent.click(screen.getByLabelText('Delete record 1'));
         expect(screen.getByText(PROGRAM_EXPENSES_TEXT.MODAL.DELETE.TITLE)).toBeInTheDocument();
@@ -529,7 +530,7 @@ describe('ProgramExpensesSection', () => {
     it('should show error toast and keep modal open when delete fails', async () => {
         (ProgramExpensesApi.delete as jest.Mock).mockRejectedValueOnce(new Error('delete failed'));
 
-        render(<ProgramExpensesSection isEditing />);
+        render(<ProgramExpensesSection />);
 
         fireEvent.click(screen.getByLabelText('Delete record 1'));
         fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.YES));
@@ -553,7 +554,7 @@ describe('ProgramExpensesSection', () => {
                 }),
         );
 
-        render(<ProgramExpensesSection isEditing />);
+        render(<ProgramExpensesSection />);
 
         fireEvent.click(screen.getByLabelText('Delete record 1'));
         fireEvent.click(screen.getByText(COMMON_TEXT_ADMIN.BUTTON.YES));
@@ -567,7 +568,7 @@ describe('ProgramExpensesSection', () => {
     });
 
     it('should open bulk delete modal when delete selected button is clicked', () => {
-        render(<ProgramExpensesSection isEditing />);
+        render(<ProgramExpensesSection />);
 
         fireEvent.click(screen.getByRole('checkbox', { name: 'Select record 1' }));
         fireEvent.click(screen.getByText(PROGRAM_EXPENSES_TEXT.BULK.DELETE_BUTTON));
@@ -577,7 +578,7 @@ describe('ProgramExpensesSection', () => {
     });
 
     it('should close bulk delete modal and clear selection when cancel is clicked', () => {
-        render(<ProgramExpensesSection isEditing />);
+        render(<ProgramExpensesSection />);
 
         fireEvent.click(screen.getByRole('checkbox', { name: 'Select record 1' }));
         fireEvent.click(screen.getByText(PROGRAM_EXPENSES_TEXT.BULK.DELETE_BUTTON));
@@ -590,7 +591,7 @@ describe('ProgramExpensesSection', () => {
     it('should bulk delete selected records and show success toast', async () => {
         (ProgramExpensesApi.bulkDelete as jest.Mock).mockResolvedValueOnce(undefined);
 
-        render(<ProgramExpensesSection isEditing />);
+        render(<ProgramExpensesSection />);
 
         fireEvent.click(screen.getByRole('checkbox', { name: 'Select record 1' }));
         fireEvent.click(screen.getByText(PROGRAM_EXPENSES_TEXT.BULK.DELETE_BUTTON));
@@ -607,7 +608,7 @@ describe('ProgramExpensesSection', () => {
     it('should show error toast when bulk delete fails', async () => {
         (ProgramExpensesApi.bulkDelete as jest.Mock).mockRejectedValueOnce(new Error('failed'));
 
-        render(<ProgramExpensesSection isEditing />);
+        render(<ProgramExpensesSection />);
 
         fireEvent.click(screen.getByRole('checkbox', { name: 'Select record 1' }));
         fireEvent.click(screen.getByText(PROGRAM_EXPENSES_TEXT.BULK.DELETE_BUTTON));
@@ -628,7 +629,7 @@ describe('ProgramExpensesSection', () => {
         it('should open modal in add mode, submit, call API.post and refetch', async () => {
             mockPost.mockResolvedValueOnce(undefined);
 
-            render(<ProgramExpensesSection isEditing />);
+            render(<ProgramExpensesSection />);
 
             fireEvent.click(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE }));
 
@@ -656,7 +657,7 @@ describe('ProgramExpensesSection', () => {
         it('should start inline row edit mode, select program category, click accept, call API.update and refetch', async () => {
             mockUpdate.mockResolvedValueOnce(undefined);
 
-            render(<ProgramExpensesSection isEditing />);
+            render(<ProgramExpensesSection />);
 
             // Click the edit button on the first record (id: 1)
             fireEvent.click(screen.getByLabelText('Edit record 1'));
@@ -685,18 +686,8 @@ describe('ProgramExpensesSection', () => {
             });
         });
 
-        it('should cancel inline edit when isEditing turns off', () => {
-            const { rerender } = render(<ProgramExpensesSection isEditing />);
-
-            fireEvent.click(screen.getByLabelText('Edit record 1'));
-            expect(screen.getByLabelText('Accept record 1')).toBeInTheDocument();
-
-            rerender(<ProgramExpensesSection isEditing={false} />);
-            expect(screen.queryByLabelText('Accept record 1')).not.toBeInTheDocument();
-        });
-
         it('should clear bulk selection and hide bulk selection bar when row edit starts', async () => {
-            render(<ProgramExpensesSection isEditing />);
+            render(<ProgramExpensesSection />);
 
             fireEvent.click(screen.getByRole('checkbox', { name: 'Select record 1' }));
             expect(screen.getByText(PROGRAM_EXPENSES_TEXT.BULK.DELETE_BUTTON)).toBeInTheDocument();
@@ -708,7 +699,7 @@ describe('ProgramExpensesSection', () => {
                 const selectionRow = deleteButton.closest('div')?.parentElement;
                 expect(selectionRow).toHaveAttribute('aria-hidden', 'true');
                 expect(screen.getByRole('checkbox', { name: 'Select record 1' })).not.toBeChecked();
-                expect(screen.getByRole('checkbox', { name: 'Select record 1' })).toBeDisabled();
+                expect(screen.getByRole('checkbox', { name: 'Select record 1' })).toBeEnabled();
             });
         });
     });

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
@@ -279,10 +279,6 @@ jest.mock('@/components/admin/multi-select-input/MultiSelectInput', () => ({
     },
 }));
 
-afterEach(() => {
-    jest.restoreAllMocks();
-});
-
 describe('ProgramExpensesSection', () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -703,7 +699,7 @@ describe('ProgramExpensesSection', () => {
                 const selectionRow = deleteButton.closest('div')?.parentElement;
                 expect(selectionRow).toHaveAttribute('aria-hidden', 'true');
                 expect(screen.getByRole('checkbox', { name: 'Select record 1' })).not.toBeChecked();
-                expect(screen.getByRole('checkbox', { name: 'Select record 1' })).toBeEnabled();
+                expect(screen.getByRole('checkbox', { name: 'Select record 1' })).toBeDisabled();
             });
         });
     });
@@ -731,7 +727,7 @@ describe('ProgramExpensesSection', () => {
     });
 
     it('should show error toast if adding a new program expense fails (catch branch)', async () => {
-        const spyPost = jest.spyOn(ProgramExpensesApi, 'post').mockRejectedValueOnce(new Error('API failed'));
+        jest.spyOn(ProgramExpensesApi, 'post').mockRejectedValueOnce(new Error('API failed'));
 
         render(<ProgramExpensesSection />);
 
@@ -745,7 +741,5 @@ describe('ProgramExpensesSection', () => {
                 expect.anything(),
             );
         });
-
-        spyPost.mockRestore();
     });
 });

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
@@ -279,6 +279,10 @@ jest.mock('@/components/admin/multi-select-input/MultiSelectInput', () => ({
     },
 }));
 
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
 describe('ProgramExpensesSection', () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -705,7 +709,7 @@ describe('ProgramExpensesSection', () => {
     });
 
     it('should show error toast if inline record update fails (catch branch)', async () => {
-        const spyUpdate = jest.spyOn(ProgramExpensesApi, 'update').mockRejectedValueOnce(new Error('Network error'));
+        jest.spyOn(ProgramExpensesApi, 'update').mockRejectedValueOnce(new Error('Network error'));
 
         render(<ProgramExpensesSection />);
 
@@ -724,8 +728,6 @@ describe('ProgramExpensesSection', () => {
                 expect.anything(),
             );
         });
-
-        spyUpdate.mockRestore();
     });
 
     it('should show error toast if adding a new program expense fails (catch branch)', async () => {

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
@@ -703,4 +703,47 @@ describe('ProgramExpensesSection', () => {
             });
         });
     });
+
+    it('should show error toast if inline record update fails (catch branch)', async () => {
+        const spyUpdate = jest.spyOn(ProgramExpensesApi, 'update').mockRejectedValueOnce(new Error('Network error'));
+
+        render(<ProgramExpensesSection />);
+
+        fireEvent.click(screen.getByLabelText('Edit record 1'));
+
+        fireEvent.click(screen.getByTestId('select-option-Program C-3'));
+
+        const uahInput = screen.getByLabelText('Amount UAH record 1');
+        fireEvent.change(uahInput, { target: { value: '99999' } });
+
+        fireEvent.click(screen.getByLabelText('Accept record 1'));
+
+        await waitFor(() => {
+            expect(mockAddToast).toHaveBeenCalledWith(
+                REPORTS_TEXT.MESSAGE.RECORD_UPDATE_FAILED_RETRY,
+                expect.anything(),
+            );
+        });
+
+        spyUpdate.mockRestore();
+    });
+
+    it('should show error toast if adding a new program expense fails (catch branch)', async () => {
+        const spyPost = jest.spyOn(ProgramExpensesApi, 'post').mockRejectedValueOnce(new Error('API failed'));
+
+        render(<ProgramExpensesSection />);
+
+        fireEvent.click(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE }));
+
+        fireEvent.click(screen.getByTestId('mock-submit-btn'));
+
+        await waitFor(() => {
+            expect(mockAddToast).toHaveBeenCalledWith(
+                PROGRAM_EXPENSES_TEXT.MESSAGE.RECORD_CREATE_FAILED_RETRY,
+                expect.anything(),
+            );
+        });
+
+        spyPost.mockRestore();
+    });
 });

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
@@ -28,16 +28,15 @@ const INITIAL_PROGRAM_EXPENSES_DATA: ProgramExpensesReadOnlyData = {
 const MAX_PROGRAM_EXPENSE_RECORDS = 4;
 
 interface ProgramExpensesSectionProps {
-    isEditing?: boolean;
     isRowEditMode?: boolean;
     onRowEditModeChange?: (isEditing: boolean) => void;
 }
 
 export const ProgramExpensesSection = ({
-    isEditing = false,
     isRowEditMode: propIsRowEditMode,
     onRowEditModeChange,
 }: ProgramExpensesSectionProps) => {
+    const isEditing = true;
     const adminClient = useAdminClient();
     const { addToast } = useToast();
     const [selectedProgramIds, setSelectedProgramIds] = useState<number[]>([]);
@@ -86,13 +85,6 @@ export const ProgramExpensesSection = ({
                 : validSelectedProgramIds;
         });
     }, [data.programs]);
-
-    useEffect(() => {
-        if (!isEditing) {
-            setIsAddProgramExpenseModalOpen(false);
-            setSelectedRecordIds([]);
-        }
-    }, [isEditing]);
 
     const filteredRecords = useMemo(() => {
         if (selectedProgramIds.length === 0) {

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
@@ -28,15 +28,16 @@ const INITIAL_PROGRAM_EXPENSES_DATA: ProgramExpensesReadOnlyData = {
 const MAX_PROGRAM_EXPENSE_RECORDS = 4;
 
 interface ProgramExpensesSectionProps {
+    isEditing?: boolean;
     isRowEditMode?: boolean;
     onRowEditModeChange?: (isEditing: boolean) => void;
 }
 
 export const ProgramExpensesSection = ({
+    isEditing = true,
     isRowEditMode: propIsRowEditMode,
     onRowEditModeChange,
 }: ProgramExpensesSectionProps) => {
-    const isEditing = true;
     const adminClient = useAdminClient();
     const { addToast } = useToast();
     const [selectedProgramIds, setSelectedProgramIds] = useState<number[]>([]);

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
@@ -87,6 +87,13 @@ export const ProgramExpensesSection = ({
         });
     }, [data.programs]);
 
+    useEffect(() => {
+        if (!isEditing) {
+            setIsAddProgramExpenseModalOpen(false);
+            setSelectedRecordIds([]);
+        }
+    }, [isEditing]);
+
     const filteredRecords = useMemo(() => {
         if (selectedProgramIds.length === 0) {
             return data.records;

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.test.tsx
@@ -243,7 +243,7 @@ describe('ProgramExpensesTable', () => {
         expect(screen.getByLabelText('Close edit for record 1')).toBeInTheDocument();
 
         // Checkboxes and other edit buttons should be disabled
-        expect(screen.getByRole('checkbox', { name: 'Select record 1' })).toBeEnabled();
+        expect(screen.getByRole('checkbox', { name: 'Select record 1' })).toBeDisabled();
         expect(screen.getByRole('checkbox', { name: 'Select record 2' })).toBeDisabled();
         expect(screen.getByRole('button', { name: 'Edit record 2' })).toBeDisabled();
         expect(screen.getByRole('button', { name: 'Delete record 2' })).toBeDisabled();
@@ -401,7 +401,7 @@ describe('ProgramExpensesTable', () => {
 
         expect(screen.getByRole('button', { name: 'Edit record 2' })).toBeDisabled();
         expect(screen.getByRole('button', { name: 'Delete record 2' })).toBeDisabled();
-        expect(screen.getByRole('checkbox', { name: 'Select record 1' })).toBeEnabled();
+        expect(screen.getByRole('checkbox', { name: 'Select record 1' })).toBeDisabled();
         expect(screen.getByRole('checkbox', { name: 'Select record 2' })).toBeDisabled();
     });
 

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.test.tsx
@@ -243,7 +243,7 @@ describe('ProgramExpensesTable', () => {
         expect(screen.getByLabelText('Close edit for record 1')).toBeInTheDocument();
 
         // Checkboxes and other edit buttons should be disabled
-        expect(screen.getByRole('checkbox', { name: 'Select record 1' })).toBeDisabled();
+        expect(screen.getByRole('checkbox', { name: 'Select record 1' })).toBeEnabled();
         expect(screen.getByRole('checkbox', { name: 'Select record 2' })).toBeDisabled();
         expect(screen.getByRole('button', { name: 'Edit record 2' })).toBeDisabled();
         expect(screen.getByRole('button', { name: 'Delete record 2' })).toBeDisabled();
@@ -401,7 +401,7 @@ describe('ProgramExpensesTable', () => {
 
         expect(screen.getByRole('button', { name: 'Edit record 2' })).toBeDisabled();
         expect(screen.getByRole('button', { name: 'Delete record 2' })).toBeDisabled();
-        expect(screen.getByRole('checkbox', { name: 'Select record 1' })).toBeDisabled();
+        expect(screen.getByRole('checkbox', { name: 'Select record 1' })).toBeEnabled();
         expect(screen.getByRole('checkbox', { name: 'Select record 2' })).toBeDisabled();
     });
 

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.tsx
@@ -303,6 +303,7 @@ export const ProgramExpensesTable = ({
                     <Button
                         buttonStyle="secondary"
                         className={styles['delete-selected-button']}
+                        disabled={isAnyRowEditing}
                         onClick={() => onOpenBulkDelete?.()}
                     >
                         {PROGRAM_EXPENSES_TEXT.BULK.DELETE_BUTTON}

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.tsx
@@ -372,7 +372,7 @@ export const ProgramExpensesTable = ({
                                             <td className={cn(styles.td, styles['checkbox-td'])}>
                                                 <input
                                                     type="checkbox"
-                                                    disabled={isAnyRowEditing && !isEditedRow}
+                                                    disabled={isAnyRowEditing}
                                                     className={styles['row-checkbox']}
                                                     aria-label={`Select record ${record.id}`}
                                                     checked={selectedRecordIds.includes(record.id)}

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-table/ProgramExpensesTable.tsx
@@ -371,7 +371,7 @@ export const ProgramExpensesTable = ({
                                             <td className={cn(styles.td, styles['checkbox-td'])}>
                                                 <input
                                                     type="checkbox"
-                                                    disabled={isAnyRowEditing}
+                                                    disabled={isAnyRowEditing && !isEditedRow}
                                                     className={styles['row-checkbox']}
                                                     aria-label={`Select record ${record.id}`}
                                                     checked={selectedRecordIds.includes(record.id)}

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.module.scss
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.module.scss
@@ -24,7 +24,7 @@
         box-shadow: none;
 
         &:hover {
-            background: c.$white;
+            background: rgba(c.$dropdown-hover, 0.3);
         }
     }
 
@@ -46,9 +46,7 @@
         padding: 8px 0;
         border: none;
         border-radius: 4px;
-        box-shadow:
-            0 1px 2px rgba(c.$black, 0.3),
-            0 2px 6px 2px rgba(c.$black, 0.15);
+        box-shadow: 0 1px 2px rgba(c.$black, 0.3), 0 2px 6px 2px rgba(c.$black, 0.15);
         overflow-y: auto;
         overflow-x: hidden;
         scrollbar-width: thin;
@@ -96,6 +94,28 @@
 
     :global(.multiselect__option--selected) {
         background: c.$dropdown-hover;
+    }
+}
+
+.program-select-disabled {
+    opacity: 1;
+    pointer-events: none;
+
+    :global(.multiselect__placeholder-container) {
+        background-color: rgba(c.$black, 0.04);
+        border-color: c.$grey-700;
+
+        &:hover {
+            background-color: rgba(c.$black, 0.04);
+        }
+    }
+
+    :global(.multiselect__placeholder-content) {
+        color: c.$grey-700;
+    }
+
+    :global(.multiselect__chevron svg path) {
+        stroke: c.$grey-700;
     }
 }
 

--- a/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/program-expenses-toolbar/ProgramExpensesToolbar.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/admin/button/Button';
 import { ReactComponent as PlusIcon } from '@/assets/icons/plus.svg';
 import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
 import { ProgramExpensesProgram } from '@/types/admin/reports';
+import cn from 'classnames';
 import styles from './ProgramExpensesToolbar.module.scss';
 
 interface ProgramExpensesToolbarProps {
@@ -61,7 +62,11 @@ export const ProgramExpensesToolbar = ({
 
     return (
         <div className={styles['toolbar-row']}>
-            <div className={styles['program-select']}>
+            <div
+                className={cn(styles['program-select'], {
+                    [styles['program-select-disabled']]: disabled,
+                })}
+            >
                 <MultiSelectInput<ProgramExpensesProgram>
                     id="program-expenses-program-filter"
                     options={programOptions}

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.test.tsx
@@ -133,11 +133,7 @@ jest.mock(
 );
 
 jest.mock('../program-expenses-section/ProgramExpensesSection', () => ({
-    ProgramExpensesSection: ({ isEditing = false }: { isEditing?: boolean }) => (
-        <div data-testid="program-expenses-section" data-editing={String(isEditing)}>
-            ProgramExpensesSection
-        </div>
-    ),
+    ProgramExpensesSection: () => <div data-testid="program-expenses-section">ProgramExpensesSection</div>,
 }));
 
 describe('ReportAnalytics', () => {
@@ -192,15 +188,6 @@ describe('ReportAnalytics', () => {
         const incomeTab = screen.getByText('Доходи та витрати');
         fireEvent.click(incomeTab);
         expect(screen.queryByTestId('pdf-files-section')).not.toBeInTheDocument();
-    });
-
-    it('sets program expenses section to editing mode when funds edit is activated', () => {
-        render(<ReportAnalytics />);
-
-        fireEvent.click(screen.getByTestId('activate-funds-edit'));
-        fireEvent.click(screen.getByText(REPORTS_TEXT.REPORT_AND_ANALYTICS.TAB.PROGRAM_EXPENSES));
-
-        expect(screen.getByTestId('program-expenses-section')).toHaveAttribute('data-editing', 'true');
     });
 
     it('should restore funds edit mode after returning from another tab', () => {

--- a/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
+++ b/src/pages/admin/reports/components/report-analytics/ReportAnalytics.tsx
@@ -118,11 +118,7 @@ export const ReportAnalytics = () => {
                     />
                 )}
                 {activeTab.id === 'program-expenses' && (
-                    <ProgramExpensesSection
-                        isEditing={isFundsEditing}
-                        isRowEditMode={isRowEditMode}
-                        onRowEditModeChange={setIsRowEditMode}
-                    />
+                    <ProgramExpensesSection isRowEditMode={isRowEditMode} onRowEditModeChange={setIsRowEditMode} />
                 )}
             </div>
 


### PR DESCRIPTION
## JIRA or Github ticker

* [1834](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1834)

## Description

This PR implements inline editing functionality for program expenses records.
As an Admin, I can now edit the UAH and USD amounts directly within the "Програмні витрати" (Program expenses) tab. This ensures that any mistakes in record details can be quickly fixed to present relevant information to users, matching the behavior previously implemented for funds and expenditures. 

## How it looks

<img width="1172" height="765" alt="image" src="https://github.com/user-attachments/assets/ba2b6869-0766-4ec6-81c3-036ccbdd6eb9" />

## Summary of change

* **ProgramExpensesSection/ReportAnalytics:** Refactored `ProgramExpensesSection` to manage its own active state by removing the external `isEditing` prop dependency. 
* **ProgramExpensesTable:** Updated checkbox logic to disable row selection (`disabled={isAnyRowEditing && !isEditedRow}`) for all other records when a specific row is in edit mode.
* **ProgramExpensesToolbar:** Added `.program-select-disabled` SCSS styles and logic to properly visually disable the filter dropdowns when an inline row edit is active.
* **Tests:** Updated test suites in `ProgramExpensesSection.test.tsx`, `ProgramExpensesTable.test.tsx`, and `ReportAnalytics.test.tsx` to align with the new editing state logic and verify the disabled states of inactive rows.

## How to recreate changes

1. Log in to the Admin panel and navigate to the **Reports** section.
2. Open the **'Програмні витрати'** (Program expenses) tab.
3. Click the **Edit** icon for any record in the list.
4. Verify that the Edit and Delete icons are replaced with Accept and Close icons for that record.
5. Verify that all other records have their checkboxes, Edit, and Delete icons disabled.
6. Verify that the filter dropdowns in the toolbar are disabled.
7. Change the USD/UAH amount and click Accept to ensure the record updates correctly.

## CHECK LIST
- [x] New tests was added or existing was modified
- [ ] Changes has severe impact on users
- [ ] Changes has medium impact on users
- [x] Changes has light impact on users
- [x] Test coverage was updated
- [x] PR meets all conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Program expense sections now open in editing mode by default.
  - Starting a row edit clears bulk selection and hides the bulk-selection bar.
  - Added retry error notifications when updating or adding program expenses fails.

- **Bug Fixes**
  - Bulk deletion is disabled while a row is being edited.
  - Disabled program filters now provide clearer visual feedback and prevent interaction.
  - Improved empty-state and missing-record behavior for program expenses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->