### PR TITLE
Fix/issue 3126 Reports] The "Змінених життів" field label is displayed incorrectly as "Кількість змінених життів"

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -8,7 +8,7 @@ export const REPORTS_TEXT = {
             COLLECTED_FUNDS_WINDOW: 'Вікно 1: Зібрано коштів',
             CHANGED_LIVES_WINDOW: 'Вікно 2: Змінено життів',
             COLLECTED_FUNDS: 'Зібрані кошти',
-            CHANGED_LIVES: 'Кількість змінених життів',
+            CHANGED_LIVES: 'Змінених життів',
             WINDOW_DESCRIPTION: 'Фото «Репрезентативне фото»',
         },
         MAX_LENGTH: {


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3126)

## Description

This PR resolves a UI text mismatch in the Reports (Звітність) admin view on the "Налаштування медіа" tab. It updates the label of the "Змінених життів" (Changed Lives) field to display the correct text according to the mock-up design rather than "Кількість змінених життів".

## How it looks

<img width="1244" height="721" alt="image" src="https://github.com/user-attachments/assets/8107b086-0f51-4062-90c7-d12bdcd75940" />

## Summary of change

*   **Label Correction (`reports.ts`)**: Updated `REPORTS_TEXT.FORM.LABEL.CHANGED_LIVES` from 'Кількість змінених життів' to 'Змінених життів' to ensure alignment with the design specifications.

## How to recreate changes

1. Log into the Admin panel and navigate to the **Reports** (Звітність) page.
2. Click on the **Налаштування медіа** (Media Settings) tab.
3. Observe the second window ("Вікно 2: Змінено життів").
4. Verify that the label for the third input field is displayed as ***Змінених життів** instead of ***Кількість змінених життів**.


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Ukrainian report form label for improved brevity and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->