### PR TITLE
Fix: EventNewsApi slug bug and stale recommended-articles cache

### DIFF
--- a/src/pages/public/detailed-event-news-page/recommended-articles/RecommendedArticles.test.tsx
+++ b/src/pages/public/detailed-event-news-page/recommended-articles/RecommendedArticles.test.tsx
@@ -117,24 +117,4 @@ describe('RecommendedArticles', () => {
 
         expect(mockGet).toHaveBeenCalledWith('', 0, 2);
     });
-
-    // The two tests below depend on the fetchHandler test above having populated the module-level cache.
-    // Jest runs tests in file order within a describe block.
-    it('passes cached items as initialData and sets autoFetchDisabled true after cache is populated', () => {
-        const articles = [mockArticle('1'), mockArticle('2')];
-        render(<RecommendedArticles />);
-        expect(mockUseDataPaginationFetch).toHaveBeenCalledWith(
-            expect.objectContaining({
-                autoFetchDisabled: true,
-                initialData: articles,
-            }),
-        );
-    });
-
-    it('does not call EventsNewsApi.get again when cache is set', async () => {
-        render(<RecommendedArticles />);
-        const { fetchHandler } = mockUseDataPaginationFetch.mock.calls[0][0];
-        await fetchHandler({});
-        expect(mockGet).not.toHaveBeenCalled();
-    });
 });

--- a/src/pages/public/detailed-event-news-page/recommended-articles/RecommendedArticles.tsx
+++ b/src/pages/public/detailed-event-news-page/recommended-articles/RecommendedArticles.tsx
@@ -1,29 +1,21 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { EventsNews } from '@/types/public/events-news';
-import { PaginationResult } from '@/types/admin/common';
 import { LinearProgress } from '@mui/material';
 import { SingleEventNews } from '../../events-news-page/events/single-event-news/SingleEventNews';
 import { useDataPaginationFetch } from '@/hooks/admin/fetch/use-data-pagination-fetch/useDataPaginationFetch';
 import { EventsNewsApi } from '@/services/api/public/events-news/events-news-api';
 import styles from './RecommendedArticles.module.scss';
 
-let recommendedCache: PaginationResult<EventsNews> | null = null;
-
 const RecommendedArticlesBase: React.FC = () => {
     const { t } = useTranslation('eventsNewsPage');
 
-    const getEvents = useCallback(async () => {
-        if (recommendedCache) return recommendedCache;
-        const result = await EventsNewsApi.get('', 0, 2);
-        recommendedCache = result;
-        return result;
-    }, []);
+    const getEvents = useCallback(async () => EventsNewsApi.get('', 0, 2), []);
 
     const { data, isLoading, error } = useDataPaginationFetch<EventsNews>({
-        initialData: recommendedCache?.items ?? [],
+        initialData: [],
         fetchHandler: getEvents,
-        autoFetchDisabled: !!recommendedCache,
+        autoFetchDisabled: false,
         pageSize: 2,
     });
 

--- a/src/services/api/public/events-news/events-news-api.test.ts
+++ b/src/services/api/public/events-news/events-news-api.test.ts
@@ -1,7 +1,7 @@
-import { EventsNewsApi } from './events-news-api';
+import { EventsNewsApi, EventNewsApi } from './events-news-api';
 import { eventsNewsMock } from '@/utils/mock-data/public/event-news';
 
-describe('EventsNewsApi.get', () => {
+describe('events-news-api', () => {
     beforeEach(() => {
         jest.useFakeTimers();
     });
@@ -85,5 +85,25 @@ describe('EventsNewsApi.get', () => {
             items: eventsNewsMock.slice(0, 0),
             totalItemsCount: eventsNewsMock.length,
         });
+    });
+
+    it('resolves with the matching mock event when given a slug present in eventsNewsMock', async () => {
+        const targetEvent = eventsNewsMock[0];
+
+        const promise = EventNewsApi.get(targetEvent.slug);
+
+        jest.advanceTimersByTime(200);
+        await jest.runAllTimers();
+
+        await expect(promise).resolves.toEqual(targetEvent);
+    });
+
+    it('rejects with an Error when given a slug not present in eventsNewsMock', async () => {
+        const promise = EventNewsApi.get('non-existent-slug');
+
+        jest.advanceTimersByTime(200);
+        await jest.runAllTimers();
+
+        await expect(promise).rejects.toThrow('Event not found');
     });
 });

--- a/src/services/api/public/events-news/events-news-api.ts
+++ b/src/services/api/public/events-news/events-news-api.ts
@@ -28,12 +28,17 @@ export const EventsNewsApi = {
 };
 
 export const EventNewsApi = {
-    get: async (): Promise<EventsNews> => {
+    get: async (slug: string): Promise<EventsNews> => {
         // const response = await axiosInstance.get(`${API_ROUTES.EVENTS.BY_SLUG}/${slug}`);
         // return response.data;
-        return new Promise((resolve) => {
+        return new Promise((resolve, reject) => {
             setTimeout(() => {
-                resolve(eventsNewsMock.find((event) => event.slug === 'test-event') ?? eventsNewsMock[0]);
+                const event = eventsNewsMock.find((event) => event.slug === slug);
+                if (event) {
+                    resolve(event);
+                } else {
+                    reject(new Error('Event not found'));
+                }
             }, 200);
         });
     },


### PR DESCRIPTION
## JIRA or Github ticker

- Follow-up fixes found during automated code review of #453 (Feature/issue 2043 - Single news/events page)

## Description

Two bugs found while reviewing #453 before it merges into `release/1.0.0`:

1. **Critical** - `EventNewsApi.get()` ignored the `slug` argument it was called with, so every event/news detail page rendered the same hardcoded event regardless of which one the user clicked. This broke the core feature #453 adds (navigating from Events and News to a specific article).
2. **Medium** - `RecommendedArticles` cached its fetched articles in a module-level variable that persists for the entire browser tab session, so the same 2 "recommended articles" were shown on every event page for the rest of the session after the first fetch, never refreshing per article.

## How it looks

No visual/UI changes - both are data-correctness fixes. Before this PR, clicking different events from the Events and News list would all land on a detail page showing the same article's content; after this PR, each event's detail page shows its own content.

## Summary of change

- `src/services/api/public/events-news/events-news-api.ts`: `EventNewsApi.get` now accepts and uses `slug` to look up the correct mock event, rejecting with `Error('Event not found')` when no match exists (mirrors the existing `fetchProgramBySlug` pattern in `programs-api.ts`).
- `src/services/api/public/events-news/events-news-api.test.ts`: added coverage for both the resolve and reject paths of `EventNewsApi.get`; merged the two `describe` blocks for this module into one since they share identical setup/teardown.
- `src/pages/public/detailed-event-news-page/recommended-articles/RecommendedArticles.tsx`: removed the module-level `recommendedCache`; now fetches fresh on every mount, consistent with how `Events.tsx` already uses `useDataPaginationFetch` without caching.
- `src/pages/public/detailed-event-news-page/recommended-articles/RecommendedArticles.test.tsx`: removed two tests that were coupled to the removed caching behavior and relied on execution order between tests (acknowledged in their own comment).

## How to recreate changes

1. On `feature/issue-2043` (pre-fix), open the Events and News page, click "Go to the article" on two different events.
2. Notice both detail pages render identical content (same title/description/image), regardless of which event was clicked.
3. Apply this PR's changes and repeat - each event now correctly shows its own content.
4. For the second fix: visit any event detail page, then a different one - the "Recommended articles" section previously never changed after the first load; it now reflects a fresh fetch each time.

## CHECK LIST

- [x] New tests were added or existing were modified
- [ ] Changes have severe impact on users
- [x] Changes have medium impact on users
- [ ] Changes have light impact on users
- [x] Test coverage was updated
- [x] PR meets all conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)