### PR TITLE
Fix/issue-3019 [Reports] [Admin] Cannot input a new category name in the 'Категорія програми' combobox field

### DIFF
--- a/src/components/common/category-combobox/CategoryCombobox.scss
+++ b/src/components/common/category-combobox/CategoryCombobox.scss
@@ -1,0 +1,32 @@
+@use '@/assets/sass/variables/colors';
+
+.select-head {
+    input {
+        flex: 1 1 auto;
+        min-width: 0;
+        border: none;
+        outline: none;
+        padding: 0;
+        background: transparent;
+        font: inherit;
+        color: colors.$blue-900;
+
+        &::placeholder {
+            color: colors.$grey-900;
+        }
+
+        &:disabled {
+            cursor: not-allowed;
+        }
+    }
+}
+
+.category-combobox-not-found {
+    padding: 8px 1rem;
+    color: colors.$grey-700;
+    font-size: 16px;
+}
+
+.select-options button.category-combobox-option-active {
+    background-color: colors.$blue-50;
+}

--- a/src/components/common/category-combobox/CategoryCombobox.test.tsx
+++ b/src/components/common/category-combobox/CategoryCombobox.test.tsx
@@ -192,11 +192,31 @@ describe('CategoryCombobox', () => {
         expect(ref.current).toHaveClass('select');
     });
 
-    it('opens the dropdown when clicking anywhere on the head', () => {
+    it('associates the head label with the input so clicking anywhere on it focuses the input natively', () => {
         const { container } = renderCombobox();
+        const input = screen.getByPlaceholderText('Оберіть програму');
+        const label = container.querySelector('.select-head') as HTMLLabelElement;
 
-        fireEvent.click(container.querySelector('.select-head') as HTMLElement);
+        expect(label.tagName).toBe('LABEL');
+        expect(label).toHaveAttribute('for', input.id);
+        expect(input.id).not.toBe('');
+    });
 
-        expect(container.querySelector('.select')).toHaveClass('select-opened');
+    it('uses the explicit id prop for both the input and its label association when provided', () => {
+        const { container } = render(
+            <CategoryCombobox
+                id="add-program-expense-category"
+                options={OPTIONS}
+                inputValue=""
+                onInputValueChange={jest.fn()}
+                onOptionSelect={jest.fn()}
+                placeholder="Оберіть програму"
+            />,
+        );
+        const input = screen.getByPlaceholderText('Оберіть програму');
+        const label = container.querySelector('.select-head') as HTMLLabelElement;
+
+        expect(input).toHaveAttribute('id', 'add-program-expense-category');
+        expect(label).toHaveAttribute('for', 'add-program-expense-category');
     });
 });

--- a/src/components/common/category-combobox/CategoryCombobox.test.tsx
+++ b/src/components/common/category-combobox/CategoryCombobox.test.tsx
@@ -1,0 +1,202 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CategoryCombobox, CategoryComboboxOption } from './CategoryCombobox';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+
+jest.mock('./CategoryCombobox.scss', () => ({}));
+jest.mock('@/components/common/select/Select.scss', () => ({}));
+
+jest.mock('@/assets/icons/chevron-down.svg', () => ({
+    ReactComponent: (props: any) => <svg {...props} data-testid="chevron-down-icon" />,
+}));
+
+jest.mock('@/assets/icons/chevron-up.svg', () => ({
+    ReactComponent: (props: any) => <svg {...props} data-testid="chevron-up-icon" />,
+}));
+
+const OPTIONS: CategoryComboboxOption[] = [
+    { id: 1, name: 'Program A' },
+    { id: 2, name: 'Program B' },
+];
+
+describe('CategoryCombobox', () => {
+    const renderCombobox = (overrides: Partial<React.ComponentProps<typeof CategoryCombobox>> = {}) =>
+        render(
+            <CategoryCombobox
+                options={OPTIONS}
+                inputValue=""
+                onInputValueChange={jest.fn()}
+                onOptionSelect={jest.fn()}
+                placeholder="Оберіть програму"
+                {...overrides}
+            />,
+        );
+
+    it('renders an input with the placeholder', () => {
+        renderCombobox();
+
+        expect(screen.getByPlaceholderText('Оберіть програму')).toBeInTheDocument();
+    });
+
+    it('opens the dropdown and shows all options on focus', () => {
+        const { container } = renderCombobox();
+        const input = screen.getByPlaceholderText('Оберіть програму');
+
+        fireEvent.focus(input);
+
+        expect(container.querySelector('.select')).toHaveClass('select-opened');
+        expect(screen.getByText('Program A')).toBeInTheDocument();
+        expect(screen.getByText('Program B')).toBeInTheDocument();
+    });
+
+    it('calls onInputValueChange while typing and filters the option list', () => {
+        const onInputValueChange = jest.fn();
+        const { rerender } = renderCombobox({ onInputValueChange });
+        const input = screen.getByPlaceholderText('Оберіть програму');
+
+        fireEvent.change(input, { target: { value: 'B' } });
+
+        expect(onInputValueChange).toHaveBeenCalledWith('B');
+
+        rerender(
+            <CategoryCombobox
+                options={OPTIONS}
+                inputValue="B"
+                onInputValueChange={onInputValueChange}
+                onOptionSelect={jest.fn()}
+                placeholder="Оберіть програму"
+            />,
+        );
+
+        expect(screen.getByText('Program B')).toBeInTheDocument();
+        expect(screen.queryByText('Program A')).not.toBeInTheDocument();
+    });
+
+    it('shows the not found message when nothing matches the query', () => {
+        renderCombobox({ inputValue: 'XXXXXXXX' });
+
+        const input = screen.getByPlaceholderText('Оберіть програму');
+        fireEvent.focus(input);
+
+        expect(screen.getByText(COMMON_TEXT_ADMIN.LIST.NOT_FOUND)).toBeInTheDocument();
+    });
+
+    it('accepts a custom notFoundMessage', () => {
+        renderCombobox({ inputValue: 'XXXXXXXX', notFoundMessage: 'Нічого' });
+
+        fireEvent.focus(screen.getByPlaceholderText('Оберіть програму'));
+
+        expect(screen.getByText('Нічого')).toBeInTheDocument();
+    });
+
+    it('does not drop free-typed text that has no matching option', () => {
+        renderCombobox({ inputValue: 'XXXXXXXX' });
+
+        expect(screen.getByDisplayValue('XXXXXXXX')).toBeInTheDocument();
+    });
+
+    it('calls onOptionSelect and closes the dropdown when an option is clicked', () => {
+        const onOptionSelect = jest.fn();
+        const { container } = renderCombobox({ onOptionSelect });
+        const input = screen.getByPlaceholderText('Оберіть програму');
+
+        fireEvent.focus(input);
+        fireEvent.click(screen.getByText('Program B'));
+
+        expect(onOptionSelect).toHaveBeenCalledWith({ id: 2, name: 'Program B' });
+        expect(container.querySelector('.select')).toHaveClass('select-closed');
+    });
+
+    it('navigates options with ArrowDown/ArrowUp and selects the highlighted one on Enter', () => {
+        const onOptionSelect = jest.fn();
+        renderCombobox({ onOptionSelect });
+        const input = screen.getByPlaceholderText('Оберіть програму');
+
+        fireEvent.focus(input);
+        fireEvent.keyDown(input, { key: 'ArrowDown' });
+        fireEvent.keyDown(input, { key: 'ArrowDown' });
+        fireEvent.keyDown(input, { key: 'ArrowUp' });
+        fireEvent.keyDown(input, { key: 'Enter' });
+
+        expect(onOptionSelect).toHaveBeenCalledWith({ id: 1, name: 'Program A' });
+    });
+
+    it('closes the dropdown on Enter when nothing is highlighted', () => {
+        const { container } = renderCombobox({ inputValue: 'XXXXXXXX' });
+        const input = screen.getByPlaceholderText('Оберіть програму');
+
+        fireEvent.focus(input);
+        fireEvent.keyDown(input, { key: 'Enter' });
+
+        expect(container.querySelector('.select')).toHaveClass('select-closed');
+    });
+
+    it('closes the dropdown on Escape', () => {
+        const { container } = renderCombobox();
+        const input = screen.getByPlaceholderText('Оберіть програму');
+
+        fireEvent.focus(input);
+        expect(container.querySelector('.select')).toHaveClass('select-opened');
+
+        fireEvent.keyDown(input, { key: 'Escape' });
+        expect(container.querySelector('.select')).toHaveClass('select-closed');
+    });
+
+    it('closes the dropdown when clicking outside', () => {
+        const { container } = render(
+            <div>
+                <CategoryCombobox
+                    options={OPTIONS}
+                    inputValue=""
+                    onInputValueChange={jest.fn()}
+                    onOptionSelect={jest.fn()}
+                    placeholder="Оберіть програму"
+                />
+                <button type="button">outside</button>
+            </div>,
+        );
+        const input = screen.getByPlaceholderText('Оберіть програму');
+
+        fireEvent.focus(input);
+        expect(container.querySelector('.select')).toHaveClass('select-opened');
+
+        fireEvent.mouseDown(screen.getByText('outside'));
+        expect(container.querySelector('.select')).toHaveClass('select-closed');
+    });
+
+    it('does not open the dropdown when disabled', () => {
+        const { container } = renderCombobox({ disabled: true });
+        const input = screen.getByPlaceholderText('Оберіть програму');
+
+        expect(input).toBeDisabled();
+
+        fireEvent.click(container.querySelector('.select-head') as HTMLElement);
+        expect(container.querySelector('.select')).toHaveClass('select-closed');
+        expect(screen.queryByText('Program A')).not.toBeInTheDocument();
+    });
+
+    it('forwards the container node through selectContainerRef', () => {
+        const ref = React.createRef<HTMLDivElement>();
+        render(
+            <CategoryCombobox
+                options={OPTIONS}
+                inputValue=""
+                onInputValueChange={jest.fn()}
+                onOptionSelect={jest.fn()}
+                selectContainerRef={ref}
+            />,
+        );
+
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+        expect(ref.current).toHaveClass('select');
+    });
+
+    it('opens the dropdown when clicking anywhere on the head', () => {
+        const { container } = renderCombobox();
+
+        fireEvent.click(container.querySelector('.select-head') as HTMLElement);
+
+        expect(container.querySelector('.select')).toHaveClass('select-opened');
+    });
+});

--- a/src/components/common/category-combobox/CategoryCombobox.tsx
+++ b/src/components/common/category-combobox/CategoryCombobox.tsx
@@ -1,4 +1,4 @@
-import React, { KeyboardEvent, RefObject, useMemo, useRef, useState } from 'react';
+import React, { KeyboardEvent, RefObject, useId, useMemo, useRef, useState } from 'react';
 import { ReactComponent as ArrowDown } from '@/assets/icons/chevron-down.svg';
 import { ReactComponent as ArrowUp } from '@/assets/icons/chevron-up.svg';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
@@ -45,6 +45,8 @@ export const CategoryCombobox = ({
     const [highlightedIndex, setHighlightedIndex] = useState(-1);
     const inputRef = useRef<HTMLInputElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
+    const generatedId = useId();
+    const inputId = id ?? generatedId;
 
     const setContainerRef = (node: HTMLDivElement | null) => {
         containerRef.current = node;
@@ -126,17 +128,10 @@ export const CategoryCombobox = ({
                 'select-disabled': disabled,
             })}
         >
-            <div
-                className={classNames('select-head', headClassName)}
-                onClick={() => {
-                    if (disabled) return;
-                    inputRef.current?.focus();
-                    openDropdown();
-                }}
-            >
+            <label htmlFor={inputId} className={classNames('select-head', headClassName)}>
                 <input
                     ref={inputRef}
-                    id={id}
+                    id={inputId}
                     type="text"
                     value={inputValue}
                     onChange={handleInputChange}
@@ -147,7 +142,7 @@ export const CategoryCombobox = ({
                     autoComplete="off"
                 />
                 {isOpen ? <ArrowUp /> : <ArrowDown />}
-            </div>
+            </label>
 
             {isOpen && !disabled && (
                 <div className="select-options">

--- a/src/components/common/category-combobox/CategoryCombobox.tsx
+++ b/src/components/common/category-combobox/CategoryCombobox.tsx
@@ -1,0 +1,178 @@
+import React, { KeyboardEvent, RefObject, useMemo, useRef, useState } from 'react';
+import { ReactComponent as ArrowDown } from '@/assets/icons/chevron-down.svg';
+import { ReactComponent as ArrowUp } from '@/assets/icons/chevron-up.svg';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { useOnClickOutside } from '@/hooks/common/use-on-click-outside/useOnClickOutside';
+import classNames from 'classnames';
+import '@/components/common/select/Select.scss';
+import './CategoryCombobox.scss';
+
+export interface CategoryComboboxOption {
+    id: number;
+    name: string;
+}
+
+export interface CategoryComboboxProps {
+    options: CategoryComboboxOption[];
+    inputValue: string;
+    onInputValueChange: (value: string) => void;
+    onOptionSelect: (option: CategoryComboboxOption) => void;
+    selectContainerRef?: RefObject<HTMLDivElement | null>;
+    placeholder?: string;
+    className?: string;
+    headClassName?: string;
+    optionClassName?: string;
+    disabled?: boolean;
+    id?: string;
+    notFoundMessage?: string;
+}
+
+export const CategoryCombobox = ({
+    options,
+    inputValue,
+    onInputValueChange,
+    onOptionSelect,
+    selectContainerRef,
+    placeholder,
+    className,
+    headClassName,
+    optionClassName,
+    disabled = false,
+    id,
+    notFoundMessage = COMMON_TEXT_ADMIN.LIST.NOT_FOUND,
+}: CategoryComboboxProps) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [highlightedIndex, setHighlightedIndex] = useState(-1);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    const setContainerRef = (node: HTMLDivElement | null) => {
+        containerRef.current = node;
+        if (selectContainerRef) {
+            selectContainerRef.current = node;
+        }
+    };
+
+    const normalizedQuery = inputValue.trim().toLowerCase();
+
+    const filteredOptions = useMemo(
+        () =>
+            normalizedQuery === ''
+                ? options
+                : options.filter((option) => option.name.toLowerCase().includes(normalizedQuery)),
+        [options, normalizedQuery],
+    );
+
+    const openDropdown = () => {
+        if (disabled) return;
+        setIsOpen(true);
+    };
+
+    const closeDropdown = () => {
+        setIsOpen(false);
+        setHighlightedIndex(-1);
+    };
+
+    useOnClickOutside({
+        ignoreClickRefs: [containerRef],
+        onOutsideClick: closeDropdown,
+        isDisabled: !isOpen,
+    });
+
+    const selectOption = (option: CategoryComboboxOption) => {
+        onOptionSelect(option);
+        closeDropdown();
+    };
+
+    const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        onInputValueChange(event.target.value);
+        setHighlightedIndex(-1);
+        openDropdown();
+    };
+
+    const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+        if (disabled) return;
+
+        if (event.key === 'ArrowDown') {
+            event.preventDefault();
+            if (!isOpen) {
+                openDropdown();
+                return;
+            }
+            setHighlightedIndex((previousIndex) =>
+                previousIndex < filteredOptions.length - 1 ? previousIndex + 1 : previousIndex,
+            );
+        } else if (event.key === 'ArrowUp') {
+            event.preventDefault();
+            setHighlightedIndex((previousIndex) => (previousIndex > 0 ? previousIndex - 1 : 0));
+        } else if (event.key === 'Enter') {
+            if (isOpen && highlightedIndex >= 0 && highlightedIndex < filteredOptions.length) {
+                event.preventDefault();
+                selectOption(filteredOptions[highlightedIndex]);
+            } else {
+                closeDropdown();
+            }
+        } else if (event.key === 'Escape') {
+            closeDropdown();
+        }
+    };
+
+    return (
+        <div
+            ref={setContainerRef}
+            className={classNames('select', className, {
+                'select-opened': isOpen,
+                'select-closed': !isOpen,
+                'select-disabled': disabled,
+            })}
+        >
+            <div
+                className={classNames('select-head', headClassName)}
+                onClick={() => {
+                    if (disabled) return;
+                    inputRef.current?.focus();
+                    openDropdown();
+                }}
+            >
+                <input
+                    ref={inputRef}
+                    id={id}
+                    type="text"
+                    value={inputValue}
+                    onChange={handleInputChange}
+                    onFocus={openDropdown}
+                    onKeyDown={handleKeyDown}
+                    placeholder={placeholder}
+                    disabled={disabled}
+                    autoComplete="off"
+                />
+                {isOpen ? <ArrowUp /> : <ArrowDown />}
+            </div>
+
+            {isOpen && !disabled && (
+                <div className="select-options">
+                    {filteredOptions.length === 0 ? (
+                        <div className="category-combobox-not-found">{notFoundMessage}</div>
+                    ) : (
+                        filteredOptions.map((option, index) => (
+                            <button
+                                key={option.id}
+                                type="button"
+                                className={classNames(optionClassName, {
+                                    'category-combobox-option-active': index === highlightedIndex,
+                                })}
+                                onClick={(event) => {
+                                    event.stopPropagation();
+                                    selectOption(option);
+                                }}
+                                onMouseEnter={() => setHighlightedIndex(index)}
+                            >
+                                <span>{option.name}</span>
+                            </button>
+                        ))
+                    )}
+                </div>
+            )}
+        </div>
+    );
+};

--- a/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.test.ts
+++ b/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.test.ts
@@ -166,6 +166,69 @@ describe('useProgramExpenseRecordForm', () => {
         expect(result.current.isDirty).toBe(false);
     });
 
+    it('matches typed text to an existing program option (case-insensitive, trimmed)', () => {
+        const { result } = renderUseProgramExpenseForm();
+
+        act(() => {
+            result.current.handleProgramInputChange('  program b  ');
+        });
+
+        expect(result.current.formState.programId).toBe(2);
+        expect(result.current.formState.programInputValue).toBe('  program b  ');
+        expect(result.current.formState.errors.programId).toBeUndefined();
+    });
+
+    it('treats typed text with no matching option as a pending custom category', () => {
+        const { result } = renderUseProgramExpenseForm();
+
+        act(() => {
+            result.current.handleProgramInputChange('XXXXXXXX');
+        });
+
+        expect(result.current.formState.programId).toBeUndefined();
+        expect(result.current.formState.programInputValue).toBe('XXXXXXXX');
+        expect(result.current.formState.errors.programId).toBeUndefined();
+    });
+
+    it('validates a too-short custom category name on blur', () => {
+        const { result } = renderUseProgramExpenseForm();
+
+        act(() => {
+            result.current.handleProgramInputChange('ab');
+        });
+        act(() => {
+            result.current.handleProgramBlur();
+        });
+
+        expect(result.current.formState.errors.programId).toBeDefined();
+        expect(result.current.isSubmitDisabled).toBe(true);
+    });
+
+    it('submits with programId undefined and the trimmed custom name when a new category is typed', async () => {
+        const onSubmit = jest.fn().mockResolvedValue(true);
+        const { result } = renderUseProgramExpenseForm({ onSubmit });
+
+        act(() => {
+            result.current.handleReportingYearChange('2026');
+            result.current.handleProgramInputChange('  New Category  ');
+            result.current.handleAmountChange('400');
+        });
+
+        expect(result.current.isSubmitDisabled).toBe(false);
+
+        await act(async () => {
+            await result.current.handleSave();
+        });
+
+        expect(onSubmit).toHaveBeenCalledWith({
+            programId: undefined,
+            programName: 'New Category',
+            reportingYear: '2026',
+            amountUah: '400',
+            amountUsd: '10',
+        });
+    });
+
     it('clears selected program when it is no longer available', () => {
         const { result, rerender } = renderHook(
             ({ nextPrograms }) =>
@@ -273,6 +336,7 @@ describe('useProgramExpenseRecordForm', () => {
 
             expect(onSubmit).toHaveBeenCalledWith({
                 programId: 1,
+                programName: 'Program A',
                 reportingYear: '2026',
                 amountUah: '400',
                 amountUsd: '10',

--- a/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.ts
+++ b/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.ts
@@ -12,6 +12,7 @@ import {
 interface ProgramExpenseFormState {
     reportingYear: string | undefined;
     programId: number | undefined;
+    programInputValue: string;
     amountUah: string;
     amountUsd: string;
     errors: {
@@ -29,7 +30,8 @@ interface UseProgramExpenseRecordFormParams {
     exchangeRate: string | null;
     recordToEdit?: ProgramExpensesRecord | null;
     onSubmit: (data: {
-        programId: number;
+        programId: number | undefined;
+        programName: string;
         reportingYear: string;
         amountUah: string;
         amountUsd: string;
@@ -39,6 +41,7 @@ interface UseProgramExpenseRecordFormParams {
 const INITIAL_STATE: ProgramExpenseFormState = {
     reportingYear: undefined,
     programId: undefined,
+    programInputValue: '',
     amountUah: '',
     amountUsd: '',
     errors: {},
@@ -70,13 +73,12 @@ export const useProgramExpenseRecordForm = ({
         [programs],
     );
 
-    const isProgramSelectDisabled = programOptions.length === 0;
-
     const getProgramError = useCallback(
-        (programId: number | undefined, trigger: 'change' | 'blur'): string | undefined =>
+        (programId: number | undefined, programName: string, trigger: 'change' | 'blur'): string | undefined =>
             validateProgramExpenseProgram({
                 recordId: recordToEdit ? recordToEdit.id : 0,
                 programId,
+                programName,
                 records,
                 trigger,
             }),
@@ -95,6 +97,7 @@ export const useProgramExpenseRecordForm = ({
             setFormState({
                 reportingYear: recordToEdit.reportingYear,
                 programId: recordToEdit.programId,
+                programInputValue: recordToEdit.programName,
                 amountUah: recordToEdit.amountUah,
                 amountUsd: recordToEdit.amountUsd,
                 errors: {},
@@ -114,17 +117,18 @@ export const useProgramExpenseRecordForm = ({
             programOptions.some((program) => program.id === formState.programId) ||
             isEditBaseline;
 
-        if (!isEditBaseline && (isProgramSelectDisabled || !selectedProgramExists)) {
+        if (!isEditBaseline && !selectedProgramExists) {
             setFormState((previousState) => ({
                 ...previousState,
                 programId: undefined,
+                programInputValue: '',
                 errors: {
                     ...previousState.errors,
                     programId: undefined,
                 },
             }));
         }
-    }, [formState.programId, isOpen, isProgramSelectDisabled, programOptions, recordToEdit]);
+    }, [formState.programId, isOpen, programOptions, recordToEdit]);
 
     const handleAmountChange = useCallback(
         (value: string) => {
@@ -183,16 +187,43 @@ export const useProgramExpenseRecordForm = ({
 
     const handleProgramChange = useCallback(
         (programId: number | undefined) => {
+            const matchedOption = programOptions.find((program) => program.id === programId);
+
             setFormState((previousState) => ({
                 ...previousState,
                 programId,
+                programInputValue: matchedOption ? matchedOption.name : previousState.programInputValue,
                 errors: {
                     ...previousState.errors,
-                    programId: getProgramError(programId, 'change'),
+                    programId: getProgramError(
+                        programId,
+                        matchedOption ? matchedOption.name : previousState.programInputValue,
+                        'change',
+                    ),
                 },
             }));
         },
-        [getProgramError],
+        [getProgramError, programOptions],
+    );
+
+    const handleProgramInputChange = useCallback(
+        (text: string) => {
+            const normalizedText = text.trim().toLowerCase();
+            const matchedOption = programOptions.find(
+                (program) => program.name.trim().toLowerCase() === normalizedText,
+            );
+
+            setFormState((previousState) => ({
+                ...previousState,
+                programInputValue: text,
+                programId: matchedOption?.id,
+                errors: {
+                    ...previousState.errors,
+                    programId: getProgramError(matchedOption?.id, text, 'change'),
+                },
+            }));
+        },
+        [getProgramError, programOptions],
     );
 
     const handleProgramBlur = useCallback(() => {
@@ -200,7 +231,7 @@ export const useProgramExpenseRecordForm = ({
             ...previousState,
             errors: {
                 ...previousState.errors,
-                programId: getProgramError(previousState.programId, 'blur'),
+                programId: getProgramError(previousState.programId, previousState.programInputValue, 'blur'),
             },
         }));
     }, [getProgramError]);
@@ -210,6 +241,7 @@ export const useProgramExpenseRecordForm = ({
         return (
             formState.reportingYear !== recordToEdit.reportingYear ||
             formState.programId !== recordToEdit.programId ||
+            formState.programInputValue.trim() !== recordToEdit.programName.trim() ||
             formState.amountUah !== recordToEdit.amountUah ||
             formState.amountUsd !== recordToEdit.amountUsd
         );
@@ -219,6 +251,7 @@ export const useProgramExpenseRecordForm = ({
         return (
             Boolean(formState.reportingYear) ||
             Boolean(formState.programId) ||
+            formState.programInputValue.trim() !== '' ||
             formState.amountUah.trim() !== '' ||
             formState.amountUsd.trim() !== ''
         );
@@ -242,7 +275,7 @@ export const useProgramExpenseRecordForm = ({
 
     const isSubmitEnabled =
         !validateProgramExpenseReportingYear(formState.reportingYear, 'save') &&
-        !getProgramError(formState.programId, 'blur') &&
+        !getProgramError(formState.programId, formState.programInputValue, 'blur') &&
         !validateProgramExpenseAmount(formState.amountUah, 'save') &&
         !validateProgramExpenseAmount(formState.amountUsd, 'save') &&
         !currentUsdMismatchMessage &&
@@ -260,7 +293,10 @@ export const useProgramExpenseRecordForm = ({
     }, []);
 
     const submitRecord = useCallback(async (): Promise<boolean> => {
-        if (!formState.programId || !formState.reportingYear || isSubmitting) return false;
+        const trimmedProgramName = formState.programInputValue.trim();
+        const hasProgram = formState.programId !== undefined || trimmedProgramName !== '';
+
+        if (!hasProgram || !formState.reportingYear || isSubmitting) return false;
 
         if (currentUsdMismatchMessage) {
             setUsdMismatchMessage(currentUsdMismatchMessage);
@@ -271,6 +307,7 @@ export const useProgramExpenseRecordForm = ({
         try {
             const success = await onSubmit({
                 programId: formState.programId,
+                programName: trimmedProgramName,
                 reportingYear: formState.reportingYear,
                 amountUah: formState.amountUah,
                 amountUsd: formState.amountUsd,
@@ -296,7 +333,6 @@ export const useProgramExpenseRecordForm = ({
     return {
         formState,
         programOptions,
-        isProgramSelectDisabled,
         isDirty,
         isSubmitDisabled,
         isSubmitting,
@@ -305,6 +341,7 @@ export const useProgramExpenseRecordForm = ({
         handleReportingYearChange,
         handleReportingYearBlur,
         handleProgramChange,
+        handleProgramInputChange,
         handleProgramBlur,
         handleAmountChange,
         handleUsdChange,

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.test.tsx
@@ -75,6 +75,13 @@ jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
     useAdminClient: () => 'mock-client',
 }));
 
+const mockAddProgramCategory = jest.fn();
+jest.mock('@/services/api/admin/programs/programs-api', () => ({
+    ProgramsCategoriesApi: {
+        addProgramCategory: (...args: unknown[]) => mockAddProgramCategory(...args),
+    },
+}));
+
 jest.mock('@/components/common/select/Select', () => {
     const React = require('react');
 
@@ -163,7 +170,8 @@ jest.mock('./components/common/add-program-expense-record-modal/AddProgramExpens
         isOpen: boolean;
         exchangeRate: string | null;
         onSubmit: (submitData: {
-            programId: number;
+            programId: number | undefined;
+            programName: string;
             reportingYear: string;
             amountUah: string;
             amountUsd: string;
@@ -180,6 +188,7 @@ jest.mock('./components/common/add-program-expense-record-modal/AddProgramExpens
                         onClick={() =>
                             onSubmit({
                                 programId: recordToEdit ? 3 : 2,
+                                programName: recordToEdit ? 'Program C' : 'Program B',
                                 reportingYear: recordToEdit ? '2027' : '2026',
                                 amountUah: recordToEdit ? '2 000' : '1 000',
                                 amountUsd: recordToEdit ? '50' : '25',
@@ -187,6 +196,20 @@ jest.mock('./components/common/add-program-expense-record-modal/AddProgramExpens
                         }
                     >
                         Submit Modal
+                    </button>
+                    <button
+                        data-testid="mock-submit-new-category-btn"
+                        onClick={() =>
+                            onSubmit({
+                                programId: undefined,
+                                programName: 'New Category',
+                                reportingYear: '2026',
+                                amountUah: '1 000',
+                                amountUsd: '25',
+                            })
+                        }
+                    >
+                        Submit New Category
                     </button>
                 </>
             )}
@@ -630,6 +653,7 @@ describe('ProgramExpensesSection', () => {
         beforeEach(() => {
             mockPost.mockReset();
             mockUpdate.mockReset();
+            mockAddProgramCategory.mockReset();
         });
 
         it('should open modal in add mode, submit, call API.post and refetch', async () => {
@@ -651,12 +675,55 @@ describe('ProgramExpensesSection', () => {
                     amountUah: 1000,
                     amountUsd: 25,
                 });
+                expect(mockAddProgramCategory).not.toHaveBeenCalled();
                 expect(mockAddToast).toHaveBeenCalledWith(
                     PROGRAM_EXPENSES_TEXT.MESSAGE.RECORD_CREATED_SUCCESSFULLY,
                     'success',
                 );
                 expect(mockRefetch).toHaveBeenCalled();
                 expect(screen.getByTestId('add-program-expense-modal')).toHaveAttribute('data-open', 'false');
+            });
+        });
+
+        it('should create a new program category first when programId is undefined, then post the record', async () => {
+            mockAddProgramCategory.mockResolvedValueOnce({ id: 99, name: 'New Category', programsCount: 0 });
+            mockPost.mockResolvedValueOnce(undefined);
+
+            render(<ProgramExpensesSection />);
+
+            fireEvent.click(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE }));
+            fireEvent.click(screen.getByTestId('mock-submit-new-category-btn'));
+
+            await waitFor(() => {
+                expect(mockAddProgramCategory).toHaveBeenCalledWith({ id: null, name: 'New Category' }, 'mock-client');
+                expect(mockPost).toHaveBeenCalledWith('mock-client', {
+                    reportingYear: 2026,
+                    hippotherapyProgramCategoryId: 99,
+                    amountUah: 1000,
+                    amountUsd: 25,
+                });
+                expect(mockAddToast).toHaveBeenCalledWith(
+                    PROGRAM_EXPENSES_TEXT.MESSAGE.RECORD_CREATED_SUCCESSFULLY,
+                    'success',
+                );
+                expect(mockRefetch).toHaveBeenCalled();
+            });
+        });
+
+        it('should show error toast and not call API.post when creating the new category fails', async () => {
+            mockAddProgramCategory.mockRejectedValueOnce(new Error('failed to create category'));
+
+            render(<ProgramExpensesSection />);
+
+            fireEvent.click(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.BUTTON.ADD_PROGRAM_EXPENSE }));
+            fireEvent.click(screen.getByTestId('mock-submit-new-category-btn'));
+
+            await waitFor(() => {
+                expect(mockPost).not.toHaveBeenCalled();
+                expect(mockAddToast).toHaveBeenCalledWith(
+                    PROGRAM_EXPENSES_TEXT.MESSAGE.RECORD_CREATE_FAILED_RETRY,
+                    'error',
+                );
             });
         });
 

--- a/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/ProgramExpensesSection.tsx
@@ -7,6 +7,7 @@ import { ToastType } from '@/types/admin/toast';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { PROGRAM_EXPENSES_TEXT, REPORTS_TEXT } from '@/const/admin/reports';
 import { ProgramExpensesApi } from '@/services/api/admin/reports/program-expenses-api';
+import { ProgramsCategoriesApi } from '@/services/api/admin/programs/programs-api';
 import { ProgramExpensesReadOnlyData, ProgramExpensesRecord } from '@/types/admin/reports';
 import { ProgramExpensesToolbar } from './components/program-expenses-toolbar/ProgramExpensesToolbar';
 import { ProgramExpensesSummaryCard } from './components/program-expenses-summary-card/ProgramExpensesSummaryCard';
@@ -151,7 +152,13 @@ export const ProgramExpensesSection = ({
     );
 
     const handleSubmitAddProgramExpense = useCallback(
-        async (submitData: { programId: number; reportingYear: string; amountUah: string; amountUsd: string }) => {
+        async (submitData: {
+            programId: number | undefined;
+            programName: string;
+            reportingYear: string;
+            amountUah: string;
+            amountUsd: string;
+        }) => {
             const reportingYear = Number.parseInt(submitData.reportingYear, 10);
             const amountUah = Number.parseFloat(submitData.amountUah.replace(/\s/g, '').replace(',', '.'));
             const amountUsd = Number.parseFloat(submitData.amountUsd.replace(/\s/g, '').replace(',', '.'));
@@ -161,9 +168,19 @@ export const ProgramExpensesSection = ({
             }
 
             try {
+                let categoryId = submitData.programId;
+
+                if (categoryId === undefined) {
+                    const createdCategory = await ProgramsCategoriesApi.addProgramCategory(
+                        { id: null, name: submitData.programName },
+                        adminClient,
+                    );
+                    categoryId = createdCategory.id;
+                }
+
                 const payload = {
                     reportingYear,
-                    hippotherapyProgramCategoryId: submitData.programId,
+                    hippotherapyProgramCategoryId: categoryId,
                     amountUah,
                     amountUsd,
                 };

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.test.tsx
@@ -118,6 +118,25 @@ const selectOption = (currentDisplayValue: string, nextDisplayValue: string) => 
     fireEvent.click(screen.getByRole('button', { name: nextDisplayValue }));
 };
 
+const getCategoryInput = (): HTMLInputElement => {
+    const input = screen.getByPlaceholderText(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER);
+
+    if (!(input instanceof HTMLInputElement)) {
+        throw new Error('Category combobox input was not found');
+    }
+
+    return input;
+};
+
+const selectCategoryOption = (optionName: string) => {
+    fireEvent.focus(getCategoryInput());
+    fireEvent.click(screen.getByRole('button', { name: optionName }));
+};
+
+const typeCategory = (text: string) => {
+    fireEvent.change(getCategoryInput(), { target: { value: text } });
+};
+
 describe('AddProgramExpenseRecordModal', () => {
     it('renders modal content, disabled submit button and sorted programs', () => {
         renderModal();
@@ -127,7 +146,7 @@ describe('AddProgramExpenseRecordModal', () => {
         expect(screen.getByLabelText(FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL)).toHaveValue('42.15');
         expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.MODAL.ADD.SUBMIT_BUTTON })).toBeDisabled();
 
-        fireEvent.click(getSelectToggle(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER));
+        fireEvent.focus(getCategoryInput());
         const programOptions = screen
             .getAllByRole('button', { name: /^Program [AB]$/ })
             .map((option) => option.textContent);
@@ -135,11 +154,22 @@ describe('AddProgramExpenseRecordModal', () => {
         expect(programOptions).toEqual(['Program A', 'Program B']);
     });
 
-    it('renders disabled program placeholder when programs are unavailable', () => {
+    it('allows typing a brand new category name when there are no existing categories yet', () => {
         renderModal({ programs: [] });
 
-        expect(screen.getByText(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_NO_AVAILABLE)).toBeInTheDocument();
-        expect(screen.queryByText(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER)).not.toBeInTheDocument();
+        typeCategory('XXXXXXXX');
+
+        expect(getCategoryInput()).toHaveValue('XXXXXXXX');
+    });
+
+    it('accepts a custom category name that does not match any existing option', () => {
+        renderModal();
+
+        fireEvent.focus(getCategoryInput());
+        typeCategory('XXXXXXXX');
+
+        expect(getCategoryInput()).toHaveValue('XXXXXXXX');
+        expect(screen.getByText(COMMON_TEXT_ADMIN.LIST.NOT_FOUND)).toBeInTheDocument();
     });
 
     it('validates program expense amount inputs on change and blur', () => {
@@ -179,16 +209,16 @@ describe('AddProgramExpenseRecordModal', () => {
     it('updates selected program value', () => {
         renderModal();
 
-        selectOption(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER, 'Program A');
+        selectCategoryOption('Program A');
 
-        expect(getSelectToggle('Program A')).toBeInTheDocument();
+        expect(getCategoryInput()).toHaveValue('Program A');
     });
 
     it('shows required errors on blur for empty selects', () => {
         renderModal();
 
         fireEvent.blur(getSelectToggle(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER));
-        fireEvent.blur(getSelectToggle(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER));
+        fireEvent.blur(getCategoryInput());
 
         expect(screen.getAllByText(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED)).toHaveLength(2);
     });
@@ -197,10 +227,10 @@ describe('AddProgramExpenseRecordModal', () => {
         renderModal();
 
         const reportingYearToggle = getSelectToggle(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER);
-        const programToggle = getSelectToggle(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER);
+        const categoryInput = getCategoryInput();
 
         fireEvent.blur(reportingYearToggle, { relatedTarget: reportingYearToggle });
-        fireEvent.blur(programToggle, { relatedTarget: programToggle });
+        fireEvent.blur(categoryInput, { relatedTarget: categoryInput });
 
         expect(screen.queryByText(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED)).not.toBeInTheDocument();
     });
@@ -209,7 +239,7 @@ describe('AddProgramExpenseRecordModal', () => {
         renderModal();
 
         selectOption(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER, '2026');
-        selectOption(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER, 'Program A');
+        selectCategoryOption('Program A');
         fireEvent.change(screen.getByTestId('add-program-expense-amount-uah'), { target: { value: '100' } });
 
         expect(screen.getByText(PROGRAM_EXPENSES_TEXT.VALIDATION.PROGRAM_UNIQUE)).toBeInTheDocument();
@@ -220,10 +250,35 @@ describe('AddProgramExpenseRecordModal', () => {
         renderModal();
 
         selectOption(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER, '2026');
-        selectOption(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER, 'Program B');
+        selectCategoryOption('Program B');
         fireEvent.change(screen.getByTestId('add-program-expense-amount-uah'), { target: { value: '100' } });
 
         expect(screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.MODAL.ADD.SUBMIT_BUTTON })).toBeEnabled();
+    });
+
+    it('enables submit with a brand new category name and submits programId undefined', async () => {
+        const onSubmit = jest.fn().mockResolvedValue(true);
+        renderModal({ onSubmit, exchangeRate: '40' });
+
+        selectOption(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER, '2026');
+        typeCategory('New Category');
+        fireEvent.change(screen.getByTestId('add-program-expense-amount-uah'), { target: { value: '400' } });
+
+        const submitButton = screen.getByRole('button', { name: PROGRAM_EXPENSES_TEXT.MODAL.ADD.SUBMIT_BUTTON });
+        expect(submitButton).toBeEnabled();
+
+        fireEvent.click(submitButton);
+        fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+        await waitFor(() => {
+            expect(onSubmit).toHaveBeenCalledWith({
+                programId: undefined,
+                programName: 'New Category',
+                reportingYear: '2026',
+                amountUah: '400',
+                amountUsd: '10',
+            });
+        });
     });
 
     it('closes immediately when the form is clean', () => {
@@ -301,6 +356,7 @@ describe('AddProgramExpenseRecordModal', () => {
         expect(screen.getByTestId('add-program-expense-amount-uah')).toHaveValue('');
         expect(screen.queryByTestId('close-confirmation')).not.toBeInTheDocument();
         expect(screen.getByLabelText(FUNDS_EXPENDITURES_TEXT.EXCHANGE_RATE_LABEL)).toHaveValue('');
+        expect(getCategoryInput()).toHaveValue('');
     });
 
     it('auto-fills USD when UAH is entered and shows mismatch message on manual USD change', () => {
@@ -328,7 +384,7 @@ describe('AddProgramExpenseRecordModal', () => {
         renderModal({ exchangeRate: '40', onSubmit });
 
         selectOption(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER, '2026');
-        selectOption(PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER, 'Program B');
+        selectCategoryOption('Program B');
         fireEvent.change(screen.getByTestId('add-program-expense-amount-uah'), { target: { value: '400' } });
         fireEvent.change(screen.getByTestId('add-program-expense-amount-usd'), { target: { value: '10' } });
         fireEvent.blur(screen.getByTestId('add-program-expense-amount-usd'));
@@ -368,7 +424,7 @@ describe('AddProgramExpenseRecordModal', () => {
             expect(screen.getByText(PROGRAM_EXPENSES_TEXT.MODAL.EDIT.SUBTITLE)).toBeInTheDocument();
 
             expect(screen.getByRole('button', { name: '2025' })).toBeInTheDocument();
-            expect(screen.getByRole('button', { name: 'Program A' })).toBeInTheDocument();
+            expect(getCategoryInput()).toHaveValue('Program A');
             expect(screen.getByTestId('add-program-expense-amount-uah')).toHaveValue('100');
             expect(screen.getByTestId('add-program-expense-amount-usd')).toHaveValue('10');
 
@@ -387,6 +443,7 @@ describe('AddProgramExpenseRecordModal', () => {
             await waitFor(() => {
                 expect(onSubmit).toHaveBeenCalledWith({
                     programId: 1,
+                    programName: 'Program A',
                     reportingYear: '2025',
                     amountUah: '200',
                     amountUsd: '4,75', // auto calculated based on rate 42.15 and rounded up

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/admin/button/Button';
 import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
 import { InputWithCharacterLimit } from '@/components/admin/input-with-character-limit/InputWithCharacterLimit';
 import { Select } from '@/components/common/select/Select';
+import { CategoryCombobox } from '@/components/common/category-combobox/CategoryCombobox';
 import { Modal } from '@/components/common/modal/Modal';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT, PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
@@ -20,7 +21,8 @@ interface AddProgramExpenseRecordModalProps {
     exchangeRate: string | null;
     onClose: () => void;
     onSubmit: (data: {
-        programId: number;
+        programId: number | undefined;
+        programName: string;
         reportingYear: string;
         amountUah: string;
         amountUsd: string;
@@ -142,7 +144,6 @@ export const AddProgramExpenseRecordModal = ({
     const {
         formState,
         programOptions,
-        isProgramSelectDisabled,
         isDirty,
         isSubmitDisabled,
         isSubmitting,
@@ -151,6 +152,7 @@ export const AddProgramExpenseRecordModal = ({
         handleReportingYearChange,
         handleReportingYearBlur,
         handleProgramChange,
+        handleProgramInputChange,
         handleProgramBlur,
         handleAmountChange,
         handleUsdChange,
@@ -255,25 +257,18 @@ export const AddProgramExpenseRecordModal = ({
                                 error={formState.errors.programId}
                                 onBlurCapture={handleProgramFieldBlur}
                             >
-                                {isProgramSelectDisabled ? (
-                                    <div className={styles['disabled-select-placeholder']}>
-                                        {PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_NO_AVAILABLE}
-                                    </div>
-                                ) : (
-                                    <Select<number>
-                                        value={formState.programId}
-                                        onValueChange={handleProgramChange}
-                                        selectContainerRef={programSelectRef}
-                                        placeholder={PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER}
-                                        className={styles.select}
-                                        optionClassName={styles['select-option']}
-                                        disabled={isSubmitting}
-                                    >
-                                        {programOptions.map((program) => (
-                                            <Select.Option key={program.id} value={program.id} name={program.name} />
-                                        ))}
-                                    </Select>
-                                )}
+                                <CategoryCombobox
+                                    id="add-program-expense-category"
+                                    options={programOptions}
+                                    inputValue={formState.programInputValue}
+                                    onInputValueChange={handleProgramInputChange}
+                                    onOptionSelect={(option) => handleProgramChange(option.id)}
+                                    selectContainerRef={programSelectRef}
+                                    placeholder={PROGRAM_EXPENSES_TEXT.MODAL.ADD.PROGRAM_PLACEHOLDER}
+                                    className={styles.select}
+                                    optionClassName={styles['select-option']}
+                                    disabled={isSubmitting}
+                                />
                             </SelectField>
 
                             <AmountField

--- a/src/validation/admin/reports-schema/program-expenses-record-schema/program-expenses-record-schema.test.ts
+++ b/src/validation/admin/reports-schema/program-expenses-record-schema/program-expenses-record-schema.test.ts
@@ -1,6 +1,7 @@
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
 import { ProgramExpensesRecord } from '@/types/admin/reports';
+import { PROGRAM_CATEGORY_VALIDATION_FUNCTIONS } from '@/validation/admin/program-category-schema/program-category-schema';
 import { validateProgramExpenseProgram } from './program-expenses-record-schema';
 
 describe('PROGRAM_EXPENSES_RECORD_VALIDATION_FUNCTIONS', () => {
@@ -68,5 +69,36 @@ describe('PROGRAM_EXPENSES_RECORD_VALIDATION_FUNCTIONS', () => {
                 records,
             }),
         ).toBeUndefined();
+    });
+
+    it('validates a custom (not yet existing) category name using category name rules', () => {
+        expect(
+            validateProgramExpenseProgram({
+                recordId: 0,
+                programId: undefined,
+                programName: 'ab',
+                records,
+            }),
+        ).toBe(PROGRAM_CATEGORY_VALIDATION_FUNCTIONS.validateName('ab'));
+        expect(
+            validateProgramExpenseProgram({
+                recordId: 0,
+                programId: undefined,
+                programName: 'New Category',
+                records,
+            }),
+        ).toBeUndefined();
+    });
+
+    it('treats whitespace-only custom category name as empty', () => {
+        expect(
+            validateProgramExpenseProgram({
+                recordId: 0,
+                programId: undefined,
+                programName: '   ',
+                records,
+                trigger: 'blur',
+            }),
+        ).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED);
     });
 });

--- a/src/validation/admin/reports-schema/program-expenses-record-schema/program-expenses-record-schema.ts
+++ b/src/validation/admin/reports-schema/program-expenses-record-schema/program-expenses-record-schema.ts
@@ -1,6 +1,7 @@
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { PROGRAM_EXPENSES_TEXT } from '@/const/admin/reports';
 import { ProgramExpensesRecord } from '@/types/admin/reports';
+import { PROGRAM_CATEGORY_VALIDATION_FUNCTIONS } from '@/validation/admin/program-category-schema/program-category-schema';
 import {
     FundsExpendituresAmountValidationTrigger,
     FundsExpendituresReportingYearValidationTrigger,
@@ -14,6 +15,7 @@ export type ProgramExpenseProgramValidationTrigger = 'change' | 'blur';
 interface ValidateProgramExpenseProgramParams {
     recordId: number;
     programId: number | undefined;
+    programName?: string;
     records: ProgramExpensesRecord[];
     trigger?: ProgramExpenseProgramValidationTrigger;
 }
@@ -33,11 +35,18 @@ export const validateProgramExpenseReportingYear = (
 export const validateProgramExpenseProgram = ({
     recordId,
     programId,
+    programName = '',
     records,
     trigger = 'change',
 }: ValidateProgramExpenseProgramParams): string | undefined => {
-    if (programId === undefined) {
+    const trimmedProgramName = programName.trim();
+
+    if (programId === undefined && trimmedProgramName === '') {
         return trigger === 'blur' ? COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED : undefined;
+    }
+
+    if (programId === undefined) {
+        return PROGRAM_CATEGORY_VALIDATION_FUNCTIONS.validateName(trimmedProgramName);
     }
 
     const hasDuplicate = records.some((item) => item.id !== recordId && item.programId === programId);


### PR DESCRIPTION
## Github ticker

* [#3019](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3019)

## Description

In the "Категорія програми" combobox field of the "Додати витрату по програмі" modal, entering a value that wasn't already in the dropdown list was ignored — the field only allowed picking an existing option, because it was rendered with the button-based `Select` component, which has no text input at all (issue #3019). The fix introduces a new `CategoryCombobox` component, modeled on the existing input+dropdown pattern used by `SearchBar`, that accepts free text and, on save, creates the category on the fly via the existing Programs category API before the expense record itself is saved.

## How it looks

https://github.com/user-attachments/assets/ae2f216f-687c-4ecc-939a-b7dc773cbeba

## Summary of change

- `CategoryCombobox.tsx` (new): editable combobox with a real `<input>`, local filtering of options, keyboard navigation (↑/↓/Enter/Esc) and closing on outside click.
- `AddProgramExpenseRecordModal.tsx`: replaced the button-based `Select` for "Категорія програми" with `CategoryCombobox`; removed the "no categories available" disabled placeholder, since an empty category list should no longer block input of the first one.
- `useProgramExpenseRecordForm.ts`: added `programInputValue` state and `handleProgramInputChange` to distinguish selecting an existing category (`programId`) from typing a new one (`programId` undefined + a pending name); the submit payload now carries both.
- `program-expenses-record-schema.ts`: a not-yet-existing category name is now validated against the existing category name rules (5–20 characters) instead of only checking that an id was picked.
- `ProgramExpensesSection.tsx`: when `programId` is undefined on submit, the category is created first via `ProgramsCategoriesApi.addProgramCategory`, then the expense record is posted with the resulting id.

## How to recreate changes

1. Log into the Admin panel and open "Звітність" → "Звіт та аналітика" tab → "Програмні витрати" sub-tab.
2. Click "+ Витрата по програмі".
3. Click the "Категорія програми" field and type a value that is not in the dropdown list, e.g. "XXXXXXXX".
4. Verify the typed text is accepted (not ignored), fill in the remaining required fields and save the record.
5. Verify the new category is created and the record is saved with it; reopening the modal shows "XXXXXXXX" as a regular option in the dropdown.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a searchable category combobox with filtering, keyboard navigation, custom empty-state messaging, and disabled-state support.
  - Users can enter new program categories directly when recording expenses.
  - New categories are created automatically before the expense is saved.

- **Bug Fixes**
  - Improved validation for custom category names, including required, whitespace, and length checks.
  - Preserved entered category names and improved form reset and edit behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->