### PR TITLE
Feature/issue-1513 [Single page] Sync Section replacement to Translation Page

### DIFF
--- a/src/pages/admin/programs/components/translate-program-modal/TranslateProgramModal.test.tsx
+++ b/src/pages/admin/programs/components/translate-program-modal/TranslateProgramModal.test.tsx
@@ -449,6 +449,65 @@ describe('TranslateProgramModal', () => {
         });
     });
 
+    it('mirrors replaced UA section structure and leaves untranslated content fields empty (issue-1513)', () => {
+        const programWithReplacedSection = {
+            ...TEST_DATA.program,
+            sections: [
+                {
+                    id: 701,
+                    template: 1,
+                    contents: [
+                        {
+                            id: 801,
+                            contentType: 0,
+                            title: 'Original section title',
+                            localizations: [
+                                {
+                                    localizationInfoDto: { id: 2 },
+                                    title: 'Localized section title',
+                                    description: 'Localized section description',
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    id: 702,
+                    template: 2,
+                    contents: [
+                        {
+                            id: 802,
+                            contentType: 0,
+                            title: 'Newly replaced section title (UA)',
+                            localizations: [],
+                        },
+                    ],
+                },
+            ],
+        } as any;
+
+        renderModal({
+            programToTranslate: programWithReplacedSection,
+            translatedLanguages: [TEST_DATA.language],
+        });
+
+        const parsed = getInitialDataFromForm();
+        expect(parsed.sections).toHaveLength(2);
+        expect(parsed.sections[0]).toMatchObject({ entityId: 701 });
+        expect(parsed.sections[0].contents[0]).toMatchObject({
+            entityId: 801,
+            title: 'Localized section title',
+            description: 'Localized section description',
+        });
+
+        expect(parsed.sections[1]).toMatchObject({ entityId: 702 });
+        expect(parsed.sections[1].contents[0]).toMatchObject({
+            entityId: 802,
+            title: null,
+            description: null,
+        });
+    });
+
     it('keeps language unchanged when unknown code is selected', () => {
         renderModal({
             translatedLanguages: [TEST_DATA.language],


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1513

## !!! Note:
The section auto-sync functionality was already supported by the existing architecture (opening the
  translation modal automatically mirrors the updated UA section structure and presents empty input fields for newly
  added/replaced sections while preserving existing translations). Automated unit tests have been added to formally
  cover and verify this scenario.

## Description

This PR verifies and covers the functionality for Issue #1513: automatically syncing section replacements on a program profile to the translation modal. When an admin replaces or adds a section on the main Ukrainian (UA) program page, opening the
translation modal automatically mirrors the updated section structure and presents empty input fields for the new
section while preserving existing translations for other sections.

## Summary of change

- Verified that `TranslateProgramModal.tsx` dynamically constructs `initialData.sections` from
  `programToTranslate.sections`, automatically mirroring section structure changes from the main UA page.
- Verified that content for newly replaced sections without target language localizations defaults to empty/null
  values for manual entry without re-translating or clearing saved translations for unchanged sections.
- Added comprehensive unit test in `TranslateProgramModal.test.tsx` (`mirrors replaced UA section structure and
  leaves untranslated content fields empty (issue-1513)`) to formally cover this behavior in the test suite.

## How to recreate changes

 • Edit an existing program on the Ukrainian (UA) page and replace one of its sections with a new section
      template.
• Save the program in UA.
• Open the "Редагувати переклад" (Edit translation) modal and select English (EN).
• Observe that the form displays the new section structure with empty input fields for the replaced section
      while retaining saved English translations for all other sections.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation handling for replaced sections.
  * Untranslated section titles and descriptions now remain blank instead of displaying incorrect content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->