### PR TITLE
Fix/issue 3052 [Reports][Media Settings] Confirmation dialog is not displayed when clicking the "Опублікувати" button

### DIFF
--- a/src/pages/admin/reports/components/reports-panel-content/ReportsPanelContent.test.tsx
+++ b/src/pages/admin/reports/components/reports-panel-content/ReportsPanelContent.test.tsx
@@ -51,20 +51,23 @@ jest.mock('@/components/admin/toast/toast-container/ToastContainer', () => ({
     ToastContainer: () => <div data-testid="mock-toast-container" />,
 }));
 
-jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
-    ConfirmationModal: (props: any) =>
-        props.isOpen ? (
-            <div data-testid="mock-confirmation-modal">
-                <span data-testid="confirmation-title">{props.title}</span>
-                <button data-testid="confirm-yes" onClick={props.onConfirm}>
-                    ТАК
-                </button>
-                <button data-testid="confirm-no" onClick={props.onCancel}>
-                    НІ
-                </button>
-            </div>
-        ) : null,
-}));
+jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => {
+    const { COMMON_TEXT_ADMIN } = require('@/const/admin/common');
+    return {
+        ConfirmationModal: (props: any) =>
+            props.isOpen ? (
+                <div data-testid="mock-confirmation-modal">
+                    <span data-testid="confirmation-title">{props.title}</span>
+                    <button data-testid="confirm-yes" onClick={props.onConfirm}>
+                        {COMMON_TEXT_ADMIN.BUTTON.YES}
+                    </button>
+                    <button data-testid="confirm-no" onClick={props.onCancel}>
+                        {COMMON_TEXT_ADMIN.BUTTON.NO}
+                    </button>
+                </div>
+            ) : null,
+    };
+});
 
 jest.mock('./ReportsPanelContent.module.scss', () => ({
     root: 'root',
@@ -201,7 +204,7 @@ describe('ReportsPanelContent', () => {
     });
 
     describe('Publish', () => {
-        it('should reset dirty state after successful publish', async () => {
+        it('should reset dirty state after successfully confirming publish', async () => {
             renderComponent();
 
             markDirty();
@@ -217,7 +220,7 @@ describe('ReportsPanelContent', () => {
             });
         });
 
-        it('should keep dirty state when publish fails', async () => {
+        it('should keep dirty state when confirmed publish fails', async () => {
             mockSubmit.mockResolvedValue(false);
             renderComponent();
 

--- a/src/pages/admin/reports/components/reports-panel-content/ReportsPanelContent.test.tsx
+++ b/src/pages/admin/reports/components/reports-panel-content/ReportsPanelContent.test.tsx
@@ -51,6 +51,21 @@ jest.mock('@/components/admin/toast/toast-container/ToastContainer', () => ({
     ToastContainer: () => <div data-testid="mock-toast-container" />,
 }));
 
+jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
+    ConfirmationModal: (props: any) =>
+        props.isOpen ? (
+            <div data-testid="mock-confirmation-modal">
+                <span data-testid="confirmation-title">{props.title}</span>
+                <button data-testid="confirm-yes" onClick={props.onConfirm}>
+                    ТАК
+                </button>
+                <button data-testid="confirm-no" onClick={props.onCancel}>
+                    НІ
+                </button>
+            </div>
+        ) : null,
+}));
+
 jest.mock('./ReportsPanelContent.module.scss', () => ({
     root: 'root',
     toolbar: 'toolbar',
@@ -63,6 +78,8 @@ const clickMsCancel = () => fireEvent.click(screen.getByTestId('ms-cancel'));
 const clickMsPublish = () => fireEvent.click(screen.getByTestId('ms-publish'));
 const markDirty = () => fireEvent.click(screen.getByTestId('ms-dirty-true'));
 const markClean = () => fireEvent.click(screen.getByTestId('ms-dirty-false'));
+const confirmInDialog = () => fireEvent.click(screen.getByTestId('confirm-yes'));
+const cancelInDialog = () => fireEvent.click(screen.getByTestId('confirm-no'));
 
 const expectPublishDisabled = (value: boolean) =>
     expect(screen.getByTestId('ms-publish-disabled')).toHaveTextContent(String(value));
@@ -151,6 +168,38 @@ describe('ReportsPanelContent', () => {
         });
     });
 
+    describe('Publish confirmation dialog', () => {
+        it('should show confirmation dialog when publish button is clicked', () => {
+            renderComponent();
+
+            expect(screen.queryByTestId('mock-confirmation-modal')).not.toBeInTheDocument();
+
+            clickMsPublish();
+
+            expect(screen.getByTestId('mock-confirmation-modal')).toBeInTheDocument();
+            expect(screen.getByTestId('confirmation-title')).toHaveTextContent('Опублікувати зміни?');
+        });
+
+        it('should close confirmation dialog when НІ is clicked without calling submit', () => {
+            renderComponent();
+
+            clickMsPublish();
+            expect(screen.getByTestId('mock-confirmation-modal')).toBeInTheDocument();
+
+            cancelInDialog();
+
+            expect(screen.queryByTestId('mock-confirmation-modal')).not.toBeInTheDocument();
+            expect(mockSubmit).not.toHaveBeenCalled();
+        });
+
+        it('should not call submit until ТАК is clicked in the dialog', () => {
+            renderComponent();
+
+            clickMsPublish();
+            expect(mockSubmit).not.toHaveBeenCalled();
+        });
+    });
+
     describe('Publish', () => {
         it('should reset dirty state after successful publish', async () => {
             renderComponent();
@@ -160,6 +209,7 @@ describe('ReportsPanelContent', () => {
             expectCancelDisabled(false);
 
             clickMsPublish();
+            confirmInDialog();
 
             await waitFor(() => {
                 expectPublishDisabled(true);
@@ -173,10 +223,25 @@ describe('ReportsPanelContent', () => {
 
             markDirty();
             clickMsPublish();
+            confirmInDialog();
 
             await waitFor(() => {
                 expectPublishDisabled(false);
                 expectCancelDisabled(false);
+            });
+        });
+
+        it('should close the confirmation dialog after confirming publish', async () => {
+            renderComponent();
+
+            markDirty();
+            clickMsPublish();
+            expect(screen.getByTestId('mock-confirmation-modal')).toBeInTheDocument();
+
+            confirmInDialog();
+
+            await waitFor(() => {
+                expect(screen.queryByTestId('mock-confirmation-modal')).not.toBeInTheDocument();
             });
         });
     });

--- a/src/pages/admin/reports/components/reports-panel-content/ReportsPanelContent.tsx
+++ b/src/pages/admin/reports/components/reports-panel-content/ReportsPanelContent.tsx
@@ -27,15 +27,18 @@ export const ReportsPanelContent = () => {
         setSelectedTab(tab);
     }, []);
 
-    const handlePublish = useCallback(() => {
+    const handlePublishClick = useCallback(() => {
         setIsConfirmOpen(true);
     }, []);
 
     const handleConfirmPublish = useCallback(async () => {
-        setIsConfirmOpen(false);
-        const result = await mediaSettingsRef.current?.submit();
-        if (result) {
-            setIsDirty(false);
+        try {
+            const result = await mediaSettingsRef.current?.submit();
+            if (result) {
+                setIsDirty(false);
+            }
+        } finally {
+            setIsConfirmOpen(false);
         }
     }, []);
 
@@ -58,7 +61,7 @@ export const ReportsPanelContent = () => {
                     resetCounter={resetCounter}
                     onDirtyChange={handleDirtyChange}
                     onCancel={handleCancel}
-                    onPublish={handlePublish}
+                    onPublish={handlePublishClick}
                     isPublishDisabled={!isDirty}
                     isCancelDisabled={!isDirty}
                     isActive={isMediaSettingsTab}

--- a/src/pages/admin/reports/components/reports-panel-content/ReportsPanelContent.tsx
+++ b/src/pages/admin/reports/components/reports-panel-content/ReportsPanelContent.tsx
@@ -8,11 +8,14 @@ import {
 } from '../reports-page-toolbar/ReportsPageToolbar';
 import { MediaSettings, MediaSettingsRef } from '../media-settings/MediaSettings';
 import { ReportAnalytics } from '../report-analytics/ReportAnalytics';
+import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 
 export const ReportsPanelContent = () => {
     const [selectedTab, setSelectedTab] = useState<ReportsToolbarTab>(REPORTS_TOOLBAR_TABS[0]);
     const [isDirty, setIsDirty] = useState(false);
     const [resetCounter, setResetCounter] = useState(0);
+    const [isConfirmOpen, setIsConfirmOpen] = useState(false);
     const mediaSettingsRef = useRef<MediaSettingsRef>(null);
 
     const handleCancel = useCallback(() => {
@@ -23,12 +26,23 @@ export const ReportsPanelContent = () => {
     const handleTabSelect = useCallback((tab: ReportsToolbarTab) => {
         setSelectedTab(tab);
     }, []);
-    const handlePublish = useCallback(async () => {
+
+    const handlePublish = useCallback(() => {
+        setIsConfirmOpen(true);
+    }, []);
+
+    const handleConfirmPublish = useCallback(async () => {
+        setIsConfirmOpen(false);
         const result = await mediaSettingsRef.current?.submit();
         if (result) {
             setIsDirty(false);
         }
     }, []);
+
+    const handleCloseConfirm = useCallback(() => {
+        setIsConfirmOpen(false);
+    }, []);
+
     const handleDirtyChange = useCallback((dirty: boolean) => setIsDirty(dirty), []);
 
     const isMediaSettingsTab = selectedTab.id === 'media-settings';
@@ -51,6 +65,13 @@ export const ReportsPanelContent = () => {
                 />
                 {!isMediaSettingsTab && <ReportAnalytics />}
             </div>
+            <ConfirmationModal
+                isOpen={isConfirmOpen}
+                onClose={handleCloseConfirm}
+                title={COMMON_TEXT_ADMIN.QUESTION.PUBLISH_CHANGES}
+                onConfirm={handleConfirmPublish}
+                onCancel={handleCloseConfirm}
+            />
             <ToastContainer />
         </div>
     );


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3052)

## Description

This PR resolves an issue in the Admin Panel's "Звітність" (Reports) page where the "Опублікувати" (Publish) button on the "Налаштування медіа" (Media Settings) tab would immediately publish changes without requesting user confirmation. The underlying component logic has been updated to include a confirmation dialog, aligning with the established pattern used across the admin panel to prevent accidental publications.

## How it looks

<img width="1334" height="792" alt="image" src="https://github.com/user-attachments/assets/f629e0a4-cb35-404c-9cfa-d8cf2df6b06d" />

## Summary of change

* **Publish Confirmation Dialog (`ReportsPanelContent.tsx`)**: Introduced `isConfirmOpen` state and integrated the `ConfirmationModal` component. Modified the publish flow to intercept the initial click, display the confirmation prompt, and only execute the API call (`submit()`) upon user confirmation.
*   **Test Suite Updates (`ReportsPanelContent.test.tsx`)**: Refactored the test suite to accommodate the new two-step publish flow. Added a mock for `ConfirmationModal` and introduced new test cases to verify the dialog's appearance, cancellation behavior without API calls, and successful publication after confirmation.

## How to recreate changes

1. Log into the Admin panel and navigate to the **"Звітність"** (Reports) page.
2. Select the **"Налаштування медіа"** (Media Settings) tab.
3. Make a change to any field (e.g., edit text or change an image) to enable the **"Опублікувати"** (Publish) button.
4. Click the **"Опублікувати"** button.
5. Observe that a confirmation popup with the message *"Опублікувати зміни?"* and **"ТАК"** / **"НІ"** buttons is now displayed.
6. Click **"НІ"** to verify that the modal closes and changes are not published.
7. Click the **"Опублікувати"** button again, click **"ТАК"** to confirm publication, and verify that the success toast appears.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog before publishing report changes.
  * Publishing is now blocked until the user explicitly confirms.
  * Canceling the dialog dismisses it without submitting, and confirming can clear the unsaved-changes state on success.
* **Tests**
  * Expanded publish-flow tests to cover the confirmation dialog behavior and confirmation/close scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->