### PR TITLE
Feature/issue-1141 [Who we are] Crop the image

### DIFF
--- a/src/components/admin/cropper-modal/CropperModal.scss
+++ b/src/components/admin/cropper-modal/CropperModal.scss
@@ -96,9 +96,20 @@
     width: 100%;
     max-width: 100%;
     position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 
     .ReactCrop {
         --ReactCrop-overlay-color: rgba(255, 0, 0, 1) !important;
+    }
+
+    .cropper-size-text {
+        margin-top: 1.5rem;
+        font-size: 1.125rem;
+        font-weight: 500;
+        color: colors.$grey-800;
+        text-align: center;
     }
 
     img {

--- a/src/components/admin/cropper-modal/CropperModal.scss
+++ b/src/components/admin/cropper-modal/CropperModal.scss
@@ -98,9 +98,9 @@
     position: relative;
     display: flex;
     flex-direction: column;
-    align-items: center;
 
     .ReactCrop {
+        margin: 0 auto;
         --ReactCrop-overlay-color: rgba(255, 0, 0, 1) !important;
     }
 
@@ -110,6 +110,7 @@
         font-weight: 500;
         color: colors.$grey-800;
         text-align: center;
+        display: block;
     }
 
     img {

--- a/src/components/admin/cropper-modal/CropperModal.test.tsx
+++ b/src/components/admin/cropper-modal/CropperModal.test.tsx
@@ -207,6 +207,11 @@ describe('CropModal', () => {
         expect(imgElement).toHaveAttribute('src', `data:${MockImageValue.mimeType};base64,${MockImageValue.base64}`);
     });
 
+    it('Renders the crop target size text below the image', () => {
+        render(<CropModal {...defaultProps} width={1440} height={860} />);
+        expect(screen.getByText('Розмір фото: 1440x860')).toBeInTheDocument();
+    });
+
     it('Calls onCancel when "Cancel" button is clicked', () => {
         render(<CropModal {...defaultProps} />);
         const cancelButton = screen.getByText(COMMON_TEXT_ADMIN.BUTTON.NO);

--- a/src/components/admin/cropper-modal/CropperModal.tsx
+++ b/src/components/admin/cropper-modal/CropperModal.tsx
@@ -151,31 +151,34 @@ export const CropModal = ({ src, onChange, width, height, onCancel, isOpen }: Cr
         >
             <Modal.Title>{CROPPER_CONSTANTS.TITLE}</Modal.Title>
             <Modal.Content>
-                <div className="cropper-container" style={{ display: 'flex', justifyContent: 'center' }}>
+                <div className="cropper-container">
                     {displaySrc ? (
-                        <ReactCrop
-                            crop={crop}
-                            onChange={onCropChange}
-                            onComplete={(pixelCrop) => {
-                                setCompletedCrop(pixelCrop);
-                            }}
-                            minWidth={crop?.width}
-                            maxWidth={crop?.width}
-                            minHeight={crop?.height}
-                            maxHeight={crop?.height}
-                            keepSelection
-                            aspect={aspectRatio}
-                            locked
-                        >
-                            <img
-                                ref={imgRef}
-                                src={displaySrc}
-                                crossOrigin="anonymous"
-                                alt="Crop target"
-                                onLoad={(e) => onImageLoaded(e.currentTarget)}
-                                style={{ maxWidth: '100%', maxHeight: '70vh' }}
-                            />
-                        </ReactCrop>
+                        <>
+                            <ReactCrop
+                                crop={crop}
+                                onChange={onCropChange}
+                                onComplete={(pixelCrop) => {
+                                    setCompletedCrop(pixelCrop);
+                                }}
+                                minWidth={crop?.width}
+                                maxWidth={crop?.width}
+                                minHeight={crop?.height}
+                                maxHeight={crop?.height}
+                                keepSelection
+                                aspect={aspectRatio}
+                                locked
+                            >
+                                <img
+                                    ref={imgRef}
+                                    src={displaySrc}
+                                    crossOrigin="anonymous"
+                                    alt="Crop target"
+                                    onLoad={(e) => onImageLoaded(e.currentTarget)}
+                                    style={{ maxWidth: '100%', maxHeight: '70vh' }}
+                                />
+                            </ReactCrop>
+                            <span className="cropper-size-text">{CROPPER_CONSTANTS.SIZE_LABEL(width, height)}</span>
+                        </>
                     ) : (
                         <InlineLoader size={8} />
                     )}

--- a/src/const/admin/cropper.ts
+++ b/src/const/admin/cropper.ts
@@ -1,3 +1,4 @@
 export const CROPPER_CONSTANTS = {
     TITLE: 'Редагувати фото',
+    SIZE_LABEL: (width: number, height: number) => `Розмір фото: ${width}x${height}`,
 };


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1141

## Description

  This PR implements the target image resolution helper label in the Admin Crop Modal, resolving issue #1141. When an
  administrator uploads a new image, they are now shown the required designed target dimension directly below the
  cropping container (e.g.  Розмір фото: 1440x860 ).

  ## How it looks

<img width="1207" height="887" alt="image" src="https://github.com/user-attachments/assets/ff870f37-0562-487c-97f8-7334991a61d5" />

  ## Summary of change

  • Added  SIZE_LABEL  translation formatter function inside cropper.ts.
  • Integrated size text rendering ( CROPPER_CONSTANTS.SIZE_LABEL(width, height) ) inside CropperModal.tsx beneath
  the  ReactCrop  node wrapper.
  • Structured the crop modal container as a flex column to center the elements cleanly inside CropperModal.scss and
  styled the new  .cropper-size-text  span element.
  • Added a new unit test asserting that the target size text is correctly rendered inside CropperModal.test.tsx.

  ## How to recreate changes

  1. Open the Admin Panel and log in.
  2. Go to the Who We Are page.
  3. Drag-and-drop or select a large image to upload under the Main Page section.
  4. Once the crop modal opens, observe the "Розмір фото: 1440x860" text positioned under the image and above the
  buttons.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [x]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible image size label to the cropper modal, showing the selected width and height.
  * Improved cropper layout with centered content and a clearer vertical arrangement.

* **Style**
  * Added styling for the image size information, including spacing, typography, color, and alignment.

* **Tests**
  * Added coverage verifying that the image dimensions are displayed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->