### PR TITLE
Fix/issue-2922 [Partners][Admin panel] 'Заголовок' field doesn't trim whitespace characters after losing focus in the Title section

### DIFF
--- a/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.test.tsx
+++ b/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.test.tsx
@@ -75,13 +75,14 @@ jest.mock('@/components/admin/input-groups/input-with-character-limit-group/Inpu
 }));
 
 jest.mock('@/components/admin/input-groups/rich-text-input-group/RichTextInputGroup', () => ({
-    RichTextInputGroup: ({ label, value, onChange, onBlur, disabled, id, error }: any) => (
+    RichTextInputGroup: ({ label, value, onChange, onBlur, disabled, id, error, trimOnBlur }: any) => (
         <div>
             <label htmlFor={id}>{label}</label>
             <div
                 id={id}
                 contentEditable={!disabled}
                 data-testid={`${id}-rich-text`}
+                data-trimonblur={trimOnBlur ? 'true' : 'false'}
                 onInput={(e) => {
                     const target = e.target as HTMLElement;
                     onChange(target.innerHTML);
@@ -718,5 +719,11 @@ describe('PartnerBanner', () => {
 
         expect(getErrorMessage()).toBeInTheDocument();
         expect(mockedPartnersApi.updateBanner).not.toHaveBeenCalled();
+    });
+
+    it('passes trimOnBlur={true} to RichTextInputGroup for the title field', () => {
+        render(<PartnerBanner />);
+        const titleInput = getTitleInput();
+        expect(titleInput).toHaveAttribute('data-trimonblur', 'true');
     });
 });

--- a/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.tsx
+++ b/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.tsx
@@ -287,6 +287,7 @@ export const PartnerBanner = () => {
                                 maxLength={PARTNER_BANNER_VALIDATION.title.max}
                                 disabled={isDisabled}
                                 isRequired={true}
+                                trimOnBlur={true}
                             />
 
                             <InputWithCharacterLimitGroup


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2922

## Description

  This PR fixes issue #2922 where the 'Заголовок' (Title) field under the Partners page banner section in the Admin
  Panel did not automatically trim leading and trailing whitespace characters on blur (losing focus). We have enabled
  the  trimOnBlur  prop for the title input field.

  ## How it looks

  When the user enters whitespace (e.g., spaces) in the 'Заголовок' field and then shifts focus to another element:

  • The spaces are automatically trimmed.
  • The character counter updates immediately (e.g., from  2/30  back to  0/30  if only spaces were typed).

  ## Summary of change

  • Enabled the  trimOnBlur={true}  prop on the  <RichTextInputGroup>  component representing the Title input field
  in PartnerBannerForm.tsx.
  • Updated the mocked  RichTextInputGroup  in PartnerBannerForm.test.tsx to support and capture the  trimOnBlur
  prop.
  • Added a new unit test in PartnerBannerForm.test.tsx asserting that the  trimOnBlur={true}  prop is passed
  successfully to the Title field.

  ## How to recreate changes

  1. Open the Admin Panel and log in as an administrator.
  2. Navigate to the Partners ('Партнери') page.
  3. Click on the 'Заголовок' field in the Title banner section and type one or more spaces using the Spacebar.
  4. Click on another element or field to shift focus away from the input.
  5. Verify that the entered spaces are automatically removed and the counter reverts to  0/30 .

  ## CHECK LIST

  - [x]  New tests was added or existing was modified
  - [ ]  Changes has severe impact on users
  - [ ]  Changes has medium impact on users
  - [x]  Changes has light impact on users
  - [x]  Test covetage was updated
  - [x]  PR meets all conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Partner banner titles are now automatically trimmed when the title field loses focus.
  * Added coverage to verify the trimming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->