### PR TITLE
fix: let author card grow to fit long names instead of a fixed height

### DIFF
--- a/src/components/common/section-templates/single-title-description-author-pairs/description-author-pair-card/DescriptionAuthorPairCard.module.scss
+++ b/src/components/common/section-templates/single-title-description-author-pairs/description-author-pair-card/DescriptionAuthorPairCard.module.scss
@@ -5,7 +5,7 @@ $field-width: 366px;
 
 .card {
     width: var(--pair-card-width, 432px);
-    height: var(--pair-card-height, 259px);
+    min-height: var(--pair-card-height, 259px);
     background-color: c.$light-blue-50;
     border-radius: var(--card-radius, 20px);
     box-sizing: border-box;
@@ -67,7 +67,6 @@ $field-width: 366px;
     display: flex;
     flex-direction: column;
     gap: 18px;
-    height: 100%;
 }
 
 .description-field,
@@ -109,6 +108,8 @@ $field-width: 366px;
     }
 
     :global(.char-limit-textarea__field) {
+        box-sizing: border-box;
+        width: 100%;
         font-family: t.$font-family-base;
         font-weight: t.$fw-bold;
         font-size: 20px;

--- a/src/components/common/section-templates/single-title-description-author-pairs/description-author-pair-card/DescriptionAuthorPairCard.tsx
+++ b/src/components/common/section-templates/single-title-description-author-pairs/description-author-pair-card/DescriptionAuthorPairCard.tsx
@@ -132,7 +132,8 @@ export const DescriptionAuthorPairCard = ({
                         error={authorError}
                         maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(authorMaxLength)}
                         rows={1}
-                        autoGrow={false}
+                        autoGrow={true}
+                        maxRows={2}
                     />
                 </div>
             </div>


### PR DESCRIPTION
## JIRA or Github ticker

* [#3093](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3093)

## Description

In the "Ім'я" (author) field of the SingleTitleDescriptionAuthorPairs section template (template 9), entering a full-length name (up to the 50-character limit) caused the field's text and character counter to be clipped or to overflow past the blue card boundary, because the field had no auto-grow behavior and the card used a fixed `height`. The fix is based on how templates 11 and 13 handle this same situation — their cards have no fixed height and grow naturally to fit content.

## How it looks

<img width="3622" height="1955" alt="Screenshot 2026-07-23 111456" src="https://github.com/user-attachments/assets/a763ffc3-3a7d-4c5f-8b7d-94e1040213e2" />

## Summary of change

- `DescriptionAuthorPairCard.tsx`: enabled `autoGrow={true}` with `maxRows={2}` on the author field (previously `autoGrow={false}`), so a long name wraps and grows the field instead of being clipped.
- `DescriptionAuthorPairCard.module.scss`: added `box-sizing: border-box; width: 100%;` on the author textarea so it can't render wider than its container. Changed `.card` from a fixed `height` to `min-height`, and removed the now-unnecessary `height: 100%` on `.fields`, so the card grows to fit its content instead of clipping it.

## How to recreate changes

1. Log into the Admin panel and open the "Add New Program" modal.
2. Click "Додати секцію".
3. Select the template for "Блок з цитатами" (template 9) and click "Обрати шаблон".
4. In the "Ім'я" field, enter a full 50-character name, e.g. "Maria Fernanda Guadalupe Hernandez-Castellanos".
5. Verify the field wraps to a second line, the character counter remains visible, and the card grows to fit the content instead of overflowing its blue background.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Author text areas now expand automatically as content is entered, up to two lines.
  * Improved card sizing and field layout for more consistent display.
  * Updated text area sizing to use the available width without overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->