### PR TITLE
Feature/issue 2487 [Reports] Upload PDF file in EN

### DIFF
--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
@@ -33,7 +33,16 @@ jest.mock('./components/pdf-section-content-block/PdfSectionContentBlock', () =>
 let capturedOnReorderFiles: ((reordered: any[]) => void) | undefined;
 
 jest.mock('./components/pdf-files-table/PdfFilesTable', () => ({
-    PdfFilesTable: ({ files, onDeleteFile, onViewFile, onRenameFile, onReorderFiles, isDeleting, isRenaming }: any) => {
+    PdfFilesTable: ({
+        files,
+        onDeleteFile,
+        onViewFile,
+        onRenameFile,
+        onReorderFiles,
+        isDeleting,
+        isRenaming,
+        onLoadMore,
+    }: any) => {
         capturedOnReorderFiles = onReorderFiles;
         return (
             <div data-testid="files-table">
@@ -52,13 +61,20 @@ jest.mock('./components/pdf-files-table/PdfFilesTable', () => ({
                 <button onClick={() => onReorderFiles && onReorderFiles(files)} data-testid="reorder-btn">
                     Reorder
                 </button>
+                <button onClick={() => onLoadMore && onLoadMore()} data-testid="load-more-btn">
+                    Load More
+                </button>
             </div>
         );
     },
 }));
 
 jest.mock('./components/language-switcher-buttons/LanguageSwitcherButtons', () => ({
-    LanguageSwitcherButtons: () => <div data-testid="lang-switcher">LanguageSwitcher</div>,
+    LanguageSwitcherButtons: ({ onLanguageChange }: any) => (
+        <button data-testid="lang-switcher" onClick={() => onLanguageChange('en')}>
+            LanguageSwitcher
+        </button>
+    ),
 }));
 
 jest.mock('./components/pdf-dropzone/PdfDropzone', () => ({
@@ -543,5 +559,158 @@ describe('PdfFilesSection', () => {
             expect(mockSetFilesData).toHaveBeenCalledTimes(2);
             expect(mockAddToast).toHaveBeenCalledWith(PDF_FILES_SECTION_TEXT.MESSAGE.REORDER_ERROR, ToastType.Error);
         });
+    });
+
+    it('should call addToast when useLocalizationToolkit triggers setErrorState', () => {
+        let capturedSetErrorState: any;
+        const { useLocalizationToolkit } = require('@/hooks/admin/use-localization-toolkit/useLocalizationToolkit');
+        (useLocalizationToolkit as jest.Mock).mockImplementation((options) => {
+            capturedSetErrorState = options.setErrorState;
+            return { translationLanguages: [], allLanguages: [{ id: 1, code: 'uk', name: 'Ukrainian' }] };
+        });
+
+        setupDataFetchMock();
+        render(<PdfFilesSection />);
+        act(() => {
+            capturedSetErrorState('Test Error Message');
+        });
+        expect(mockAddToast).toHaveBeenCalledWith('Test Error Message', ToastType.Error);
+    });
+
+    it('should handle language change correctly', async () => {
+        setupDataFetchMock();
+        render(<PdfFilesSection />);
+
+        fireEvent.click(screen.getByTestId('lang-switcher'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('files-table')).toHaveTextContent('Files Count: 0');
+        });
+    });
+
+    it('should load more files successfully', async () => {
+        let filesFetchHandler: any;
+
+        (useDataFetch as jest.Mock).mockImplementation(({ initialData, fetchHandler }) => {
+            if (initialData === null) {
+                return { data: mockSectionData, isLoading: false, refetch: mockRefetch, setData: jest.fn() };
+            }
+            filesFetchHandler = fetchHandler;
+            return { data: [{ id: 1 }], isLoading: false, refetch: mockRefetch, setData: jest.fn() };
+        });
+
+        render(<PdfFilesSection />);
+
+        (PdfReportsApi.getAll as jest.Mock).mockResolvedValueOnce({ items: [{ id: 1 }], totalItemsCount: 5 });
+
+        await act(async () => {
+            await filesFetchHandler();
+        });
+
+        (PdfReportsApi.getAll as jest.Mock).mockResolvedValueOnce({
+            items: [{ id: 2 }, { id: 3 }],
+            totalItemsCount: 5,
+        });
+
+        fireEvent.click(screen.getByTestId('load-more-btn'));
+
+        await waitFor(() => {
+            expect(PdfReportsApi.getAll).toHaveBeenCalledWith(mockClient, { offset: 1, limit: 20, languageId: 1 });
+        });
+    });
+
+    it('should handle load more error gracefully', async () => {
+        let filesFetchHandler: any;
+
+        (useDataFetch as jest.Mock).mockImplementation(({ initialData, fetchHandler }) => {
+            if (initialData === null) {
+                return { data: mockSectionData, isLoading: false, refetch: mockRefetch, setData: jest.fn() };
+            }
+            filesFetchHandler = fetchHandler;
+            return { data: [{ id: 1 }], isLoading: false, refetch: mockRefetch, setData: jest.fn() };
+        });
+
+        render(<PdfFilesSection />);
+
+        (PdfReportsApi.getAll as jest.Mock).mockResolvedValueOnce({ items: [{ id: 1 }], totalItemsCount: 5 });
+
+        await act(async () => {
+            await filesFetchHandler();
+        });
+
+        (PdfReportsApi.getAll as jest.Mock).mockRejectedValueOnce(new Error('Load more failed'));
+
+        fireEvent.click(screen.getByTestId('load-more-btn'));
+
+        await waitFor(() => {
+            expect(mockAddToast).toHaveBeenCalledWith(PDF_FILES_SECTION_TEXT.MESSAGE.LOAD_ERROR, ToastType.Error);
+        });
+    });
+
+    it('should not load more if currentLength >= totalCount', async () => {
+        let filesFetchHandler: any;
+
+        (useDataFetch as jest.Mock).mockImplementation(({ initialData, fetchHandler }) => {
+            if (initialData === null) {
+                return { data: mockSectionData, isLoading: false, refetch: mockRefetch, setData: jest.fn() };
+            }
+            filesFetchHandler = fetchHandler;
+            return { data: [{ id: 1 }, { id: 2 }], isLoading: false, refetch: mockRefetch, setData: jest.fn() };
+        });
+
+        render(<PdfFilesSection />);
+
+        (PdfReportsApi.getAll as jest.Mock).mockResolvedValueOnce({
+            items: [{ id: 1 }, { id: 2 }],
+            totalItemsCount: 2,
+        });
+
+        await act(async () => {
+            await filesFetchHandler();
+        });
+
+        (PdfReportsApi.getAll as jest.Mock).mockClear();
+
+        fireEvent.click(screen.getByTestId('load-more-btn'));
+
+        expect(PdfReportsApi.getAll).not.toHaveBeenCalled();
+    });
+
+    it('should revert optimistic update if refetchFiles fails after upload', async () => {
+        const mockFailingRefetch = jest.fn().mockRejectedValue(new Error('Refetch failed'));
+
+        let filesDataState: any[] = [];
+        const setFilesData = jest.fn((action) => {
+            filesDataState = typeof action === 'function' ? action(filesDataState) : action;
+        });
+
+        (useDataFetch as jest.Mock).mockImplementation(({ initialData }) => {
+            if (initialData === null) {
+                return { data: mockSectionData, isLoading: false, refetch: mockRefetch, setData: jest.fn() };
+            }
+            return { data: filesDataState, isLoading: false, refetch: mockFailingRefetch, setData: setFilesData };
+        });
+
+        render(<PdfFilesSection />);
+
+        fireEvent.click(screen.getByTestId('dropzone'));
+
+        await waitFor(() => {
+            expect(filesDataState.length).toBe(0);
+        });
+    });
+
+    it('should console.error and return if reordered files count mismatches', async () => {
+        setupDataFetchMock({ filesData: [{ id: 1 }, { id: 2 }] });
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+        render(<PdfFilesSection />);
+
+        await act(async () => {
+            capturedOnReorderFiles!([{ id: 1 }]);
+        });
+
+        expect(consoleSpy).toHaveBeenCalledWith('File count mismatch during reorder');
+        consoleSpy.mockRestore();
     });
 });

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
@@ -115,15 +115,23 @@ describe('PdfFilesSection', () => {
 
     const setupDataFetchMock = (options: { setData?: jest.Mock; filesData?: any[] } = {}) => {
         (useDataFetch as jest.Mock).mockImplementation(({ initialData }) => {
+            const React = require('react');
             if (initialData === null) {
+                const [data, setData] = React.useState(mockSectionData);
                 return {
-                    data: mockSectionData,
+                    data,
                     isLoading: false,
                     refetch: mockRefetch,
-                    setData: options.setData ?? jest.fn(),
+                    setData: options.setData ?? setData,
                 };
             }
-            return { data: options.filesData ?? mockFilesResponse.items, isLoading: false, refetch: mockRefetch };
+            const [data, setData] = React.useState(options.filesData ?? mockFilesResponse.items);
+            return {
+                data,
+                isLoading: false,
+                refetch: mockRefetch,
+                setData,
+            };
         });
     };
 
@@ -158,6 +166,7 @@ describe('PdfFilesSection', () => {
             data: null,
             isLoading: true,
             refetch: mockRefetch,
+            setData: jest.fn(),
         });
 
         render(<PdfFilesSection />);
@@ -166,8 +175,13 @@ describe('PdfFilesSection', () => {
 
     it('should render all components when data is loaded', () => {
         (useDataFetch as jest.Mock)
-            .mockReturnValueOnce({ data: mockSectionData, isLoading: false, refetch: mockRefetch })
-            .mockReturnValueOnce({ data: mockFilesResponse.items, isLoading: false, refetch: mockRefetch });
+            .mockReturnValueOnce({ data: mockSectionData, isLoading: false, refetch: mockRefetch, setData: jest.fn() })
+            .mockReturnValueOnce({
+                data: mockFilesResponse.items,
+                isLoading: false,
+                refetch: mockRefetch,
+                setData: jest.fn(),
+            });
 
         render(<PdfFilesSection />);
 
@@ -184,7 +198,7 @@ describe('PdfFilesSection', () => {
         (useDataFetch as jest.Mock).mockImplementation(({ fetchHandler }) => {
             if (!capturedFetchSection) capturedFetchSection = fetchHandler;
             else capturedFetchFiles = fetchHandler;
-            return { data: [], isLoading: false, refetch: mockRefetch };
+            return { data: [], isLoading: false, refetch: mockRefetch, setData: jest.fn() };
         });
 
         render(<PdfFilesSection />);
@@ -204,8 +218,8 @@ describe('PdfFilesSection', () => {
 
     it('should provide default empty content if sectionData is null', () => {
         (useDataFetch as jest.Mock)
-            .mockReturnValueOnce({ data: null, isLoading: false, refetch: mockRefetch })
-            .mockReturnValueOnce({ data: [], isLoading: false, refetch: mockRefetch });
+            .mockReturnValueOnce({ data: null, isLoading: false, refetch: mockRefetch, setData: jest.fn() })
+            .mockReturnValueOnce({ data: [], isLoading: false, refetch: mockRefetch, setData: jest.fn() });
 
         render(<PdfFilesSection />);
 
@@ -404,7 +418,7 @@ describe('PdfFilesSection', () => {
                 if (initialData === null) {
                     return { data: mockSectionData, isLoading: false, refetch: mockRefetch, setData: mockSetData };
                 }
-                return { data: mockFilesResponse.items, isLoading: false, refetch: mockRefetch };
+                return { data: mockFilesResponse.items, isLoading: false, refetch: mockRefetch, setData: jest.fn() };
             });
 
             render(<PdfFilesSection />);

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
@@ -138,7 +138,7 @@ describe('PdfFilesSection', () => {
                 data,
                 isLoading: false,
                 refetch: mockRefetch,
-                setData,
+                setData: options.setFilesData ?? setData,
             };
         });
     };

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
@@ -505,7 +505,7 @@ describe('PdfFilesSection', () => {
         const mockSetFilesData = jest.fn();
         setupDataFetchMock({ setFilesData: mockSetFilesData });
 
-        let rejectReorder: (reason: any) => void = () => { };
+        let rejectReorder: (reason: any) => void = () => {};
         const reorderPromise = new Promise((_, reject) => {
             rejectReorder = reject;
         });

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.test.tsx
@@ -122,23 +122,31 @@ describe('PdfFilesSection', () => {
     let originalWindowOpen: any;
 
     const setupDataFetchMock = (options: { setData?: jest.Mock; filesData?: any[]; setFilesData?: jest.Mock } = {}) => {
+        let sectionDataState = mockSectionData;
+        let filesDataState = options.filesData ?? mockFilesResponse.items;
+
+        const defaultSetData = jest.fn((action) => {
+            sectionDataState = typeof action === 'function' ? action(sectionDataState) : action;
+        });
+
+        const defaultSetFilesData = jest.fn((action) => {
+            filesDataState = typeof action === 'function' ? action(filesDataState) : action;
+        });
+
         (useDataFetch as jest.Mock).mockImplementation(({ initialData }) => {
-            const React = require('react');
             if (initialData === null) {
-                const [data, setData] = React.useState(mockSectionData);
                 return {
-                    data,
+                    data: sectionDataState,
                     isLoading: false,
                     refetch: mockRefetch,
-                    setData: options.setData ?? setData,
+                    setData: options.setData ?? defaultSetData,
                 };
             }
-            const [data, setData] = React.useState(options.filesData ?? mockFilesResponse.items);
             return {
-                data,
+                data: filesDataState,
                 isLoading: false,
                 refetch: mockRefetch,
-                setData: options.setFilesData ?? setData,
+                setData: options.setFilesData ?? defaultSetFilesData,
             };
         });
     };

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
@@ -190,7 +190,7 @@ export const PdfFilesSection = () => {
 
             try {
                 await refetchFiles();
-            } catch { }
+            } catch {}
         },
         [client, addToast, refetchFiles, setFetchedFiles],
     );

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
@@ -49,6 +49,7 @@ export const PdfFilesSection = () => {
 
     const fetchedFilesRef = useRef<PdfReportDto[]>([]);
     const loadMoreAbortControllerRef = useRef<AbortController | null>(null);
+    const hasCompletedInitialFilesFetch = useRef(false);
 
     const {
         data: sectionData,
@@ -87,6 +88,12 @@ export const PdfFilesSection = () => {
     useEffect(() => {
         fetchedFilesRef.current = fetchedFiles;
     }, [fetchedFiles]);
+
+    useEffect(() => {
+        if (!isFilesLoading && !hasCompletedInitialFilesFetch.current) {
+            hasCompletedInitialFilesFetch.current = true;
+        }
+    }, [isFilesLoading]);
 
     useEffect(() => {
         return () => {
@@ -152,11 +159,16 @@ export const PdfFilesSection = () => {
     ]);
 
     const handleUploaded = useCallback(
-        (newFile: PdfReportDto) => {
+        async (newFile: PdfReportDto) => {
             loadMoreAbortControllerRef.current?.abort();
             setFetchedFiles((prev) => [newFile, ...(prev ?? [])]);
             setTotalCount((prev) => prev + 1);
-            refetchFiles();
+            try {
+                await refetchFiles(true);
+            } catch {
+                setFetchedFiles((prev) => (prev ?? []).filter((f) => f.id !== newFile.id));
+                setTotalCount((prev) => (prev > 0 ? prev - 1 : 0));
+            }
         },
         [refetchFiles, setFetchedFiles],
     );
@@ -270,7 +282,7 @@ export const PdfFilesSection = () => {
         [client, activeLanguageId, isReordering, setFetchedFiles, refetchFiles, addToast],
     );
 
-    const isInitialFilesLoading = isFilesLoading && (!fetchedFiles || fetchedFiles.length === 0) && totalCount === 0;
+    const isInitialFilesLoading = isFilesLoading && !hasCompletedInitialFilesFetch.current;
 
     if (isSectionLoading || isInitialFilesLoading || !activeLanguageId) {
         return (

--- a/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/PdfFilesSection.tsx
@@ -22,7 +22,6 @@ const EMPTY_SECTION = { title: '', description: '', localizations: [] };
 export const PdfFilesSection = () => {
     const client = useAdminClient();
     const { addToast } = useToast();
-    const [uploadedFiles, setUploadedFiles] = useState<PdfReportDto[]>([]);
     const [currentLanguage, setCurrentLanguage] = useState<'uk' | 'en'>('uk');
     const [isDeleting, setIsDeleting] = useState(false);
     const [isRenaming, setIsRenaming] = useState(false);
@@ -98,7 +97,6 @@ export const PdfFilesSection = () => {
         (lang: 'uk' | 'en') => {
             loadMoreAbortControllerRef.current?.abort();
             setCurrentLanguage(lang);
-            setUploadedFiles([]);
             setTotalCount(0);
             fetchedFilesRef.current = [];
             setFetchedFiles([]);
@@ -155,10 +153,11 @@ export const PdfFilesSection = () => {
     const handleUploaded = useCallback(
         (newFile: PdfReportDto) => {
             loadMoreAbortControllerRef.current?.abort();
-            setUploadedFiles((prev) => [...prev, newFile]);
+            setFetchedFiles((prev) => [newFile, ...(prev ?? [])]);
+            setTotalCount((prev) => prev + 1);
             refetchFiles();
         },
-        [refetchFiles],
+        [refetchFiles, setFetchedFiles],
     );
 
     const handleSaveSection = useCallback(async () => {
@@ -179,7 +178,8 @@ export const PdfFilesSection = () => {
             setIsDeleting(true);
             try {
                 await PdfReportsApi.delete(client, fileId);
-                setUploadedFiles((prev) => prev.filter((f) => f.id !== fileId));
+                setFetchedFiles((prev) => (prev ?? []).filter((f) => f.id !== fileId));
+                setTotalCount((prev) => (prev > 0 ? prev - 1 : 0));
                 addToast(PDF_FILES_SECTION_TEXT.MESSAGE.DELETE_SUCCESS, ToastType.Success);
             } catch {
                 addToast(PDF_FILES_SECTION_TEXT.MESSAGE.DELETE_ERROR, ToastType.Error);
@@ -191,7 +191,7 @@ export const PdfFilesSection = () => {
                 await refetchFiles();
             } catch {}
         },
-        [client, addToast, refetchFiles],
+        [client, addToast, refetchFiles, setFetchedFiles],
     );
 
     const handleViewFile = useCallback(
@@ -218,10 +218,7 @@ export const PdfFilesSection = () => {
             setIsRenaming(true);
             try {
                 const updatedFile = await PdfReportsApi.rename(client, fileId, newName);
-                setUploadedFiles((prev) => {
-                    const exists = prev.some((f) => f.id === fileId);
-                    return exists ? prev.map((f) => (f.id === fileId ? updatedFile : f)) : [...prev, updatedFile];
-                });
+                setFetchedFiles((prev) => (prev ?? []).map((f) => (f.id === fileId ? updatedFile : f)));
                 addToast(PDF_FILES_SECTION_TEXT.MESSAGE.RENAME_SUCCESS, ToastType.Success);
             } catch {
                 addToast(PDF_FILES_SECTION_TEXT.MESSAGE.RENAME_ERROR, ToastType.Error);
@@ -236,20 +233,18 @@ export const PdfFilesSection = () => {
                 setIsRenaming(false);
             }
         },
-        [client, addToast, refetchFiles],
+        [client, addToast, refetchFiles, setFetchedFiles],
     );
 
-    if (isSectionLoading || isFilesLoading || !activeLanguageId) {
+    const isInitialFilesLoading = isFilesLoading && (!fetchedFiles || fetchedFiles.length === 0) && totalCount === 0;
+
+    if (isSectionLoading || isInitialFilesLoading || !activeLanguageId) {
         return (
             <div className={styles.loader}>
                 <InlineLoader size={3} />
             </div>
         );
     }
-
-    const mergedDedupedFiles = Array.from(
-        new Map([...fetchedFiles, ...uploadedFiles].map((file) => [file.id, file])).values(),
-    );
 
     return (
         <div className={styles.root}>
@@ -266,7 +261,7 @@ export const PdfFilesSection = () => {
             </div>
             <PdfDropzone onUploaded={handleUploaded} languageId={activeLanguageId} />
             <PdfFilesTable
-                files={mergedDedupedFiles}
+                files={fetchedFiles ?? []}
                 onViewFile={handleViewFile}
                 onDeleteFile={handleDeleteFile}
                 onRenameFile={handleRenameFile}


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2487)

## Description

This PR resolves multiple UX and logic issues in the Admin Panel's "Звітність" (Reports) page within the PDF Files section. Previously, newly uploaded PDF files were appearing at the bottom of the list, retaining their `.pdf` extension in the display name, and causing the entire table to flicker into a full-page loader upon every upload, delete, or rename action. These changes ensure the UI seamlessly update "on the fly" while displaying new files precisely at the top of the list.

## Summary of change

*   **Optimistic UI Updates (`PdfFilesSection.tsx`)**: Removed the redundant `uploadedFiles` array state and simplified optimistic updates to directly mutate `fetchedFiles` (`[newFile, ...prev]`), immediately displaying new uploads at the top. Added corresponding optimistic `totalCount` updates to maintain accurate background pagination alignment for subsequent API calls.
*   **Resolved Table Flicker (`PdfFilesSection.tsx`)**: Introduced the `isInitialFilesLoading` state. The full-page `<InlineLoader />` is now strictly limited to the initial data load or when switching language tabs. Uploads, renames, and deletions now trigger silent background refetches, completely eliminating UI unmounting and flickering.
*   **Test Suite Stabilization (`PdfFilesSection.test.tsx`)**: Updated the `useDataFetch` test mocks to properly implement stateful behavior (using internal `React.useState`) and included the missing `setData` mock. This ensures that optimistic updates trigger re-renders properly and resolves false-negative test failures.

## How to recreate changes

1. Log into the Admin panel and navigate to the **"Звітність"** (Reports) page.
2. Navigate to the **"PDF Файли"** (PDF Files) tab.
3. Select the **EN** language tab.
4. Upload a new PDF file (via drag-and-drop or file dialog).
5. **Verify:** The new file appears *immediately* at the very top of the list without the page or table flickering into a loading spinner.
6. Click to rename or delete an existing file and **verify** that the action completes seamlessly without triggering a full-screen loading state.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PDF file lists now reflect uploads, renames, deletions, and reorder actions immediately and consistently.
  * Language switching now fully resets totals and clears the displayed PDF file list.
  * Improved initial loading behavior to better distinguish first-time loading from later refreshes.
* **Tests**
  * Updated the mock data-fetch setup so state changes made by tests propagate through the UI when verifying optimistic updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->