### PR TITLE
fix/issue-2332 [Single Program] "Заголовок" field contains wrong placeholder (frame 633435)

### DIFF
--- a/src/const/admin/sections.ts
+++ b/src/const/admin/sections.ts
@@ -37,7 +37,7 @@ export const SECTIONS_TEXT = {
         FORM: {
             TITLE: {
                 TEXT: 'Заголовок',
-                PLACEHOLDER: 'ВВЕДІТЬ НАЗВУ',
+                PLACEHOLDER: 'ВВЕДІТЬ ЗАГОЛОВОК',
             },
             DESCRIPTION: {
                 TEXT: 'Опис',


### PR DESCRIPTION
## JIRA or Github ticker

* [2332](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2332)

## Description

This PR fixes a bug where the "Заголовок" field displayed the incorrect placeholder text "ВВЕДІТЬ НАЗВУ". The placeholder has been updated to the expected text "ВВЕДІТЬ ЗАГОЛОВОК" according to the bug report [#2332](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2332).

## How it looks

<img width="1163" height="607" alt="image" src="https://github.com/user-attachments/assets/385735b6-8e9f-402e-ab5f-579d5d477097" />

## Summary of change

- `src/const/admin/sections.ts`: Updated the PLACEHOLDER value inside SECTIONS_TEXT.FORM.TITLE from 'ВВЕДІТЬ НАЗВУ' to 'ВВЕДІТЬ ЗАГОЛОВОК'.

## How to recreate changes

1. Log in to the application as an Admin.
2. Open the template selection modal with the carousel.
3. Select Frame 633435.
4. Observe the placeholder for the "Заголовок" input field.
5. Verify that it now displays "Введіть заголовок" instead of "Введіть назву".


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Ukrainian placeholder text for the section title input to “ВВЕДІТЬ ЗАГОЛОВОК”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->