### PR TITLE
fix/issue-2344 [Single Program] Application does not show bullet point in "Опис" fields (frame 633435)

### DIFF
--- a/src/components/common/section-templates/single-title-quintuple-description/SingleTitleQuintupleDescription.module.scss
+++ b/src/components/common/section-templates/single-title-quintuple-description/SingleTitleQuintupleDescription.module.scss
@@ -213,17 +213,21 @@ $desc-input-height: 115px;
         color: c.$grey-700;
     }
 
-    :global(textarea) {
+    :global(.char-limit-textarea__field) {
         width: $desc-input-width;
         height: $desc-input-height;
         box-sizing: border-box;
 
         background-color: c.$white;
+        background-image: radial-gradient(circle, #{c.$blue-900} 45%, transparent 55%);
+        background-size: 6px 6px;
+        background-position: 16px 20px;
+        background-repeat: no-repeat;
+        background-attachment: local;
         border: none;
         outline: none;
         border-radius: 8px;
-
-        padding: 12px 16px;
+        padding: 12px 16px 12px 32px;
         resize: none;
 
         font-family: t.$font-family-base;


### PR DESCRIPTION
##Github ticket

* [2344](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2344)

## Description

The main goal of this PR is to refine the styling of the textarea within the `SingleTitleQuintupleDescription` component. It prevents the styles from leaking to all textareas globally by targeting a specific class, and introduces a new visual indicator (a radial-gradient background) inside the text field.

## How it looks

<img width="1745" height="582" alt="image" src="https://github.com/user-attachments/assets/87c49015-0f17-4852-964d-aa32d67fca2d" />

## Summary of change

* **Selector Update:** Changed the global selector from a generic textarea tag to a specific `.char-limit-textarea__field` class to scope the styles correctly.
* **Background Styling:** Added a custom radial-gradient background image with specific sizing (6px 6px), positioning, and local attachment.
* **Padding Adjustment:** Increased the left padding from 16px to 32px (padding: 12px 16px 12px 32px;) to properly accommodate the new background image without text overlapping it.

## How to recreate changes

Run the application.
Navigate to a view or page that utilizes the `SingleTitleQuintupleDescription` template.
Locate the textarea field with the `char-limit-textarea__field` class.
Verify that the new background visual indicator is present on the left side of the input.
Type text into the field to ensure the new left padding prevents the text from overlapping the background indicator.


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the description text field’s visual styling with a blue dotted background pattern.
  * Added extra left-side spacing and a white background for improved text-field presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->