### PR TITLE
Fix/issue-3112 [Reports] [UI]"Додати витрату" button visual design mismatches Figma mock-up

### DIFF
--- a/src/hooks/admin/use-amount-blur/useAmountBlur.ts
+++ b/src/hooks/admin/use-amount-blur/useAmountBlur.ts
@@ -7,19 +7,33 @@ import {
     validateFundsExpendituresAmount,
 } from '@/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema';
 
+export const getUsdMismatchMessage = (
+    amountUah: string,
+    amountUsd: string,
+    exchangeRate: string | null | undefined,
+): string | undefined =>
+    isUsdAmountMismatch(amountUah, amountUsd, exchangeRate)
+        ? FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH
+        : undefined;
+
 export const useAmountBlur = (exchangeRate: string | null) => {
     const [usdMismatchMessage, setUsdMismatchMessage] = useState<string | undefined>();
 
     const handleAmountBlur = useCallback(
-        (field: 'amountUah' | 'amountUsd', setFormState: React.Dispatch<React.SetStateAction<any>>) => {
+        (
+            field: 'amountUah' | 'amountUsd',
+            setFormState: React.Dispatch<React.SetStateAction<any>>,
+            suppressMismatchCheck = false,
+        ) => {
             if (field === 'amountUsd') {
                 setFormState((prev: any) => {
                     const normalizedAmountUsd = normalizeFundsExpendituresAmountInput(prev.amountUsd, true);
                     const amountUsdError = validateFundsExpendituresAmount(normalizedAmountUsd, 'blur');
 
-                    const hasMismatch = isUsdAmountMismatch(prev.amountUah, normalizedAmountUsd, exchangeRate);
                     setUsdMismatchMessage(
-                        hasMismatch ? FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH : undefined,
+                        suppressMismatchCheck
+                            ? undefined
+                            : getUsdMismatchMessage(prev.amountUah, normalizedAmountUsd, exchangeRate),
                     );
 
                     return {

--- a/src/hooks/admin/use-funds-expenditures-record-form/useFundsExpendituresRecordForm.test.ts
+++ b/src/hooks/admin/use-funds-expenditures-record-form/useFundsExpendituresRecordForm.test.ts
@@ -96,6 +96,24 @@ describe('useFundsExpendituresRecordForm', () => {
         expect(result.current.formState.amountUsd).toBe('');
     });
 
+    it('blocks submit when UAH and USD amounts mismatch the exchange rate', () => {
+        const { result } = renderUseFundsForm();
+
+        act(() => {
+            result.current.handleReportingYearChange('2026');
+            result.current.handleCategoryChange(3);
+            result.current.handleAmountChange('100');
+            result.current.handleUsdChange('15');
+        });
+
+        act(() => {
+            result.current.handleAmountBlur('amountUsd');
+        });
+
+        expect(result.current.usdMismatchMessage).toBe(FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH);
+        expect(result.current.isSubmitDisabled).toBe(true);
+    });
+
     it('blocks submit and surfaces required error when reporting year is missing', async () => {
         const onSubmit = jest.fn().mockResolvedValue(true);
         const { result } = renderUseFundsForm({ onSubmit });

--- a/src/hooks/admin/use-funds-expenditures-record-form/useFundsExpendituresRecordForm.test.ts
+++ b/src/hooks/admin/use-funds-expenditures-record-form/useFundsExpendituresRecordForm.test.ts
@@ -114,6 +114,27 @@ describe('useFundsExpendituresRecordForm', () => {
         expect(result.current.isSubmitDisabled).toBe(true);
     });
 
+    it('blocks handleConfirmAdd on mismatch even without a preceding USD blur', async () => {
+        const onSubmit = jest.fn().mockResolvedValue(true);
+        const { result } = renderUseFundsForm({ onSubmit });
+
+        act(() => {
+            result.current.handleReportingYearChange('2026');
+            result.current.handleCategoryChange(3);
+            result.current.handleAmountChange('100');
+            result.current.handleUsdChange('15');
+        });
+
+        expect(result.current.usdMismatchMessage).toBeUndefined();
+
+        await act(async () => {
+            await result.current.handleConfirmAdd();
+        });
+
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(result.current.usdMismatchMessage).toBe(FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH);
+    });
+
     it('blocks submit and surfaces required error when reporting year is missing', async () => {
         const onSubmit = jest.fn().mockResolvedValue(true);
         const { result } = renderUseFundsForm({ onSubmit });

--- a/src/hooks/admin/use-funds-expenditures-record-form/useFundsExpendituresRecordForm.ts
+++ b/src/hooks/admin/use-funds-expenditures-record-form/useFundsExpendituresRecordForm.ts
@@ -199,7 +199,8 @@ export const useFundsExpendituresRecordForm = ({
         Boolean(amountUsdValidationError) ||
         Boolean(categoryValidationError) ||
         Boolean(formState.errors.amountUah) ||
-        Boolean(formState.errors.amountUsd);
+        Boolean(formState.errors.amountUsd) ||
+        Boolean(usdMismatchMessage);
 
     const handleOpenAddConfirmation = useCallback(() => {
         setIsAddConfirmationOpen(true);

--- a/src/hooks/admin/use-funds-expenditures-record-form/useFundsExpendituresRecordForm.ts
+++ b/src/hooks/admin/use-funds-expenditures-record-form/useFundsExpendituresRecordForm.ts
@@ -11,7 +11,7 @@ import {
     validateFundsExpendituresCategory,
     validateFundsExpendituresReportingYear,
 } from '@/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema';
-import { useAmountBlur } from '@/hooks/admin/use-amount-blur/useAmountBlur';
+import { getUsdMismatchMessage, useAmountBlur } from '@/hooks/admin/use-amount-blur/useAmountBlur';
 
 interface FundsExpendituresRecordFormState {
     reportingYear: string | undefined;
@@ -157,6 +157,12 @@ export const useFundsExpendituresRecordForm = ({
             return;
         }
 
+        const mismatchMessage = getUsdMismatchMessage(normalizedAmountUah, normalizedAmountUsd, exchangeRate);
+        if (mismatchMessage) {
+            setUsdMismatchMessage(mismatchMessage);
+            return;
+        }
+
         if (!formState.categoryId) {
             return;
         }
@@ -178,7 +184,7 @@ export const useFundsExpendituresRecordForm = ({
         } finally {
             setIsSubmitting(false);
         }
-    }, [formState, getCategoryError, onSubmit, transactionType, setUsdMismatchMessage]);
+    }, [formState, getCategoryError, onSubmit, transactionType, exchangeRate, setUsdMismatchMessage]);
 
     const isDirty =
         Boolean(formState.reportingYear) ||
@@ -190,6 +196,7 @@ export const useFundsExpendituresRecordForm = ({
     const amountUsdValidationError = validateFundsExpendituresAmount(formState.amountUsd, 'save');
     const categoryValidationError = getCategoryError(formState.categoryId, 'blur');
     const reportingYearValidationError = validateFundsExpendituresReportingYear(formState.reportingYear, 'save');
+    const currentUsdMismatchMessage = getUsdMismatchMessage(formState.amountUah, formState.amountUsd, exchangeRate);
 
     const isSubmitDisabled =
         isSubmitting ||
@@ -200,7 +207,7 @@ export const useFundsExpendituresRecordForm = ({
         Boolean(categoryValidationError) ||
         Boolean(formState.errors.amountUah) ||
         Boolean(formState.errors.amountUsd) ||
-        Boolean(usdMismatchMessage);
+        Boolean(currentUsdMismatchMessage);
 
     const handleOpenAddConfirmation = useCallback(() => {
         setIsAddConfirmationOpen(true);

--- a/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.test.ts
+++ b/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.test.ts
@@ -75,9 +75,9 @@ describe('useProgramExpenseRecordForm', () => {
             result.current.handleReportingYearChange('2026');
             result.current.handleProgramChange(2);
             result.current.handleAmountChange('100');
-            result.current.handleUsdChange('10');
         });
 
+        expect(result.current.formState.amountUsd).toBe('2,5');
         expect(result.current.isSubmitDisabled).toBe(false);
     });
 
@@ -97,6 +97,26 @@ describe('useProgramExpenseRecordForm', () => {
 
         expect(result.current.usdMismatchMessage).toBe(FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH);
         expect(result.current.isSubmitDisabled).toBe(true);
+    });
+
+    it('blocks submitRecord on mismatch even without a preceding USD blur', async () => {
+        const onSubmit = jest.fn().mockResolvedValue(true);
+        const { result } = renderUseProgramExpenseForm({ onSubmit });
+
+        act(() => {
+            result.current.handleReportingYearChange('2026');
+            result.current.handleProgramChange(2);
+            result.current.handleAmountChange('100');
+            result.current.handleUsdChange('999');
+        });
+
+        expect(result.current.usdMismatchMessage).toBeUndefined();
+
+        await act(async () => {
+            await result.current.handleSave();
+        });
+
+        expect(onSubmit).not.toHaveBeenCalled();
     });
 
     it('validates amount fields on change and blur', () => {
@@ -228,6 +248,49 @@ describe('useProgramExpenseRecordForm', () => {
             });
 
             expect(result.current.isDirty).toBe(false);
+            expect(result.current.isSubmitDisabled).toBe(true);
+        });
+
+        it('does not block saving a legacy record whose stored amounts mismatch the current exchange rate, as long as amounts are untouched', async () => {
+            const onSubmit = jest.fn().mockResolvedValue(true);
+            const { result } = renderUseProgramExpenseForm({ recordToEdit, onSubmit, exchangeRate: '40' });
+
+            act(() => {
+                result.current.handleAmountBlur('amountUsd');
+            });
+
+            expect(result.current.usdMismatchMessage).toBeUndefined();
+
+            act(() => {
+                result.current.handleReportingYearChange('2026');
+            });
+
+            expect(result.current.isSubmitDisabled).toBe(false);
+
+            await act(async () => {
+                await result.current.handleSave();
+            });
+
+            expect(onSubmit).toHaveBeenCalledWith({
+                programId: 1,
+                reportingYear: '2026',
+                amountUah: '100',
+                amountUsd: '10',
+            });
+        });
+
+        it('still blocks saving a legacy record once its amounts are actively edited to mismatch the current rate', () => {
+            const { result } = renderUseProgramExpenseForm({ recordToEdit, exchangeRate: '40' });
+
+            act(() => {
+                result.current.handleUsdChange('15');
+            });
+
+            act(() => {
+                result.current.handleAmountBlur('amountUsd');
+            });
+
+            expect(result.current.usdMismatchMessage).toBe(FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH);
             expect(result.current.isSubmitDisabled).toBe(true);
         });
 

--- a/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.test.ts
+++ b/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.test.ts
@@ -81,6 +81,24 @@ describe('useProgramExpenseRecordForm', () => {
         expect(result.current.isSubmitDisabled).toBe(false);
     });
 
+    it('blocks submit when UAH and USD amounts mismatch the exchange rate', () => {
+        const { result } = renderUseProgramExpenseForm();
+
+        act(() => {
+            result.current.handleReportingYearChange('2026');
+            result.current.handleProgramChange(2);
+            result.current.handleAmountChange('100');
+            result.current.handleUsdChange('10');
+        });
+
+        act(() => {
+            result.current.handleAmountBlur('amountUsd');
+        });
+
+        expect(result.current.usdMismatchMessage).toBe(FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH);
+        expect(result.current.isSubmitDisabled).toBe(true);
+    });
+
     it('validates amount fields on change and blur', () => {
         const { result } = renderUseProgramExpenseForm();
 

--- a/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.ts
+++ b/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ProgramExpensesProgram, ProgramExpensesRecord } from '@/types/admin/reports';
 import { updateFundsAmounts } from '@/utils/functions/update-funds-amounts/update-funds-amounts';
-import { useAmountBlur } from '@/hooks/admin/use-amount-blur/useAmountBlur';
+import { getUsdMismatchMessage, useAmountBlur } from '@/hooks/admin/use-amount-blur/useAmountBlur';
 import {
     validateProgramExpenseAmount,
     validateProgramExpenseProgram,
@@ -148,8 +148,15 @@ export const useProgramExpenseRecordForm = ({
     );
 
     const handleAmountBlur = useCallback(
-        (field: 'amountUah' | 'amountUsd') => handleAmountBlurBase(field, setFormState),
-        [handleAmountBlurBase],
+        (field: 'amountUah' | 'amountUsd') => {
+            const isAmountsUnchangedFromRecord =
+                recordToEdit !== null &&
+                formState.amountUah === recordToEdit.amountUah &&
+                formState.amountUsd === recordToEdit.amountUsd;
+
+            handleAmountBlurBase(field, setFormState, isAmountsUnchangedFromRecord);
+        },
+        [handleAmountBlurBase, recordToEdit, formState.amountUah, formState.amountUsd],
     );
 
     const handleReportingYearChange = useCallback((reportingYear: string | undefined) => {
@@ -218,12 +225,21 @@ export const useProgramExpenseRecordForm = ({
 
     const isDirty = recordToEdit ? isEditModeDirty() : isCreateModeDirty();
 
+    const areAmountsUnchangedFromRecord = Boolean(
+        recordToEdit &&
+            formState.amountUah === recordToEdit.amountUah &&
+            formState.amountUsd === recordToEdit.amountUsd,
+    );
+    const currentUsdMismatchMessage = areAmountsUnchangedFromRecord
+        ? undefined
+        : getUsdMismatchMessage(formState.amountUah, formState.amountUsd, exchangeRate);
+
     const isSubmitEnabled =
         !validateProgramExpenseReportingYear(formState.reportingYear, 'save') &&
         !getProgramError(formState.programId, 'blur') &&
         !validateProgramExpenseAmount(formState.amountUah, 'save') &&
         !validateProgramExpenseAmount(formState.amountUsd, 'save') &&
-        !usdMismatchMessage &&
+        !currentUsdMismatchMessage &&
         !isSubmitting &&
         isDirty;
 
@@ -240,6 +256,11 @@ export const useProgramExpenseRecordForm = ({
     const submitRecord = useCallback(async (): Promise<boolean> => {
         if (!formState.programId || !formState.reportingYear || isSubmitting) return false;
 
+        if (currentUsdMismatchMessage) {
+            setUsdMismatchMessage(currentUsdMismatchMessage);
+            return false;
+        }
+
         setIsSubmitting(true);
         try {
             const success = await onSubmit({
@@ -252,7 +273,7 @@ export const useProgramExpenseRecordForm = ({
         } finally {
             setIsSubmitting(false);
         }
-    }, [formState, isSubmitting, onSubmit]);
+    }, [formState, isSubmitting, onSubmit, currentUsdMismatchMessage, setUsdMismatchMessage]);
 
     const handleConfirmAdd = useCallback(async () => {
         const success = await submitRecord();

--- a/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.ts
+++ b/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.ts
@@ -223,6 +223,7 @@ export const useProgramExpenseRecordForm = ({
         !getProgramError(formState.programId, 'blur') &&
         !validateProgramExpenseAmount(formState.amountUah, 'save') &&
         !validateProgramExpenseAmount(formState.amountUsd, 'save') &&
+        !usdMismatchMessage &&
         !isSubmitting &&
         isDirty;
 

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.test.tsx
@@ -330,7 +330,7 @@ describe('AddProgramExpenseRecordModal', () => {
         selectOption(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER, '2026');
         selectOption(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER, 'Program B');
         fireEvent.change(screen.getByTestId('add-program-expense-amount-uah'), { target: { value: '100' } });
-        fireEvent.change(screen.getByTestId('add-program-expense-amount-usd'), { target: { value: '999' } });
+        fireEvent.change(screen.getByTestId('add-program-expense-amount-usd'), { target: { value: '2.5' } });
         fireEvent.blur(screen.getByTestId('add-program-expense-amount-usd'));
 
         fireEvent.click(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.MODAL.ADD.SUBMIT_BUTTON }));


### PR DESCRIPTION
## JIRA or Github ticker

* [#3112](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3112)

## Description

The `Сума (USD)` field in the `Додати витрату` modal (and the `Додати витрату по програмі` modal, which shares the same logic) in the Reports section showed an inline warning `Сума в USD не відповідає сумі в UAH` when the UAH and USD amounts did not match the exchange rate, but the submit button remained enabled. The button state was derived only from field validation errors and never checked the mismatch warning, so a record with inconsistent amounts could still be submitted.

## How it looks

https://github.com/user-attachments/assets/d04328dd-9e3a-48e6-bf81-71fd8c07acad

## Summary of change

- `useFundsExpendituresRecordForm.ts`: `isSubmitDisabled` now also returns `true` when `usdMismatchMessage` is set, so the submit button is disabled while the UAH and USD amounts do not match the exchange rate.
- `useProgramExpenseRecordForm.ts`: `isSubmitEnabled` now also requires that `usdMismatchMessage` is not set, applying the same fix to the `Додати витрату по програмі` modal.
- `useFundsExpendituresRecordForm.test.ts` and `useProgramExpenseRecordForm.test.ts`: added tests asserting that `isSubmitDisabled` becomes `true` once a UAH/USD mismatch is detected on blur.
- `AddProgramExpenseRecordModal.test.tsx`: updated an existing test that used inconsistent UAH/USD test values unrelated to this scenario, so it no longer triggers the mismatch guard by accident.

## How to recreate changes

1. Log into the Admin panel and navigate to the `Звітність` page.
2. Click `Додати витрату`.
3. Enter `450` into `Сума (UAH)` (the system auto-calculates `Сума (USD)` to `10` based on a rate of `45.00`).
4. Manually change the value in `Сума (USD)` to an inconsistent amount, for example `15`, and remove focus from the field.
5. Verify the message `Сума в USD не відповідає сумі в UAH` appears and the `Додати витрату` submit button becomes disabled.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked saving/submission for both expenditure and program expense forms when UAH/USD amounts don’t match the configured exchange rate.
  * Ensured the mismatch warning is correctly shown and the submit button is disabled when a mismatch is detected (including during edit flows with previously stored “legacy” values).

* **Tests**
  * Added and expanded unit test coverage for USD/UАH exchange-rate mismatch scenarios, including cases where confirmation is attempted without a prior USD blur.
  * Updated modal coverage related to submission-pending behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->