### PR TITLE
Fix/issue-426 [Team page][Admin panel][Functional] On-fly validation of "Ім'я та прізвище" field doesn't work, error message isn't shown.  #426

### DIFF
--- a/src/hooks/admin/use-common-member-fields/useCommonMemberFields.test.ts
+++ b/src/hooks/admin/use-common-member-fields/useCommonMemberFields.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { useCommonMemberFields } from './useCommonMemberFields';
+import { TEAM_MEMBER_VALIDATION } from '@/const/admin/team';
 
 describe('useCommonMemberFields', () => {
     const initialFormState = {
@@ -75,6 +76,108 @@ describe('useCommonMemberFields', () => {
         const newState = updaterFn({ fullName: '', description: '' });
         expect(newState.fullName).toBe('');
         expect(newState.description).toBe('Test description');
+    });
+
+    it('should report digits error immediately on fullName change, without blur', () => {
+        const { result } = renderHook(() =>
+            useCommonMemberFields({
+                formState: initialFormState,
+                setFormState,
+                setErrors,
+            }),
+        );
+
+        act(() => {
+            result.current.handleFullNameChange({
+                target: { value: 'John123' },
+            } as React.ChangeEvent<HTMLInputElement>);
+        });
+
+        expect(setErrors).toHaveBeenCalledWith(expect.any(Function));
+
+        const updaterFn = setErrors.mock.calls[0][0];
+        const newErrors = updaterFn({});
+        expect(newErrors.fullName).toEqual([TEAM_MEMBER_VALIDATION.fullName.getDigitsError()]);
+    });
+
+    it('should report invalid-chars error immediately on fullName change, without blur', () => {
+        const { result } = renderHook(() =>
+            useCommonMemberFields({
+                formState: initialFormState,
+                setFormState,
+                setErrors,
+            }),
+        );
+
+        act(() => {
+            result.current.handleFullNameChange({
+                target: { value: 'John#Doe' },
+            } as React.ChangeEvent<HTMLInputElement>);
+        });
+
+        const updaterFn = setErrors.mock.calls[0][0];
+        const newErrors = updaterFn({});
+        expect(newErrors.fullName).toEqual([TEAM_MEMBER_VALIDATION.fullName.getInvalidCharsError()]);
+    });
+
+    it('should clear fullName error on change when value becomes valid', () => {
+        const { result } = renderHook(() =>
+            useCommonMemberFields({
+                formState: initialFormState,
+                setFormState,
+                setErrors,
+            }),
+        );
+
+        act(() => {
+            result.current.handleFullNameChange({
+                target: { value: 'John Doe' },
+            } as React.ChangeEvent<HTMLInputElement>);
+        });
+
+        const updaterFn = setErrors.mock.calls[0][0];
+        const newErrors = updaterFn({ fullName: [TEAM_MEMBER_VALIDATION.fullName.getDigitsError()] });
+        expect(newErrors.fullName).toBeUndefined();
+    });
+
+    it('should report min-length error immediately on description change, without blur', () => {
+        const { result } = renderHook(() =>
+            useCommonMemberFields({
+                formState: initialFormState,
+                setFormState,
+                setErrors,
+            }),
+        );
+
+        act(() => {
+            result.current.handleDescriptionChange({
+                target: { value: 'short' },
+            } as React.ChangeEvent<HTMLTextAreaElement>);
+        });
+
+        const updaterFn = setErrors.mock.calls[0][0];
+        const newErrors = updaterFn({});
+        expect(newErrors.description).toBe(TEAM_MEMBER_VALIDATION.description.getMinError());
+    });
+
+    it('should clear description error on change when value becomes valid', () => {
+        const { result } = renderHook(() =>
+            useCommonMemberFields({
+                formState: initialFormState,
+                setFormState,
+                setErrors,
+            }),
+        );
+
+        act(() => {
+            result.current.handleDescriptionChange({
+                target: { value: 'Valid description text' },
+            } as React.ChangeEvent<HTMLTextAreaElement>);
+        });
+
+        const updaterFn = setErrors.mock.calls[0][0];
+        const newErrors = updaterFn({ description: TEAM_MEMBER_VALIDATION.description.getMinError() });
+        expect(newErrors.description).toBeUndefined();
     });
 
     it('should call handleFullNameBlur without errors', () => {

--- a/src/hooks/admin/use-common-member-fields/useCommonMemberFields.ts
+++ b/src/hooks/admin/use-common-member-fields/useCommonMemberFields.ts
@@ -26,9 +26,14 @@ export const useCommonMemberFields = <T extends CommonFormState, E extends Commo
 }: UseCommonMemberFieldsParams<T, E>) => {
     const handleFullNameChange = useCallback(
         (e: React.ChangeEvent<HTMLInputElement>) => {
-            setFormState((prev) => ({ ...prev, fullName: e.target.value }));
+            const value = e.target.value;
+            setFormState((prev) => ({ ...prev, fullName: value }));
+            setErrors((prev) => ({
+                ...prev,
+                fullName: TEAM_MEMBER_VALIDATION_FUNCTIONS.validateFullName(value, false),
+            }));
         },
-        [setFormState],
+        [setFormState, setErrors],
     );
 
     const handleFullNameBlur = useCallback(() => {
@@ -40,9 +45,14 @@ export const useCommonMemberFields = <T extends CommonFormState, E extends Commo
 
     const handleDescriptionChange = useCallback(
         (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-            setFormState((prev) => ({ ...prev, description: e.target.value }));
+            const value = e.target.value;
+            setFormState((prev) => ({ ...prev, description: value }));
+            setErrors((prev) => ({
+                ...prev,
+                description: TEAM_MEMBER_VALIDATION_FUNCTIONS.validateDescription(value, false),
+            }));
         },
-        [setFormState],
+        [setFormState, setErrors],
     );
 
     const handleDescriptionBlur = useCallback(() => {


### PR DESCRIPTION
## Github ticker

* [#426](https://github.com/ita-social-projects/VictoryCenter-Back/issues/426)

## Description

The "Ім'я та прізвище" field in the "Додати в команду" / team member form did not show validation errors ("Поле може містити лише літери, пробіли, ’ -" and "Поле не може містити цифри") while typing. The errors only appeared after the field lost focus (`blur`), because the `onChange` handler updated the form state but never ran validation — only the `onBlur` handler did.

## How it looks

https://github.com/user-attachments/assets/d71019eb-2e6d-4f04-ac6c-6ac27230c91d

## Summary of change

- `useCommonMemberFields.ts`: `handleFullNameChange` and `handleDescriptionChange` now call `TEAM_MEMBER_VALIDATION_FUNCTIONS.validateFullName` / `validateDescription` and update `setErrors` on every keystroke, in addition to the existing `onBlur` validation.
- `useCommonMemberFields.test.ts`: added tests asserting that invalid-chars, digits, and min-length errors are reported immediately via `setErrors` on `change`, without requiring `blur`, and that errors clear once the value becomes valid.

## How to recreate changes

1. Log into the Admin panel and navigate to the "Команда" page.
2. Click "Додати в команду".
3. In the "Ім'я та прізвище" field, type invalid characters (`#`, `+`, `,`) and verify the error "Поле може містити лише літери, пробіли, ’ -" appears immediately, without clicking away from the field.
4. Clear the field and type digits, and verify the error "Поле не може містити цифри" appears immediately, without clicking away from the field.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation errors for full name and description now appear immediately as users edit these fields.
  * Errors clear automatically once the entered values become valid.
  * Existing validation on leaving a field continues to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->