### PR TITLE
fix: address PR #501 code review findings (Donate section)

### DIFF
--- a/src/pages/public/main-page/danatation-section/DonationSection.module.scss
+++ b/src/pages/public/main-page/danatation-section/DonationSection.module.scss
@@ -27,6 +27,15 @@
     height: 100%;
     overflow: hidden;
     background: rgba(black, 0.5);
+
+    .backgroundImage,
+    .backgroundVideo {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
 }
 
 .overlay {

--- a/src/pages/public/main-page/danatation-section/DonationSection.test.tsx
+++ b/src/pages/public/main-page/danatation-section/DonationSection.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { DonationSection } from './DonationSection';
 import { PUBLIC_ROUTES } from '@/const/public/routes';
 import { MainDonationDto } from '@/types/public/main-page';
+import { useLocale } from '@/hooks/common/use-locale/useLocale';
 
 jest.mock('@/assets/videos/quote-background.webm', () => 'mocked-video.webm');
 
@@ -28,9 +29,15 @@ jest.mock('react-i18next', () => ({
     useTranslation: () => ({ t: mockT }),
 }));
 
+jest.mock('@/hooks/common/use-locale/useLocale', () => ({
+    useLocale: jest.fn(),
+}));
+
 jest.mock('../../../public/donate-page/donate-section/DonateSection', () => ({
     DonateSection: () => <div data-testid="donate-section-mock" />,
 }));
+
+const mockedUseLocale = useLocale as jest.Mock;
 
 const createDonationData = (overrides: Partial<MainDonationDto> = {}): MainDonationDto => ({
     id: 1,
@@ -43,6 +50,7 @@ const createDonationData = (overrides: Partial<MainDonationDto> = {}): MainDonat
 describe('DonationSection', () => {
     beforeEach(() => {
         mockT.mockImplementation((key: string) => translations[key] ?? key);
+        mockedUseLocale.mockReturnValue({ currentLanguage: 'uk' });
     });
 
     it('renders background video when no image is provided', () => {
@@ -58,7 +66,7 @@ describe('DonationSection', () => {
 
     it('renders background image when donationData has an image', () => {
         const { container } = render(
-            <DonationSection donationData={createDonationData({ image: '/uploaded-image.webp' })} />,
+            <DonationSection donationData={createDonationData({ image: { url: '/uploaded-image.webp' } })} />,
         );
 
         const image = screen.getByAltText('Donation Background');
@@ -107,5 +115,57 @@ describe('DonationSection', () => {
 
         expect(screen.queryByRole('heading', { level: 2 })).not.toBeInTheDocument();
         expect(screen.getByRole('link', { name: 'View more' })).toBeInTheDocument();
+    });
+
+    it('renders localized title and description when a localization matches the current language', () => {
+        mockedUseLocale.mockReturnValue({ currentLanguage: 'en' });
+
+        render(
+            <DonationSection
+                donationData={createDonationData({
+                    title: 'Донат заголовок',
+                    description: 'Опис донату',
+                    localizations: [
+                        {
+                            entityId: 1,
+                            localizationInfoDto: { id: 2, code: 'en' },
+                            translationStatus: 'Relevant' as any,
+                            title: 'Donation title (en)',
+                            description: 'Donation description (en)',
+                        },
+                    ],
+                })}
+            />,
+        );
+
+        expect(screen.getByRole('heading', { level: 2, name: 'Donation title (en)' })).toBeInTheDocument();
+        expect(screen.getByText('Donation description (en)')).toBeInTheDocument();
+        expect(screen.queryByText('Донат заголовок')).not.toBeInTheDocument();
+        expect(screen.queryByText('Опис донату')).not.toBeInTheDocument();
+    });
+
+    it('falls back to base title and description when no localization matches the current language', () => {
+        mockedUseLocale.mockReturnValue({ currentLanguage: 'en' });
+
+        render(
+            <DonationSection
+                donationData={createDonationData({
+                    title: 'Base title',
+                    description: 'Base description',
+                    localizations: [
+                        {
+                            entityId: 1,
+                            localizationInfoDto: { id: 1, code: 'uk' },
+                            translationStatus: 'Relevant' as any,
+                            title: 'Заголовок',
+                            description: 'Опис',
+                        },
+                    ],
+                })}
+            />,
+        );
+
+        expect(screen.getByRole('heading', { level: 2, name: 'Base title' })).toBeInTheDocument();
+        expect(screen.getByText('Base description')).toBeInTheDocument();
     });
 });

--- a/src/pages/public/main-page/danatation-section/DonationSection.test.tsx
+++ b/src/pages/public/main-page/danatation-section/DonationSection.test.tsx
@@ -66,7 +66,11 @@ describe('DonationSection', () => {
 
     it('renders background image when donationData has an image', () => {
         const { container } = render(
-            <DonationSection donationData={createDonationData({ image: { url: '/uploaded-image.webp' } })} />,
+            <DonationSection
+                donationData={createDonationData({
+                    image: { id: 1, url: '/uploaded-image.webp', mimeType: 'image/webp' },
+                })}
+            />,
         );
 
         const image = screen.getByAltText('Donation Background');

--- a/src/pages/public/main-page/danatation-section/DonationSection.tsx
+++ b/src/pages/public/main-page/danatation-section/DonationSection.tsx
@@ -6,18 +6,36 @@ import horseVideo from '@/assets/videos/quote-background.webm';
 import { PUBLIC_ROUTES } from '@/const/public/routes';
 import styles from './DonationSection.module.scss';
 import { MainDonationDto } from '@/types/public/main-page';
+import { useLocale } from '@/hooks/common/use-locale/useLocale';
+import { getImageSrc } from '@/utils/functions/image-helper/image-helper';
 
 interface DonationSectionProps {
     donationData: MainDonationDto | null | undefined;
 }
+
+const getLocalizedDonationTitle = (donationData: MainDonationDto, currentLanguage: string): string => {
+    const loc = donationData.localizations?.find((l) => l.localizationInfoDto?.code === currentLanguage);
+    return loc?.title ?? donationData.title ?? '';
+};
+
+const getLocalizedDonationDescription = (donationData: MainDonationDto, currentLanguage: string): string => {
+    const loc = donationData.localizations?.find((l) => l.localizationInfoDto?.code === currentLanguage);
+    return loc?.description ?? donationData.description ?? '';
+};
+
 export const DonationSection: React.FC<DonationSectionProps> = ({ donationData }) => {
     const { t } = useTranslation('mainPage');
+    const { currentLanguage } = useLocale();
+
+    const title = donationData ? getLocalizedDonationTitle(donationData, currentLanguage) : '';
+    const description = donationData ? getLocalizedDonationDescription(donationData, currentLanguage) : '';
+    const imageSrc = getImageSrc(donationData?.image);
 
     return (
         <div className={styles['donation-section']}>
             <div className={styles['video-background-container']}>
-                {donationData?.image ? (
-                    <img src={donationData?.image} alt="Donation Background" className={styles.backgroundImage} />
+                {imageSrc ? (
+                    <img src={imageSrc} alt="Donation Background" className={styles.backgroundImage} />
                 ) : (
                     <video autoPlay muted loop playsInline className={styles.backgroundVideo}>
                         <source src={horseVideo} type="video/webm" />
@@ -26,10 +44,8 @@ export const DonationSection: React.FC<DonationSectionProps> = ({ donationData }
             </div>
             <div className={styles.overlay}>
                 <div className={styles.heading}>
-                    {donationData?.title && <SafeHtml as="h2" className={styles.title} html={donationData?.title} />}
-                    {donationData?.description && (
-                        <SafeHtml as="p" className={styles.description} html={donationData?.description} />
-                    )}
+                    {title && <SafeHtml as="h2" className={styles.title} html={title} />}
+                    {description && <SafeHtml as="p" className={styles.description} html={description} />}
                 </div>
                 <div className={styles.donation}>
                     <DonateSection />

--- a/src/types/public/main-page.ts
+++ b/src/types/public/main-page.ts
@@ -63,7 +63,7 @@ export interface MainDonationDto {
     id: number;
     title?: string;
     description?: string;
-    image: any;
+    image?: Image | ImageValues | null;
     localizations?: PublicMainPageLocalizationDto[];
 }
 
@@ -74,7 +74,7 @@ export interface PublicMainPageDto {
     image?: Image | ImageValues | null;
     mainAboutUs?: PublicMainAboutUsDto | null;
     mainPartners?: PublicMainPartnersDto | null;
-    mainDonations?: MainDonationDto;
+    mainDonations?: MainDonationDto | null;
     impactStatistics?: PublicImpactStatisticDto | null;
     localizations?: PublicMainPageLocalizationDto[];
 }


### PR DESCRIPTION
## JIRA or Github ticker

- [Backend issue #2039](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2039)
- [PR #501 (original Donate section PR)](https://github.com/ita-social-projects/VictoryCenter-Client/pull/501)

## Description

<!--- Please describe the main goal of this PR and why was it created --->

Code review fixes for the Main Page Donate section introduced in #501. Three bugs were found that would have shipped silently (no build/lint/test failure) and are fixed here on top of `feature/issue-2039`:

1. `MainDonationDto.image` was typed `any` and rendered directly as an `<img>` `src`. Every sibling DTO in the same file (`PublicImpactStatisticDto`, `PublicMainPageDto`) returns image data as an `Image | ImageValues` object, not a raw string — in production this would have rendered `src="[object Object]"`.
2. `DonationSection` never read `donationData.localizations`, so the title/description always rendered the base-language field regardless of the UK/EN switch — the section would silently show the wrong language.
3. The component referenced `styles.backgroundImage` / `styles.backgroundVideo` classes that didn't exist in `DonationSection.module.scss`, so the hero background had no sizing/positioning and would not fill or crop to the container. This was masked in tests because the SCSS-module jest mock stubbed those class names as if they were real.

## How it looks

<!--- Please provide images (screenshots or screen recording) of changes --->

No visual/markup changes intended beyond correct rendering of the existing design from #501 (background image now actually sized/cropped, correct text now shown per selected language, image now actually loads instead of breaking). No new screenshots — see #501 for the section's visual design.

## Summary of change

<!--- Please specify what was changed --->

- `src/types/public/main-page.ts`: `MainDonationDto.image` changed from `any` to `Image | ImageValues | null`; `PublicMainPageDto.mainDonations` changed to `MainDonationDto | null` for consistency with sibling optional fields.
- `src/pages/public/main-page/danatation-section/DonationSection.tsx`: resolves the image via `getImageSrc()` and the title/description via a `localizations` lookup keyed on `currentLanguage` (`useLocale`), following the existing pattern in `MainStatisticsSection.tsx`.
- `src/pages/public/main-page/danatation-section/DonationSection.module.scss`: added the missing `.backgroundImage` / `.backgroundVideo` rules (`position: absolute; inset: 0; object-fit: cover;`), matching `IntroSection.module.scss`.
- `src/pages/public/main-page/danatation-section/DonationSection.test.tsx`: updated the image fixture to the new object shape, added tests for localized title/description resolution and the fallback-to-base-fields behavior.

## How to recreate changes

<!--- Please provide short step-by-step instructions on how to see changes that were implemented by this PR --->

1. Checkout this branch, run `npm start`, open the main page.
2. Confirm the Donate section's background image (when the API returns one) renders and is cropped to fill the hero area, not broken/misplaced.
3. Switch the site language (UK ⇄ EN) and confirm the Donate section's title/description update accordingly, sourced from `localizations`.
4. Run `npm run test:cover` — `DonationSection.test.tsx` and `MainPage.test.tsx` should pass, with `DonationSection.tsx` fully covered.

## CHECK LIST

- [x] New tests were added or existing were modified
- [ ] Changes have severe impact on users
- [x] Changes have medium impact on users
- [ ] Changes have light impact on users
- [x] Test coverage was updated
- [x] PR meets all conventions
