### PR TITLE
Fix/issue 2639 [Programs] Program Profile Does Not Navigate to Assigned Category Tab After Search

### DIFF
--- a/src/components/admin/admin-panel-toolbar/AdminPageToolbar.test.tsx
+++ b/src/components/admin/admin-panel-toolbar/AdminPageToolbar.test.tsx
@@ -209,7 +209,7 @@ describe('AdminPanelToolbar', () => {
             onSearchItemSelect(mockItems[0]);
         });
 
-        expect(mockOnSuggestionSelect).toHaveBeenCalledWith(1);
+        expect(mockOnSuggestionSelect).toHaveBeenCalledWith(1, { id: 1, name: 'Item 1' });
         expect(mockHookImplementation.resetList).toHaveBeenCalledTimes(1);
     });
 

--- a/src/components/admin/admin-panel-toolbar/AdminPageToolbar.tsx
+++ b/src/components/admin/admin-panel-toolbar/AdminPageToolbar.tsx
@@ -36,7 +36,7 @@ export interface AdminPanelToolbarProps<T> extends LocalizationToolkitProps {
     onStatusFilterChange: (statusFilter: VisibilityStatus | undefined) => void;
     onAddItem: () => void;
     AddItemButtonText: string;
-    onSuggestionSelect: (itemKey: string | number) => void;
+    onSuggestionSelect: (itemKey: string | number, item: T) => void;
     maxCharactersToSearch?: number;
 }
 
@@ -96,7 +96,7 @@ export const AdminPanelToolbar = <T,>({
 
     const onSuggestionSelected = useCallback(
         (suggestion: T) => {
-            onSuggestionSelect(getSearchItemKey(suggestion));
+            onSuggestionSelect(getSearchItemKey(suggestion), suggestion);
             resetSearchItemsList();
             setLocalSearchItems([]);
             setCurrentSearchTerm('');

--- a/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.test.tsx
+++ b/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.test.tsx
@@ -67,10 +67,16 @@ jest.mock('@/components/admin/admin-panel-toolbar/AdminPageToolbar', () => ({
         fetchSearchItems,
     }: AdminPanelToolbarProps<any>) => (
         <div data-testid="programs-toolbar">
-            <button data-testid="select-program" onClick={() => onSuggestionSelect(1)}>
+            <button
+                data-testid="select-program"
+                onClick={() => onSuggestionSelect(1, { id: 1, name: 'Alpha', categories: ['Category A'] })}
+            >
                 Select Program
             </button>
-            <button data-testid="select-program-string" onClick={() => onSuggestionSelect('1')}>
+            <button
+                data-testid="select-program-string"
+                onClick={() => onSuggestionSelect('1', { id: 1, name: 'Alpha', categories: ['Category A'] })}
+            >
                 Select Program String
             </button>
             <button
@@ -1023,6 +1029,25 @@ describe('ProgramsPageContent', () => {
 
         await waitFor(() => {
             expect(screen.getByText('Category A Updated')).toBeInTheDocument();
+        });
+    });
+
+    it('switches category tab to the one assigned to selected search result', async () => {
+        await renderAndWaitForCategoryBar();
+
+        await waitFor(() => {
+            expect(screen.getByTestId('category-1')).toBeDisabled();
+            expect(screen.getByTestId('category-2')).not.toBeDisabled();
+        });
+
+        fireEvent.click(screen.getByTestId('category-2'));
+        await waitFor(() => expect(screen.getByTestId('category-2')).toBeDisabled());
+
+        fireEvent.click(screen.getByTestId('select-program'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('category-1')).toBeDisabled();
+            expect(screen.getByTestId('category-2')).not.toBeDisabled();
         });
     });
 });

--- a/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.tsx
+++ b/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.tsx
@@ -296,13 +296,20 @@ export const ProgramsPageContent = () => {
     );
 
     const handleProgramSuggestionSelect = useCallback(
-        (programId: string | number) => {
+        (programId: string | number, item: ProgramSearchItemData) => {
             setIsSearchResultView(true);
             setSearchProgramId(typeof programId === 'string' ? parseInt(programId, 10) : programId);
             setStatusFilter(undefined);
             resetProgramsList();
+
+            if (item?.categories?.length) {
+                const cat = categories.find((c) => item.categories.includes(c.name));
+                if (cat) {
+                    setSelectedCategory(cat);
+                }
+            }
         },
-        [resetProgramsList],
+        [resetProgramsList, categories],
     );
 
     const handleSearchClear = useCallback(() => {


### PR DESCRIPTION
## Github ticker
* [#2639](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2639)

## Description
When an admin selects a program from the search suggestions dropdown, the Programs page did not switch to the category tab that the found program actually belongs to. The program details were shown, but the active category tab remained the one the search was performed from.

## How it looks
before click:
<img width="967" height="243" alt="image" src="https://github.com/user-attachments/assets/0238426a-f376-41fd-b5c3-d849a2c55335" />
after click:
<img width="981" height="292" alt="image" src="https://github.com/user-attachments/assets/873f96c7-40ab-4bf3-b4a9-7e030e44b6ef" />

## Summary of change
- `AdminPageToolbar.tsx`: extended `onSuggestionSelect` signature to pass the full selected search item (`onSuggestionSelect(itemKey, item)`), not just its id.
- `ProgramsPageContent.tsx`: `handleProgramSuggestionSelect` now matches the selected search item's categories against the loaded category list and updates `selectedCategory` accordingly.

## How to recreate changes
1. Open the admin panel → **Програми** (Programs).
2. Make sure a category (e.g. "Ветеранська програма") is selected/active.
3. In the search bar, type the name of a program that belongs to a **different** category (e.g. "Дитяча програма").
4. Select the program from the dropdown suggestions.
5. Verify that the category tab automatically switches to the program's actual category.


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Selecting a program from search results now automatically aligns the category filter with the program’s assigned category.
  * Program selections provide the full selected item details for more accurate filtering and navigation.

* **Bug Fixes**
  * Improved category tab state when navigating to a program through search results.

* **Tests**
  * Added coverage for category updates and detailed suggestion-selection data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->