### PR TITLE
Fix/issue 3124 [Reports][Media Settings] The "Опублікувати" button becomes enabled after focusing and unfocusing an input field without modifying its value

### DIFF
--- a/src/pages/admin/reports/components/block-component/ReportsMediaBlock.test.tsx
+++ b/src/pages/admin/reports/components/block-component/ReportsMediaBlock.test.tsx
@@ -1,14 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import {
-    ReportsMediaBlock,
-    ReportsMediaBlockProps,
-    ReportsMediaBlockValues,
-    ReportsMediaBlockErrors,
-    ReportsMediaBlockValidationFunctions,
-} from './ReportsMediaBlock';
-import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
-import { Image, ImageValues } from '@/types/common/image';
+import { ReportsMediaBlock, ReportsMediaBlockProps, ReportsMediaBlockValues } from './ReportsMediaBlock';
 
 jest.mock(
     '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup',
@@ -25,19 +17,7 @@ jest.mock(
             error,
             isRequired,
             maxLimitWarning,
-        }: {
-            label: string;
-            id: string;
-            name: string;
-            value: string;
-            onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
-            onBlur?: (e: React.FocusEvent<HTMLTextAreaElement>) => void;
-            maxLength: number;
-            disabled: boolean;
-            error?: string;
-            isRequired?: boolean;
-            maxLimitWarning?: string;
-        }) => (
+        }: any) => (
             <div>
                 <label htmlFor={id}>
                     {isRequired && '*'}
@@ -61,19 +41,7 @@ jest.mock(
 );
 
 jest.mock('@/components/admin/image-input/ImageInput', () => ({
-    ImageInput: ({
-        onChange,
-        label,
-        setError,
-        disabled,
-        value,
-    }: {
-        onChange: (val: ImageValues | null) => void;
-        label: string;
-        setError: (err: string | null) => void;
-        disabled: boolean;
-        value: ImageValues | null;
-    }) => (
+    ImageInput: ({ onChange, label, setError, disabled, value }: any) => (
         <div data-testid="mock-image-input">
             <span>{label}</span>
             <span data-testid="mock-image-disabled">{disabled ? 'disabled' : 'enabled'}</span>
@@ -117,10 +85,13 @@ jest.mock('./ReportsMediaBlock.module.scss', () => ({
 }));
 
 describe('ReportsMediaBlock', () => {
-    const mockOnValuesChange = jest.fn();
-    const mockValidateTitle = jest.fn();
-    const mockValidateTitleEn = jest.fn();
-    const mockValidateTotalAmount = jest.fn();
+    const mockOnTitleChange = jest.fn();
+    const mockOnTitleBlur = jest.fn();
+    const mockOnTitleEnChange = jest.fn();
+    const mockOnTitleEnBlur = jest.fn();
+    const mockOnTotalAmountChange = jest.fn();
+    const mockOnImageChange = jest.fn();
+    const mockOnImageError = jest.fn();
 
     const defaultValues: ReportsMediaBlockValues = {
         title: 'Test Title',
@@ -130,17 +101,8 @@ describe('ReportsMediaBlock', () => {
         imageId: null,
     };
 
-    const defaultErrors: ReportsMediaBlockErrors = {};
-
-    const defaultValidationFunctions: ReportsMediaBlockValidationFunctions = {
-        validateTitle: mockValidateTitle,
-        validateTitleEn: mockValidateTitleEn,
-        validateTotalAmount: mockValidateTotalAmount,
-    };
-
     const defaultProps: ReportsMediaBlockProps = {
         values: defaultValues,
-        errors: defaultErrors,
         windowTitle: 'Вікно 1: Зібрано коштів',
         windowDescription: 'Фото «Репрезентативне фото»',
         descriptionTitle: 'Зібрані кошти',
@@ -149,8 +111,13 @@ describe('ReportsMediaBlock', () => {
         imageUrl: 'https://example.com/default.png',
         isValueEditable: true,
         totalAmountMaxLength: 15,
-        validationFunctions: defaultValidationFunctions,
-        onValuesChange: mockOnValuesChange,
+        onTitleChange: mockOnTitleChange,
+        onTitleBlur: mockOnTitleBlur,
+        onTitleEnChange: mockOnTitleEnChange,
+        onTitleEnBlur: mockOnTitleEnBlur,
+        onTotalAmountChange: mockOnTotalAmountChange,
+        onImageChange: mockOnImageChange,
+        onImageError: mockOnImageError,
     };
 
     const renderComponent = (overrideProps: Partial<ReportsMediaBlockProps> = {}) =>
@@ -160,315 +127,103 @@ describe('ReportsMediaBlock', () => {
         jest.clearAllMocks();
     });
 
-    describe('Rendering', () => {
-        it('should render window title and description', () => {
-            renderComponent();
-
-            expect(screen.getByText('Вікно 1: Зібрано коштів')).toBeInTheDocument();
-            expect(screen.getByText('Фото «Репрезентативне фото»')).toBeInTheDocument();
-        });
-
+    describe('Rendering and props', () => {
         it('should render title input with correct value', () => {
             renderComponent();
-
             const titleInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-title');
             expect(titleInput).toHaveValue('Test Title');
         });
 
-        it('should pass the title max length warning to the title textarea', () => {
-            renderComponent();
+        it('should display errors when provided', () => {
+            renderComponent({
+                titleError: 'Title error message',
+                totalAmountError: 'Amount error message',
+                imageError: 'Image error message',
+            });
 
-            const titleInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-title');
-            expect(titleInput).toHaveAttribute(
-                'data-max-limit-warning',
-                COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(50),
-            );
-        });
-
-        it('should render total amount input with correct value', () => {
-            renderComponent();
-
-            const valueInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-value');
-            expect(valueInput).toHaveValue('250000');
-        });
-
-        it('should render description title as label', () => {
-            renderComponent();
-
-            expect(screen.getByText(/Зібрані кошти/)).toBeInTheDocument();
-        });
-
-        it('should render image input', () => {
-            renderComponent();
-
-            expect(screen.getByTestId('mock-image-input')).toBeInTheDocument();
-        });
-
-        it('should render image input label', () => {
-            renderComponent();
-
-            expect(screen.getByText(COMMON_TEXT_ADMIN.INPUT.ADD_FILE_HERE)).toBeInTheDocument();
-        });
-    });
-
-    describe('Editing state', () => {
-        it('should always enable title input (editing mode only)', () => {
-            renderComponent();
-
-            const titleInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-title');
-            expect(titleInput).not.toBeDisabled();
-        });
-
-        it('should disable total amount input when isValueEditable is false', () => {
-            renderComponent({ isValueEditable: false });
-
-            const valueInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-value');
-            expect(valueInput).toBeDisabled();
-        });
-
-        it('should enable total amount input when isValueEditable is true', () => {
-            renderComponent({ isValueEditable: true });
-
-            const valueInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-value');
-            expect(valueInput).not.toBeDisabled();
-        });
-
-        it('should always enable image input (editing mode only)', () => {
-            renderComponent();
-
-            expect(screen.getByTestId('mock-image-disabled')).toHaveTextContent('enabled');
+            expect(screen.getByText('Title error message')).toBeInTheDocument();
+            expect(screen.getByText('Amount error message')).toBeInTheDocument();
+            expect(screen.getByText('Image error message')).toBeInTheDocument();
         });
     });
 
     describe('Title handling', () => {
-        it('should call onValuesChange with updated title and validation error on change', () => {
-            const titleError = 'Title is too short';
-            mockValidateTitle.mockReturnValue(titleError);
+        it('should call onTitleChange on change', () => {
             renderComponent();
-
             const titleInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-title');
             fireEvent.change(titleInput, { target: { value: 'New' } });
-
-            expect(mockValidateTitle).toHaveBeenCalledWith('New');
-            expect(mockOnValuesChange).toHaveBeenCalledWith({ ...defaultValues, title: 'New' }, { title: titleError });
+            expect(mockOnTitleChange).toHaveBeenCalledWith('New');
         });
 
-        it('should call onValuesChange with no error when title is valid on change', () => {
-            mockValidateTitle.mockReturnValue(undefined);
+        it('should NOT call onTitleBlur if the normalized value is identical to current value', () => {
             renderComponent();
-
-            const titleInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-title');
-            fireEvent.change(titleInput, { target: { value: 'Valid Title Text' } });
-
-            expect(mockValidateTitle).toHaveBeenCalledWith('Valid Title Text');
-            expect(mockOnValuesChange).toHaveBeenCalledWith(
-                { ...defaultValues, title: 'Valid Title Text' },
-                { title: undefined },
-            );
-        });
-
-        it('should validate title on blur', () => {
-            const titleError = "Заголовок обов'язковий";
-            mockValidateTitle.mockReturnValue(titleError);
-            renderComponent();
-
             const titleInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-title');
             fireEvent.blur(titleInput);
 
-            expect(mockValidateTitle).toHaveBeenCalledWith('Test Title');
-            expect(mockOnValuesChange).toHaveBeenCalledWith({ ...defaultValues }, { title: titleError });
+            expect(mockOnTitleBlur).not.toHaveBeenCalled();
+        });
+
+        it('should call onTitleBlur if the normalized value is different', () => {
+            renderComponent({ values: { ...defaultValues, title: '  Different  ' } });
+            const titleInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-title');
+            fireEvent.blur(titleInput);
+
+            expect(mockOnTitleBlur).toHaveBeenCalledWith('Different');
+        });
+
+        it('should call onTitleEnChange on change', () => {
+            renderComponent();
+            const titleInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-title-en');
+            fireEvent.change(titleInput, { target: { value: 'New EN' } });
+            expect(mockOnTitleEnChange).toHaveBeenCalledWith('New EN');
+        });
+
+        it('should NOT call onTitleEnBlur if the normalized value is identical to current value', () => {
+            renderComponent();
+            const titleInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-title-en');
+            fireEvent.blur(titleInput);
+
+            expect(mockOnTitleEnBlur).not.toHaveBeenCalled();
+        });
+
+        it('should call onTitleEnBlur if the normalized value is different', () => {
+            renderComponent({ values: { ...defaultValues, titleEn: '  Different EN  ' } });
+            const titleInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-title-en');
+            fireEvent.blur(titleInput);
+
+            expect(mockOnTitleEnBlur).toHaveBeenCalledWith('Different EN');
         });
     });
 
     describe('Total amount handling', () => {
-        it('should call onValuesChange with updated numeric value on change', () => {
-            mockValidateTotalAmount.mockReturnValue(undefined);
-            renderComponent({ isValueEditable: true });
-
+        it('should call onTotalAmountChange on change', () => {
+            renderComponent();
             const valueInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-value');
-            fireEvent.change(valueInput, { target: { value: '300000' } });
-
-            expect(mockValidateTotalAmount).toHaveBeenCalledWith('300000');
-            expect(mockOnValuesChange).toHaveBeenCalledWith(
-                { ...defaultValues, totalAmount: '300000' },
-                { totalAmount: undefined },
-            );
-        });
-
-        it('should call onValuesChange with validation error for invalid value', () => {
-            const valueError = 'Значення повинно бути числом';
-            mockValidateTotalAmount.mockReturnValue(valueError);
-            renderComponent({ isValueEditable: true });
-
-            const valueInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-value');
-            fireEvent.change(valueInput, { target: { value: 'abc' } });
-
-            expect(mockOnValuesChange).toHaveBeenCalledWith(
-                { ...defaultValues, totalAmount: 'abc' },
-                { totalAmount: valueError },
-            );
-        });
-
-        it('should validate total amount on blur', () => {
-            mockValidateTotalAmount.mockReturnValue(undefined);
-            renderComponent({ isValueEditable: true });
-
-            const valueInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-value');
-            fireEvent.change(valueInput, { target: { value: '250000' } });
-            jest.clearAllMocks();
-            fireEvent.change(valueInput, { target: { value: '250000 ' } });
-            jest.clearAllMocks();
-            fireEvent.blur(valueInput);
-
-            expect(mockValidateTotalAmount).toHaveBeenCalledWith('250000 ');
-            expect(mockOnValuesChange).toHaveBeenCalledWith(
-                { ...defaultValues, totalAmount: '250000 ' },
-                { totalAmount: undefined },
-            );
-        });
-
-        it('should work without validateTotalAmount function', () => {
-            renderComponent({
-                isValueEditable: true,
-                validationFunctions: { validateTitle: mockValidateTitle, validateTitleEn: mockValidateTitleEn },
-            });
-
-            const valueInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-value');
-            fireEvent.change(valueInput, { target: { value: '500' } });
-
-            expect(mockOnValuesChange).toHaveBeenCalledWith(
-                { ...defaultValues, totalAmount: '500' },
-                { totalAmount: undefined },
-            );
-        });
-
-        it('should set totalAmount maxLength from props', () => {
-            renderComponent({ totalAmountMaxLength: 10 });
-
-            const valueInput = screen.getByTestId('mock-textarea-Вікно 1: Зібрано коштів-value');
-            expect(valueInput).toHaveAttribute('maxlength', '10');
+            fireEvent.change(valueInput, { target: { value: '300' } });
+            expect(mockOnTotalAmountChange).toHaveBeenCalledWith('300');
         });
     });
 
     describe('Image handling', () => {
-        it('should call onValuesChange with new image on upload', () => {
+        it('should call onImageChange on upload', () => {
             renderComponent();
-
             fireEvent.click(screen.getByTestId('mock-image-upload'));
-
-            expect(mockOnValuesChange).toHaveBeenCalledWith(
-                {
-                    ...defaultValues,
-                    image: { base64: 'data:image/png;base64,abc123', mimeType: 'image/png' },
-                    imageId: null,
-                },
-                { image: undefined },
-            );
+            expect(mockOnImageChange).toHaveBeenCalledWith({
+                base64: 'data:image/png;base64,abc123',
+                mimeType: 'image/png',
+            });
         });
 
-        it('should clear imageId when image is cleared', () => {
-            const valuesWithImage: ReportsMediaBlockValues = {
-                ...defaultValues,
-                image: { base64: 'data:image/png;base64,abc123', mimeType: 'image/png' },
-                imageId: 5,
-            };
-            renderComponent({ values: valuesWithImage });
-
-            fireEvent.click(screen.getByTestId('mock-image-clear'));
-
-            expect(mockOnValuesChange).toHaveBeenCalledWith(
-                { ...valuesWithImage, image: null, imageId: null },
-                { image: undefined },
-            );
-        });
-
-        it('should clear imageId when new image is uploaded (pending upload replaces server image)', () => {
-            const valuesWithImageId: ReportsMediaBlockValues = {
-                ...defaultValues,
-                imageId: 10,
-            };
-            renderComponent({ values: valuesWithImageId });
-
-            fireEvent.click(screen.getByTestId('mock-image-upload'));
-
-            expect(mockOnValuesChange).toHaveBeenCalledWith(
-                {
-                    ...valuesWithImageId,
-                    image: { base64: 'data:image/png;base64,abc123', mimeType: 'image/png' },
-                    imageId: null,
-                },
-                { image: undefined },
-            );
-        });
-
-        it('should call onValuesChange with image error from setError', () => {
+        it('should call onImageError when setError is called with an error', () => {
             renderComponent();
-
             fireEvent.click(screen.getByTestId('mock-image-set-error'));
-
-            expect(mockOnValuesChange).toHaveBeenCalledWith({ ...defaultValues }, { image: 'Image too large' });
+            expect(mockOnImageError).toHaveBeenCalledWith('Image too large');
         });
 
         it('should ignore null error from setError', () => {
             renderComponent();
-
             fireEvent.click(screen.getByTestId('mock-image-clear-error'));
-
-            expect(mockOnValuesChange).not.toHaveBeenCalled();
-        });
-
-        it('should show user-uploaded image (with base64) in ImageInput', () => {
-            const userImage: ImageValues = {
-                base64: 'data:image/png;base64,userImage',
-                mimeType: 'image/png',
-            };
-            renderComponent({ values: { ...defaultValues, image: userImage } });
-
-            expect(screen.getByTestId('mock-image-value')).toHaveTextContent('has-value');
-        });
-
-        it('should not show server image (with url) in ImageInput', () => {
-            const serverImage: Image = {
-                id: 1,
-                url: 'https://example.com/image.png',
-                mimeType: 'image/png',
-            };
-            renderComponent({ values: { ...defaultValues, image: serverImage } });
-
-            expect(screen.getByTestId('mock-image-value')).toHaveTextContent('no-value');
-        });
-
-        it('should show no-value when image is null', () => {
-            renderComponent({ values: { ...defaultValues, image: null } });
-
-            expect(screen.getByTestId('mock-image-value')).toHaveTextContent('no-value');
-        });
-    });
-
-    describe('Error display', () => {
-        it('should display title error', () => {
-            renderComponent({ errors: { title: 'Title error message' } });
-
-            expect(screen.getByText('Title error message')).toBeInTheDocument();
-        });
-
-        it('should display totalAmount error via TextAreaWithCharacterLimitGroup', () => {
-            renderComponent({ errors: { totalAmount: 'Value error message' } });
-
-            const errorEl = screen.getByTestId('mock-textarea-error-Вікно 1: Зібрано коштів-value');
-            expect(errorEl).toHaveTextContent('Value error message');
-        });
-
-        it('should display image error', () => {
-            renderComponent({ errors: { image: 'Image error message' } });
-
-            expect(screen.getByText('Image error message')).toBeInTheDocument();
-        });
-
-        it('should not display errors when errors object is empty', () => {
-            renderComponent({ errors: {} });
-
-            expect(screen.queryAllByTestId('mock-input-error')).toHaveLength(0);
+            expect(mockOnImageError).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/pages/admin/reports/components/block-component/ReportsMediaBlock.tsx
+++ b/src/pages/admin/reports/components/block-component/ReportsMediaBlock.tsx
@@ -1,5 +1,5 @@
 import { Image, ImageValues } from '@/types/common/image';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback } from 'react';
 import styles from './ReportsMediaBlock.module.scss';
 import { InputError } from '@/components/admin/input-error/InputError';
 import { REPORTS_TEXT } from '@/const/admin/reports';
@@ -17,22 +17,12 @@ export interface ReportsMediaBlockValues {
     imageId: number | null;
 }
 
-export interface ReportsMediaBlockErrors {
-    title?: string;
-    titleEn?: string;
-    totalAmount?: string;
-    image?: string;
-}
-
-export interface ReportsMediaBlockValidationFunctions {
-    validateTitle: (value: string) => string | undefined;
-    validateTitleEn: (value: string) => string | undefined;
-    validateTotalAmount?: (value: number | string) => string | undefined;
-}
-
 export interface ReportsMediaBlockProps {
     values: ReportsMediaBlockValues;
-    errors: ReportsMediaBlockErrors;
+    titleError?: string;
+    titleEnError?: string;
+    totalAmountError?: string;
+    imageError?: string;
     windowTitle: string;
     windowDescription: string;
     descriptionTitle: string;
@@ -41,13 +31,21 @@ export interface ReportsMediaBlockProps {
     imageUrl: string;
     isValueEditable: boolean;
     totalAmountMaxLength: number;
-    validationFunctions: ReportsMediaBlockValidationFunctions;
-    onValuesChange: (values: ReportsMediaBlockValues, errors: ReportsMediaBlockErrors) => void;
+    onTitleChange: (value: string) => void;
+    onTitleBlur: (normalizedValue: string) => void;
+    onTitleEnChange: (value: string) => void;
+    onTitleEnBlur: (normalizedValue: string) => void;
+    onTotalAmountChange: (value: string) => void;
+    onImageChange: (value: ImageValues | null) => void;
+    onImageError: (error: string | null) => void;
 }
 
 export const ReportsMediaBlock = ({
     values,
-    errors,
+    titleError,
+    titleEnError,
+    totalAmountError,
+    imageError,
     windowTitle,
     windowDescription,
     descriptionTitle,
@@ -56,81 +54,68 @@ export const ReportsMediaBlock = ({
     imageUrl,
     isValueEditable,
     totalAmountMaxLength,
-    validationFunctions,
-    onValuesChange,
+    onTitleChange,
+    onTitleBlur,
+    onTitleEnChange,
+    onTitleEnBlur,
+    onTotalAmountChange,
+    onImageChange,
+    onImageError,
 }: ReportsMediaBlockProps) => {
-    const [localTotalAmount, setLocalTotalAmount] = useState<string>(values.totalAmount.toString());
-
-    useEffect(() => {
-        setLocalTotalAmount(values.totalAmount.toString());
-    }, [values.totalAmount]);
     const handleTitleChange = useCallback(
         (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-            const value = e.target.value;
-            const error = validationFunctions.validateTitle(value);
-            onValuesChange({ ...values, title: value }, { ...errors, title: error });
+            onTitleChange(e.target.value);
         },
-        [onValuesChange, values, errors, validationFunctions],
+        [onTitleChange],
     );
 
     const handleTitleBlur = useCallback(
         (_e: React.FocusEvent<HTMLTextAreaElement>) => {
             const normalizedTitle = getNormalizedInputText(values.title);
-            const error = validationFunctions.validateTitle(normalizedTitle);
-            onValuesChange({ ...values, title: normalizedTitle }, { ...errors, title: error });
+            if (normalizedTitle !== values.title) {
+                onTitleBlur(normalizedTitle);
+            }
         },
-        [onValuesChange, values, errors, validationFunctions],
+        [onTitleBlur, values.title],
     );
 
     const handleTitleEnChange = useCallback(
         (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-            const value = e.target.value;
-            const error = validationFunctions.validateTitleEn(value);
-            onValuesChange({ ...values, titleEn: value }, { ...errors, titleEn: error });
+            onTitleEnChange(e.target.value);
         },
-        [onValuesChange, values, errors, validationFunctions],
+        [onTitleEnChange],
     );
 
     const handleTitleEnBlur = useCallback(
         (_e: React.FocusEvent<HTMLTextAreaElement>) => {
             const normalizedTitle = getNormalizedInputText(values.titleEn);
-            const error = validationFunctions.validateTitleEn(normalizedTitle);
-            onValuesChange({ ...values, titleEn: normalizedTitle }, { ...errors, titleEn: error });
+            if (normalizedTitle !== values.titleEn) {
+                onTitleEnBlur(normalizedTitle);
+            }
         },
-        [onValuesChange, values, errors, validationFunctions],
+        [onTitleEnBlur, values.titleEn],
     );
 
     const handleTotalAmountChange = useCallback(
         (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-            const rawValue = e.target.value;
-            setLocalTotalAmount(rawValue);
-
-            const error = validationFunctions.validateTotalAmount?.(rawValue);
-            onValuesChange({ ...values, totalAmount: rawValue }, { ...errors, totalAmount: error });
+            onTotalAmountChange(e.target.value);
         },
-        [onValuesChange, values, errors, validationFunctions],
+        [onTotalAmountChange],
     );
-
-    const handleTotalAmountBlur = useCallback(() => {
-        if (String(localTotalAmount) === String(values.totalAmount)) return;
-
-        const error = validationFunctions.validateTotalAmount?.(localTotalAmount);
-        onValuesChange({ ...values, totalAmount: localTotalAmount }, { ...errors, totalAmount: error });
-    }, [onValuesChange, values, errors, validationFunctions, localTotalAmount]);
 
     const handleImageChange = useCallback(
         (value: ImageValues | null) => {
-            onValuesChange({ ...values, image: value, imageId: null }, { ...errors, image: undefined });
+            onImageChange(value);
         },
-        [onValuesChange, values, errors],
+        [onImageChange],
     );
 
-    const handleImageError = useCallback(
+    const handleImageErrorInternal = useCallback(
         (error: string | null) => {
             if (!error) return;
-            onValuesChange({ ...values }, { ...errors, image: error });
+            onImageError(error);
         },
-        [onValuesChange, values, errors],
+        [onImageError],
     );
 
     return (
@@ -156,7 +141,7 @@ export const ReportsMediaBlock = ({
                             maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
                                 REPORTS_TEXT.FORM.MAX_LENGTH.TITLE,
                             )}
-                            error={errors.title}
+                            error={titleError}
                             rows={1}
                             isRequired={true}
                             errorCounterContainerClassName={styles['error-counter']}
@@ -175,7 +160,7 @@ export const ReportsMediaBlock = ({
                             maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
                                 REPORTS_TEXT.FORM.MAX_LENGTH.TITLE,
                             )}
-                            error={errors.titleEn}
+                            error={titleEnError}
                             rows={1}
                             isRequired={true}
                             errorCounterContainerClassName={styles['error-counter']}
@@ -187,12 +172,11 @@ export const ReportsMediaBlock = ({
                             label={descriptionTitle}
                             id={`${windowTitle}-value`}
                             name={`${windowTitle}-value`}
-                            value={localTotalAmount}
+                            value={String(values.totalAmount)}
                             onChange={handleTotalAmountChange}
-                            onBlur={handleTotalAmountBlur}
                             maxLength={totalAmountMaxLength}
                             disabled={!isValueEditable}
-                            error={errors.totalAmount}
+                            error={totalAmountError}
                             rows={1}
                             isRequired={true}
                             errorCounterContainerClassName={styles['error-counter']}
@@ -208,7 +192,7 @@ export const ReportsMediaBlock = ({
                             subText={COMMON_TEXT_ADMIN.INPUT.getImageSizeSubText(imageWidth, imageHeight)}
                             value={values.image && 'base64' in values.image ? values.image : null}
                             onChange={handleImageChange}
-                            setError={handleImageError}
+                            setError={handleImageErrorInternal}
                             cropWidth={imageWidth}
                             cropHeight={imageHeight}
                             minWidth={imageWidth}
@@ -224,7 +208,7 @@ export const ReportsMediaBlock = ({
                             }}
                         />
                         <div className={styles['image-error']}>
-                            <InputError error={errors.image} />
+                            <InputError error={imageError} />
                         </div>
                     </div>
                 </div>

--- a/src/pages/admin/reports/components/media-settings/MediaSettings.test.tsx
+++ b/src/pages/admin/reports/components/media-settings/MediaSettings.test.tsx
@@ -1,5 +1,5 @@
 import React, { createRef } from 'react';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MediaSettings, MediaSettingsRef } from './MediaSettings';
 import { useDataFetch } from '@/hooks/common/use-data-fetch/useDataFetch';
@@ -7,7 +7,6 @@ import { ReportsApi } from '@/services/api/admin/reports/reports-api';
 import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
 import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextProvider';
 import { REPORTS_TEXT } from '@/const/admin/reports';
-import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { ToastType } from '@/types/admin/toast';
 import { ReportsMediaBlockProps } from '../block-component/ReportsMediaBlock';
 import { fetchDefaultImageAsImageValues } from '@/utils/functions/fetch-default-image/fetch-default-image';
@@ -28,7 +27,7 @@ let collectedFundsBlockProps: ReportsMediaBlockProps | null = null;
 let changedLivesBlockProps: ReportsMediaBlockProps | null = null;
 
 jest.mock('../block-component/ReportsMediaBlock', () => ({
-    ReportsMediaBlock: (props: ReportsMediaBlockProps) => {
+    ReportsMediaBlock: (props: any) => {
         if (props.windowTitle === 'Вікно 1: Зібрано коштів') {
             collectedFundsBlockProps = props;
         } else {
@@ -39,9 +38,6 @@ jest.mock('../block-component/ReportsMediaBlock', () => ({
             <div data-testid={`media-block-${props.windowTitle}`}>
                 <span data-testid={`title-${props.windowTitle}`}>{props.values.title}</span>
                 <span data-testid={`amount-${props.windowTitle}`}>{props.values.totalAmount}</span>
-                <span data-testid={`value-editable-${props.windowTitle}`}>
-                    {props.isValueEditable ? 'editable' : 'readonly'}
-                </span>
             </div>
         );
     },
@@ -103,7 +99,6 @@ describe('MediaSettings', () => {
     };
 
     const defaultProps = {
-        isEditing: false,
         resetCounter: 0,
         onDirtyChange: mockOnDirtyChange,
         onCancel: jest.fn(),
@@ -139,9 +134,9 @@ describe('MediaSettings', () => {
         });
     });
 
-    describe('Loading state', () => {
+    describe('Loading and Edge states', () => {
         it('should render loader when data is loading', () => {
-            mockedUseDataFetch.mockReturnValueOnce({
+            mockedUseDataFetch.mockReturnValue({
                 data: null,
                 isLoading: true,
                 error: null,
@@ -154,29 +149,23 @@ describe('MediaSettings', () => {
             expect(screen.getByTestId('inline-loader')).toBeInTheDocument();
         });
 
-        it('should not render media blocks while loading', () => {
-            mockedUseDataFetch.mockReturnValueOnce({
+        it('should handle null data gracefully', () => {
+            mockedUseDataFetch.mockReturnValue({
                 data: null,
-                isLoading: true,
+                isLoading: false,
                 error: null,
                 refetch: mockRefetch,
                 setData: mockSetData,
             });
 
             renderComponent();
-
-            expect(
-                screen.queryByTestId(`media-block-${REPORTS_TEXT.FORM.LABEL.COLLECTED_FUNDS_WINDOW}`),
-            ).not.toBeInTheDocument();
-            expect(
-                screen.queryByTestId(`media-block-${REPORTS_TEXT.FORM.LABEL.CHANGED_LIVES_WINDOW}`),
-            ).not.toBeInTheDocument();
+            expect(screen.queryByTestId('inline-loader')).not.toBeInTheDocument();
         });
     });
 
     describe('Error state', () => {
         it('should render error message and retry button when fetch fails', () => {
-            mockedUseDataFetch.mockReturnValueOnce({
+            mockedUseDataFetch.mockReturnValue({
                 data: null,
                 isLoading: false,
                 error: new Error('Failed to load'),
@@ -187,38 +176,6 @@ describe('MediaSettings', () => {
             renderComponent();
 
             expect(screen.getByText(REPORTS_TEXT.MESSAGE.FAIL_TO_FETCH_REPORTS)).toBeInTheDocument();
-            expect(screen.getByText(REPORTS_TEXT.BUTTON.TRY_AGAIN)).toBeInTheDocument();
-        });
-
-        it('should call refetch when retry button is clicked', () => {
-            mockedUseDataFetch.mockReturnValueOnce({
-                data: null,
-                isLoading: false,
-                error: new Error('Failed to load'),
-                refetch: mockRefetch,
-                setData: mockSetData,
-            });
-
-            renderComponent();
-
-            fireEvent.click(screen.getByText(REPORTS_TEXT.BUTTON.TRY_AGAIN));
-            expect(mockRefetch).toHaveBeenCalledTimes(1);
-        });
-
-        it('should not render media blocks when fetch fails', () => {
-            mockedUseDataFetch.mockReturnValueOnce({
-                data: null,
-                isLoading: false,
-                error: new Error('Failed'),
-                refetch: mockRefetch,
-                setData: mockSetData,
-            });
-
-            renderComponent();
-
-            expect(
-                screen.queryByTestId(`media-block-${REPORTS_TEXT.FORM.LABEL.COLLECTED_FUNDS_WINDOW}`),
-            ).not.toBeInTheDocument();
         });
     });
 
@@ -226,155 +183,60 @@ describe('MediaSettings', () => {
         it('should render both media blocks with fetched data', () => {
             renderComponent();
 
-            expect(
-                screen.getByTestId(`media-block-${REPORTS_TEXT.FORM.LABEL.COLLECTED_FUNDS_WINDOW}`),
-            ).toBeInTheDocument();
-            expect(
-                screen.getByTestId(`media-block-${REPORTS_TEXT.FORM.LABEL.CHANGED_LIVES_WINDOW}`),
-            ).toBeInTheDocument();
-        });
-
-        it('should pass correct values to collected funds block', () => {
-            renderComponent();
-
             expect(collectedFundsBlockProps).not.toBeNull();
             expect(collectedFundsBlockProps!.values.title).toBe('Зібрано коштів');
             expect(collectedFundsBlockProps!.values.totalAmount).toBe(0);
-            expect(collectedFundsBlockProps!.windowTitle).toBe(REPORTS_TEXT.FORM.LABEL.COLLECTED_FUNDS_WINDOW);
-            expect(collectedFundsBlockProps!.descriptionTitle).toBe(REPORTS_TEXT.FORM.LABEL.COLLECTED_FUNDS);
-            expect(collectedFundsBlockProps!.isValueEditable).toBe(false);
-        });
-
-        it('should pass correct values to changed lives block', () => {
-            renderComponent();
 
             expect(changedLivesBlockProps).not.toBeNull();
             expect(changedLivesBlockProps!.values.title).toBe('Змінено життів');
             expect(changedLivesBlockProps!.values.totalAmount).toBe(56);
-            expect(changedLivesBlockProps!.windowTitle).toBe(REPORTS_TEXT.FORM.LABEL.CHANGED_LIVES_WINDOW);
-            expect(changedLivesBlockProps!.descriptionTitle).toBe(REPORTS_TEXT.FORM.LABEL.CHANGED_LIVES);
-            expect(changedLivesBlockProps!.isValueEditable).toBe(true);
-        });
-
-        it('should pass correct image dimensions to collected funds block', () => {
-            renderComponent();
-
-            expect(collectedFundsBlockProps!.imageWidth).toBe(600);
-            expect(collectedFundsBlockProps!.imageHeight).toBe(500);
-        });
-
-        it('should pass correct image dimensions to changed lives block', () => {
-            renderComponent();
-
-            expect(changedLivesBlockProps!.imageWidth).toBe(280);
-            expect(changedLivesBlockProps!.imageHeight).toBe(890);
-        });
-
-        it('should pass window description to both blocks', () => {
-            renderComponent();
-
-            expect(collectedFundsBlockProps!.windowDescription).toBe(REPORTS_TEXT.FORM.LABEL.WINDOW_DESCRIPTION);
-            expect(changedLivesBlockProps!.windowDescription).toBe(REPORTS_TEXT.FORM.LABEL.WINDOW_DESCRIPTION);
         });
     });
 
-    describe('Change handlers', () => {
-        it('should call onDirtyChange(true) when collected funds values change', () => {
+    describe('Change handlers & Dirty state', () => {
+        it('should call onDirtyChange(true) when values change via callbacks', () => {
             renderComponent();
 
-            const newValues = {
-                title: 'New Title',
-                titleEn: 'New Title UK',
-                totalAmount: 300000,
-                image: null,
-                imageId: null,
-            };
-            const newErrors = {};
-
             act(() => {
-                collectedFundsBlockProps!.onValuesChange(newValues, newErrors);
+                collectedFundsBlockProps!.onTitleChange('New Title');
+                collectedFundsBlockProps!.onTitleBlur('New Title');
+                collectedFundsBlockProps!.onTitleEnChange('New EN Title');
+                collectedFundsBlockProps!.onTitleEnBlur('New EN Title');
+                collectedFundsBlockProps!.onTotalAmountChange('100');
+                collectedFundsBlockProps!.onImageChange({ base64: 'base64str', mimeType: 'image/jpeg' });
+                collectedFundsBlockProps!.onImageError('Error CF');
+
+                changedLivesBlockProps!.onTitleChange('New CL Title');
+                changedLivesBlockProps!.onTitleBlur('New CL Title');
+                changedLivesBlockProps!.onTitleEnChange('New CL EN');
+                changedLivesBlockProps!.onTitleEnBlur('New CL EN');
+                changedLivesBlockProps!.onTotalAmountChange('99');
+                changedLivesBlockProps!.onImageChange(null);
+                changedLivesBlockProps!.onImageError(null);
             });
 
             expect(mockOnDirtyChange).toHaveBeenCalledWith(true);
         });
 
-        it('should call onDirtyChange(true) when changed lives values change', () => {
+        it('should call onDirtyChange(false) when value reverts to original', () => {
             renderComponent();
 
-            const newValues = {
-                title: 'New Title',
-                titleEn: 'New Title UK',
-                totalAmount: 100,
-                image: null,
-                imageId: null,
-            };
-            const newErrors = {};
-
             act(() => {
-                changedLivesBlockProps!.onValuesChange(newValues, newErrors);
+                collectedFundsBlockProps!.onTitleChange('New Title');
             });
-
             expect(mockOnDirtyChange).toHaveBeenCalledWith(true);
-        });
-
-        it('should disable publish button while there are validation errors', () => {
-            renderComponent({ isPublishDisabled: false });
 
             act(() => {
-                changedLivesBlockProps!.onValuesChange(
-                    { ...changedLivesBlockProps!.values, title: '' },
-                    { title: COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED },
-                );
+                collectedFundsBlockProps!.onTitleChange('Зібрано коштів');
             });
-
-            expect(screen.getByText(REPORTS_TEXT.BUTTON.PUBLISH)).toBeDisabled();
-        });
-
-        it('should update collected funds block values after change', () => {
-            renderComponent();
-
-            const newValues = {
-                title: 'Updated Title',
-                titleEn: 'Updated Title UK',
-                totalAmount: 500000,
-                image: null,
-                imageId: null,
-            };
-            const newErrors = { title: 'Some error' };
-
-            act(() => {
-                collectedFundsBlockProps!.onValuesChange(newValues, newErrors);
-            });
-
-            expect(collectedFundsBlockProps!.values).toEqual(newValues);
-            expect(collectedFundsBlockProps!.errors).toEqual(newErrors);
-        });
-
-        it('should update changed lives block values after change', () => {
-            renderComponent();
-
-            const newValues = {
-                title: 'Updated Lives',
-                titleEn: 'Updated Lives UK',
-                totalAmount: 99,
-                image: null,
-                imageId: null,
-            };
-            const newErrors = { totalAmount: 'Invalid' };
-
-            act(() => {
-                changedLivesBlockProps!.onValuesChange(newValues, newErrors);
-            });
-
-            expect(changedLivesBlockProps!.values).toEqual(newValues);
-            expect(changedLivesBlockProps!.errors).toEqual(newErrors);
+            // JSON.stringify equality in useFormManager will mark it clean
+            expect(mockOnDirtyChange).toHaveBeenCalledWith(false);
         });
     });
 
     describe('Submit via ref (publish)', () => {
         it('should call ReportsApi.updateMediaSettings on submit', async () => {
-            const updatedData = { ...defaultMediaSettingsData };
-            mockedReportsApi.updateMediaSettings.mockResolvedValue(updatedData);
+            mockedReportsApi.updateMediaSettings.mockResolvedValue(defaultMediaSettingsData as any);
 
             const { ref } = renderComponent();
 
@@ -387,8 +249,18 @@ describe('MediaSettings', () => {
             expect(result).toBe(true);
         });
 
-        it('should show success toast after successful publish', async () => {
-            mockedReportsApi.updateMediaSettings.mockResolvedValue(defaultMediaSettingsData);
+        it('should fetch default image if no image or imageId is provided', async () => {
+            mockedReportsApi.updateMediaSettings.mockResolvedValue(defaultMediaSettingsData as any);
+            mockedUseDataFetch.mockReturnValue({
+                data: {
+                    collectedFunds: { title: '1', titleEn: '2', image: null, imageId: null },
+                    changedLives: { title: '3', titleEn: '4', changedLives: 5, image: null, imageId: null },
+                },
+                isLoading: false,
+                error: null,
+                refetch: mockRefetch,
+                setData: mockSetData,
+            });
 
             const { ref } = renderComponent();
 
@@ -396,10 +268,41 @@ describe('MediaSettings', () => {
                 await ref.current?.submit();
             });
 
-            expect(mockAddToast).toHaveBeenCalledWith(
-                COMMON_TEXT_ADMIN.MESSAGE.SUCCESSFULLY_PUBLISHED,
-                ToastType.Success,
-            );
+            expect(mockedFetchDefaultImage).toHaveBeenCalledTimes(2);
+        });
+
+        it('should return false without hitting API if validation fails', async () => {
+            jest.spyOn(
+                require('@/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema')
+                    .REPORTS_COLLECTED_FUNDS_VALIDATION_FUNCTIONS,
+                'validateTitle',
+            ).mockReturnValue('Error');
+
+            const { ref } = renderComponent();
+
+            let result: boolean | undefined;
+            await act(async () => {
+                result = await ref.current?.submit();
+            });
+
+            expect(result).toBe(false);
+            expect(mockedReportsApi.updateMediaSettings).not.toHaveBeenCalled();
+        });
+
+        it('should handle cancellation errors quietly', async () => {
+            const cancelError = new Error('Canceled');
+            cancelError.name = 'CanceledError';
+            mockedReportsApi.updateMediaSettings.mockRejectedValue(cancelError);
+
+            const { ref } = renderComponent();
+
+            let result: boolean | undefined;
+            await act(async () => {
+                result = await ref.current?.submit();
+            });
+
+            expect(result).toBe(false);
+            expect(mockAddToast).not.toHaveBeenCalled();
         });
 
         it('should show error toast when publish fails', async () => {
@@ -414,276 +317,6 @@ describe('MediaSettings', () => {
 
             expect(result).toBe(false);
             expect(mockAddToast).toHaveBeenCalledWith(REPORTS_TEXT.MESSAGE.FAIL_TO_UPDATE_REPORT, ToastType.Error);
-        });
-
-        it('should return false without showing error toast when error is CanceledError', async () => {
-            const canceledError = new Error('Canceled');
-            canceledError.name = 'CanceledError';
-            mockedReportsApi.updateMediaSettings.mockRejectedValue(canceledError);
-
-            const { ref } = renderComponent();
-
-            let result: boolean | undefined;
-            await act(async () => {
-                result = await ref.current?.submit();
-            });
-
-            expect(result).toBe(false);
-            expect(mockAddToast).not.toHaveBeenCalled();
-        });
-
-        it('should return false without showing error toast when error is AbortError', async () => {
-            const abortError = new Error('Aborted');
-            abortError.name = 'AbortError';
-            mockedReportsApi.updateMediaSettings.mockRejectedValue(abortError);
-
-            const { ref } = renderComponent();
-
-            let result: boolean | undefined;
-            await act(async () => {
-                result = await ref.current?.submit();
-            });
-
-            expect(result).toBe(false);
-            expect(mockAddToast).not.toHaveBeenCalled();
-        });
-
-        it('should pass correct data to updateMediaSettings API', async () => {
-            mockedReportsApi.updateMediaSettings.mockResolvedValue(defaultMediaSettingsData);
-
-            const { ref } = renderComponent();
-
-            await act(async () => {
-                await ref.current?.submit();
-            });
-
-            expect(mockedReportsApi.updateMediaSettings).toHaveBeenCalledWith(
-                'mock-client',
-                expect.objectContaining({
-                    collectedFunds: expect.objectContaining({
-                        title: 'Зібрано коштів',
-                    }),
-                    changedLives: expect.objectContaining({
-                        title: 'Змінено життів',
-                        changedLives: 56,
-                    }),
-                }),
-            );
-            expect(mockedReportsApi.updateMediaSettings.mock.calls[0][1].collectedFunds).not.toHaveProperty(
-                'collectedFunds',
-            );
-        });
-
-        it('should fetch default image for collected funds when no image and no imageId', async () => {
-            const noImageData = {
-                ...defaultMediaSettingsData,
-                collectedFunds: {
-                    ...defaultMediaSettingsData.collectedFunds,
-                    image: null,
-                    imageId: null,
-                },
-            };
-            mockedUseDataFetch.mockReturnValue({
-                data: noImageData,
-                isLoading: false,
-                error: null,
-                refetch: mockRefetch,
-                setData: mockSetData,
-            });
-
-            mockedReportsApi.updateMediaSettings.mockResolvedValue(noImageData);
-
-            const { ref } = renderComponent();
-
-            await act(async () => {
-                await ref.current?.submit();
-            });
-
-            expect(mockedFetchDefaultImage).toHaveBeenCalledWith('collected.webp', 600, 500);
-        });
-
-        it('should fetch default image for changed lives when no image and no imageId', async () => {
-            const noImageData = {
-                ...defaultMediaSettingsData,
-                changedLives: {
-                    ...defaultMediaSettingsData.changedLives,
-                    image: null,
-                    imageId: null,
-                },
-            };
-            mockedUseDataFetch.mockReturnValue({
-                data: noImageData,
-                isLoading: false,
-                error: null,
-                refetch: mockRefetch,
-                setData: mockSetData,
-            });
-
-            mockedReportsApi.updateMediaSettings.mockResolvedValue(noImageData);
-
-            const { ref } = renderComponent();
-
-            await act(async () => {
-                await ref.current?.submit();
-            });
-
-            expect(mockedFetchDefaultImage).toHaveBeenCalledWith('man-facing-horse-forehead.webp', 280, 890);
-        });
-
-        it('should not fetch default image when image exists', async () => {
-            mockedReportsApi.updateMediaSettings.mockResolvedValue(defaultMediaSettingsData);
-
-            const { ref } = renderComponent();
-
-            await act(async () => {
-                await ref.current?.submit();
-            });
-
-            expect(mockedFetchDefaultImage).not.toHaveBeenCalled();
-        });
-
-        it('should not fetch default image when imageId exists even if image is null', async () => {
-            const dataWithImageId = {
-                ...defaultMediaSettingsData,
-                collectedFunds: {
-                    ...defaultMediaSettingsData.collectedFunds,
-                    image: null,
-                    imageId: 5,
-                },
-            };
-            mockedUseDataFetch.mockReturnValue({
-                data: dataWithImageId,
-                isLoading: false,
-                error: null,
-                refetch: mockRefetch,
-                setData: mockSetData,
-            });
-
-            mockedReportsApi.updateMediaSettings.mockResolvedValue(dataWithImageId);
-
-            const { ref } = renderComponent();
-
-            await act(async () => {
-                await ref.current?.submit();
-            });
-
-            expect(mockedFetchDefaultImage).not.toHaveBeenCalledWith(
-                'collected.webp',
-                expect.any(Number),
-                expect.any(Number),
-            );
-        });
-
-        it('should update state with response data after successful publish', async () => {
-            const updatedData = {
-                collectedFunds: {
-                    title: 'Updated CF Title',
-                    titleEn: 'Updated CF Title UK',
-                    image: { id: 3, url: 'new-cf.jpg', mimeType: 'image/jpeg' },
-                    imageId: 3,
-                },
-                changedLives: {
-                    title: 'Updated CL Title',
-                    titleEn: 'Updated CL Title UK',
-                    changedLives: 100,
-                    image: { id: 4, url: 'new-cl.jpg', mimeType: 'image/jpeg' },
-                    imageId: 4,
-                },
-            };
-            mockedReportsApi.updateMediaSettings.mockResolvedValue(updatedData);
-
-            const { ref } = renderComponent();
-
-            await act(async () => {
-                await ref.current?.submit();
-            });
-
-            expect(collectedFundsBlockProps!.values.title).toBe('Updated CF Title');
-            expect(collectedFundsBlockProps!.values.totalAmount).toBe(0);
-            expect(changedLivesBlockProps!.values.title).toBe('Updated CL Title');
-            expect(changedLivesBlockProps!.values.totalAmount).toBe(100);
-        });
-    });
-
-    describe('Reset on resetCounter change', () => {
-        it('should sync data when mediaSettingsData changes', () => {
-            renderComponent();
-
-            expect(collectedFundsBlockProps!.values.title).toBe('Зібрано коштів');
-            expect(changedLivesBlockProps!.values.title).toBe('Змінено життів');
-        });
-    });
-
-    describe('useDataFetch configuration', () => {
-        it('should call useDataFetch with correct parameters', () => {
-            renderComponent();
-
-            expect(mockedUseDataFetch).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    initialData: expect.objectContaining({
-                        collectedFunds: expect.objectContaining({
-                            title: '',
-                        }),
-                        changedLives: expect.objectContaining({
-                            title: '',
-                            changedLives: 0,
-                        }),
-                    }),
-                    autoFetchDisabled: false,
-                }),
-            );
-        });
-    });
-
-    describe('Error toast on fetch error', () => {
-        it('should show error toast when fetch error occurs (not canceled)', () => {
-            const fetchError = new Error('Network error');
-
-            mockedUseDataFetch.mockReturnValue({
-                data: null,
-                isLoading: false,
-                error: fetchError,
-                refetch: mockRefetch,
-                setData: mockSetData,
-            });
-
-            renderComponent();
-
-            expect(mockAddToast).toHaveBeenCalledWith(REPORTS_TEXT.MESSAGE.FAIL_TO_FETCH_REPORTS, ToastType.Error);
-        });
-
-        it('should not show error toast when fetch error is CanceledError', () => {
-            const cancelError = new Error('Canceled');
-            cancelError.name = 'CanceledError';
-
-            mockedUseDataFetch.mockReturnValue({
-                data: null,
-                isLoading: false,
-                error: cancelError,
-                refetch: mockRefetch,
-                setData: mockSetData,
-            });
-
-            renderComponent();
-
-            expect(mockAddToast).not.toHaveBeenCalled();
-        });
-
-        it('should not show error toast when fetch error is AbortError', () => {
-            const abortError = new Error('Aborted');
-            abortError.name = 'AbortError';
-
-            mockedUseDataFetch.mockReturnValue({
-                data: null,
-                isLoading: false,
-                error: abortError,
-                refetch: mockRefetch,
-                setData: mockSetData,
-            });
-
-            renderComponent();
-
-            expect(mockAddToast).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/pages/admin/reports/components/media-settings/MediaSettings.tsx
+++ b/src/pages/admin/reports/components/media-settings/MediaSettings.tsx
@@ -13,12 +13,8 @@ import { ReportsMediaSettings } from '@/types/admin/reports';
 import { ToastType } from '@/types/admin/toast';
 import { Button } from '@/components/admin/button/Button';
 import axios from 'axios';
-import { forwardRef, useState, useCallback, useEffect, useImperativeHandle } from 'react';
-import {
-    ReportsMediaBlockValues,
-    ReportsMediaBlockErrors,
-    ReportsMediaBlock,
-} from '../block-component/ReportsMediaBlock';
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useMemo } from 'react';
+import { ReportsMediaBlock } from '../block-component/ReportsMediaBlock';
 import CollectedFundsImage from '@/assets/images/collected.webp';
 import ChangedLivesImage from '@/assets/images/man-facing-horse-forehead.webp';
 import styles from './MediaSettings.module.scss';
@@ -27,6 +23,9 @@ import {
     REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS,
 } from '@/validation/admin/reports-schema/reports-media-settings/reports-media-settings-schema';
 import { fetchDefaultImageAsImageValues } from '@/utils/functions/fetch-default-image/fetch-default-image';
+import { Image, ImageValues } from '@/types/common/image';
+import { useFormManager } from '@/hooks/admin/use-form-manager/useFormManager';
+import { VisibilityStatus } from '@/types/admin/common';
 
 interface MediaSettingsProps {
     resetCounter: number;
@@ -42,43 +41,89 @@ export interface MediaSettingsRef {
     submit: () => Promise<boolean>;
 }
 
-const INITIAL_BLOCK_VALUES: ReportsMediaBlockValues = {
-    title: '',
-    titleEn: '',
-    totalAmount: 0,
-    image: null,
-    imageId: null,
+export interface MediaBlockFormValues {
+    title: string;
+    titleEn: string;
+    totalAmount: number | string;
+    image: ImageValues | Image | null;
+    imageId: number | null;
+}
+
+export interface MediaSettingsFormValues {
+    collectedFunds: MediaBlockFormValues;
+    changedLives: MediaBlockFormValues;
+}
+
+export interface MediaSettingsFormErrors {
+    collectedFundsTitle?: string;
+    collectedFundsTitleEn?: string;
+    collectedFundsTotalAmount?: string;
+    collectedFundsImage?: string;
+    changedLivesTitle?: string;
+    changedLivesTitleEn?: string;
+    changedLivesTotalAmount?: string;
+    changedLivesImage?: string;
+    [key: string]: string | undefined;
+}
+
+const DEFAULT_FORM_STATE: MediaSettingsFormValues = {
+    collectedFunds: {
+        title: '',
+        titleEn: '',
+        totalAmount: 0,
+        image: null,
+        imageId: null,
+    },
+    changedLives: {
+        title: '',
+        titleEn: '',
+        totalAmount: 0,
+        image: null,
+        imageId: null,
+    },
 };
 
-const INITIAL_BLOCK_ERRORS: ReportsMediaBlockErrors = {};
+const syncValuesFromData = (data: ReportsMediaSettings | null): MediaSettingsFormValues => {
+    if (!data) return DEFAULT_FORM_STATE;
+    return {
+        collectedFunds: {
+            title: data.collectedFunds.title ?? '',
+            titleEn: data.collectedFunds.titleEn ?? '',
+            totalAmount: 0,
+            image: data.collectedFunds.image ?? null,
+            imageId: data.collectedFunds.imageId ?? null,
+        },
+        changedLives: {
+            title: data.changedLives.title ?? '',
+            titleEn: data.changedLives.titleEn ?? '',
+            totalAmount: data.changedLives.changedLives ?? 0,
+            image: data.changedLives.image ?? null,
+            imageId: data.changedLives.imageId ?? null,
+        },
+    };
+};
 
-const syncValuesFromData = (data: ReportsMediaSettings) => ({
-    collectedFunds: {
-        title: data.collectedFunds.title ?? '',
-        titleEn: data.collectedFunds.titleEn ?? '',
-        totalAmount: 0,
-        image: data.collectedFunds.image ?? null,
-        imageId: data.collectedFunds.imageId ?? null,
-    } satisfies ReportsMediaBlockValues,
-    changedLives: {
-        title: data.changedLives.title ?? '',
-        titleEn: data.changedLives.titleEn ?? '',
-        totalAmount: data.changedLives.changedLives ?? 0,
-        image: data.changedLives.image ?? null,
-        imageId: data.changedLives.imageId ?? null,
-    } satisfies ReportsMediaBlockValues,
-});
+const validateForm = (formState: MediaSettingsFormValues): MediaSettingsFormErrors => {
+    return {
+        collectedFundsTitle: REPORTS_COLLECTED_FUNDS_VALIDATION_FUNCTIONS.validateTitle(formState.collectedFunds.title),
+        collectedFundsTitleEn: REPORTS_COLLECTED_FUNDS_VALIDATION_FUNCTIONS.validateTitleEn(
+            formState.collectedFunds.titleEn,
+        ),
+        collectedFundsTotalAmount: undefined,
+        collectedFundsImage: undefined,
+        changedLivesTitle: REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTitle(formState.changedLives.title),
+        changedLivesTitleEn: REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTitleEn(formState.changedLives.titleEn),
+        changedLivesTotalAmount: REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTotalAmount(
+            formState.changedLives.totalAmount,
+        ),
+        changedLivesImage: undefined,
+    };
+};
 
 export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
     ({ resetCounter, onDirtyChange, onCancel, onPublish, isPublishDisabled, isCancelDisabled, isActive }, ref) => {
         const client = useAdminClient();
         const { addToast } = useToast();
-
-        const [collectedFundsValues, setCollectedFundsValues] = useState<ReportsMediaBlockValues>(INITIAL_BLOCK_VALUES);
-        const [collectedFundsErrors, setCollectedFundsErrors] = useState<ReportsMediaBlockErrors>(INITIAL_BLOCK_ERRORS);
-
-        const [changedLivesValues, setChangedLivesValues] = useState<ReportsMediaBlockValues>(INITIAL_BLOCK_VALUES);
-        const [changedLivesErrors, setChangedLivesErrors] = useState<ReportsMediaBlockErrors>(INITIAL_BLOCK_ERRORS);
 
         const fetchMediaSettingsHandler = useCallback(() => ReportsApi.getMediaSettings(client), [client]);
 
@@ -104,154 +149,142 @@ export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
             addToast(REPORTS_TEXT.MESSAGE.FAIL_TO_FETCH_REPORTS, ToastType.Error);
         }, [fetchError, addToast]);
 
-        useEffect(() => {
-            if (!mediaSettingsData) return;
+        const initialData = useMemo(() => syncValuesFromData(mediaSettingsData), [mediaSettingsData]);
 
-            const { collectedFunds, changedLives } = syncValuesFromData(mediaSettingsData);
-            setCollectedFundsValues(collectedFunds);
-            setCollectedFundsErrors(INITIAL_BLOCK_ERRORS);
-            setChangedLivesValues(changedLives);
-            setChangedLivesErrors(INITIAL_BLOCK_ERRORS);
-        }, [mediaSettingsData, resetCounter]);
+        const internalFormRef = useRef<any>(null);
 
-        const hasBlockErrors = (errors: ReportsMediaBlockErrors) =>
-            Boolean(Object.values(errors).find((error) => Boolean(error)));
+        const resolveSubmitPromise = useRef<((value: boolean) => void) | null>(null);
 
-        const handleCollectedFundsChange = useCallback(
-            (values: ReportsMediaBlockValues, errors: ReportsMediaBlockErrors) => {
-                setCollectedFundsValues(values);
-                setCollectedFundsErrors(errors);
-                onDirtyChange(true);
-            },
-            [onDirtyChange],
-        );
-
-        const handleChangedLivesChange = useCallback(
-            (values: ReportsMediaBlockValues, errors: ReportsMediaBlockErrors) => {
-                setChangedLivesValues(values);
-                setChangedLivesErrors(errors);
-                onDirtyChange(true);
-            },
-            [onDirtyChange],
-        );
-
-        const validateCurrentValues = useCallback((): boolean => {
-            const collectedFundsTitleEnError = REPORTS_COLLECTED_FUNDS_VALIDATION_FUNCTIONS.validateTitleEn(
-                collectedFundsValues.titleEn,
-            );
-            const collectedFundsTitleError = REPORTS_COLLECTED_FUNDS_VALIDATION_FUNCTIONS.validateTitle(
-                collectedFundsValues.title,
-            );
-            const changedLivesTitleEnError = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTitleEn(
-                changedLivesValues.titleEn,
-            );
-            const changedLivesTitleError = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTitle(
-                changedLivesValues.title,
-            );
-            const changedLivesValueError = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTotalAmount(
-                changedLivesValues.totalAmount,
-            );
-
-            const hasValidationErrors = Boolean(
-                collectedFundsTitleEnError ||
-                    collectedFundsTitleError ||
-                    changedLivesTitleEnError ||
-                    changedLivesTitleError ||
-                    changedLivesValueError,
-            );
-
-            if (!hasValidationErrors) {
-                return true;
-            }
-
-            setCollectedFundsErrors((prev) => ({
-                ...prev,
-                titleEn: collectedFundsTitleEnError,
-                title: collectedFundsTitleError,
-            }));
-            setChangedLivesErrors((prev) => ({
-                ...prev,
-                titleEn: changedLivesTitleEnError,
-                title: changedLivesTitleError,
-                totalAmount: changedLivesValueError,
-            }));
-
-            return false;
-        }, [collectedFundsValues, changedLivesValues]);
-
-        const handlePublish = useCallback(async (): Promise<boolean> => {
-            if (!validateCurrentValues()) {
-                return false;
-            }
-
-            try {
-                let collectedFundsImage = collectedFundsValues.image;
-                let collectedFundsImageId = collectedFundsValues.imageId;
-
-                if (!collectedFundsImage && !collectedFundsImageId) {
-                    collectedFundsImage = await fetchDefaultImageAsImageValues(
-                        CollectedFundsImage,
-                        REPORTS_MEDIA_SETTINGS_COLLECTED_FUNDS_VALIDATION.image.width,
-                        REPORTS_MEDIA_SETTINGS_COLLECTED_FUNDS_VALIDATION.image.height,
-                    );
-                }
-
-                let changedLivesImage = changedLivesValues.image;
-                let changedLivesImageId = changedLivesValues.imageId;
-
-                if (!changedLivesImage && !changedLivesImageId) {
-                    changedLivesImage = await fetchDefaultImageAsImageValues(
-                        ChangedLivesImage,
-                        REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.image.width,
-                        REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.image.height,
-                    );
-                }
-
-                const updated = await ReportsApi.updateMediaSettings(client, {
-                    collectedFunds: {
-                        title: collectedFundsValues.title,
-                        titleEn: collectedFundsValues.titleEn,
-                        image: collectedFundsImage,
-                        imageId: collectedFundsImageId,
-                    },
-                    changedLives: {
-                        title: changedLivesValues.title,
-                        titleEn: changedLivesValues.titleEn,
-                        changedLives: (() => {
-                            const parsed = parseInt(String(changedLivesValues.totalAmount).trim(), 10);
-                            if (isNaN(parsed)) throw new Error('changedLives is not a valid integer');
-                            return parsed;
-                        })(),
-                        image: changedLivesImage,
-                        imageId: changedLivesImageId,
-                    },
-                });
-
-                const { collectedFunds, changedLives } = syncValuesFromData(updated);
-                setCollectedFundsValues(collectedFunds);
-                setCollectedFundsErrors(INITIAL_BLOCK_ERRORS);
-                setChangedLivesValues(changedLives);
-                setChangedLivesErrors(INITIAL_BLOCK_ERRORS);
-
-                addToast(COMMON_TEXT_ADMIN.MESSAGE.SUCCESSFULLY_PUBLISHED, ToastType.Success);
-
+        const onSubmit = useCallback(
+            async (data: MediaSettingsFormValues) => {
                 try {
-                    await refetch(true);
-                } catch {
-                    // Refetch error handled by useDataFetch
-                }
+                    let collectedFundsImage = data.collectedFunds.image;
+                    let collectedFundsImageId = data.collectedFunds.imageId;
 
-                return true;
-            } catch (error: any) {
-                if (axios.isCancel?.(error) || error.name === 'CanceledError' || error.name === 'AbortError') {
-                    return false;
-                }
-                addToast(REPORTS_TEXT.MESSAGE.FAIL_TO_UPDATE_REPORT, ToastType.Error);
-                return false;
-            }
-        }, [addToast, client, collectedFundsValues, changedLivesValues, refetch, validateCurrentValues]);
+                    if (!collectedFundsImage && !collectedFundsImageId) {
+                        collectedFundsImage = await fetchDefaultImageAsImageValues(
+                            CollectedFundsImage,
+                            REPORTS_MEDIA_SETTINGS_COLLECTED_FUNDS_VALIDATION.image.width,
+                            REPORTS_MEDIA_SETTINGS_COLLECTED_FUNDS_VALIDATION.image.height,
+                        );
+                    }
 
-        useImperativeHandle(ref, () => ({ submit: handlePublish }));
+                    let changedLivesImage = data.changedLives.image;
+                    let changedLivesImageId = data.changedLives.imageId;
+
+                    if (!changedLivesImage && !changedLivesImageId) {
+                        changedLivesImage = await fetchDefaultImageAsImageValues(
+                            ChangedLivesImage,
+                            REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.image.width,
+                            REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.image.height,
+                        );
+                    }
+
+                    await ReportsApi.updateMediaSettings(client, {
+                        collectedFunds: {
+                            title: data.collectedFunds.title,
+                            titleEn: data.collectedFunds.titleEn,
+                            image: collectedFundsImage,
+                            imageId: collectedFundsImageId,
+                        },
+                        changedLives: {
+                            title: data.changedLives.title,
+                            titleEn: data.changedLives.titleEn,
+                            changedLives: (() => {
+                                const parsed = parseInt(String(data.changedLives.totalAmount).trim(), 10);
+                                if (isNaN(parsed)) throw new Error('changedLives is not a valid integer');
+                                return parsed;
+                            })(),
+                            image: changedLivesImage,
+                            imageId: changedLivesImageId,
+                        },
+                    });
+
+                    addToast(COMMON_TEXT_ADMIN.MESSAGE.SUCCESSFULLY_PUBLISHED, ToastType.Success);
+
+                    try {
+                        await refetch(true);
+                    } catch {
+                        // Refetch error handled by useDataFetch
+                    }
+
+                    if (resolveSubmitPromise.current) {
+                        resolveSubmitPromise.current(true);
+                    }
+                } catch (error: any) {
+                    if (axios.isCancel?.(error) || error.name === 'CanceledError' || error.name === 'AbortError') {
+                        if (resolveSubmitPromise.current) resolveSubmitPromise.current(false);
+                        return;
+                    }
+                    addToast(REPORTS_TEXT.MESSAGE.FAIL_TO_UPDATE_REPORT, ToastType.Error);
+                    if (resolveSubmitPromise.current) resolveSubmitPromise.current(false);
+                }
+            },
+            [client, addToast, refetch],
+        );
+
+        const { formState, setFormState, errors, setErrors, reset, isDirty, isValid } = useFormManager<
+            MediaSettingsFormValues,
+            MediaSettingsFormErrors
+        >({
+            defaultFormState: DEFAULT_FORM_STATE,
+            initialData,
+            validateForm,
+            onSubmit,
+            ref: internalFormRef,
+        });
+
+        useEffect(() => {
+            reset(initialData);
+        }, [initialData, resetCounter, reset]);
+
+        useEffect(() => {
+            onDirtyChange(isDirty());
+        }, [formState, isDirty, onDirtyChange]);
+
+        const updateField = useCallback(
+            <TBlock extends keyof MediaSettingsFormValues>(
+                block: TBlock,
+                field: keyof MediaBlockFormValues,
+                value: any,
+                blurValidationField?: keyof MediaSettingsFormErrors,
+            ) => {
+                setFormState((prev) => ({
+                    ...prev,
+                    [block]: {
+                        ...prev[block],
+                        [field]: value,
+                    },
+                }));
+                if (blurValidationField) {
+                    const newFormState = {
+                        ...formState,
+                        [block]: {
+                            ...formState[block],
+                            [field]: value,
+                        },
+                    };
+                    const validationErrors = validateForm(newFormState);
+                    setErrors((prev) => ({ ...prev, [blurValidationField]: validationErrors[blurValidationField] }));
+                }
+            },
+            [formState, setFormState, setErrors],
+        );
+
+        const handlePublishProxy = useCallback(async (): Promise<boolean> => {
+            return new Promise<boolean>((resolve) => {
+                resolveSubmitPromise.current = resolve;
+                if (!isValid(false)) {
+                    internalFormRef.current?.submit(VisibilityStatus.Published).then(() => {
+                        resolve(false);
+                    });
+                } else {
+                    internalFormRef.current?.submit(VisibilityStatus.Published);
+                }
+            });
+        }, [isValid]);
+
+        useImperativeHandle(ref, () => ({ submit: handlePublishProxy }));
 
         return (
             <div style={{ display: isActive ? 'block' : 'none' }}>
@@ -272,8 +305,11 @@ export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
                     <div>
                         <div className={styles.blocks}>
                             <ReportsMediaBlock
-                                values={collectedFundsValues}
-                                errors={collectedFundsErrors}
+                                values={formState.collectedFunds}
+                                titleError={errors.collectedFundsTitle}
+                                titleEnError={errors.collectedFundsTitleEn}
+                                totalAmountError={errors.collectedFundsTotalAmount}
+                                imageError={errors.collectedFundsImage}
                                 windowTitle={REPORTS_TEXT.FORM.LABEL.COLLECTED_FUNDS_WINDOW}
                                 windowDescription={REPORTS_TEXT.FORM.LABEL.WINDOW_DESCRIPTION}
                                 descriptionTitle={REPORTS_TEXT.FORM.LABEL.COLLECTED_FUNDS}
@@ -284,12 +320,30 @@ export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
                                 imageHeight={REPORTS_MEDIA_SETTINGS_COLLECTED_FUNDS_VALIDATION.image.height}
                                 imageUrl={CollectedFundsImage}
                                 isValueEditable={false}
-                                validationFunctions={REPORTS_COLLECTED_FUNDS_VALIDATION_FUNCTIONS}
-                                onValuesChange={handleCollectedFundsChange}
+                                onTitleChange={(v) => updateField('collectedFunds', 'title', v)}
+                                onTitleBlur={(v) => updateField('collectedFunds', 'title', v, 'collectedFundsTitle')}
+                                onTitleEnChange={(v) => updateField('collectedFunds', 'titleEn', v)}
+                                onTitleEnBlur={(v) =>
+                                    updateField('collectedFunds', 'titleEn', v, 'collectedFundsTitleEn')
+                                }
+                                onTotalAmountChange={(v) => updateField('collectedFunds', 'totalAmount', v)}
+                                onImageChange={(v) => {
+                                    setFormState((prev) => ({
+                                        ...prev,
+                                        collectedFunds: { ...prev.collectedFunds, image: v, imageId: null },
+                                    }));
+                                    setErrors((prev) => ({ ...prev, collectedFundsImage: undefined }));
+                                }}
+                                onImageError={(err) =>
+                                    setErrors((prev) => ({ ...prev, collectedFundsImage: err || undefined }))
+                                }
                             />
                             <ReportsMediaBlock
-                                values={changedLivesValues}
-                                errors={changedLivesErrors}
+                                values={formState.changedLives}
+                                titleError={errors.changedLivesTitle}
+                                titleEnError={errors.changedLivesTitleEn}
+                                totalAmountError={errors.changedLivesTotalAmount}
+                                imageError={errors.changedLivesImage}
                                 windowTitle={REPORTS_TEXT.FORM.LABEL.CHANGED_LIVES_WINDOW}
                                 windowDescription={REPORTS_TEXT.FORM.LABEL.WINDOW_DESCRIPTION}
                                 descriptionTitle={REPORTS_TEXT.FORM.LABEL.CHANGED_LIVES}
@@ -298,8 +352,25 @@ export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
                                 imageHeight={REPORTS_MEDIA_SETTINGS_CHANGED_LIVES_VALIDATION.image.height}
                                 imageUrl={ChangedLivesImage}
                                 isValueEditable={true}
-                                validationFunctions={REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS}
-                                onValuesChange={handleChangedLivesChange}
+                                onTitleChange={(v) => updateField('changedLives', 'title', v)}
+                                onTitleBlur={(v) => updateField('changedLives', 'title', v, 'changedLivesTitle')}
+                                onTitleEnChange={(v) => updateField('changedLives', 'titleEn', v)}
+                                onTitleEnBlur={(v) => updateField('changedLives', 'titleEn', v, 'changedLivesTitleEn')}
+                                onTotalAmountChange={(v) => {
+                                    updateField('changedLives', 'totalAmount', v);
+                                    const err = REPORTS_CHANGED_LIVES_VALIDATION_FUNCTIONS.validateTotalAmount(v);
+                                    setErrors((prev) => ({ ...prev, changedLivesTotalAmount: err }));
+                                }}
+                                onImageChange={(v) => {
+                                    setFormState((prev) => ({
+                                        ...prev,
+                                        changedLives: { ...prev.changedLives, image: v, imageId: null },
+                                    }));
+                                    setErrors((prev) => ({ ...prev, changedLivesImage: undefined }));
+                                }}
+                                onImageError={(err) =>
+                                    setErrors((prev) => ({ ...prev, changedLivesImage: err || undefined }))
+                                }
                             />
                         </div>
                         <div className={styles.actions}>
@@ -315,11 +386,7 @@ export const MediaSettings = forwardRef<MediaSettingsRef, MediaSettingsProps>(
                                 buttonStyle="primary"
                                 className={styles.button}
                                 onClick={onPublish}
-                                disabled={
-                                    isPublishDisabled ||
-                                    hasBlockErrors(collectedFundsErrors) ||
-                                    hasBlockErrors(changedLivesErrors)
-                                }
+                                disabled={isPublishDisabled || Object.values(errors).some((err) => err !== undefined)}
                             >
                                 {REPORTS_TEXT.BUTTON.PUBLISH}
                             </Button>


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3124)

## Description

This PR resolves a state management bug in the Media Settings tab where the "Опублікувати" (Publish) button became incorrectly enabled when a user clicked into an input field and clicked away without making changes. The fix migrates the component to the centralized useFormManager hook, ensuring robust form state and dirty-tracking.

## Summary of change

*   **Centralized Form Management (`MediaSettings.tsx`)**: Migrated the entire Media Settings form state to use the `useFormManager` hook. This replaced the fragile, localized `useState` tracking that caused false-positive dirty states, guaranteeing the publish button only enables when actual data modifications exist.
*   **Prevent False-Positive Blurs (`ReportsMediaBlock.tsx`)**: Implemented early returns in the `onTitleBlur` and `onTitleEnBlur` handlers. If the normalized input matches the existing value, state updates are bypassed entirely to prevent unnecessary re-renders and dirty flag triggers.

## How to recreate changes

1. Log into the Admin panel and navigate to the **"Налаштування медіа"** (Media Settings) tab on the Reports page.
2. Click on any input field so it gains focus. Make no changes, and click outside the field to remove focus. 
3. Observe that the **"Опублікувати"** (Publish) button correctly remains disabled.



## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Streamlined the admin media settings form with more consistent field updates and validation.
  - Displays field-specific errors directly for titles, amounts, and images.
  - Title text is normalized when leaving the field.
  - Image changes and image errors are handled more reliably, including clearing images.
  - Publish actions now validate the form before saving and provide clearer success or failure feedback.
  - Missing images can be populated with default images during publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->