### PR TITLE
Feature/issue-1109 [Who we are] Upload image (new validation rule)

### DIFF
--- a/src/const/admin/who-we-are.ts
+++ b/src/const/admin/who-we-are.ts
@@ -45,11 +45,11 @@ export const IMAGE_CONFIGS = {
         minHeight: 750,
     } as WhoWeAreImageConfigParams,
     WHO_WE_SUPPORT_CARDS: {
-        cropWidth: 500,
+        cropWidth: 540,
         cropHeight: 430,
-        minWidth: 500,
+        minWidth: 540,
         minHeight: 430,
-        displayWidth: 480,
+        displayWidth: 540,
         displayHeight: 430,
     } as WhoWeAreImageConfigParams,
     PEOPLE_CARDS: {


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1109

## Description

This PR updates the image validation and cropper dimension rules for the **"Who we are"** admin page blocks according to [Issue#1109](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1109). Specifically, it updates the required image display and crop dimensions for the **"Кого підтримуємо"** block cards to `540 x 430` px.


## Summary of change

- Updated `IMAGE_CONFIGS.WHO_WE_SUPPORT_CARDS` in `src/const/admin/who-we-are.ts` to set `cropWidth: 540`, `minWidth: 540`, and `displayWidth:
  540` (matching the required `540x430` display area rule).
 - Verified image upload configuration dimensions across all 4 Who We Are page blocks:
      - **Основне** (`MAIN_PAGE`): `1440 x 860` px
      - **Команда** (`TEAM_PAGE`): `840 x 750` px
      - **Кого підтримуємо** (`WHO_WE_SUPPORT_CARDS`): `540 x 430` px
      - **Люди** (`PEOPLE_CARDS`): `360 x 430` px

## How to recreate changes

• Log in as Admin and navigate to the "Про нас" (Who We Are) management page.
• Go to the "Кого підтримуємо" block and click to upload/replace an image on any card.
• Observe that the image helper subtext displays 540x430 and the cropper enforces the 540x430 aspect ratio and minimum dimensions.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated “Who We Support” card image sizing for improved display quality and consistency.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->