### PR TITLE
Fix/issue 2500 [Single Program][UI] Multiple UI inconsistencies in Frame 633433 compared to mockup (title, blocks, navigation, visibility)

### DIFF
--- a/src/components/common/section-templates/single-title-description-author-pairs/SingleTitleDescriptionAuthorPairs.module.scss
+++ b/src/components/common/section-templates/single-title-description-author-pairs/SingleTitleDescriptionAuthorPairs.module.scss
@@ -29,12 +29,18 @@
 .template {
     height: 100%;
     width: 100%;
-    padding: clamp(48px, 6vh, 84px) 0;
+    padding: 48px 0;
     padding-left: 30px;
 
-    --pair-card-width: 400px;
-    --pair-card-height: 240px;
+    --pair-card-width: 270px;
+    --pair-card-height: 162px;
 
+    --card-padding: 24px;
+    --card-radius: 15px;
+    --desc-font-size: 14px;
+    --desc-line-height: 18px;
+    --auth-font-size: 15px;
+    --auth-line-height: 18px;
     --peek: 0.35;
 }
 

--- a/src/components/common/section-templates/single-title-description-author-pairs/description-author-pair-card/DescriptionAuthorPairCard.module.scss
+++ b/src/components/common/section-templates/single-title-description-author-pairs/description-author-pair-card/DescriptionAuthorPairCard.module.scss
@@ -1,7 +1,6 @@
 @use '@/assets/sass/variables/colors' as c;
 @use '@/assets/sass/variables/typography' as t;
 
-$radius: 20px;
 $field-width: 366px;
 
 .card {

--- a/src/components/common/section-templates/single-title-description-author-pairs/description-author-pair-card/DescriptionAuthorPairCard.module.scss
+++ b/src/components/common/section-templates/single-title-description-author-pairs/description-author-pair-card/DescriptionAuthorPairCard.module.scss
@@ -8,9 +8,9 @@ $field-width: 366px;
     width: var(--pair-card-width, 432px);
     height: var(--pair-card-height, 259px);
     background-color: c.$light-blue-50;
-    border-radius: $radius;
+    border-radius: var(--card-radius, 20px);
     box-sizing: border-box;
-    padding: 32px;
+    padding: var(--card-padding, 32px);
     display: flex;
     flex-direction: column;
     gap: 16px;
@@ -25,8 +25,8 @@ $field-width: 366px;
 .description {
     font-family: t.$font-family-base;
     font-weight: t.$fw-medium;
-    font-size: 18px;
-    line-height: 24px;
+    font-size: var(--desc-font-size, 18px);
+    line-height: var(--desc-line-height, 24px);
     color: c.$blue-900;
     display: -webkit-box;
     -webkit-line-clamp: 4;
@@ -38,8 +38,8 @@ $field-width: 366px;
     margin-top: auto;
     font-family: t.$font-family-base;
     font-weight: t.$fw-bold;
-    font-size: 20px;
-    line-height: 24px;
+    font-size: var(--auth-font-size, 20px);
+    line-height: var(--auth-line-height, 24px);
     color: c.$blue-900;
 }
 

--- a/src/components/common/section-templates/single-title-description-author-pairs/description-author-pair-card/DescriptionAuthorPairCard.tsx
+++ b/src/components/common/section-templates/single-title-description-author-pairs/description-author-pair-card/DescriptionAuthorPairCard.tsx
@@ -109,11 +109,11 @@ export const DescriptionAuthorPairCard = ({
                         onChange={handleDescriptionChange}
                         onBlur={handleDescriptionBlur}
                         maxLength={descriptionMaxLength}
-                        rows={4}
+                        rows={2}
                         placeholder={SECTIONS_TEXT.SECTION.CARD.FORM.DESCRIPTION.PLACEHOLDER}
                         error={descriptionError}
                         maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(descriptionMaxLength)}
-                        autoGrow={true}
+                        autoGrow={false}
                     />
                 </div>
 
@@ -132,7 +132,7 @@ export const DescriptionAuthorPairCard = ({
                         error={authorError}
                         maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(authorMaxLength)}
                         rows={1}
-                        autoGrow={true}
+                        autoGrow={false}
                         maxRows={4}
                     />
                 </div>

--- a/src/components/common/section-templates/single-title-description-author-pairs/description-author-pair-card/DescriptionAuthorPairCard.tsx
+++ b/src/components/common/section-templates/single-title-description-author-pairs/description-author-pair-card/DescriptionAuthorPairCard.tsx
@@ -133,7 +133,6 @@ export const DescriptionAuthorPairCard = ({
                         maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(authorMaxLength)}
                         rows={1}
                         autoGrow={false}
-                        maxRows={4}
                     />
                 </div>
             </div>

--- a/src/pages/admin/programs/components/programs-page-modals/add-section-modal/AddSectionModal.test.tsx
+++ b/src/pages/admin/programs/components/programs-page-modals/add-section-modal/AddSectionModal.test.tsx
@@ -270,7 +270,7 @@ describe('AddSectionModal', () => {
         renderModal();
 
         const call = getCallByTemplate(SectionTemplate.SingleTitleDescriptionAuthorPairs);
-        expect(call?.data?.title).toBe(SECTIONS_TEXT.SECTION.TITLE_SAMPLE_TEXT);
+        expect(call?.data?.title).toBe(SECTIONS_TEXT.SECTION.SINGLE_TITLE_DESCRIPTION_AUTHOR_PAIRS.DEFAULT_TITLE);
         expect(call?.data?.description).toBe(SECTIONS_TEXT.SECTION.DESCRIPTION_SAMPLE_TEXT);
     });
 

--- a/src/pages/admin/programs/components/programs-page-modals/add-section-modal/AddSectionModal.tsx
+++ b/src/pages/admin/programs/components/programs-page-modals/add-section-modal/AddSectionModal.tsx
@@ -154,12 +154,22 @@ export const AddSectionModal = ({ isOpen, onClose, onSelectTemplate, templates }
             });
         }
 
+        const getSectionTitle = () => {
+            if (templateId === SectionTemplate.SingleTitleDescriptionAuthorPairs) {
+                return SECTIONS_TEXT.SECTION.SINGLE_TITLE_DESCRIPTION_AUTHOR_PAIRS.DEFAULT_TITLE;
+            }
+            return SECTIONS_TEXT.SECTION.TITLE_SAMPLE_TEXT;
+        };
+
         return renderProgramSection({
             templateId,
             data: cards
-                ? { cards }
+                ? {
+                      cards,
+                      title: getSectionTitle(),
+                  }
                 : {
-                      title: SECTIONS_TEXT.SECTION.TITLE_SAMPLE_TEXT,
+                      title: getSectionTitle(),
                       description: SECTIONS_TEXT.SECTION.DESCRIPTION_SAMPLE_TEXT,
                       descriptions: getPlaceholderDescriptions(templateId),
                       images: getPlaceholderImages(templateId),


### PR DESCRIPTION
## JIRA or Github ticker

* [2500](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2500)

## Description

The main goal of this PR is to fix multiple UI inconsistencies in the `SingleTitleDescriptionAuthorPairs` component (Frame 633433) as reported in issue #2500. It addresses the incorrect default title, the wrong dimensions and styling of the feedback cards, and the text area behaviors to ensure the implementation matches the provided mockup.

## How it looks

<img width="1702" height="786" alt="image" src="https://github.com/user-attachments/assets/219c2ce7-23e4-4cd4-8ccc-77688313fc4e" />

<img width="1447" height="705" alt="image" src="https://github.com/user-attachments/assets/52e1547e-5afa-4310-b0ef-4f7587f06a8a" />


## Summary of change

- AddSectionModal.tsx & AddSectionModal.test.tsx: Updated the default section title to correctly display `SECTIONS_TEXT.SECTION.SINGLE_TITLE_DESCRIPTION_AUTHOR_PAIRS.DEFAULT_TITLE` instead of the generic sample text.
- DescriptionAuthorPairCard.module.scss: Refactored hardcoded CSS values (width, height, padding, border-radius, font sizes) to use CSS variables to match the mockup's dimensions and styling.
- DescriptionAuthorPairCard.tsx: Disabled `autoGrow` and adjusted the default `rows` attribute for both the description (from 4 to 2) and author (fixed to 1) text areas to constrain the card size properly.

## How to recreate changes

1. Log in as an Admin.
2. Open the "Add New Program" modal.
3. Click the "Додати нову секцію" button.
4. Use side arrows to find and select the template (Frame 633433 / SingleTitleDescriptionAuthorPairs).
5. Observe the frame: verify the title reads correctly, the block sizes match the mockup, and the text input fields do not auto-grow excessively.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a template-specific default title when creating Single Title, Description & Author sections.
  * Improved card layout customization across padding, sizing, spacing, and typography.

* **Bug Fixes**
  * Prevented description and author fields from automatically expanding.
  * Reduced the initial visible height of description fields for a more compact editing experience.

* **Tests**
  * Updated modal coverage to verify the new template-specific default title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->