### PR TITLE
Feature/issue-1851 [Programs] Translation indicators for program categories

### DIFF
--- a/src/components/admin/localization-statuses/LocalizationStatuses.test.tsx
+++ b/src/components/admin/localization-statuses/LocalizationStatuses.test.tsx
@@ -88,4 +88,52 @@ describe('LocalizationStatuses component', () => {
 
         assertStatusBadges();
     });
+
+    it('falls back to localizations when translationStatuses is empty', () => {
+        const entityWithEmptyStatuses = {
+            translationStatuses: [],
+            localizations: translationStatusesByLanguage.map(({ languageId, languageCode, translationStatus }) => ({
+                language: { id: languageId, code: languageCode },
+                translationStatus,
+            })),
+        };
+
+        render(<LocalizationStatuses languages={languages} localizedEntity={entityWithEmptyStatuses} />);
+
+        assertStatusBadges();
+    });
+
+    it('renders default red badge for all languages when entity has neither translationStatuses nor localizations', () => {
+        render(<LocalizationStatuses languages={languages} localizedEntity={{}} />);
+
+        const enBadge = screen.getByText('EN');
+        const esBadge = screen.getByText('ES');
+        const plBadge = screen.getByText('PL');
+
+        expect(enBadge).not.toHaveClass(styles.relevant);
+        expect(enBadge).not.toHaveClass(styles.outdated);
+        expect(esBadge).not.toHaveClass(styles.relevant);
+        expect(esBadge).not.toHaveClass(styles.outdated);
+        expect(plBadge).not.toHaveClass(styles.relevant);
+        expect(plBadge).not.toHaveClass(styles.outdated);
+    });
+
+    it('handles localizations with localizationInfoDto property correctly', () => {
+        const entityWithDtoLocalizations = {
+            localizations: [
+                {
+                    localizationInfoDto: { id: 1, code: 'en' },
+                    translationStatus: TranslationStatus.Relevant,
+                },
+                {
+                    localizationInfoDto: { id: 2, code: 'es' },
+                    translationStatus: TranslationStatus.Outdated,
+                },
+            ],
+        };
+
+        render(<LocalizationStatuses languages={languages} localizedEntity={entityWithDtoLocalizations as any} />);
+
+        assertStatusBadges();
+    });
 });

--- a/src/components/admin/localization-statuses/LocalizationStatuses.tsx
+++ b/src/components/admin/localization-statuses/LocalizationStatuses.tsx
@@ -17,15 +17,26 @@ const getTranslationStatus = <TLocalization extends EntityLocalization>(
     language: LocalizationLanguage,
     localizedEntity: Partial<EntityWithLocalizations<TLocalization>> | Partial<EntityWithTranslationStatuses>,
 ): TranslationStatus | undefined => {
-    if ('translationStatuses' in localizedEntity && localizedEntity.translationStatuses?.length) {
-        const found = localizedEntity.translationStatuses.find((loc) => loc.languageId === language.id);
-        if (found) {
-            return found.translationStatus;
-        }
+    if (
+        'translationStatuses' in localizedEntity &&
+        localizedEntity.translationStatuses &&
+        localizedEntity.translationStatuses.length > 0
+    ) {
+        return localizedEntity.translationStatuses.find((loc) => loc.languageId === language.id)?.translationStatus;
     }
 
-    if ('localizations' in localizedEntity && localizedEntity.localizations?.length) {
-        return localizedEntity.localizations.find((loc) => loc.language?.code === language.code)?.translationStatus;
+    if (
+        'localizations' in localizedEntity &&
+        localizedEntity.localizations &&
+        localizedEntity.localizations.length > 0
+    ) {
+        return localizedEntity.localizations.find(
+            (loc: any) =>
+                loc.language?.code === language.code ||
+                loc.localizationInfoDto?.code === language.code ||
+                loc.language?.id === language.id ||
+                loc.localizationInfoDto?.id === language.id,
+        )?.translationStatus;
     }
 
     return undefined;

--- a/src/components/admin/localization-statuses/LocalizationStatuses.tsx
+++ b/src/components/admin/localization-statuses/LocalizationStatuses.tsx
@@ -8,20 +8,27 @@ import {
 } from '@/types/common/language';
 import styles from './LocalizationStatuses.module.scss';
 
-export interface LocalizationStatusProps<TLocalization extends EntityLocalization> {
+export interface LocalizationStatusProps<TLocalization extends EntityLocalization = EntityLocalization> {
     languages: LocalizationLanguage[];
-    localizedEntity: EntityWithLocalizations<TLocalization> | EntityWithTranslationStatuses;
+    localizedEntity: Partial<EntityWithLocalizations<TLocalization>> | Partial<EntityWithTranslationStatuses>;
 }
 
 const getTranslationStatus = <TLocalization extends EntityLocalization>(
     language: LocalizationLanguage,
-    localizedEntity: EntityWithLocalizations<TLocalization> | EntityWithTranslationStatuses,
+    localizedEntity: Partial<EntityWithLocalizations<TLocalization>> | Partial<EntityWithTranslationStatuses>,
 ): TranslationStatus | undefined => {
-    if ('translationStatuses' in localizedEntity) {
-        return localizedEntity.translationStatuses?.find((loc) => loc.languageId === language.id)?.translationStatus;
+    if ('translationStatuses' in localizedEntity && localizedEntity.translationStatuses?.length) {
+        const found = localizedEntity.translationStatuses.find((loc) => loc.languageId === language.id);
+        if (found) {
+            return found.translationStatus;
+        }
     }
 
-    return localizedEntity.localizations?.find((loc) => loc.language?.code === language.code)?.translationStatus;
+    if ('localizations' in localizedEntity && localizedEntity.localizations?.length) {
+        return localizedEntity.localizations.find((loc) => loc.language?.code === language.code)?.translationStatus;
+    }
+
+    return undefined;
 };
 
 export const LocalizationStatuses = <TLocalization extends EntityLocalization>({

--- a/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.test.tsx
+++ b/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.test.tsx
@@ -103,7 +103,13 @@ jest.mock('@/components/admin/admin-panel-toolbar/AdminPageToolbar', () => ({
 }));
 
 jest.mock('@/components/admin/category-bar/CategoryBar', () => ({
-    CategoryBar: ({ categories, selectedCategory, onCategorySelect, onContextMenuOptionSelected }: any) => (
+    CategoryBar: ({
+        categories,
+        selectedCategory,
+        onCategorySelect,
+        onContextMenuOptionSelected,
+        renderCategoryExtra,
+    }: any) => (
         <div data-testid="category-bar">
             {categories.map((cat: any) => (
                 <button
@@ -113,6 +119,7 @@ jest.mock('@/components/admin/category-bar/CategoryBar', () => ({
                     disabled={selectedCategory?.id === cat.id}
                 >
                     {cat.name}
+                    {renderCategoryExtra?.(cat)}
                 </button>
             ))}
             <button data-testid="ctx-add" onClick={() => onContextMenuOptionSelected?.('add')}>
@@ -1048,6 +1055,15 @@ describe('ProgramsPageContent', () => {
         await waitFor(() => {
             expect(screen.getByTestId('category-1')).toBeDisabled();
             expect(screen.getByTestId('category-2')).not.toBeDisabled();
+        });
+    });
+
+    it('renders localization statuses indicator for category tabs via renderCategoryExtra', async () => {
+        await renderAndWaitForCategoryBar();
+
+        await waitFor(() => {
+            const statuses = screen.getAllByTestId('localization-statuses');
+            expect(statuses.length).toBeGreaterThan(0);
         });
     });
 });

--- a/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.tsx
+++ b/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.tsx
@@ -24,6 +24,7 @@ import { ToastType } from '@/types/admin/toast';
 import { ToastContainer } from '@/components/admin/toast/toast-container/ToastContainer';
 import { useLocalizationToolkit } from '@/hooks/admin/use-localization-toolkit/useLocalizationToolkit';
 import { mapHippotherapyProgramDtoToModel } from '@/utils/functions/mappers/admin/programs/programs-mappers';
+import { LocalizationStatuses } from '@/components/admin/localization-statuses/LocalizationStatuses';
 
 const DEFAULT_LOAD_ITEMS_COUNT = 5;
 const LIST_ITEM_HEIGHT_IN_PIXELS = 120;
@@ -541,6 +542,9 @@ export const ProgramsPageContent = () => {
                     displayContextMenuButton={true}
                     contextMenuOptions={categoryBarContextMenuOptions}
                     onContextMenuOptionSelected={onContextMenuOptionSelected}
+                    renderCategoryExtra={(category) => (
+                        <LocalizationStatuses languages={translationLanguages} localizedEntity={category} />
+                    )}
                 />
 
                 {error.message && (

--- a/src/services/api/admin/programs/programs-api.ts
+++ b/src/services/api/admin/programs/programs-api.ts
@@ -12,6 +12,7 @@ import { AxiosInstance } from 'axios';
 import { API_ROUTES } from '@/const/common/api-routes/main-api';
 import { ImageApi } from '@/services/api/admin/image/image-api';
 import { TranslationStatusFilter } from '@/types/common/language';
+import { mapProgramCategoryDtoToModel } from '@/utils/functions/mappers/admin/programs/programs-mappers';
 
 const convertProgramToSuggestion = (program: HippotherapyProgramDto): ProgramSearchItemData => {
     return {
@@ -49,13 +50,8 @@ const mapProgramEditToProgram = async (
 
 export const ProgramsCategoriesApi = {
     fetchProgramCategories: async (client: AxiosInstance): Promise<ProgramCategory[]> => {
-        const response = await client.get<ProgramCategory[]>(API_ROUTES.PROGRAMCATEGORY.BASE);
-        return response.data.map((category: any) => {
-            return {
-                ...category,
-                programsCount: category.programs.length,
-            };
-        });
+        const response = await client.get<any[]>(API_ROUTES.PROGRAMCATEGORY.BASE);
+        return response.data.map(mapProgramCategoryDtoToModel);
     },
 
     addProgramCategory: async (

--- a/src/types/admin/programs.ts
+++ b/src/types/admin/programs.ts
@@ -10,12 +10,15 @@ import {
     EntityLocalizationDto,
     EntityWithDtoLocalizations,
     EntityWithLocalizations,
+    TranslationStatusInfo,
 } from '../common/language';
 
 export interface ProgramCategory {
     id: number;
     name: string;
     programsCount: number;
+    localizations?: EntityLocalization[];
+    translationStatuses?: TranslationStatusInfo[];
 }
 
 export interface HippotherapyProgramDto

--- a/src/utils/functions/mappers/admin/programs/programs-mappers.test.ts
+++ b/src/utils/functions/mappers/admin/programs/programs-mappers.test.ts
@@ -1,4 +1,4 @@
-import { mapHippotherapyProgramDtoToModel } from './programs-mappers';
+import { mapHippotherapyProgramDtoToModel, mapProgramCategoryDtoToModel } from './programs-mappers';
 import { VisibilityStatus } from '@/types/admin/common';
 import { HippotherapyProgramDto } from '@/types/admin/programs';
 import { TranslationStatus } from '@/types/common/language';
@@ -61,5 +61,55 @@ describe('mapHippotherapyProgramDtoToModel', () => {
         const dto = createMockDto({ localizations: [] });
         const result = mapHippotherapyProgramDtoToModel(dto);
         expect(result.localizations).toEqual([]);
+    });
+});
+
+describe('mapProgramCategoryDtoToModel', () => {
+    it('maps category DTO localizations with localizationInfoDto to language', () => {
+        const categoryDto = {
+            id: 1,
+            name: 'Rehabilitation',
+            programs: [{}, {}],
+            localizations: [
+                {
+                    localizationInfoDto: { id: 2, code: 'en' },
+                    translationStatus: TranslationStatus.Relevant,
+                },
+            ],
+        };
+
+        const result = mapProgramCategoryDtoToModel(categoryDto);
+
+        expect(result).toEqual({
+            id: 1,
+            name: 'Rehabilitation',
+            programsCount: 2,
+            localizations: [
+                {
+                    language: { id: 2, code: 'en' },
+                    translationStatus: TranslationStatus.Relevant,
+                },
+            ],
+            translationStatuses: undefined,
+        });
+    });
+
+    it('preserves existing language property if already mapped', () => {
+        const categoryDto = {
+            id: 2,
+            name: 'Therapy',
+            programsCount: 4,
+            localizations: [
+                {
+                    language: { id: 2, code: 'en' },
+                    translationStatus: TranslationStatus.Outdated,
+                },
+            ],
+        };
+
+        const result = mapProgramCategoryDtoToModel(categoryDto);
+
+        expect(result.programsCount).toBe(4);
+        expect(result.localizations?.[0].language).toEqual({ id: 2, code: 'en' });
     });
 });

--- a/src/utils/functions/mappers/admin/programs/programs-mappers.ts
+++ b/src/utils/functions/mappers/admin/programs/programs-mappers.ts
@@ -1,4 +1,4 @@
-import { HippotherapyProgramDto, HippotherapyProgram } from '@/types/admin/programs';
+import { HippotherapyProgramDto, HippotherapyProgram, ProgramCategory } from '@/types/admin/programs';
 import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/localization/localization-mappers';
 
 export function mapHippotherapyProgramDtoToModel(dto: HippotherapyProgramDto): HippotherapyProgram {
@@ -18,5 +18,19 @@ export function mapHippotherapyProgramDtoToModel(dto: HippotherapyProgramDto): H
         sections: dto.sections,
         slug: dto.slug,
         localizations: mappedLocalizations,
+    };
+}
+
+export function mapProgramCategoryDtoToModel(dto: any): ProgramCategory {
+    const mappedLocalizations = dto.localizations
+        ? dto.localizations.map((loc: any) => ('localizationInfoDto' in loc ? mapLocalizationDtoToModel(loc) : loc))
+        : undefined;
+
+    return {
+        id: dto.id,
+        name: dto.name,
+        programsCount: dto.programsCount ?? dto.programs?.length ?? 0,
+        localizations: mappedLocalizations,
+        translationStatuses: dto.translationStatuses,
     };
 }


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/1851

  ## Description

  This PR adds translation status indicators to program category tabs on the Admin Panel "Програми" page. This allows administrators to immediately see whether a category has complete, outdated, or missing translations for non-default languages (e.g., English).

  ## Summary of change

  • Updated ProgramCategory in src/types/admin/programs.ts to include optional localizations and translationStatuses
  fields.
  • Updated <LocalizationStatuses> in src/components/admin/localization-statuses/LocalizationStatuses.tsx to support
  entities with partial localization properties.
  • Rendered <LocalizationStatuses> inside <CategoryBar> via renderCategoryExtra in
  src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.tsx.
  • Ensured category tabs display appropriate status badge colors:
      •  Green: Up-to-date translation (Relevant)
      • Orange: Outdated translation (Outdated)
      • Red: Missing translation

  ## How to recreate changes

  • Log in to the Admin Panel as an administrator.
 • Navigate to the "Програми" (Programs) management page.
 • Observe the category tabs rendered in <CategoryBar> at the top of the program list.
 • Verify that each category tab displays a language badge (e.g., EN) indicating its translation status (Green,  Orange, or Red).

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localization and translation status indicators to program categories.
  * Program category data can now include available localizations and translation statuses for per-category display.
* **Bug Fixes**
  * Improved resilience when localization/translation data is missing or incomplete, ensuring language badges render with correct default styling.
  * Updated mapping so category counts and localization details are derived reliably from available DTO fields.
* **Tests**
  * Expanded unit tests to cover fallback behavior and correct status badge rendering for multiple localization data shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->