### PR TITLE
Fix/issue-2506 [Single Program] Application shows incorrect name for delete image pop up

### DIFF
--- a/src/const/admin/image.ts
+++ b/src/const/admin/image.ts
@@ -1,6 +1,6 @@
 export const COMMON_IMAGE_TEXT = {
     DELETE: {
-        TITLE: 'Видалити фото?',
+        TITLE: 'Видалити зображення?',
     },
 };
 


### PR DESCRIPTION
## Github ticker

* [#2506](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2506)

## Description

The delete-image confirmation popup showed the title `Видалити фото?` instead of the specified `Видалити зображення?` when deleting an image from a Program profile section (templates T-1 through T-7).

## How it looks

<img width="2477" height="965" alt="Screenshot 2026-07-21 114155" src="https://github.com/user-attachments/assets/247a86bc-906f-4c70-ba69-114171ae3076" />

## Summary of change

- `image.ts`: `COMMON_IMAGE_TEXT.DELETE.TITLE` corrected from `Видалити фото?` to `Видалити зображення?`. This is a shared constant used by `ImageInput.tsx`, so the fix applies to all image-delete confirmations across the app.

## How to recreate changes

1. Log into the Admin panel and navigate to the `Program profile` page.
2. Scroll to a section with template T-1 (or any template T-1 through T-7 that has images).
3. Click the `Edit` icon.
4. Click the `Delete` icon on an image.
5. Verify the confirmation popup now shows `Видалити зображення?` instead of `Видалити фото?`.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Ukrainian confirmation text for deleting an image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->