### PR TITLE
Fix/issue-2756 [Partners] [Admin] [UI] No gap between buttons "Видалити секцію"+"Опублікувати" and character counter

### DIFF
--- a/src/pages/admin/partners/components/partner-form/PartnerForm.module.scss
+++ b/src/pages/admin/partners/components/partner-form/PartnerForm.module.scss
@@ -1,4 +1,4 @@
-﻿@use '@/assets/sass/variables/colors' as c;
+@use '@/assets/sass/variables/colors' as c;
 
 .root {
     width: 13rem;
@@ -6,6 +6,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+    margin-top: 1.875rem;
 }
 
 .header {

--- a/src/pages/admin/partners/components/partner-section/PartnerSectionForm.module.scss
+++ b/src/pages/admin/partners/components/partner-section/PartnerSectionForm.module.scss
@@ -44,6 +44,7 @@
     display: flex;
     justify-content: flex-start;
     align-items: center;
+    margin-top: 1.875rem;
 }
 
 .add-card button {
@@ -69,6 +70,7 @@
     width: 100%;
     height: 2.5rem;
     gap: 4rem;
+    margin-top: 4rem;
 }
 
 .actions button {


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/2756

## Description

This PR fixes a UI layout issue on the Admin Panel **"Партнери"** (Partners) page. Previously, the action buttons ("Видалити секцію" and "Зберегти як опубліковане" / "Опублікувати") were rendered directly against the bottom of the partner cards and character counters with no visible vertical gap. This change adds proper vertical margins to align with the Figma design specifications.

## How it looks

<img width="1524" height="791" alt="image" src="https://github.com/user-attachments/assets/64609033-1e0f-4e60-a984-4d0cbf64e27c" />


## Summary of change

- Added `margin-top: 4rem;` to the `.actions` container in `PartnerSectionForm.module.scss` to introduce proper
  vertical spacing between partner cards' character counters and section action buttons.
- Added `margin-top: 1.875rem;` to `.add-card` in `PartnerSectionForm.module.scss` to align the "Add Partner"
  card with partner cards.
- Added `margin-top: 1.875rem;` to `.root` in `PartnerForm.module.scss` for top spacing above individual partner
  cards.

## How to recreate changes

1. Log in to the Admin Panel as an administrator.
2. Navigate to the **"Партнери"** (Partners) page.
3. Scroll down to a partner section containing partner cards and character counters.
4. Observe the spacing below the partner cards and character counters:
- **Expected**: A clear, visible vertical gap separates the partner card character counters from the
  **"Видалити секцію"** and **"Опублікувати"** action buttons below.

    ## CHECK LIST
    - [ ]  New tests was added or existing was modified
    - [ ]  Changes has severe impact on users
    - [ ]  Changes has medium impact on users
    - [x]  Changes has light impact on users
    - [ ]  Test covetage was updated
    - [x]  PR meets all conventions