### PR TITLE
Fix/issue-3125 [Reports] The character counter for the "Зібрані кошти" field allows 15 digits instead of the allowed 10

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -46,7 +46,7 @@ export const REPORTS_MEDIA_SETTINGS_COLLECTED_FUNDS_VALIDATION = {
         getRequiredError: () => `Заголовок обов'язковий`,
     },
     collectedAmount: {
-        max: 15,
+        max: 10,
     },
     image: {
         width: 600,


### PR DESCRIPTION
## Github ticker

* [#3125](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3125)

## Description

The `Зібрано коштів` field in the `Налаштування медіа` tab in the Reports section allowed up to 15 digits in its character counter and input, instead of the specified maximum of 10 digits.

## How it looks

<img width="3780" height="1900" alt="Screenshot 2026-07-20 170513" src="https://github.com/user-attachments/assets/0da131a6-2692-4e71-96dc-018fc7e7a135" />

## Summary of change

- `reports.ts`: `REPORTS_MEDIA_SETTINGS_COLLECTED_FUNDS_VALIDATION.collectedAmount.max` corrected from `15` to `10`, matching the specification and the equivalent `changedLives.max` limit.

## How to recreate changes

1. Log into the Admin panel and navigate to the `Звітність` page.
2. Click the `Налаштування медіа` tab.
3. Check the `Зібрано кошти` field in the `Зібрано коштів` section.
4. Verify the character counter and input now allow a maximum of 10 digits instead of 15.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the maximum allowed collected amount from 15 to 10 in media settings validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->