### PR TITLE
Implement localization for partners page

### DIFF
--- a/src/components/admin/translation-controls/TranslationControls.module.scss
+++ b/src/components/admin/translation-controls/TranslationControls.module.scss
@@ -5,7 +5,8 @@
     position: relative;
     display: flex;
     flex-direction: row;
-    justify-content: space-between;
+    justify-content: center;
+    align-items: center;
     gap: 10px;
     margin: 0.5rem 0;
 }
@@ -39,6 +40,8 @@
 }
 
 .generate-button {
+    position: absolute;
+    right: 0;
     width: 45%;
     font-size: 16px;
 

--- a/src/const/admin/partners.ts
+++ b/src/const/admin/partners.ts
@@ -54,6 +54,9 @@ export const PARTNERS_TEXT = {
         FAIL_TO_LOAD_BANNER: 'Виникла помилка під час завантаження банеру',
         FAIL_TO_TRANSLATE_BANNER: 'Виникла помилка під час додавання перекладу для банера',
         FAIL_TO_UPDATE_TRANSLATION_FOR_BANNER: 'Виникла помилка під час оновлення перекладу для банера',
+        FAIL_TO_TRANSLATE_SECTION: 'Виникла помилка під час додавання перекладу для секції партнерів',
+        FAIL_TO_UPDATE_TRANSLATION_FOR_SECTION: 'Виникла помилка під час оновлення перекладу для секції партнерів',
+        FAIL_TO_LOAD_TRANSLATION_FOR_SECTION: 'Виникла помилка під час завантаження перекладу для секції партнерів',
     },
 };
 

--- a/src/const/admin/partners.ts
+++ b/src/const/admin/partners.ts
@@ -52,6 +52,8 @@ export const PARTNERS_TEXT = {
         FAIL_TO_PUBLISH_SECTION: 'Виникла помилка під час публікації секції',
         FAIL_TO_DELETE_SECTION: 'Виникла помилка під час видалення секції',
         FAIL_TO_LOAD_BANNER: 'Виникла помилка під час завантаження банеру',
+        FAIL_TO_TRANSLATE_BANNER: 'Виникла помилка під час додавання перекладу для банера',
+        FAIL_TO_UPDATE_TRANSLATION_FOR_BANNER: 'Виникла помилка під час оновлення перекладу для банера',
     },
 };
 

--- a/src/const/common/api-routes/main-api.ts
+++ b/src/const/common/api-routes/main-api.ts
@@ -95,6 +95,9 @@ export const API_ROUTES = {
         SECTIONS: 'Partners/sections',
         PAGE: 'Partners/page',
     },
+    PARTNERS_PAGE_BANNER_LOCALIZATIONS: {
+        BASE: 'PartnersPageBannerLocalizations',
+    },
     REPORTS: {
         MEDIA_SETTINGS: 'Report/report',
         BASE: 'Report',

--- a/src/const/common/api-routes/main-api.ts
+++ b/src/const/common/api-routes/main-api.ts
@@ -98,6 +98,9 @@ export const API_ROUTES = {
     PARTNERS_PAGE_BANNER_LOCALIZATIONS: {
         BASE: 'PartnersPageBannerLocalizations',
     },
+    PARTNER_SECTION_LOCALIZATIONS: {
+        BASE: 'PartnerSectionLocalizations',
+    },
     REPORTS: {
         MEDIA_SETTINGS: 'Report/report',
         BASE: 'Report',

--- a/src/hooks/admin/use-translate-partner-banner/useTranslatePartnerBanner.test.ts
+++ b/src/hooks/admin/use-translate-partner-banner/useTranslatePartnerBanner.test.ts
@@ -1,0 +1,269 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useTranslatePartnerBanner } from './useTranslatePartnerBanner';
+import { PartnerBannerLocalizationApi } from '@/services/api/admin/partners/partners-banner-localizations-api';
+import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/localization/localization-mappers';
+import { PARTNERS_TEXT } from '@/const/admin/partners';
+import { LocalizationLanguage } from '@/types/common/language';
+import { PartnerBanner, PartnerBannerLocalization } from '@/types/admin/partners';
+import { ModalMode } from '@/types/admin/common';
+
+jest.mock('@/services/api/admin/partners/partners-banner-localizations-api');
+jest.mock('@/utils/functions/mappers/common/localization/localization-mappers');
+jest.mock('../use-admin-client/useAdminClient', () => ({
+    useAdminClient: () => ({ post: jest.fn() }),
+}));
+
+const mockedCreate = PartnerBannerLocalizationApi.create as jest.MockedFunction<
+    typeof PartnerBannerLocalizationApi.create
+>;
+const mockedUpdate = PartnerBannerLocalizationApi.update as jest.MockedFunction<
+    typeof PartnerBannerLocalizationApi.update
+>;
+const mockedMapper = mapLocalizationDtoToModel as jest.MockedFunction<typeof mapLocalizationDtoToModel>;
+
+const bannerMock: PartnerBanner = {
+    id: 1,
+    title: 'Original banner title',
+    description: 'Original banner description',
+    image: null,
+    imageId: null,
+    localizations: [],
+};
+
+const languageMock: LocalizationLanguage = {
+    id: 2,
+    code: 'en',
+    name: 'English',
+};
+
+const formValues = {
+    title: 'Translated banner title',
+    description: 'Translated banner description',
+};
+
+const localizationDtoMock = {
+    entityId: 1,
+    localizationInfoDto: {
+        id: 2,
+        code: 'en',
+    },
+    title: 'Translated banner title',
+    description: 'Translated banner description',
+    translationStatus: 1,
+};
+
+const localizationModelMock: PartnerBannerLocalization = {
+    title: 'Translated banner title',
+    description: 'Translated banner description',
+    language: {
+        id: 2,
+        code: 'en',
+    },
+    translationStatus: 1,
+};
+
+describe('useTranslatePartnerBanner', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should initialize with default state', () => {
+        const { result } = renderHook(() =>
+            useTranslatePartnerBanner({
+                banner: bannerMock,
+                language: languageMock,
+                onSuccess: jest.fn(),
+                mode: ModalMode.Add,
+            }),
+        );
+
+        expect(result.current.isSubmitting).toBe(false);
+        expect(result.current.error).toBe('');
+    });
+
+    it('should translate partner banner successfully', async () => {
+        const onSuccess = jest.fn();
+
+        mockedCreate.mockResolvedValue(localizationDtoMock as any);
+        mockedMapper.mockReturnValue(localizationModelMock);
+
+        const { result } = renderHook(() =>
+            useTranslatePartnerBanner({
+                banner: bannerMock,
+                language: languageMock,
+                onSuccess,
+                mode: ModalMode.Add,
+            }),
+        );
+
+        act(() => {
+            result.current.translateBanner(formValues);
+        });
+
+        await waitFor(() => {
+            expect(onSuccess).toHaveBeenCalled();
+        });
+
+        expect(mockedCreate).toHaveBeenCalledWith(expect.anything(), {
+            entityId: 1,
+            languageId: 2,
+            title: formValues.title,
+            description: formValues.description,
+        });
+
+        expect(onSuccess).toHaveBeenCalledWith({
+            ...bannerMock,
+            localizations: [localizationModelMock],
+        });
+
+        expect(result.current.isSubmitting).toBe(false);
+        expect(result.current.error).toBe('');
+    });
+
+    it('should update translation successfully in edit mode', async () => {
+        const onSuccess = jest.fn();
+
+        mockedUpdate.mockResolvedValue(localizationDtoMock as any);
+        mockedMapper.mockReturnValue(localizationModelMock);
+
+        const bannerWithLocalization: PartnerBanner = {
+            ...bannerMock,
+            localizations: [
+                {
+                    ...localizationModelMock,
+                    language: languageMock,
+                },
+            ],
+        };
+
+        const { result } = renderHook(() =>
+            useTranslatePartnerBanner({
+                banner: bannerWithLocalization,
+                language: languageMock,
+                onSuccess,
+                mode: ModalMode.Edit,
+            }),
+        );
+
+        await act(async () => {
+            await result.current.translateBanner(formValues);
+        });
+
+        expect(mockedUpdate).toHaveBeenCalledWith(expect.anything(), bannerMock.id, languageMock.id, {
+            title: formValues.title,
+            description: formValues.description,
+        });
+
+        expect(onSuccess).toHaveBeenCalledWith({
+            ...bannerWithLocalization,
+            localizations: [localizationModelMock],
+        });
+    });
+
+    it('should set error when translation fails', async () => {
+        const onSuccess = jest.fn();
+
+        mockedCreate.mockRejectedValue(new Error('API error'));
+
+        const { result } = renderHook(() =>
+            useTranslatePartnerBanner({
+                banner: bannerMock,
+                language: languageMock,
+                onSuccess,
+                mode: ModalMode.Add,
+            }),
+        );
+
+        await act(async () => {
+            try {
+                await result.current.translateBanner(formValues);
+            } catch {
+                // Ignoring error for test
+            }
+        });
+
+        await waitFor(() => {
+            expect(result.current.error).toBe(PARTNERS_TEXT.MESSAGE.FAIL_TO_TRANSLATE_BANNER);
+        });
+
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(result.current.isSubmitting).toBe(false);
+    });
+
+    it('should set error when update fails in edit mode', async () => {
+        const onSuccess = jest.fn();
+
+        mockedUpdate.mockRejectedValue(new Error('API error'));
+
+        const bannerWithLocalization: PartnerBanner = {
+            ...bannerMock,
+            localizations: [
+                {
+                    ...localizationModelMock,
+                    language: languageMock,
+                },
+            ],
+        };
+
+        const { result } = renderHook(() =>
+            useTranslatePartnerBanner({
+                banner: bannerWithLocalization,
+                language: languageMock,
+                onSuccess,
+                mode: ModalMode.Edit,
+            }),
+        );
+
+        await act(async () => {
+            try {
+                await result.current.translateBanner(formValues);
+            } catch {
+                // Ignoring error for test
+            }
+        });
+
+        await waitFor(() => {
+            expect(result.current.error).toBe(PARTNERS_TEXT.MESSAGE.FAIL_TO_UPDATE_TRANSLATION_FOR_BANNER);
+        });
+
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(result.current.isSubmitting).toBe(false);
+    });
+
+    it('should clear error', () => {
+        const { result } = renderHook(() =>
+            useTranslatePartnerBanner({
+                banner: bannerMock,
+                language: languageMock,
+                onSuccess: jest.fn(),
+                mode: ModalMode.Add,
+            }),
+        );
+
+        act(() => {
+            result.current.clearError();
+        });
+
+        expect(result.current.error).toBe('');
+    });
+
+    it('should do nothing if banner is null', async () => {
+        const onSuccess = jest.fn();
+
+        const { result } = renderHook(() =>
+            useTranslatePartnerBanner({
+                banner: null,
+                language: languageMock,
+                onSuccess,
+                mode: ModalMode.Add,
+            }),
+        );
+
+        await act(async () => {
+            await result.current.translateBanner(formValues);
+        });
+
+        expect(mockedCreate).not.toHaveBeenCalled();
+        expect(onSuccess).not.toHaveBeenCalled();
+    });
+});

--- a/src/hooks/admin/use-translate-partner-banner/useTranslatePartnerBanner.ts
+++ b/src/hooks/admin/use-translate-partner-banner/useTranslatePartnerBanner.ts
@@ -1,0 +1,94 @@
+import { ModalMode } from '@/types/admin/common';
+import { PartnerBanner, PartnerBannerLocalization } from '@/types/admin/partners';
+import { LocalizationLanguage } from '@/types/common/language';
+import { useAdminClient } from '../use-admin-client/useAdminClient';
+import { useState } from 'react';
+import { PartnerBannerLocalizationApi } from '@/services/api/admin/partners/partners-banner-localizations-api';
+import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/localization/localization-mappers';
+import { PARTNERS_TEXT } from '@/const/admin/partners';
+import { TranslatePartnerBannerFormValues } from '@/pages/admin/partners/components/translate-partner-banner-form/TranslatePartnerBannerForm';
+
+interface UseTranslatePartnerBannerParams {
+    banner: PartnerBanner | null;
+    language: LocalizationLanguage;
+    onSuccess: (updatedBanner: PartnerBanner) => void;
+    mode: ModalMode;
+}
+
+export const useTranslatePartnerBanner = ({ banner, language, onSuccess, mode }: UseTranslatePartnerBannerParams) => {
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [error, setError] = useState<string>('');
+
+    const client = useAdminClient();
+    const isEditMode = mode === ModalMode.Edit;
+
+    const translateBanner = async (data: TranslatePartnerBannerFormValues) => {
+        if (!banner) return;
+
+        try {
+            setIsSubmitting(true);
+            setError('');
+
+            if (isEditMode) {
+                const updatedLocalizationDto = await PartnerBannerLocalizationApi.update(
+                    client,
+                    banner.id,
+                    language.id,
+                    {
+                        title: data.title,
+                        description: data.description,
+                    },
+                );
+
+                const updatedLocalization = mapLocalizationDtoToModel<
+                    typeof updatedLocalizationDto,
+                    PartnerBannerLocalization
+                >(updatedLocalizationDto);
+
+                const updatedBanner: PartnerBanner = {
+                    ...banner,
+                    localizations:
+                        banner.localizations?.map((loc) =>
+                            loc.language.id === language.id ? updatedLocalization : loc,
+                        ) || [],
+                };
+                onSuccess(updatedBanner);
+            } else {
+                const createdLocalizationDto = await PartnerBannerLocalizationApi.create(client, {
+                    entityId: banner.id,
+                    languageId: language.id,
+                    title: data.title,
+                    description: data.description,
+                });
+
+                const createdLocalization = mapLocalizationDtoToModel<
+                    typeof createdLocalizationDto,
+                    PartnerBannerLocalization
+                >(createdLocalizationDto);
+
+                const updatedBanner: PartnerBanner = {
+                    ...banner,
+                    localizations: [...(banner.localizations || []), createdLocalization],
+                };
+                onSuccess(updatedBanner);
+            }
+        } catch (err) {
+            const errorMessage = isEditMode
+                ? PARTNERS_TEXT.MESSAGE.FAIL_TO_UPDATE_TRANSLATION_FOR_BANNER
+                : PARTNERS_TEXT.MESSAGE.FAIL_TO_TRANSLATE_BANNER;
+            setError(errorMessage);
+            throw err;
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const clearError = () => setError('');
+
+    return {
+        translateBanner,
+        isSubmitting,
+        error,
+        clearError,
+    };
+};

--- a/src/hooks/admin/use-translate-partner-banner/useTranslatePartnerBanner.ts
+++ b/src/hooks/admin/use-translate-partner-banner/useTranslatePartnerBanner.ts
@@ -72,12 +72,11 @@ export const useTranslatePartnerBanner = ({ banner, language, onSuccess, mode }:
                 };
                 onSuccess(updatedBanner);
             }
-        } catch (err) {
+        } catch (_err) {
             const errorMessage = isEditMode
                 ? PARTNERS_TEXT.MESSAGE.FAIL_TO_UPDATE_TRANSLATION_FOR_BANNER
                 : PARTNERS_TEXT.MESSAGE.FAIL_TO_TRANSLATE_BANNER;
             setError(errorMessage);
-            throw err;
         } finally {
             setIsSubmitting(false);
         }

--- a/src/hooks/admin/use-translate-partner-banner/useTranslatePartnerBanner.ts
+++ b/src/hooks/admin/use-translate-partner-banner/useTranslatePartnerBanner.ts
@@ -10,7 +10,7 @@ import { TranslatePartnerBannerFormValues } from '@/pages/admin/partners/compone
 
 interface UseTranslatePartnerBannerParams {
     banner: PartnerBanner | null;
-    language: LocalizationLanguage;
+    language: LocalizationLanguage | null;
     onSuccess: (updatedBanner: PartnerBanner) => void;
     mode: ModalMode;
 }
@@ -23,7 +23,7 @@ export const useTranslatePartnerBanner = ({ banner, language, onSuccess, mode }:
     const isEditMode = mode === ModalMode.Edit;
 
     const translateBanner = async (data: TranslatePartnerBannerFormValues) => {
-        if (!banner) return;
+        if (!banner || !language) return;
 
         try {
             setIsSubmitting(true);

--- a/src/hooks/admin/use-translate-partner-banner/useTranslatePartnerBanner.ts
+++ b/src/hooks/admin/use-translate-partner-banner/useTranslatePartnerBanner.ts
@@ -72,7 +72,7 @@ export const useTranslatePartnerBanner = ({ banner, language, onSuccess, mode }:
                 };
                 onSuccess(updatedBanner);
             }
-        } catch (_err) {
+        } catch {
             const errorMessage = isEditMode
                 ? PARTNERS_TEXT.MESSAGE.FAIL_TO_UPDATE_TRANSLATION_FOR_BANNER
                 : PARTNERS_TEXT.MESSAGE.FAIL_TO_TRANSLATE_BANNER;

--- a/src/hooks/admin/use-translate-partner-section/useTranslatePartnerSection.test.ts
+++ b/src/hooks/admin/use-translate-partner-section/useTranslatePartnerSection.test.ts
@@ -261,6 +261,53 @@ describe('useTranslatePartnerSection', () => {
         expect(onSuccess).not.toHaveBeenCalled();
     });
 
+    it('clears the previous translation immediately when language changes while open, before the new fetch resolves', async () => {
+        const existingTranslationA: PartnerSectionLocalizationDto = {
+            entityId: 1,
+            title: 'Existing A title',
+            description: 'Existing A description',
+            partners: [],
+            localizationInfoDto: { id: 2, code: 'en' },
+            translationStatus: 1,
+        };
+        const languageB: LocalizationLanguage = { id: 3, code: 'pl', name: 'Polish' };
+
+        mockedGet.mockResolvedValueOnce(existingTranslationA);
+
+        const { result, rerender } = renderHook(
+            ({ language }: { language: LocalizationLanguage }) =>
+                useTranslatePartnerSection({
+                    section: sectionMock,
+                    language,
+                    isOpen: true,
+                    onSuccess: jest.fn(),
+                }),
+            { initialProps: { language: languageMock } },
+        );
+
+        await waitFor(() => {
+            expect(result.current.existingTranslation).toEqual(existingTranslationA);
+        });
+        expect(result.current.isEditMode).toBe(true);
+
+        let resolveSecondFetch: (value: PartnerSectionLocalizationDto | null) => void = () => {};
+        mockedGet.mockImplementationOnce(
+            () =>
+                new Promise((resolve) => {
+                    resolveSecondFetch = resolve;
+                }),
+        );
+
+        rerender({ language: languageB });
+
+        expect(result.current.existingTranslation).toBeNull();
+        expect(result.current.isEditMode).toBe(false);
+
+        await act(async () => {
+            resolveSecondFetch(null);
+        });
+    });
+
     it('should clear error', () => {
         const { result } = renderHook(() =>
             useTranslatePartnerSection({

--- a/src/hooks/admin/use-translate-partner-section/useTranslatePartnerSection.test.ts
+++ b/src/hooks/admin/use-translate-partner-section/useTranslatePartnerSection.test.ts
@@ -1,0 +1,280 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useTranslatePartnerSection } from './useTranslatePartnerSection';
+import { PartnerSectionLocalizationApi } from '@/services/api/admin/partners/partner-section-localizations-api';
+import { PARTNERS_TEXT } from '@/const/admin/partners';
+import { LocalizationLanguage } from '@/types/common/language';
+import { PartnerSection, PartnerSectionLocalizationDto } from '@/types/admin/partners';
+
+jest.mock('@/services/api/admin/partners/partner-section-localizations-api');
+jest.mock('../use-admin-client/useAdminClient', () => ({
+    useAdminClient: () => 'mock-client',
+}));
+
+const mockedGet = PartnerSectionLocalizationApi.get as jest.MockedFunction<typeof PartnerSectionLocalizationApi.get>;
+const mockedCreate = PartnerSectionLocalizationApi.create as jest.MockedFunction<
+    typeof PartnerSectionLocalizationApi.create
+>;
+const mockedUpdate = PartnerSectionLocalizationApi.update as jest.MockedFunction<
+    typeof PartnerSectionLocalizationApi.update
+>;
+
+const sectionMock: PartnerSection = {
+    id: 1,
+    title: 'Original section title',
+    description: 'Original section description',
+    partners: [
+        { id: 5, description: 'Partner 1', image: null, imageId: null },
+        { id: 6, description: 'Partner 2', image: null, imageId: null },
+    ],
+    localizations: [],
+};
+
+const languageMock: LocalizationLanguage = {
+    id: 2,
+    code: 'en',
+    name: 'English',
+};
+
+const formValues = {
+    title: 'Translated section title',
+    description: 'Translated section description',
+    partners: [
+        { partnerId: 5, description: 'Translated partner 1' },
+        { partnerId: 6, description: 'Translated partner 2' },
+    ],
+};
+
+describe('useTranslatePartnerSection', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should initialize with default state and not fetch while closed', () => {
+        const { result } = renderHook(() =>
+            useTranslatePartnerSection({
+                section: sectionMock,
+                language: languageMock,
+                isOpen: false,
+                onSuccess: jest.fn(),
+            }),
+        );
+
+        expect(result.current.isSubmitting).toBe(false);
+        expect(result.current.error).toBe('');
+        expect(result.current.existingTranslation).toBeNull();
+        expect(mockedGet).not.toHaveBeenCalled();
+    });
+
+    it('should fetch the existing translation when opened and enter edit mode when found', async () => {
+        const existingTranslation: PartnerSectionLocalizationDto = {
+            entityId: 1,
+            title: 'Existing EN title',
+            description: 'Existing EN description',
+            partners: [{ partnerId: 5, description: 'Existing EN partner' }],
+            localizationInfoDto: { id: 2, code: 'en' },
+            translationStatus: 1,
+        };
+        mockedGet.mockResolvedValue(existingTranslation);
+
+        const { result } = renderHook(() =>
+            useTranslatePartnerSection({
+                section: sectionMock,
+                language: languageMock,
+                isOpen: true,
+                onSuccess: jest.fn(),
+            }),
+        );
+
+        expect(mockedGet).toHaveBeenCalledWith('mock-client', 1, 2);
+
+        await waitFor(() => {
+            expect(result.current.isLoadingTranslation).toBe(false);
+        });
+
+        expect(result.current.existingTranslation).toEqual(existingTranslation);
+        expect(result.current.isEditMode).toBe(true);
+    });
+
+    it('should stay in add mode when the translation is not found (404 -> null)', async () => {
+        mockedGet.mockResolvedValue(null);
+
+        const { result } = renderHook(() =>
+            useTranslatePartnerSection({
+                section: sectionMock,
+                language: languageMock,
+                isOpen: true,
+                onSuccess: jest.fn(),
+            }),
+        );
+
+        await waitFor(() => {
+            expect(result.current.isLoadingTranslation).toBe(false);
+        });
+
+        expect(result.current.existingTranslation).toBeNull();
+        expect(result.current.isEditMode).toBe(false);
+    });
+
+    it('should set a fetch error when loading the translation fails', async () => {
+        mockedGet.mockRejectedValue(new Error('network error'));
+
+        const { result } = renderHook(() =>
+            useTranslatePartnerSection({
+                section: sectionMock,
+                language: languageMock,
+                isOpen: true,
+                onSuccess: jest.fn(),
+            }),
+        );
+
+        await waitFor(() => {
+            expect(result.current.translationFetchError).toBe(
+                PARTNERS_TEXT.MESSAGE.FAIL_TO_LOAD_TRANSLATION_FOR_SECTION,
+            );
+        });
+    });
+
+    it('should create a translation when in add mode', async () => {
+        const onSuccess = jest.fn();
+        mockedGet.mockResolvedValue(null);
+        mockedCreate.mockResolvedValue({} as PartnerSectionLocalizationDto);
+
+        const { result } = renderHook(() =>
+            useTranslatePartnerSection({
+                section: sectionMock,
+                language: languageMock,
+                isOpen: true,
+                onSuccess,
+            }),
+        );
+
+        await waitFor(() => {
+            expect(result.current.isLoadingTranslation).toBe(false);
+        });
+
+        await act(async () => {
+            await result.current.translateSection(formValues);
+        });
+
+        expect(mockedCreate).toHaveBeenCalledWith('mock-client', {
+            entityId: 1,
+            languageId: 2,
+            title: formValues.title,
+            description: formValues.description,
+            partners: [
+                { partnerId: 5, description: 'Translated partner 1' },
+                { partnerId: 6, description: 'Translated partner 2' },
+            ],
+        });
+        expect(onSuccess).toHaveBeenCalled();
+    });
+
+    it('should update a translation when in edit mode', async () => {
+        const onSuccess = jest.fn();
+        mockedGet.mockResolvedValue({
+            entityId: 1,
+            title: 'Existing',
+            description: 'Existing',
+            partners: [],
+            localizationInfoDto: { id: 2, code: 'en' },
+            translationStatus: 1,
+        });
+        mockedUpdate.mockResolvedValue({} as PartnerSectionLocalizationDto);
+
+        const { result } = renderHook(() =>
+            useTranslatePartnerSection({
+                section: sectionMock,
+                language: languageMock,
+                isOpen: true,
+                onSuccess,
+            }),
+        );
+
+        await waitFor(() => {
+            expect(result.current.isEditMode).toBe(true);
+        });
+
+        await act(async () => {
+            await result.current.translateSection(formValues);
+        });
+
+        expect(mockedUpdate).toHaveBeenCalledWith('mock-client', 1, 2, {
+            title: formValues.title,
+            description: formValues.description,
+            partners: [
+                { partnerId: 5, description: 'Translated partner 1' },
+                { partnerId: 6, description: 'Translated partner 2' },
+            ],
+        });
+        expect(onSuccess).toHaveBeenCalled();
+    });
+
+    it('should set an error when create fails', async () => {
+        mockedGet.mockResolvedValue(null);
+        mockedCreate.mockRejectedValue(new Error('API error'));
+
+        const { result } = renderHook(() =>
+            useTranslatePartnerSection({
+                section: sectionMock,
+                language: languageMock,
+                isOpen: true,
+                onSuccess: jest.fn(),
+            }),
+        );
+
+        await waitFor(() => {
+            expect(result.current.isLoadingTranslation).toBe(false);
+        });
+
+        await act(async () => {
+            try {
+                await result.current.translateSection(formValues);
+            } catch {
+                // Ignoring error for test
+            }
+        });
+
+        await waitFor(() => {
+            expect(result.current.error).toBe(PARTNERS_TEXT.MESSAGE.FAIL_TO_TRANSLATE_SECTION);
+        });
+        expect(result.current.isSubmitting).toBe(false);
+    });
+
+    it('should do nothing if section is null', async () => {
+        const onSuccess = jest.fn();
+
+        const { result } = renderHook(() =>
+            useTranslatePartnerSection({
+                section: null,
+                language: languageMock,
+                isOpen: true,
+                onSuccess,
+            }),
+        );
+
+        await act(async () => {
+            await result.current.translateSection(formValues);
+        });
+
+        expect(mockedCreate).not.toHaveBeenCalled();
+        expect(mockedGet).not.toHaveBeenCalled();
+        expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('should clear error', () => {
+        const { result } = renderHook(() =>
+            useTranslatePartnerSection({
+                section: sectionMock,
+                language: languageMock,
+                isOpen: false,
+                onSuccess: jest.fn(),
+            }),
+        );
+
+        act(() => {
+            result.current.clearError();
+        });
+
+        expect(result.current.error).toBe('');
+    });
+});

--- a/src/hooks/admin/use-translate-partner-section/useTranslatePartnerSection.ts
+++ b/src/hooks/admin/use-translate-partner-section/useTranslatePartnerSection.ts
@@ -100,7 +100,7 @@ export const useTranslatePartnerSection = ({
             }
 
             onSuccess();
-        } catch (_err) {
+        } catch {
             const errorMessage = isEditMode
                 ? PARTNERS_TEXT.MESSAGE.FAIL_TO_UPDATE_TRANSLATION_FOR_SECTION
                 : PARTNERS_TEXT.MESSAGE.FAIL_TO_TRANSLATE_SECTION;

--- a/src/hooks/admin/use-translate-partner-section/useTranslatePartnerSection.ts
+++ b/src/hooks/admin/use-translate-partner-section/useTranslatePartnerSection.ts
@@ -34,9 +34,10 @@ export const useTranslatePartnerSection = ({
     const [error, setError] = useState<string>('');
 
     useEffect(() => {
+        setExistingTranslation(null);
+        setTranslationFetchError('');
+
         if (!isOpen || !section || !language) {
-            setExistingTranslation(null);
-            setTranslationFetchError('');
             return;
         }
 
@@ -44,7 +45,6 @@ export const useTranslatePartnerSection = ({
 
         const fetchTranslation = async () => {
             setIsLoadingTranslation(true);
-            setTranslationFetchError('');
 
             try {
                 const result = await PartnerSectionLocalizationApi.get(client, section.id, language.id);
@@ -100,12 +100,11 @@ export const useTranslatePartnerSection = ({
             }
 
             onSuccess();
-        } catch (err) {
+        } catch (_err) {
             const errorMessage = isEditMode
                 ? PARTNERS_TEXT.MESSAGE.FAIL_TO_UPDATE_TRANSLATION_FOR_SECTION
                 : PARTNERS_TEXT.MESSAGE.FAIL_TO_TRANSLATE_SECTION;
             setError(errorMessage);
-            throw err;
         } finally {
             setIsSubmitting(false);
         }

--- a/src/hooks/admin/use-translate-partner-section/useTranslatePartnerSection.ts
+++ b/src/hooks/admin/use-translate-partner-section/useTranslatePartnerSection.ts
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react';
+import { useAdminClient } from '../use-admin-client/useAdminClient';
+import { PartnerSectionLocalizationApi } from '@/services/api/admin/partners/partner-section-localizations-api';
+import { PartnerLocalizationDto, PartnerSection, PartnerSectionLocalizationDto } from '@/types/admin/partners';
+import { LocalizationLanguage } from '@/types/common/language';
+import { PARTNERS_TEXT } from '@/const/admin/partners';
+
+export interface TranslatePartnerSectionFormValues {
+    title: string;
+    description: string;
+    partners: { partnerId: number; description: string }[];
+}
+
+interface UseTranslatePartnerSectionParams {
+    section: PartnerSection | null;
+    language: LocalizationLanguage | null;
+    isOpen: boolean;
+    onSuccess: () => void;
+}
+
+export const useTranslatePartnerSection = ({
+    section,
+    language,
+    isOpen,
+    onSuccess,
+}: UseTranslatePartnerSectionParams) => {
+    const client = useAdminClient();
+
+    const [isLoadingTranslation, setIsLoadingTranslation] = useState(false);
+    const [translationFetchError, setTranslationFetchError] = useState<string>('');
+    const [existingTranslation, setExistingTranslation] = useState<PartnerSectionLocalizationDto | null>(null);
+
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [error, setError] = useState<string>('');
+
+    useEffect(() => {
+        if (!isOpen || !section || !language) {
+            setExistingTranslation(null);
+            setTranslationFetchError('');
+            return;
+        }
+
+        let cancelled = false;
+
+        const fetchTranslation = async () => {
+            setIsLoadingTranslation(true);
+            setTranslationFetchError('');
+
+            try {
+                const result = await PartnerSectionLocalizationApi.get(client, section.id, language.id);
+                if (!cancelled) {
+                    setExistingTranslation(result);
+                }
+            } catch {
+                if (!cancelled) {
+                    setTranslationFetchError(PARTNERS_TEXT.MESSAGE.FAIL_TO_LOAD_TRANSLATION_FOR_SECTION);
+                }
+            } finally {
+                if (!cancelled) {
+                    setIsLoadingTranslation(false);
+                }
+            }
+        };
+
+        fetchTranslation();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [isOpen, section, language, client]);
+
+    const isEditMode = existingTranslation !== null;
+
+    const translateSection = async (data: TranslatePartnerSectionFormValues) => {
+        if (!section || !language) return;
+
+        try {
+            setIsSubmitting(true);
+            setError('');
+
+            const partnersPayload: PartnerLocalizationDto[] = data.partners.map((partner) => ({
+                partnerId: partner.partnerId,
+                description: partner.description,
+            }));
+
+            if (isEditMode) {
+                await PartnerSectionLocalizationApi.update(client, section.id, language.id, {
+                    title: data.title,
+                    description: data.description,
+                    partners: partnersPayload,
+                });
+            } else {
+                await PartnerSectionLocalizationApi.create(client, {
+                    entityId: section.id,
+                    languageId: language.id,
+                    title: data.title,
+                    description: data.description,
+                    partners: partnersPayload,
+                });
+            }
+
+            onSuccess();
+        } catch (err) {
+            const errorMessage = isEditMode
+                ? PARTNERS_TEXT.MESSAGE.FAIL_TO_UPDATE_TRANSLATION_FOR_SECTION
+                : PARTNERS_TEXT.MESSAGE.FAIL_TO_TRANSLATE_SECTION;
+            setError(errorMessage);
+            throw err;
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const clearError = () => setError('');
+
+    return {
+        translateSection,
+        isSubmitting,
+        error,
+        clearError,
+        isEditMode,
+        existingTranslation,
+        isLoadingTranslation,
+        translationFetchError,
+    };
+};

--- a/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.module.scss
+++ b/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.module.scss
@@ -7,6 +7,14 @@
     border-bottom: 1px solid c.$grey-700;
 }
 
+.status-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    margin-bottom: 1rem;
+}
+
 .content {
     display: flex;
     width: 100%;

--- a/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.module.scss
+++ b/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.module.scss
@@ -12,7 +12,7 @@
     justify-content: space-between;
     align-items: center;
     width: 100%;
-    margin-bottom: 1rem;
+    margin-bottom: 16px;
 }
 
 .content {

--- a/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.test.tsx
+++ b/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { PartnerBanner } from './PartnerBannerForm';
+import { PartnerBanner, PartnerBannerProps } from './PartnerBannerForm';
 import { useDataFetch } from '@/hooks/common/use-data-fetch/useDataFetch';
 import { PartnersApi } from '@/services/api/admin/partners/partners-api';
 import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
@@ -76,7 +76,7 @@ jest.mock('@/components/admin/input-groups/input-with-character-limit-group/Inpu
 }));
 
 jest.mock('@/components/admin/input-groups/rich-text-input-group/RichTextInputGroup', () => ({
-    RichTextInputGroup: ({ label, value, onChange, onBlur, disabled, id, error, trimOnBlur }: any) => (
+    RichTextInputGroup: ({ label, value, onChange, onBlur, disabled, id, error, trimOnBlur, hideToolbar }: any) => (
         <div>
             <label htmlFor={id}>{label}</label>
             <div
@@ -84,6 +84,7 @@ jest.mock('@/components/admin/input-groups/rich-text-input-group/RichTextInputGr
                 contentEditable={!disabled}
                 data-testid={`${id}-rich-text`}
                 data-trimonblur={trimOnBlur ? 'true' : 'false'}
+                data-hidetoolbar={hideToolbar ? 'true' : 'false'}
                 onInput={(e) => {
                     const target = e.target as HTMLElement;
                     onChange(target.innerHTML);
@@ -121,19 +122,9 @@ jest.mock('@/validation/admin/partner-schema/partner-schema', () => ({
     },
 }));
 
-const mockTranslationLanguages = [{ id: 2, code: 'en', name: 'English' }];
-
-jest.mock('@/hooks/admin/use-localization-toolkit/useLocalizationToolkit', () => ({
-    useLocalizationToolkit: () => ({
-        allLanguages: mockTranslationLanguages,
-        translationLanguages: mockTranslationLanguages,
-        selectedLanguage: mockTranslationLanguages[0],
-        onLanguageChange: jest.fn(),
-        translationStatusFilter: undefined,
-        onTranslationStatusFilterChange: jest.fn(),
-        retryFetchLanguages: jest.fn(),
-    }),
-}));
+const UK_LANGUAGE = { id: 1, code: 'uk', name: 'Ukrainian' };
+const EN_LANGUAGE = { id: 2, code: 'en', name: 'English' };
+const mockTranslationLanguages = [EN_LANGUAGE];
 
 jest.mock('../translate-partner-banner-modal/TranslatePartnerBannerModal', () => ({
     TranslatePartnerBannerModal: ({ isOpen, onClose, banner, onTranslateBanner }: any) =>
@@ -225,6 +216,14 @@ describe('PartnerBanner', () => {
         if (button) fireEvent.click(button);
     };
 
+    const renderBanner = (props: Partial<PartnerBannerProps> = {}) => {
+        const defaultProps: PartnerBannerProps = {
+            language: UK_LANGUAGE,
+            translationLanguages: mockTranslationLanguages,
+        };
+        return render(<PartnerBanner {...defaultProps} {...props} />);
+    };
+
     beforeEach(() => {
         jest.clearAllMocks();
         mockedUseAdminClient.mockReturnValue('mock-client');
@@ -250,7 +249,7 @@ describe('PartnerBanner', () => {
             setData: mockSetData,
         });
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         expect(getLoader()).toBeInTheDocument();
     });
@@ -265,7 +264,7 @@ describe('PartnerBanner', () => {
             setData: mockSetData,
         });
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         expect(getErrorMessage()).toBeInTheDocument();
         expect(getTryAgainButton()).toBeInTheDocument();
@@ -275,7 +274,7 @@ describe('PartnerBanner', () => {
     });
 
     it('renders banner form with fetched data and validates field updates', async () => {
-        render(<PartnerBanner />);
+        renderBanner();
 
         const descriptionInput = getDescriptionInput();
 
@@ -291,7 +290,7 @@ describe('PartnerBanner', () => {
     });
 
     it('handles image change', async () => {
-        render(<PartnerBanner />);
+        renderBanner();
 
         clickChangeImage();
 
@@ -301,7 +300,7 @@ describe('PartnerBanner', () => {
     });
 
     it('handles image removal', async () => {
-        render(<PartnerBanner />);
+        renderBanner();
 
         clickRemoveImage();
 
@@ -313,7 +312,7 @@ describe('PartnerBanner', () => {
     it('disables publish button when validation fails and re-enables when corrected', async () => {
         mockValidateTitle.mockImplementation((value: string) => (value ? undefined : 'Title is required'));
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         changeDescriptionValue('Changed Description');
         const publishButton = getPublishButton();
@@ -341,7 +340,7 @@ describe('PartnerBanner', () => {
         };
         mockedPartnersApi.updateBanner.mockResolvedValue(updatedBanner);
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         changeDescriptionValue(updatedBanner.description);
 
@@ -393,7 +392,7 @@ describe('PartnerBanner', () => {
             localizations: [],
         });
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         changeDescriptionValue('Published Description');
         clickPublish();
@@ -409,7 +408,7 @@ describe('PartnerBanner', () => {
     it('shows error toast when publishing banner fails', async () => {
         mockedPartnersApi.updateBanner.mockRejectedValue(new Error('Update failed'));
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         changeDescriptionValue('Changed');
         clickPublish();
@@ -432,7 +431,7 @@ describe('PartnerBanner', () => {
     it('does not call updateBanner if form is invalid', async () => {
         mockValidateTitle.mockReturnValue('Title is required');
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         changeDescriptionValue('');
 
@@ -456,7 +455,7 @@ describe('PartnerBanner', () => {
 
         mockedPartnersApi.updateBanner.mockImplementation(createDelayedPromise as any);
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         changeDescriptionValue('Changed');
         clickPublish();
@@ -476,7 +475,7 @@ describe('PartnerBanner', () => {
     });
 
     it('shows image error and disables publish until resolved', async () => {
-        render(<PartnerBanner />);
+        renderBanner();
 
         changeDescriptionValue('Changed');
         const publishButton = getPublishButton();
@@ -496,7 +495,7 @@ describe('PartnerBanner', () => {
     });
 
     it('renders title input as enabled', () => {
-        render(<PartnerBanner />);
+        renderBanner();
         expect(getTitleInput()).toHaveAttribute('contentEditable', 'true');
     });
 
@@ -510,7 +509,7 @@ describe('PartnerBanner', () => {
             setData: mockSetData,
         });
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         expect(mockAddToast).toHaveBeenCalledWith(PARTNERS_TEXT.MESSAGE.FAIL_TO_LOAD_BANNER, ToastType.Error);
     });
@@ -518,7 +517,7 @@ describe('PartnerBanner', () => {
     it('does not call updateBanner when form has validation errors', async () => {
         mockValidateDescription.mockReturnValue('Description is required');
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         changeDescriptionValue('');
 
@@ -534,7 +533,7 @@ describe('PartnerBanner', () => {
     it('validates description on change and sets error correctly', async () => {
         mockValidateDescription.mockReturnValue('Description too short');
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         changeDescriptionValue('AB');
 
@@ -544,7 +543,7 @@ describe('PartnerBanner', () => {
     });
 
     it('clears image error when handleImageError is called with null', async () => {
-        render(<PartnerBanner />);
+        renderBanner();
 
         fireEvent.click(screen.getByRole('button', { name: 'Trigger image error' }));
 
@@ -558,7 +557,7 @@ describe('PartnerBanner', () => {
     });
 
     it('maintains imageId when image is changed', async () => {
-        render(<PartnerBanner />);
+        renderBanner();
 
         clickChangeImage();
 
@@ -594,7 +593,7 @@ describe('PartnerBanner', () => {
             setData: mockSetData,
         });
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         expect(getErrorMessage()).toBeInTheDocument();
         expect(getTryAgainButton()).toBeInTheDocument();
@@ -607,7 +606,7 @@ describe('PartnerBanner', () => {
 
         mockedPartnersApi.updateBanner.mockReturnValue(delayedPromise as any);
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         changeDescriptionValue('Changed');
         clickPublish();
@@ -629,7 +628,7 @@ describe('PartnerBanner', () => {
         mockValidateTitle.mockReturnValue(undefined);
         mockValidateDescription.mockReturnValue(undefined);
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         changeDescriptionValue('Changed');
         await waitFor(() => {
@@ -644,7 +643,7 @@ describe('PartnerBanner', () => {
         };
         mockedPartnersApi.updateBanner.mockResolvedValue(updatedBanner);
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         // Create an error by changing description to empty
         changeDescriptionValue('');
@@ -681,7 +680,7 @@ describe('PartnerBanner', () => {
             setData: mockSetData,
         });
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         expect(mockAddToast).not.toHaveBeenCalledWith(PARTNERS_TEXT.MESSAGE.FAIL_TO_LOAD_BANNER, ToastType.Error);
     });
@@ -690,7 +689,7 @@ describe('PartnerBanner', () => {
         const canceledError = { name: 'CanceledError' };
         mockedPartnersApi.updateBanner.mockRejectedValue(canceledError);
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         changeDescriptionValue('Changed');
         clickPublish();
@@ -706,7 +705,7 @@ describe('PartnerBanner', () => {
     });
 
     it('resets imageId when image is removed', async () => {
-        render(<PartnerBanner />);
+        renderBanner();
 
         clickRemoveImage();
 
@@ -749,7 +748,7 @@ describe('PartnerBanner', () => {
             setData: mockSetData,
         });
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         await waitFor(() => {
             expect(getTitleInput()).toHaveTextContent('Initial Title');
@@ -762,7 +761,7 @@ describe('PartnerBanner', () => {
         const htmlTitle = '<p><strong>Bold</strong> Title</p>';
         mockValidateTitle.mockReturnValue(undefined);
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         const titleInput = getTitleInput();
         titleInput.innerHTML = htmlTitle;
@@ -778,7 +777,7 @@ describe('PartnerBanner', () => {
     it('marks description as touched on change and shows error', async () => {
         mockValidateDescription.mockReturnValue('Description is required');
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         changeDescriptionValue('');
 
@@ -798,20 +797,20 @@ describe('PartnerBanner', () => {
             setData: mockSetData,
         });
 
-        render(<PartnerBanner />);
+        renderBanner();
 
         expect(getErrorMessage()).toBeInTheDocument();
         expect(mockedPartnersApi.updateBanner).not.toHaveBeenCalled();
     });
 
     it('passes trimOnBlur={true} to RichTextInputGroup for the title field', () => {
-        render(<PartnerBanner />);
+        renderBanner();
         const titleInput = getTitleInput();
         expect(titleInput).toHaveAttribute('data-trimonblur', 'true');
     });
 
     it('opens the translate modal when the translate icon is clicked', () => {
-        render(<PartnerBanner />);
+        renderBanner();
 
         expect(screen.queryByTestId('translate-partner-banner-modal')).not.toBeInTheDocument();
 
@@ -823,7 +822,7 @@ describe('PartnerBanner', () => {
     });
 
     it('disables the translate icon while there are unpublished changes', () => {
-        render(<PartnerBanner />);
+        renderBanner();
 
         const translateButton = screen.getByRole('button', {
             name: COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION,
@@ -836,7 +835,7 @@ describe('PartnerBanner', () => {
     });
 
     it('merges updated localizations and shows success toast after translating', async () => {
-        render(<PartnerBanner />);
+        renderBanner();
 
         fireEvent.click(
             screen.getByRole('button', { name: COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION }),
@@ -852,7 +851,7 @@ describe('PartnerBanner', () => {
     });
 
     it('closes the translate modal via onClose', () => {
-        render(<PartnerBanner />);
+        renderBanner();
 
         fireEvent.click(
             screen.getByRole('button', { name: COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION }),
@@ -862,5 +861,63 @@ describe('PartnerBanner', () => {
         fireEvent.click(screen.getByText('mock-translate-close'));
 
         expect(screen.queryByTestId('translate-partner-banner-modal')).not.toBeInTheDocument();
+    });
+
+    it('shows translated content and disables fields when a non-base language is selected', () => {
+        const bannerWithLocalization = {
+            ...defaultBannerData,
+            localizations: [
+                {
+                    title: 'Banner title EN',
+                    description: 'Banner description EN',
+                    language: { id: EN_LANGUAGE.id, code: EN_LANGUAGE.code },
+                    translationStatus: 1,
+                },
+            ],
+        };
+        mockedUseDataFetch.mockReturnValue({
+            data: bannerWithLocalization,
+            isLoading: false,
+            error: null,
+            refetch: mockRefetch,
+            setData: mockSetData,
+        });
+
+        renderBanner({ language: EN_LANGUAGE });
+
+        expect(getTitleInput()).toHaveTextContent('Banner title EN');
+        expect(getTitleInput()).toHaveAttribute('contentEditable', 'false');
+        expect(getTitleInput()).toHaveAttribute('data-hidetoolbar', 'true');
+        expect(getDescriptionInput()).toHaveValue('Banner description EN');
+        expect(getDescriptionInput()).toBeDisabled();
+        expect(getChangeImageButton()).toBeDisabled();
+        expect(getRemoveImageButton()).toBeDisabled();
+        expect(
+            screen.queryByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('shows empty fields when the banner has no translation for the selected language', () => {
+        renderBanner({ language: EN_LANGUAGE });
+
+        expect(getTitleInput()).toHaveTextContent('');
+        expect(getDescriptionInput()).toHaveValue('');
+    });
+
+    it('ignores field changes while a non-base language is selected', () => {
+        renderBanner({ language: EN_LANGUAGE });
+
+        fireEvent.change(getDescriptionInput(), { target: { value: 'Should be ignored' } });
+
+        expect(getDescriptionInput()).toHaveValue('');
+    });
+
+    it('renders the publish button and enabled fields for the base language', () => {
+        renderBanner({ language: UK_LANGUAGE });
+
+        expect(getTitleInput()).toHaveAttribute('contentEditable', 'true');
+        expect(getTitleInput()).toHaveAttribute('data-hidetoolbar', 'false');
+        expect(getDescriptionInput()).toBeEnabled();
+        expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED })).toBeInTheDocument();
     });
 });

--- a/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.test.tsx
+++ b/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.test.tsx
@@ -14,6 +14,7 @@ import { ButtonProps } from '@/components/admin/button/Button';
 import { ImageInputProps } from '@/components/admin/image-input/ImageInput';
 import { InputErrorProps } from '@/components/admin/input-error/InputError';
 import { InputWithCharacterLimitGroupProps } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
+import localizationStatusesStyles from '@/components/admin/localization-statuses/LocalizationStatuses.module.scss';
 
 jest.mock('@/components/common/inline-loader/InlineLoader', () => ({
     InlineLoader: ({ size }: { size: number }) => <div data-testid="inline-loader">Loader size {size}</div>,
@@ -120,6 +121,46 @@ jest.mock('@/validation/admin/partner-schema/partner-schema', () => ({
     },
 }));
 
+const mockTranslationLanguages = [{ id: 2, code: 'en', name: 'English' }];
+
+jest.mock('@/hooks/admin/use-localization-toolkit/useLocalizationToolkit', () => ({
+    useLocalizationToolkit: () => ({
+        allLanguages: mockTranslationLanguages,
+        translationLanguages: mockTranslationLanguages,
+        selectedLanguage: mockTranslationLanguages[0],
+        onLanguageChange: jest.fn(),
+        translationStatusFilter: undefined,
+        onTranslationStatusFilterChange: jest.fn(),
+        retryFetchLanguages: jest.fn(),
+    }),
+}));
+
+jest.mock('../translate-partner-banner-modal/TranslatePartnerBannerModal', () => ({
+    TranslatePartnerBannerModal: ({ isOpen, onClose, banner, onTranslateBanner }: any) =>
+        isOpen ? (
+            <div data-testid="translate-partner-banner-modal">
+                <button
+                    onClick={() =>
+                        onTranslateBanner({
+                            ...banner,
+                            localizations: [
+                                {
+                                    title: 'Banner title EN',
+                                    description: 'Banner description EN',
+                                    language: { id: 2, code: 'en' },
+                                    translationStatus: 1,
+                                },
+                            ],
+                        })
+                    }
+                >
+                    mock-translate-success
+                </button>
+                <button onClick={onClose}>mock-translate-close</button>
+            </div>
+        ) : null,
+}));
+
 const mockedUseDataFetch = useDataFetch as jest.Mock;
 const mockedPartnersApi = PartnersApi as jest.Mocked<typeof PartnersApi>;
 const mockedUseAdminClient = useAdminClient as jest.Mock;
@@ -134,10 +175,12 @@ describe('PartnerBanner', () => {
     const mockAddToast = jest.fn();
 
     const defaultBannerData = {
+        id: 1,
         title: 'Initial Title',
         description: 'Initial Description',
         image: { id: 1, url: 'initial.jpg', mimeType: 'image/jpeg' },
         imageId: 1,
+        localizations: [],
     };
 
     const getLoader = () => screen.queryByTestId('inline-loader');
@@ -321,6 +364,46 @@ describe('PartnerBanner', () => {
         await waitFor(() => {
             expect(getDescriptionInput()).toHaveValue(updatedBanner.description);
         });
+    });
+
+    it('keeps existing localizations when the update response omits them', async () => {
+        const bannerWithLocalization = {
+            ...defaultBannerData,
+            localizations: [
+                {
+                    title: 'Banner title EN',
+                    description: 'Banner description EN',
+                    language: { id: 2, code: 'en' },
+                    translationStatus: 1,
+                },
+            ],
+        };
+
+        mockedUseDataFetch.mockReturnValue({
+            data: bannerWithLocalization,
+            isLoading: false,
+            error: null,
+            refetch: mockRefetch,
+            setData: mockSetData,
+        });
+
+        mockedPartnersApi.updateBanner.mockResolvedValue({
+            ...bannerWithLocalization,
+            description: 'Published Description',
+            localizations: [],
+        });
+
+        render(<PartnerBanner />);
+
+        changeDescriptionValue('Published Description');
+        clickPublish();
+        clickConfirmPublish();
+
+        await waitFor(() => {
+            expect(mockAddToast).toHaveBeenCalledWith(PARTNERS_TEXT.MESSAGE.BANNER_SAVED, ToastType.Success);
+        });
+
+        expect(screen.getByText('EN')).toHaveClass(localizationStatusesStyles.relevant);
     });
 
     it('shows error toast when publishing banner fails', async () => {
@@ -725,5 +808,59 @@ describe('PartnerBanner', () => {
         render(<PartnerBanner />);
         const titleInput = getTitleInput();
         expect(titleInput).toHaveAttribute('data-trimonblur', 'true');
+    });
+
+    it('opens the translate modal when the translate icon is clicked', () => {
+        render(<PartnerBanner />);
+
+        expect(screen.queryByTestId('translate-partner-banner-modal')).not.toBeInTheDocument();
+
+        fireEvent.click(
+            screen.getByRole('button', { name: COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION }),
+        );
+
+        expect(screen.getByTestId('translate-partner-banner-modal')).toBeInTheDocument();
+    });
+
+    it('disables the translate icon while there are unpublished changes', () => {
+        render(<PartnerBanner />);
+
+        const translateButton = screen.getByRole('button', {
+            name: COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION,
+        });
+        expect(translateButton).toBeEnabled();
+
+        changeDescriptionValue('Changed Description');
+
+        expect(translateButton).toBeDisabled();
+    });
+
+    it('merges updated localizations and shows success toast after translating', async () => {
+        render(<PartnerBanner />);
+
+        fireEvent.click(
+            screen.getByRole('button', { name: COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION }),
+        );
+        fireEvent.click(screen.getByText('mock-translate-success'));
+
+        await waitFor(() => {
+            expect(mockAddToast).toHaveBeenCalledWith(
+                COMMON_TEXT_ADMIN.MESSAGE.TRANSLATION_SAVED_SUCCESS,
+                ToastType.Success,
+            );
+        });
+    });
+
+    it('closes the translate modal via onClose', () => {
+        render(<PartnerBanner />);
+
+        fireEvent.click(
+            screen.getByRole('button', { name: COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION }),
+        );
+        expect(screen.getByTestId('translate-partner-banner-modal')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText('mock-translate-close'));
+
+        expect(screen.queryByTestId('translate-partner-banner-modal')).not.toBeInTheDocument();
     });
 });

--- a/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.tsx
+++ b/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.tsx
@@ -11,7 +11,7 @@ import { InlineLoader } from '@/components/common/inline-loader/InlineLoader';
 import { Button } from '@/components/admin/button/Button';
 import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
 import axios from 'axios';
-import { PartnerBanner as PartnerBannerType } from '@/types/admin/partners';
+import { PartnerBanner as PartnerBannerType, PartnerBannerLocalization } from '@/types/admin/partners';
 import { PARTNER_BANNER_VALIDATION_FUNCTIONS } from '@/validation/admin/partner-schema/partner-schema';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { ImageInput } from '@/components/admin/image-input/ImageInput';
@@ -20,12 +20,19 @@ import BannerImage from '@/assets/images/horses.webp';
 import { RichTextInputGroup } from '@/components/admin/input-groups/rich-text-input-group/RichTextInputGroup';
 import { getPlainTextFromHtml } from '@/utils/functions/get-plain-text-from-html/get-plain-text-from-html';
 import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
+import { IconButton } from '@/components/admin/icon-button/IconButton';
+import { LocalizationStatuses } from '@/components/admin/localization-statuses/LocalizationStatuses';
+import { ACTION_ICONS } from '@/const/common/action-icons';
+import { useLocalizationToolkit } from '@/hooks/admin/use-localization-toolkit/useLocalizationToolkit';
+import { TranslatePartnerBannerModal } from '../translate-partner-banner-modal/TranslatePartnerBannerModal';
 
 export interface PartnerBannerValues {
+    id: number;
     title: string;
     description: string;
     image: ImageValues | Image | null;
     imageId: number | null;
+    localizations: PartnerBannerLocalization[];
 }
 
 export interface PartnerBannerErrorState {
@@ -75,6 +82,16 @@ export const PartnerBanner = () => {
     const [isPublishing, setIsPublishing] = useState(false);
     const [isPublishModalOpen, setIsPublishModalOpen] = useState(false);
     const [titleKey, setTitleKey] = useState(0);
+    const [isTranslateModalOpen, setIsTranslateModalOpen] = useState(false);
+
+    const handleLocalizationError = useCallback(
+        (message: string) => {
+            addToast(message, ToastType.Error);
+        },
+        [addToast],
+    );
+
+    const { translationLanguages } = useLocalizationToolkit({ setErrorState: handleLocalizationError });
 
     const fetchBannerHandler = useCallback(() => {
         return PartnersApi.getBanner(client);
@@ -86,7 +103,7 @@ export const PartnerBanner = () => {
         error: fetchError,
         refetch: refetchBanner,
     } = useDataFetch<PartnerBannerType>({
-        initialData: { title: '', description: '', image: null, imageId: null },
+        initialData: { id: 0, title: '', description: '', image: null, imageId: null, localizations: [] },
         fetchHandler: fetchBannerHandler,
         autoFetchDisabled: false,
     });
@@ -187,7 +204,12 @@ export const PartnerBanner = () => {
                 imageId: values.imageId,
             });
 
-            setFormState({ values: updatedBanner, savedValues: updatedBanner });
+            const nextBanner: PartnerBannerType = {
+                ...updatedBanner,
+                localizations: updatedBanner.localizations.length ? updatedBanner.localizations : values.localizations,
+            };
+
+            setFormState({ values: nextBanner, savedValues: nextBanner });
             setTouched({});
             setErrors({});
             addToast(PARTNERS_TEXT.MESSAGE.BANNER_SAVED, ToastType.Success);
@@ -200,6 +222,27 @@ export const PartnerBanner = () => {
             setIsPublishing(false);
         }
     }, [values, errors, client, addToast]);
+
+    const handleOpenTranslateModal = useCallback(() => {
+        setIsTranslateModalOpen(true);
+    }, []);
+
+    const handleCloseTranslateModal = useCallback(() => {
+        setIsTranslateModalOpen(false);
+    }, []);
+
+    const handleTranslateBannerSuccess = useCallback(
+        (updatedBanner: PartnerBannerType) => {
+            setFormState((prev) => ({
+                values: prev.values ? { ...prev.values, localizations: updatedBanner.localizations } : prev.values,
+                savedValues: prev.savedValues
+                    ? { ...prev.savedValues, localizations: updatedBanner.localizations }
+                    : prev.savedValues,
+            }));
+            addToast(COMMON_TEXT_ADMIN.MESSAGE.TRANSLATION_SAVED_SUCCESS, ToastType.Success);
+        },
+        [addToast],
+    );
 
     if (isLoadingData) {
         return (
@@ -240,81 +283,94 @@ export const PartnerBanner = () => {
             )}
 
             {!isLoadingData && !fetchError && values && (
-                <div className={styles.content}>
-                    <div className={styles.image}>
-                        <div className={styles['image-input']}>
-                            <ImageInput
-                                variant="partnerBanner"
-                                label={PARTNERS_TEXT.BANNER.ADD_IMAGE_HERE}
-                                subText={COMMON_TEXT_ADMIN.INPUT.getImageSizeSubText(
-                                    PARTNER_BANNER_VALIDATION.image.height,
-                                    PARTNER_BANNER_VALIDATION.image.width,
-                                )}
-                                value={values.image}
-                                onChange={handleImageChange}
-                                id="banner-image"
-                                name="banner-image"
-                                disabled={isDisabled}
-                                setError={handleImageError}
-                                style={{
-                                    backgroundImage: `
+                <>
+                    <div className={styles['status-bar']}>
+                        <LocalizationStatuses languages={translationLanguages} localizedEntity={values} />
+                        <IconButton
+                            aria-label={COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION}
+                            type="button"
+                            onClick={handleOpenTranslateModal}
+                            DefaultIcon={ACTION_ICONS.translate.default}
+                            disabled={isDisabled || isDirty}
+                        />
+                    </div>
+
+                    <div className={styles.content}>
+                        <div className={styles.image}>
+                            <div className={styles['image-input']}>
+                                <ImageInput
+                                    variant="partnerBanner"
+                                    label={PARTNERS_TEXT.BANNER.ADD_IMAGE_HERE}
+                                    subText={COMMON_TEXT_ADMIN.INPUT.getImageSizeSubText(
+                                        PARTNER_BANNER_VALIDATION.image.height,
+                                        PARTNER_BANNER_VALIDATION.image.width,
+                                    )}
+                                    value={values.image}
+                                    onChange={handleImageChange}
+                                    id="banner-image"
+                                    name="banner-image"
+                                    disabled={isDisabled}
+                                    setError={handleImageError}
+                                    style={{
+                                        backgroundImage: `
                                 linear-gradient(rgba(245, 245, 245, 0.85), rgba(245, 245, 245, 0.85)),
                                 url(${BannerImage})
                               `,
-                                }}
-                                cropWidth={PARTNER_BANNER_VALIDATION.image.width}
-                                cropHeight={PARTNER_BANNER_VALIDATION.image.height}
-                                minWidth={PARTNER_BANNER_VALIDATION.image.width}
-                                minHeight={PARTNER_BANNER_VALIDATION.image.height}
-                            />
+                                    }}
+                                    cropWidth={PARTNER_BANNER_VALIDATION.image.width}
+                                    cropHeight={PARTNER_BANNER_VALIDATION.image.height}
+                                    minWidth={PARTNER_BANNER_VALIDATION.image.width}
+                                    minHeight={PARTNER_BANNER_VALIDATION.image.height}
+                                />
+                            </div>
+                            <div className={styles['image-error']}>
+                                <InputError error={errors.image} />
+                            </div>
                         </div>
-                        <div className={styles['image-error']}>
-                            <InputError error={errors.image} />
+
+                        <div className={styles.main}>
+                            <div className={styles.fields}>
+                                <RichTextInputGroup
+                                    key={`title-${titleKey}`}
+                                    label={PARTNERS_TEXT.FORM.LABEL.TITLE}
+                                    value={values.title}
+                                    error={touched.title ? errors.title : undefined}
+                                    onChange={handleTitleChange}
+                                    onBlur={handleTitleBlur}
+                                    name="title"
+                                    id="title"
+                                    maxLength={PARTNER_BANNER_VALIDATION.title.max}
+                                    disabled={isDisabled}
+                                    isRequired={true}
+                                    trimOnBlur={true}
+                                />
+
+                                <InputWithCharacterLimitGroup
+                                    label={PARTNERS_TEXT.FORM.LABEL.DESCRIPTION}
+                                    value={values.description}
+                                    error={touched.description ? errors.description : undefined}
+                                    onChange={handleDescriptionChange}
+                                    id="description"
+                                    name="description"
+                                    disabled={isDisabled}
+                                    maxLength={PARTNER_BANNER_VALIDATION.description.max}
+                                    isRequired={true}
+                                />
+                            </div>
+
+                            <div className={styles.actions}>
+                                <Button
+                                    type="button"
+                                    buttonStyle="primary"
+                                    onClick={handlePublishClick}
+                                    disabled={isDisabled || !isDirty || !isFormValid(values, errors)}
+                                >
+                                    {COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED}
+                                </Button>
+                            </div>
                         </div>
                     </div>
-
-                    <div className={styles.main}>
-                        <div className={styles.fields}>
-                            <RichTextInputGroup
-                                key={`title-${titleKey}`}
-                                label={PARTNERS_TEXT.FORM.LABEL.TITLE}
-                                value={values.title}
-                                error={touched.title ? errors.title : undefined}
-                                onChange={handleTitleChange}
-                                onBlur={handleTitleBlur}
-                                name="title"
-                                id="title"
-                                maxLength={PARTNER_BANNER_VALIDATION.title.max}
-                                disabled={isDisabled}
-                                isRequired={true}
-                                trimOnBlur={true}
-                            />
-
-                            <InputWithCharacterLimitGroup
-                                label={PARTNERS_TEXT.FORM.LABEL.DESCRIPTION}
-                                value={values.description}
-                                error={touched.description ? errors.description : undefined}
-                                onChange={handleDescriptionChange}
-                                id="description"
-                                name="description"
-                                disabled={isDisabled}
-                                maxLength={PARTNER_BANNER_VALIDATION.description.max}
-                                isRequired={true}
-                            />
-                        </div>
-
-                        <div className={styles.actions}>
-                            <Button
-                                type="button"
-                                buttonStyle="primary"
-                                onClick={handlePublishClick}
-                                disabled={isDisabled || !isDirty || !isFormValid(values, errors)}
-                            >
-                                {COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED}
-                            </Button>
-                        </div>
-                    </div>
-                </div>
+                </>
             )}
 
             <ConfirmationModal
@@ -325,6 +381,14 @@ export const PartnerBanner = () => {
                 onClose={() => setIsPublishModalOpen(false)}
                 confirmText={COMMON_TEXT_ADMIN.BUTTON.YES}
                 cancelText={COMMON_TEXT_ADMIN.BUTTON.NO}
+            />
+
+            <TranslatePartnerBannerModal
+                isOpen={isTranslateModalOpen}
+                onClose={handleCloseTranslateModal}
+                banner={values}
+                onTranslateBanner={handleTranslateBannerSuccess}
+                translatedLanguages={translationLanguages}
             />
         </div>
     );

--- a/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.tsx
+++ b/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.tsx
@@ -23,7 +23,9 @@ import { ConfirmationModal } from '@/components/admin/confirmation-modal/Confirm
 import { IconButton } from '@/components/admin/icon-button/IconButton';
 import { LocalizationStatuses } from '@/components/admin/localization-statuses/LocalizationStatuses';
 import { ACTION_ICONS } from '@/const/common/action-icons';
-import { useLocalizationToolkit } from '@/hooks/admin/use-localization-toolkit/useLocalizationToolkit';
+import { LocalizationLanguage } from '@/types/common/language';
+import { DEFAULT_LOCALE } from '@/const/common/locales';
+import { returnDisplayedLocalization } from '@/utils/functions/localization/localization';
 import { TranslatePartnerBannerModal } from '../translate-partner-banner-modal/TranslatePartnerBannerModal';
 
 export interface PartnerBannerValues {
@@ -70,7 +72,12 @@ const isImageEqual = (img1: ImageValues | Image | null, img2: ImageValues | Imag
     return false;
 };
 
-export const PartnerBanner = () => {
+export interface PartnerBannerProps {
+    language: LocalizationLanguage;
+    translationLanguages: LocalizationLanguage[];
+}
+
+export const PartnerBanner = ({ language, translationLanguages }: PartnerBannerProps) => {
     const client = useAdminClient();
     const { addToast } = useToast();
     const [formState, setFormState] = useState<FormState>({
@@ -84,14 +91,7 @@ export const PartnerBanner = () => {
     const [titleKey, setTitleKey] = useState(0);
     const [isTranslateModalOpen, setIsTranslateModalOpen] = useState(false);
 
-    const handleLocalizationError = useCallback(
-        (message: string) => {
-            addToast(message, ToastType.Error);
-        },
-        [addToast],
-    );
-
-    const { translationLanguages } = useLocalizationToolkit({ setErrorState: handleLocalizationError });
+    const isBaseLanguage = language.code === DEFAULT_LOCALE;
 
     const fetchBannerHandler = useCallback(() => {
         return PartnersApi.getBanner(client);
@@ -142,50 +142,72 @@ export const PartnerBanner = () => {
         }
     }, [fetchError, addToast]);
 
-    const handleTitleChange = useCallback((newValue: string) => {
-        setFormState((prev) => ({
-            ...prev,
-            values: prev.values ? { ...prev.values, title: newValue } : null,
-        }));
+    const handleTitleChange = useCallback(
+        (newValue: string) => {
+            if (!isBaseLanguage) return;
 
-        const plainText = getPlainTextFromHtml(newValue);
+            setFormState((prev) => ({
+                ...prev,
+                values: prev.values ? { ...prev.values, title: newValue } : null,
+            }));
 
-        setErrors((prev) => ({
-            ...prev,
-            title: PARTNER_BANNER_VALIDATION_FUNCTIONS.validateTitle(plainText),
-        }));
-    }, []);
+            const plainText = getPlainTextFromHtml(newValue);
+
+            setErrors((prev) => ({
+                ...prev,
+                title: PARTNER_BANNER_VALIDATION_FUNCTIONS.validateTitle(plainText),
+            }));
+        },
+        [isBaseLanguage],
+    );
 
     const handleTitleBlur = useCallback(() => {
         setTouched((prev) => ({ ...prev, title: true }));
     }, []);
 
-    const handleDescriptionChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-        const newValue = e.target.value;
-        setFormState((prev) => ({
-            ...prev,
-            values: prev.values ? { ...prev.values, description: newValue } : null,
-        }));
-        setTouched((prev) => ({ ...prev, description: true }));
-        setErrors((prev) => ({
-            ...prev,
-            description: PARTNER_BANNER_VALIDATION_FUNCTIONS.validateDescription(newValue),
-        }));
-    }, []);
+    const handleDescriptionChange = useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            if (!isBaseLanguage) return;
 
-    const handleImageChange = useCallback((value: ImageValues | null) => {
-        setFormState((prev) => ({
-            ...prev,
-            values: prev.values ? { ...prev.values, image: value, imageId: value ? prev.values.imageId : null } : null,
-        }));
-    }, []);
+            const newValue = e.target.value;
+            setFormState((prev) => ({
+                ...prev,
+                values: prev.values ? { ...prev.values, description: newValue } : null,
+            }));
+            setTouched((prev) => ({ ...prev, description: true }));
+            setErrors((prev) => ({
+                ...prev,
+                description: PARTNER_BANNER_VALIDATION_FUNCTIONS.validateDescription(newValue),
+            }));
+        },
+        [isBaseLanguage],
+    );
 
-    const handleImageError = useCallback((error: string | null) => {
-        setErrors((prev) => ({
-            ...prev,
-            image: error ? error : undefined,
-        }));
-    }, []);
+    const handleImageChange = useCallback(
+        (value: ImageValues | null) => {
+            if (!isBaseLanguage) return;
+
+            setFormState((prev) => ({
+                ...prev,
+                values: prev.values
+                    ? { ...prev.values, image: value, imageId: value ? prev.values.imageId : null }
+                    : null,
+            }));
+        },
+        [isBaseLanguage],
+    );
+
+    const handleImageError = useCallback(
+        (error: string | null) => {
+            if (!isBaseLanguage) return;
+
+            setErrors((prev) => ({
+                ...prev,
+                image: error ? error : undefined,
+            }));
+        },
+        [isBaseLanguage],
+    );
 
     const handlePublishClick = useCallback(() => {
         setIsPublishModalOpen(true);
@@ -264,6 +286,9 @@ export const PartnerBanner = () => {
     }
 
     const isDisabled = isPublishing;
+    const displayedLocalization = isBaseLanguage ? null : returnDisplayedLocalization(values, language.code);
+    const displayedTitle = isBaseLanguage ? values.title : (displayedLocalization?.title ?? '');
+    const displayedDescription = isBaseLanguage ? values.description : (displayedLocalization?.description ?? '');
 
     return (
         <div className={styles.root}>
@@ -309,7 +334,7 @@ export const PartnerBanner = () => {
                                     onChange={handleImageChange}
                                     id="banner-image"
                                     name="banner-image"
-                                    disabled={isDisabled}
+                                    disabled={isDisabled || !isBaseLanguage}
                                     setError={handleImageError}
                                     style={{
                                         backgroundImage: `
@@ -331,43 +356,46 @@ export const PartnerBanner = () => {
                         <div className={styles.main}>
                             <div className={styles.fields}>
                                 <RichTextInputGroup
-                                    key={`title-${titleKey}`}
+                                    key={`title-${titleKey}-${language.code}`}
                                     label={PARTNERS_TEXT.FORM.LABEL.TITLE}
-                                    value={values.title}
+                                    value={displayedTitle}
                                     error={touched.title ? errors.title : undefined}
                                     onChange={handleTitleChange}
                                     onBlur={handleTitleBlur}
                                     name="title"
                                     id="title"
                                     maxLength={PARTNER_BANNER_VALIDATION.title.max}
-                                    disabled={isDisabled}
+                                    disabled={isDisabled || !isBaseLanguage}
+                                    hideToolbar={!isBaseLanguage}
                                     isRequired={true}
                                     trimOnBlur={true}
                                 />
 
                                 <InputWithCharacterLimitGroup
                                     label={PARTNERS_TEXT.FORM.LABEL.DESCRIPTION}
-                                    value={values.description}
+                                    value={displayedDescription}
                                     error={touched.description ? errors.description : undefined}
                                     onChange={handleDescriptionChange}
                                     id="description"
                                     name="description"
-                                    disabled={isDisabled}
+                                    disabled={isDisabled || !isBaseLanguage}
                                     maxLength={PARTNER_BANNER_VALIDATION.description.max}
                                     isRequired={true}
                                 />
                             </div>
 
-                            <div className={styles.actions}>
-                                <Button
-                                    type="button"
-                                    buttonStyle="primary"
-                                    onClick={handlePublishClick}
-                                    disabled={isDisabled || !isDirty || !isFormValid(values, errors)}
-                                >
-                                    {COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED}
-                                </Button>
-                            </div>
+                            {isBaseLanguage && (
+                                <div className={styles.actions}>
+                                    <Button
+                                        type="button"
+                                        buttonStyle="primary"
+                                        onClick={handlePublishClick}
+                                        disabled={isDisabled || !isDirty || !isFormValid(values, errors)}
+                                    >
+                                        {COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED}
+                                    </Button>
+                                </div>
+                            )}
                         </div>
                     </div>
                 </>

--- a/src/pages/admin/partners/components/partner-form/PartnerForm.test.tsx
+++ b/src/pages/admin/partners/components/partner-form/PartnerForm.test.tsx
@@ -103,6 +103,9 @@ const cardHtmlId = defaultValues.localId;
 const descriptionTestId = `partner-form-description-${cardHtmlId}`;
 const imageTestId = `partner-form-image-${cardHtmlId}`;
 
+const UK_LANGUAGE = { id: 1, code: 'uk', name: 'Ukrainian' };
+const EN_LANGUAGE = { id: 2, code: 'en', name: 'English' };
+
 describe('PartnerForm', () => {
     let onValuesChange: jest.Mock;
     let onDelete: jest.Mock;
@@ -134,6 +137,7 @@ describe('PartnerForm', () => {
                 disabled={false}
                 onValuesChange={onValuesChange}
                 onDelete={onDelete}
+                language={UK_LANGUAGE}
                 {...props}
             />,
         );
@@ -252,5 +256,38 @@ describe('PartnerForm', () => {
         expect(getImageRemoveButton()).toBeDisabled();
         expect(getImageSetErrorButton()).toBeDisabled();
         expect(getDescriptionTextarea()).toBeDisabled();
+    });
+
+    it('shows the translated description and disables fields when a non-base language is selected', () => {
+        renderComponent({ language: EN_LANGUAGE, translatedDescription: 'Translated description' });
+
+        expect(getDescriptionTextarea()).toHaveValue('Translated description');
+        expect(getDescriptionTextarea()).toBeDisabled();
+        expect(getImageChangeButton()).toBeDisabled();
+        expect(getImageRemoveButton()).toBeDisabled();
+        expect(getImageSetErrorButton()).toBeDisabled();
+    });
+
+    it('falls back to an empty description when no translation exists yet', () => {
+        renderComponent({ language: EN_LANGUAGE, translatedDescription: undefined });
+
+        expect(getDescriptionTextarea()).toHaveValue('');
+    });
+
+    it('ignores description and image changes while a non-base language is selected', () => {
+        renderComponent({ language: EN_LANGUAGE });
+
+        fireEvent.change(getDescriptionTextarea(), { target: { value: 'Should be ignored' } });
+        clickImageChange();
+        clickImageRemove();
+        clickImageSetError();
+
+        expect(onValuesChange).not.toHaveBeenCalled();
+    });
+
+    it('disables the delete button when structural actions are disabled', () => {
+        renderComponent({ disableStructuralActions: true });
+
+        expect(getDeleteButton()).toBeDisabled();
     });
 });

--- a/src/pages/admin/partners/components/partner-form/PartnerForm.tsx
+++ b/src/pages/admin/partners/components/partner-form/PartnerForm.tsx
@@ -7,6 +7,8 @@ import { TextAreaWithCharacterLimitGroup } from '@/components/admin/input-groups
 import { PARTNER_VALIDATION_FUNCTIONS } from '@/validation/admin/partner-schema/partner-schema';
 import { PARTNER_VALIDATION, PARTNERS_TEXT } from '@/const/admin/partners';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { DEFAULT_LOCALE } from '@/const/common/locales';
+import { LocalizationLanguage } from '@/types/common/language';
 import styles from './PartnerForm.module.scss';
 import './PartnerForm.scss';
 import { ACTION_ICONS } from '@/const/common/action-icons';
@@ -30,33 +32,50 @@ export interface PartnerFormProps {
     disabled: boolean;
     onValuesChange: (values: PartnerFormValues, errors: PartnerFormErrors) => void;
     onDelete: (localId: string) => void;
+    language: LocalizationLanguage;
+    translatedDescription?: string;
+    disableStructuralActions?: boolean;
 }
 
-const PartnerFormComponent = ({ values, errors, disabled, onValuesChange, onDelete }: PartnerFormProps) => {
+const PartnerFormComponent = ({
+    values,
+    errors,
+    disabled,
+    onValuesChange,
+    onDelete,
+    language,
+    translatedDescription,
+    disableStructuralActions = false,
+}: PartnerFormProps) => {
+    const isBaseLanguage = language.code === DEFAULT_LOCALE;
+    const displayedDescription = isBaseLanguage ? values.description : (translatedDescription ?? '');
     const handleDescriptionChange = useCallback(
         (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+            if (!isBaseLanguage) return;
             const value = e.target.value;
             const error = PARTNER_VALIDATION_FUNCTIONS.validateDescription(value);
             onValuesChange({ ...values, description: value }, { ...errors, description: error });
         },
-        [onValuesChange, values, errors],
+        [onValuesChange, values, errors, isBaseLanguage],
     );
 
     const handleImageChange = useCallback(
         (value: ImageValues | null) => {
+            if (!isBaseLanguage) return;
             onValuesChange({ ...values, image: value, imageId: null }, { ...errors, image: undefined });
         },
-        [onValuesChange, values, errors],
+        [onValuesChange, values, errors, isBaseLanguage],
     );
 
     const handleImageError = useCallback(
         (error: string | null) => {
+            if (!isBaseLanguage) return;
             if (!error) {
                 return;
             }
             onValuesChange({ ...values }, { ...errors, image: error });
         },
-        [onValuesChange, values, errors],
+        [onValuesChange, values, errors, isBaseLanguage],
     );
 
     const handleDelete = useCallback(() => {
@@ -75,6 +94,7 @@ const PartnerFormComponent = ({ values, errors, disabled, onValuesChange, onDele
                     data-testid={`partner-form-delete-button-${cardHtmlId}`}
                     DefaultIcon={ACTION_ICONS.delete.default}
                     FilledIcon={ACTION_ICONS.delete.hover}
+                    disabled={disabled || disableStructuralActions}
                 />
             </div>
             <div className={styles.content}>
@@ -86,7 +106,7 @@ const PartnerFormComponent = ({ values, errors, disabled, onValuesChange, onDele
                         name={`partner-form-image-${cardHtmlId}`}
                         onChange={handleImageChange}
                         setError={handleImageError}
-                        disabled={disabled}
+                        disabled={disabled || !isBaseLanguage}
                         enableCrop={true}
                         cropWidth={PARTNER_VALIDATION.image.width}
                         cropHeight={PARTNER_VALIDATION.image.height}
@@ -108,14 +128,14 @@ const PartnerFormComponent = ({ values, errors, disabled, onValuesChange, onDele
                     <TextAreaWithCharacterLimitGroup
                         label={PARTNERS_TEXT.PARTNER.DESCRIPTION_LABEL}
                         placeholder={PARTNERS_TEXT.PARTNER.DESCRIPTION_PLACEHOLDER}
-                        value={values.description}
+                        value={displayedDescription}
                         error={errors.description}
                         onChange={handleDescriptionChange}
                         name={`partner-form-description-${cardHtmlId}`}
                         id={`partner-form-description-${cardHtmlId}`}
                         maxLength={PARTNER_VALIDATION.description.max}
                         isRequired={true}
-                        disabled={disabled}
+                        disabled={disabled || !isBaseLanguage}
                         rows={3}
                     />
                 </div>

--- a/src/pages/admin/partners/components/partner-page-toolbar/PartnerPageToolbar.module.scss
+++ b/src/pages/admin/partners/components/partner-page-toolbar/PartnerPageToolbar.module.scss
@@ -4,7 +4,7 @@
     height: 5.625rem;
     display: flex;
     align-items: center;
-    justify-content: end;
+    justify-content: space-between;
     padding: 0.5rem 1.5rem;
     width: 100%;
     border-bottom: 1px solid c.$grey-50;

--- a/src/pages/admin/partners/components/partner-page-toolbar/PartnerPageToolbar.test.tsx
+++ b/src/pages/admin/partners/components/partner-page-toolbar/PartnerPageToolbar.test.tsx
@@ -31,8 +31,6 @@ jest.mock('@/components/admin/language-toolkit/LanguageToolkit', () => ({
     ),
 }));
 
-jest.mock('./PartnerPageToolbar.scss', () => ({}));
-
 describe('PartnerPageToolbar', () => {
     const user = userEvent.setup();
 

--- a/src/pages/admin/partners/components/partner-page-toolbar/PartnerPageToolbar.test.tsx
+++ b/src/pages/admin/partners/components/partner-page-toolbar/PartnerPageToolbar.test.tsx
@@ -4,8 +4,8 @@ import userEvent from '@testing-library/user-event';
 import { PartnerPageToolbar, PartnerPageToolbarProps } from './PartnerPageToolbar';
 
 jest.mock('@/components/admin/button/Button', () => ({
-    Button: ({ children, onClick, buttonStyle }: any) => (
-        <button onClick={onClick} data-button-style={buttonStyle}>
+    Button: ({ children, onClick, buttonStyle, disabled }: any) => (
+        <button onClick={onClick} data-button-style={buttonStyle} disabled={disabled}>
             {children}
         </button>
     ),
@@ -23,6 +23,14 @@ jest.mock('@/const/admin/partners', () => ({
     },
 }));
 
+jest.mock('@/components/admin/language-toolkit/LanguageToolkit', () => ({
+    LanguageToolkit: ({ languages }: any) => (
+        <div data-testid="mock-language-toolkit">
+            <span data-testid="lang-count">{languages.length}</span>
+        </div>
+    ),
+}));
+
 jest.mock('./PartnerPageToolbar.scss', () => ({}));
 
 describe('PartnerPageToolbar', () => {
@@ -30,6 +38,8 @@ describe('PartnerPageToolbar', () => {
 
     const mockProps: PartnerPageToolbarProps = {
         onAddSection: jest.fn(),
+        languages: [{ id: 1, code: 'uk', name: 'Ukrainian' }],
+        onLanguageChange: jest.fn(),
     };
 
     beforeEach(() => {
@@ -55,5 +65,31 @@ describe('PartnerPageToolbar', () => {
         render(<PartnerPageToolbar {...mockProps} />);
 
         expect(mockProps.onAddSection).not.toHaveBeenCalled();
+    });
+
+    it('renders the language toolkit with the provided languages', () => {
+        render(
+            <PartnerPageToolbar
+                {...mockProps}
+                languages={[
+                    { id: 1, code: 'uk', name: 'Ukrainian' },
+                    { id: 2, code: 'en', name: 'English' },
+                ]}
+            />,
+        );
+
+        expect(screen.getByTestId('lang-count')).toHaveTextContent('2');
+    });
+
+    it('disables the add-section button when disableAddSection is true', () => {
+        render(<PartnerPageToolbar {...mockProps} disableAddSection={true} />);
+
+        expect(screen.getByRole('button', { name: /add partner section/i })).toBeDisabled();
+    });
+
+    it('keeps the add-section button enabled by default', () => {
+        render(<PartnerPageToolbar {...mockProps} />);
+
+        expect(screen.getByRole('button', { name: /add partner section/i })).toBeEnabled();
     });
 });

--- a/src/pages/admin/partners/components/partner-page-toolbar/PartnerPageToolbar.tsx
+++ b/src/pages/admin/partners/components/partner-page-toolbar/PartnerPageToolbar.tsx
@@ -1,16 +1,24 @@
 import { Button } from '@/components/admin/button/Button';
 import { PARTNERS_TEXT } from '@/const/admin/partners';
 import { ReactComponent as PlusIcon } from '@/assets/icons/plus.svg';
+import { LanguageToolkit, LanguageToolkitProps } from '@/components/admin/language-toolkit/LanguageToolkit';
 import styles from './PartnerPageToolbar.module.scss';
 
-export interface PartnerPageToolbarProps {
+export interface PartnerPageToolbarProps extends LanguageToolkitProps {
     onAddSection: () => void;
+    disableAddSection?: boolean;
 }
 
-export const PartnerPageToolbar = ({ onAddSection }: PartnerPageToolbarProps) => {
+export const PartnerPageToolbar = ({
+    onAddSection,
+    disableAddSection = false,
+    languages,
+    onLanguageChange,
+}: PartnerPageToolbarProps) => {
     return (
         <div className={styles['partner-page-toolbar']} data-testid="partner-page-toolbar">
-            <Button onClick={onAddSection} buttonStyle="primary">
+            <LanguageToolkit languages={languages} onLanguageChange={onLanguageChange} />
+            <Button onClick={onAddSection} buttonStyle="primary" disabled={disableAddSection}>
                 {PARTNERS_TEXT.BUTTON.ADD_PARTNER_SECTION}
                 <PlusIcon />
             </Button>

--- a/src/pages/admin/partners/components/partner-panel-content/PartnerPanelContent.module.scss
+++ b/src/pages/admin/partners/components/partner-panel-content/PartnerPanelContent.module.scss
@@ -25,3 +25,12 @@
     justify-content: center;
     padding: 2rem 0;
 }
+
+.error {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    padding: 2rem 0;
+}

--- a/src/pages/admin/partners/components/partner-panel-content/PartnerPanelContent.module.scss
+++ b/src/pages/admin/partners/components/partner-panel-content/PartnerPanelContent.module.scss
@@ -23,7 +23,7 @@
 .loader {
     display: flex;
     justify-content: center;
-    padding: 2rem 0;
+    padding: 32px 0;
 }
 
 .error {
@@ -31,6 +31,6 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 1rem;
-    padding: 2rem 0;
+    gap: 16px;
+    padding: 32px 0;
 }

--- a/src/pages/admin/partners/components/partner-panel-content/PartnerPanelContent.module.scss
+++ b/src/pages/admin/partners/components/partner-panel-content/PartnerPanelContent.module.scss
@@ -19,3 +19,9 @@
     overflow-y: auto;
     padding: 24px 32px;
 }
+
+.loader {
+    display: flex;
+    justify-content: center;
+    padding: 2rem 0;
+}

--- a/src/pages/admin/partners/components/partner-panel-content/PartnerPanelContent.test.tsx
+++ b/src/pages/admin/partners/components/partner-panel-content/PartnerPanelContent.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { PartnerPanelContent } from './PartnerPanelContent';
 import { PartnerSectionsEditorRef } from '../partner-sections-editor/PartnerSectionsEditor';
@@ -114,5 +114,39 @@ describe('PartnerPanelContent', () => {
         render(<PartnerPanelContent />);
 
         expect(screen.getByText('Add Section')).toBeDisabled();
+    });
+
+    it('shows an error with a retry action when languages fail to load, instead of spinning forever', () => {
+        const retryFetchLanguages = jest.fn();
+        let capturedSetErrorState: (message: string) => void = () => {};
+
+        mockedUseLocalizationToolkit.mockImplementation(({ setErrorState }: any) => {
+            capturedSetErrorState = setErrorState;
+            return {
+                allLanguages: [],
+                translationLanguages: [],
+                selectedLanguage: undefined,
+                onLanguageChange: jest.fn(),
+                translationStatusFilter: undefined,
+                onTranslationStatusFilterChange: jest.fn(),
+                retryFetchLanguages,
+            };
+        });
+
+        render(<PartnerPanelContent />);
+
+        expect(screen.queryByTestId('partner-banner')).not.toBeInTheDocument();
+
+        act(() => {
+            capturedSetErrorState('Failed to load languages');
+        });
+
+        expect(screen.getByText('Failed to load languages')).toBeInTheDocument();
+        expect(screen.queryByTestId('partner-banner')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByText('Спробувати ще раз'));
+
+        expect(retryFetchLanguages).toHaveBeenCalledTimes(1);
+        expect(screen.queryByText('Failed to load languages')).not.toBeInTheDocument();
     });
 });

--- a/src/pages/admin/partners/components/partner-panel-content/PartnerPanelContent.test.tsx
+++ b/src/pages/admin/partners/components/partner-panel-content/PartnerPanelContent.test.tsx
@@ -3,17 +3,24 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { PartnerPanelContent } from './PartnerPanelContent';
 import { PartnerSectionsEditorRef } from '../partner-sections-editor/PartnerSectionsEditor';
+import { useLocalizationToolkit } from '@/hooks/admin/use-localization-toolkit/useLocalizationToolkit';
+import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextProvider';
+
+const UK_LANGUAGE = { id: 1, code: 'uk', name: 'Ukrainian' };
+const EN_LANGUAGE = { id: 2, code: 'en', name: 'English' };
 
 jest.mock('../partner-page-toolbar/PartnerPageToolbar', () => ({
-    PartnerPageToolbar: ({ onAddSection }: { onAddSection: () => void }) => (
+    PartnerPageToolbar: ({ onAddSection, disableAddSection }: any) => (
         <div data-testid="partner-page-toolbar">
-            <button onClick={onAddSection}>Add Section</button>
+            <button onClick={onAddSection} disabled={disableAddSection}>
+                Add Section
+            </button>
         </div>
     ),
 }));
 
 jest.mock('../partner-banner-form/PartnerBannerForm', () => ({
-    PartnerBanner: () => <div data-testid="partner-banner" />,
+    PartnerBanner: ({ language }: any) => <div data-testid="partner-banner" data-language={language?.code} />,
 }));
 
 const mockPartnerSectionsEditor = jest.fn();
@@ -21,12 +28,12 @@ const mockPartnerSectionsEditor = jest.fn();
 jest.mock('../partner-sections-editor/PartnerSectionsEditor', () => {
     const React = require('react');
     return {
-        PartnerSectionsEditor: React.forwardRef((_: unknown, ref: React.Ref<PartnerSectionsEditorRef>) => {
+        PartnerSectionsEditor: React.forwardRef(({ language }: any, ref: React.Ref<PartnerSectionsEditorRef>) => {
             React.useImperativeHandle(ref, () => ({
                 addSection: mockPartnerSectionsEditor,
             }));
 
-            return <div data-testid="partner-sections-editor" />;
+            return <div data-testid="partner-sections-editor" data-language={language?.code} />;
         }),
     };
 });
@@ -35,18 +42,36 @@ jest.mock('@/components/admin/toast/toast-container/ToastContainer', () => ({
     ToastContainer: () => <div data-testid="toast-container" />,
 }));
 
+jest.mock('@/contexts/admin/toast-context-provider/ToastContextProvider');
+jest.mock('@/hooks/admin/use-localization-toolkit/useLocalizationToolkit');
+
+const mockedUseLocalizationToolkit = useLocalizationToolkit as jest.Mock;
+const mockedUseToast = useToast as jest.Mock;
+
 describe('PartnerPanelContent', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockPartnerSectionsEditor.mockReset();
+
+        mockedUseToast.mockReturnValue({ addToast: jest.fn() });
+
+        mockedUseLocalizationToolkit.mockReturnValue({
+            allLanguages: [UK_LANGUAGE, EN_LANGUAGE],
+            translationLanguages: [EN_LANGUAGE],
+            selectedLanguage: UK_LANGUAGE,
+            onLanguageChange: jest.fn(),
+            translationStatusFilter: undefined,
+            onTranslationStatusFilterChange: jest.fn(),
+            retryFetchLanguages: jest.fn(),
+        });
     });
 
     it('renders toolbar, banner, sections editor, and toast container', () => {
         render(<PartnerPanelContent />);
 
         expect(screen.getByTestId('partner-page-toolbar')).toBeInTheDocument();
-        expect(screen.getByTestId('partner-banner')).toBeInTheDocument();
-        expect(screen.getByTestId('partner-sections-editor')).toBeInTheDocument();
+        expect(screen.getByTestId('partner-banner')).toHaveAttribute('data-language', 'uk');
+        expect(screen.getByTestId('partner-sections-editor')).toHaveAttribute('data-language', 'uk');
         expect(screen.getByTestId('toast-container')).toBeInTheDocument();
     });
 
@@ -56,5 +81,38 @@ describe('PartnerPanelContent', () => {
         fireEvent.click(screen.getByText('Add Section'));
 
         expect(mockPartnerSectionsEditor).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows a loader instead of the banner/sections while the language has not been selected yet', () => {
+        mockedUseLocalizationToolkit.mockReturnValue({
+            allLanguages: [],
+            translationLanguages: [],
+            selectedLanguage: undefined,
+            onLanguageChange: jest.fn(),
+            translationStatusFilter: undefined,
+            onTranslationStatusFilterChange: jest.fn(),
+            retryFetchLanguages: jest.fn(),
+        });
+
+        render(<PartnerPanelContent />);
+
+        expect(screen.queryByTestId('partner-banner')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('partner-sections-editor')).not.toBeInTheDocument();
+    });
+
+    it('disables the add-section toolbar button when a non-base language is selected', () => {
+        mockedUseLocalizationToolkit.mockReturnValue({
+            allLanguages: [UK_LANGUAGE, EN_LANGUAGE],
+            translationLanguages: [EN_LANGUAGE],
+            selectedLanguage: EN_LANGUAGE,
+            onLanguageChange: jest.fn(),
+            translationStatusFilter: undefined,
+            onTranslationStatusFilterChange: jest.fn(),
+            retryFetchLanguages: jest.fn(),
+        });
+
+        render(<PartnerPanelContent />);
+
+        expect(screen.getByText('Add Section')).toBeDisabled();
     });
 });

--- a/src/pages/admin/partners/components/partner-panel-content/PartnerPanelContent.tsx
+++ b/src/pages/admin/partners/components/partner-panel-content/PartnerPanelContent.tsx
@@ -1,10 +1,10 @@
-import React, { useRef, useCallback } from 'react';
+import React, { useRef, useCallback, useState } from 'react';
 import { PartnerPageToolbar } from '../partner-page-toolbar/PartnerPageToolbar';
 import { ToastContainer } from '@/components/admin/toast/toast-container/ToastContainer';
 import { PartnerSectionsEditor, PartnerSectionsEditorRef } from '../partner-sections-editor/PartnerSectionsEditor';
 import { InlineLoader } from '@/components/common/inline-loader/InlineLoader';
-import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextProvider';
-import { ToastType } from '@/types/admin/toast';
+import { Button } from '@/components/admin/button/Button';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { useLocalizationToolkit } from '@/hooks/admin/use-localization-toolkit/useLocalizationToolkit';
 import { DEFAULT_LOCALE } from '@/const/common/locales';
 import styles from './PartnerPanelContent.module.scss';
@@ -12,18 +12,17 @@ import { PartnerBanner } from '../partner-banner-form/PartnerBannerForm';
 
 export const PartnerPanelContent = () => {
     const sectionsEditorRef = useRef<PartnerSectionsEditorRef>(null);
-    const { addToast } = useToast();
+    const [languagesError, setLanguagesError] = useState<string | null>(null);
 
-    const handleLocalizationError = useCallback(
-        (message: string) => {
-            addToast(message, ToastType.Error);
-        },
-        [addToast],
-    );
+    const { allLanguages, translationLanguages, selectedLanguage, onLanguageChange, retryFetchLanguages } =
+        useLocalizationToolkit({
+            setErrorState: setLanguagesError,
+        });
 
-    const { allLanguages, translationLanguages, selectedLanguage, onLanguageChange } = useLocalizationToolkit({
-        setErrorState: handleLocalizationError,
-    });
+    const handleRetryFetchLanguages = useCallback(() => {
+        setLanguagesError(null);
+        retryFetchLanguages();
+    }, [retryFetchLanguages]);
 
     const handleAddSection = useCallback(() => {
         sectionsEditorRef.current?.addSection();
@@ -41,7 +40,14 @@ export const PartnerPanelContent = () => {
             </div>
 
             <div className={styles['scrollable-area']}>
-                {selectedLanguage ? (
+                {languagesError ? (
+                    <div className={styles.error}>
+                        <p>{languagesError}</p>
+                        <Button onClick={handleRetryFetchLanguages} buttonStyle="primary">
+                            {COMMON_TEXT_ADMIN.BUTTON.TRY_AGAIN}
+                        </Button>
+                    </div>
+                ) : selectedLanguage ? (
                     <>
                         <PartnerBanner language={selectedLanguage} translationLanguages={translationLanguages} />
                         <PartnerSectionsEditor

--- a/src/pages/admin/partners/components/partner-panel-content/PartnerPanelContent.tsx
+++ b/src/pages/admin/partners/components/partner-panel-content/PartnerPanelContent.tsx
@@ -2,11 +2,28 @@ import React, { useRef, useCallback } from 'react';
 import { PartnerPageToolbar } from '../partner-page-toolbar/PartnerPageToolbar';
 import { ToastContainer } from '@/components/admin/toast/toast-container/ToastContainer';
 import { PartnerSectionsEditor, PartnerSectionsEditorRef } from '../partner-sections-editor/PartnerSectionsEditor';
+import { InlineLoader } from '@/components/common/inline-loader/InlineLoader';
+import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextProvider';
+import { ToastType } from '@/types/admin/toast';
+import { useLocalizationToolkit } from '@/hooks/admin/use-localization-toolkit/useLocalizationToolkit';
+import { DEFAULT_LOCALE } from '@/const/common/locales';
 import styles from './PartnerPanelContent.module.scss';
 import { PartnerBanner } from '../partner-banner-form/PartnerBannerForm';
 
 export const PartnerPanelContent = () => {
     const sectionsEditorRef = useRef<PartnerSectionsEditorRef>(null);
+    const { addToast } = useToast();
+
+    const handleLocalizationError = useCallback(
+        (message: string) => {
+            addToast(message, ToastType.Error);
+        },
+        [addToast],
+    );
+
+    const { allLanguages, translationLanguages, selectedLanguage, onLanguageChange } = useLocalizationToolkit({
+        setErrorState: handleLocalizationError,
+    });
 
     const handleAddSection = useCallback(() => {
         sectionsEditorRef.current?.addSection();
@@ -15,12 +32,29 @@ export const PartnerPanelContent = () => {
     return (
         <div className={styles.root}>
             <div className={styles.toolbar}>
-                <PartnerPageToolbar onAddSection={handleAddSection} />
+                <PartnerPageToolbar
+                    onAddSection={handleAddSection}
+                    disableAddSection={selectedLanguage?.code !== DEFAULT_LOCALE}
+                    languages={allLanguages}
+                    onLanguageChange={onLanguageChange}
+                />
             </div>
 
             <div className={styles['scrollable-area']}>
-                <PartnerBanner />
-                <PartnerSectionsEditor ref={sectionsEditorRef} />
+                {selectedLanguage ? (
+                    <>
+                        <PartnerBanner language={selectedLanguage} translationLanguages={translationLanguages} />
+                        <PartnerSectionsEditor
+                            ref={sectionsEditorRef}
+                            language={selectedLanguage}
+                            translationLanguages={translationLanguages}
+                        />
+                    </>
+                ) : (
+                    <div className={styles.loader}>
+                        <InlineLoader size={2} />
+                    </div>
+                )}
             </div>
 
             <ToastContainer />

--- a/src/pages/admin/partners/components/partner-section/PartnerSectionForm.module.scss
+++ b/src/pages/admin/partners/components/partner-section/PartnerSectionForm.module.scss
@@ -11,6 +11,13 @@
     border-bottom: 1px solid c.$grey-700;
 }
 
+.status-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+}
+
 .inputs {
     display: flex;
     flex-direction: row;

--- a/src/pages/admin/partners/components/partner-section/PartnerSectionForm.test.tsx
+++ b/src/pages/admin/partners/components/partner-section/PartnerSectionForm.test.tsx
@@ -143,6 +143,7 @@ const renderComponent = (props: Partial<React.ComponentProps<typeof PartnerSecti
         value: defaultSectionValue,
         errors: defaultSectionErrors,
         isDirty: true,
+        isTextDirty: true,
         disabled: false,
         onChange: jest.fn(),
         onDelete: jest.fn(),
@@ -362,6 +363,7 @@ describe('PartnerSectionForm', () => {
                 value={defaultSectionValue}
                 errors={defaultSectionErrors}
                 isDirty={true}
+                isTextDirty={true}
                 disabled={false}
                 onChange={jest.fn()}
                 onDelete={jest.fn()}

--- a/src/pages/admin/partners/components/partner-section/PartnerSectionForm.test.tsx
+++ b/src/pages/admin/partners/components/partner-section/PartnerSectionForm.test.tsx
@@ -11,6 +11,8 @@ import {
 import { TextAreaWithCharacterLimitGroupProps } from '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup';
 import { PartnerFormProps } from '../partner-form/PartnerForm';
 import { ButtonProps } from '@/components/admin/button/Button';
+import { LocalizationLanguage } from '@/types/common/language';
+import { PartnerSectionLocalizationDto } from '@/types/admin/partners';
 
 jest.mock(
     '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup',
@@ -38,9 +40,9 @@ jest.mock(
 );
 
 jest.mock('../partner-form/PartnerForm', () => ({
-    PartnerForm: ({ values, errors, disabled, onValuesChange, onDelete }: PartnerFormProps) => (
+    PartnerForm: ({ values, errors, disabled, onValuesChange, onDelete, translatedDescription }: PartnerFormProps) => (
         <div data-testid={`mock-partner-${values.localId}`}>
-            <span>{values.description}</span>
+            <span>{translatedDescription ?? values.description}</span>
             <button
                 type="button"
                 data-testid={`partner-change-${values.localId}`}
@@ -93,6 +95,9 @@ const mockValidateSectionTitle = PARTNER_SECTION_VALIDATION_FUNCTIONS.validateTi
 const mockValidateSectionDescription = PARTNER_SECTION_VALIDATION_FUNCTIONS.validateDescription as jest.Mock;
 const mockValidatePartnerDescription = PARTNER_VALIDATION_FUNCTIONS.validateDescription as jest.Mock;
 
+const UK_LANGUAGE: LocalizationLanguage = { id: 1, code: 'uk', name: 'Ukrainian' };
+const EN_LANGUAGE: LocalizationLanguage = { id: 2, code: 'en', name: 'English' };
+
 const defaultPartner = {
     localId: 'partner-1',
     partnerId: 5,
@@ -133,22 +138,28 @@ beforeEach(() => {
     mockValidatePartnerDescription.mockImplementation(() => undefined);
 });
 
+const renderComponent = (props: Partial<React.ComponentProps<typeof PartnerSectionForm>> = {}) => {
+    const defaultProps: React.ComponentProps<typeof PartnerSectionForm> = {
+        value: defaultSectionValue,
+        errors: defaultSectionErrors,
+        isDirty: true,
+        disabled: false,
+        onChange: jest.fn(),
+        onDelete: jest.fn(),
+        onPublish: jest.fn(),
+        onTranslate: jest.fn(),
+        localizations: [],
+        translationLanguages: [],
+        language: UK_LANGUAGE,
+        translatedContent: null,
+    };
+
+    return render(<PartnerSectionForm {...defaultProps} {...props} />);
+};
+
 describe('PartnerSectionForm', () => {
     it('renders section fields and partner list', () => {
-        render(
-            <PartnerSectionForm
-                value={defaultSectionValue}
-                errors={defaultSectionErrors}
-                isDirty={true}
-                disabled={false}
-                onChange={jest.fn()}
-                onDelete={jest.fn()}
-                onPublish={jest.fn()}
-                onTranslate={jest.fn()}
-                localizations={[]}
-                translationLanguages={[]}
-            />,
-        );
+        renderComponent();
 
         expect(screen.getByTestId(`partner-section-title-${defaultSectionValue.localId}`)).toHaveValue(
             defaultSectionValue.title,
@@ -164,20 +175,7 @@ describe('PartnerSectionForm', () => {
         const onChange = jest.fn();
         mockValidateSectionTitle.mockImplementation(() => 'Title error');
 
-        render(
-            <PartnerSectionForm
-                value={defaultSectionValue}
-                errors={defaultSectionErrors}
-                isDirty={true}
-                disabled={false}
-                onChange={onChange}
-                onDelete={jest.fn()}
-                onPublish={jest.fn()}
-                onTranslate={jest.fn()}
-                localizations={[]}
-                translationLanguages={[]}
-            />,
-        );
+        renderComponent({ onChange });
 
         fireEvent.change(screen.getByTestId(`partner-section-title-${defaultSectionValue.localId}`), {
             target: { value: 'New title' },
@@ -194,20 +192,7 @@ describe('PartnerSectionForm', () => {
         const onChange = jest.fn();
         mockValidateSectionDescription.mockImplementation(() => 'Description error');
 
-        render(
-            <PartnerSectionForm
-                value={defaultSectionValue}
-                errors={defaultSectionErrors}
-                isDirty={true}
-                disabled={false}
-                onChange={onChange}
-                onDelete={jest.fn()}
-                onPublish={jest.fn()}
-                onTranslate={jest.fn()}
-                localizations={[]}
-                translationLanguages={[]}
-            />,
-        );
+        renderComponent({ onChange });
 
         fireEvent.change(screen.getByTestId(`partner-section-description-${defaultSectionValue.localId}`), {
             target: { value: 'New description' },
@@ -223,20 +208,7 @@ describe('PartnerSectionForm', () => {
     it('adds a new partner and expands errors array', () => {
         const onChange = jest.fn();
 
-        render(
-            <PartnerSectionForm
-                value={defaultSectionValue}
-                errors={defaultSectionErrors}
-                isDirty={true}
-                disabled={false}
-                onChange={onChange}
-                onDelete={jest.fn()}
-                onPublish={jest.fn()}
-                onTranslate={jest.fn()}
-                localizations={[]}
-                translationLanguages={[]}
-            />,
-        );
+        renderComponent({ onChange });
 
         fireEvent.click(screen.getByText(PARTNERS_TEXT.BUTTON.ADD_PARTNER));
 
@@ -262,20 +234,7 @@ describe('PartnerSectionForm', () => {
     it('updates partner data when partner form changes', () => {
         const onChange = jest.fn();
 
-        render(
-            <PartnerSectionForm
-                value={defaultSectionValue}
-                errors={defaultSectionErrors}
-                isDirty={true}
-                disabled={false}
-                onChange={onChange}
-                onDelete={jest.fn()}
-                onPublish={jest.fn()}
-                onTranslate={jest.fn()}
-                localizations={[]}
-                translationLanguages={[]}
-            />,
-        );
+        renderComponent({ onChange });
 
         fireEvent.click(screen.getByTestId(`partner-change-${defaultPartner.localId}`));
 
@@ -299,20 +258,7 @@ describe('PartnerSectionForm', () => {
     it('removes partner and tracks deleted ids', () => {
         const onChange = jest.fn();
 
-        render(
-            <PartnerSectionForm
-                value={defaultSectionValue}
-                errors={defaultSectionErrors}
-                isDirty={true}
-                disabled={false}
-                onChange={onChange}
-                onDelete={jest.fn()}
-                onPublish={jest.fn()}
-                onTranslate={jest.fn()}
-                localizations={[]}
-                translationLanguages={[]}
-            />,
-        );
+        renderComponent({ onChange });
 
         fireEvent.click(screen.getByTestId(`partner-delete-${defaultPartner.localId}`));
 
@@ -329,39 +275,13 @@ describe('PartnerSectionForm', () => {
     it('disables publish button when validation fails', () => {
         mockValidateSectionTitle.mockImplementation(() => 'Title invalid');
 
-        render(
-            <PartnerSectionForm
-                value={defaultSectionValue}
-                errors={defaultSectionErrors}
-                isDirty={true}
-                disabled={false}
-                onChange={jest.fn()}
-                onDelete={jest.fn()}
-                onPublish={jest.fn()}
-                onTranslate={jest.fn()}
-                localizations={[]}
-                translationLanguages={[]}
-            />,
-        );
+        renderComponent();
 
         expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED })).toBeDisabled();
     });
 
     it('enables publish button when validation passes', () => {
-        render(
-            <PartnerSectionForm
-                value={defaultSectionValue}
-                errors={defaultSectionErrors}
-                isDirty={true}
-                disabled={false}
-                onChange={jest.fn()}
-                onDelete={jest.fn()}
-                onPublish={jest.fn()}
-                onTranslate={jest.fn()}
-                localizations={[]}
-                translationLanguages={[]}
-            />,
-        );
+        renderComponent();
 
         expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED })).toBeEnabled();
     });
@@ -369,20 +289,7 @@ describe('PartnerSectionForm', () => {
     it('disables publish when partner description validation fails', () => {
         mockValidatePartnerDescription.mockImplementation(() => 'desc error');
 
-        render(
-            <PartnerSectionForm
-                value={defaultSectionValue}
-                errors={defaultSectionErrors}
-                isDirty={true}
-                disabled={false}
-                onChange={jest.fn()}
-                onDelete={jest.fn()}
-                onPublish={jest.fn()}
-                onTranslate={jest.fn()}
-                localizations={[]}
-                translationLanguages={[]}
-            />,
-        );
+        renderComponent();
 
         expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED })).toBeDisabled();
     });
@@ -394,20 +301,7 @@ describe('PartnerSectionForm', () => {
         };
         const errorsWithImageIssue = { ...defaultSectionErrors, partners: [{ image: 'Image required' }] };
 
-        render(
-            <PartnerSectionForm
-                value={valueWithoutImage}
-                errors={errorsWithImageIssue}
-                isDirty={true}
-                disabled={false}
-                onChange={jest.fn()}
-                onDelete={jest.fn()}
-                onPublish={jest.fn()}
-                onTranslate={jest.fn()}
-                localizations={[]}
-                translationLanguages={[]}
-            />,
-        );
+        renderComponent({ value: valueWithoutImage, errors: errorsWithImageIssue });
 
         expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED })).toBeDisabled();
     });
@@ -415,39 +309,13 @@ describe('PartnerSectionForm', () => {
     it('keeps publish enabled when image error exists but stored image is unchanged', () => {
         const errorsWithImageIssue = { ...defaultSectionErrors, partners: [{ image: 'Image too large' }] };
 
-        render(
-            <PartnerSectionForm
-                value={defaultSectionValue}
-                errors={errorsWithImageIssue}
-                isDirty={true}
-                disabled={false}
-                onChange={jest.fn()}
-                onDelete={jest.fn()}
-                onPublish={jest.fn()}
-                onTranslate={jest.fn()}
-                localizations={[]}
-                translationLanguages={[]}
-            />,
-        );
+        renderComponent({ errors: errorsWithImageIssue });
 
         expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED })).toBeEnabled();
     });
 
     it('shows loader and disables actions when form is disabled', () => {
-        render(
-            <PartnerSectionForm
-                value={defaultSectionValue}
-                errors={defaultSectionErrors}
-                isDirty={true}
-                disabled={true}
-                onChange={jest.fn()}
-                onDelete={jest.fn()}
-                onPublish={jest.fn()}
-                onTranslate={jest.fn()}
-                localizations={[]}
-                translationLanguages={[]}
-            />,
-        );
+        renderComponent({ disabled: true });
 
         expect(screen.getByTestId('inline-loader-2')).toBeInTheDocument();
         expect(screen.getByText(PARTNERS_TEXT.SECTION.DELETE_SECTION)).toBeDisabled();
@@ -458,20 +326,7 @@ describe('PartnerSectionForm', () => {
         const onDelete = jest.fn();
         const onPublish = jest.fn();
 
-        render(
-            <PartnerSectionForm
-                value={defaultSectionValue}
-                errors={defaultSectionErrors}
-                isDirty={true}
-                disabled={false}
-                onChange={jest.fn()}
-                onDelete={onDelete}
-                onPublish={onPublish}
-                onTranslate={jest.fn()}
-                localizations={[]}
-                translationLanguages={[]}
-            />,
-        );
+        renderComponent({ onDelete, onPublish });
 
         fireEvent.click(screen.getByText(PARTNERS_TEXT.SECTION.DELETE_SECTION));
         fireEvent.click(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED }));
@@ -484,20 +339,7 @@ describe('PartnerSectionForm', () => {
         const partnerWithoutId = { ...defaultPartner, partnerId: null };
         const onChange = jest.fn();
 
-        render(
-            <PartnerSectionForm
-                value={{ ...defaultSectionValue, partners: [partnerWithoutId] }}
-                errors={defaultSectionErrors}
-                isDirty={true}
-                disabled={false}
-                onChange={onChange}
-                onDelete={jest.fn()}
-                onPublish={jest.fn()}
-                onTranslate={jest.fn()}
-                localizations={[]}
-                translationLanguages={[]}
-            />,
-        );
+        renderComponent({ value: { ...defaultSectionValue, partners: [partnerWithoutId] }, onChange });
 
         fireEvent.click(screen.getByTestId(`partner-delete-${partnerWithoutId.localId}`));
 
@@ -505,38 +347,14 @@ describe('PartnerSectionForm', () => {
     });
 
     it('disables publish button when not dirty', () => {
-        render(
-            <PartnerSectionForm
-                value={defaultSectionValue}
-                errors={defaultSectionErrors}
-                isDirty={false}
-                disabled={false}
-                onChange={jest.fn()}
-                onDelete={jest.fn()}
-                onPublish={jest.fn()}
-                onTranslate={jest.fn()}
-                localizations={[]}
-                translationLanguages={[]}
-            />,
-        );
+        renderComponent({ isDirty: false });
+
         expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED })).toBeDisabled();
     });
 
     it('enables publish button only when dirty and valid', () => {
-        const { rerender } = render(
-            <PartnerSectionForm
-                value={defaultSectionValue}
-                errors={defaultSectionErrors}
-                isDirty={false}
-                disabled={false}
-                onChange={jest.fn()}
-                onDelete={jest.fn()}
-                onPublish={jest.fn()}
-                onTranslate={jest.fn()}
-                localizations={[]}
-                translationLanguages={[]}
-            />,
-        );
+        const { rerender } = renderComponent({ isDirty: false });
+
         expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED })).toBeDisabled();
 
         rerender(
@@ -551,8 +369,73 @@ describe('PartnerSectionForm', () => {
                 onTranslate={jest.fn()}
                 localizations={[]}
                 translationLanguages={[]}
+                language={UK_LANGUAGE}
+                translatedContent={null}
             />,
         );
         expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED })).toBeEnabled();
+    });
+
+    it('shows translated content and disables fields/structural actions when a non-base language is selected', () => {
+        const translatedContent: PartnerSectionLocalizationDto = {
+            entityId: 9,
+            title: 'Section title EN',
+            description: 'Section description EN',
+            partners: [{ partnerId: defaultPartner.partnerId, description: 'Partner description EN' }],
+            localizationInfoDto: { id: EN_LANGUAGE.id, code: EN_LANGUAGE.code },
+            translationStatus: 1,
+        };
+
+        renderComponent({ language: EN_LANGUAGE, translatedContent, disableStructuralActions: true });
+
+        expect(screen.getByTestId(`partner-section-title-${defaultSectionValue.localId}`)).toHaveValue(
+            'Section title EN',
+        );
+        expect(screen.getByTestId(`partner-section-title-${defaultSectionValue.localId}`)).toBeDisabled();
+        expect(screen.getByTestId(`partner-section-description-${defaultSectionValue.localId}`)).toHaveValue(
+            'Section description EN',
+        );
+        expect(screen.getByTestId(`partner-section-description-${defaultSectionValue.localId}`)).toBeDisabled();
+        expect(screen.getByText('Partner description EN')).toBeInTheDocument();
+        expect(screen.getByText(PARTNERS_TEXT.SECTION.DELETE_SECTION)).toBeDisabled();
+        expect(screen.getByText(PARTNERS_TEXT.BUTTON.ADD_PARTNER).closest('button')).toBeDisabled();
+        expect(
+            screen.queryByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('shows empty section fields when the section has no translation yet', () => {
+        renderComponent({ language: EN_LANGUAGE, translatedContent: null });
+
+        expect(screen.getByTestId(`partner-section-title-${defaultSectionValue.localId}`)).toHaveValue('');
+        expect(screen.getByTestId(`partner-section-description-${defaultSectionValue.localId}`)).toHaveValue('');
+    });
+
+    it('ignores title and description changes while a non-base language is selected', () => {
+        const onChange = jest.fn();
+
+        renderComponent({ language: EN_LANGUAGE, onChange });
+
+        fireEvent.change(screen.getByTestId(`partner-section-title-${defaultSectionValue.localId}`), {
+            target: { value: 'Should be ignored' },
+        });
+        fireEvent.change(screen.getByTestId(`partner-section-description-${defaultSectionValue.localId}`), {
+            target: { value: 'Should be ignored' },
+        });
+
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('ignores delete-section and add-partner clicks when structural actions are disabled', () => {
+        const onDelete = jest.fn();
+        const onChange = jest.fn();
+
+        renderComponent({ disableStructuralActions: true, onDelete, onChange });
+
+        fireEvent.click(screen.getByText(PARTNERS_TEXT.SECTION.DELETE_SECTION));
+        fireEvent.click(screen.getByText(PARTNERS_TEXT.BUTTON.ADD_PARTNER));
+
+        expect(onDelete).not.toHaveBeenCalled();
+        expect(onChange).not.toHaveBeenCalled();
     });
 });

--- a/src/pages/admin/partners/components/partner-section/PartnerSectionForm.test.tsx
+++ b/src/pages/admin/partners/components/partner-section/PartnerSectionForm.test.tsx
@@ -144,6 +144,9 @@ describe('PartnerSectionForm', () => {
                 onChange={jest.fn()}
                 onDelete={jest.fn()}
                 onPublish={jest.fn()}
+                onTranslate={jest.fn()}
+                localizations={[]}
+                translationLanguages={[]}
             />,
         );
 
@@ -170,6 +173,9 @@ describe('PartnerSectionForm', () => {
                 onChange={onChange}
                 onDelete={jest.fn()}
                 onPublish={jest.fn()}
+                onTranslate={jest.fn()}
+                localizations={[]}
+                translationLanguages={[]}
             />,
         );
 
@@ -197,6 +203,9 @@ describe('PartnerSectionForm', () => {
                 onChange={onChange}
                 onDelete={jest.fn()}
                 onPublish={jest.fn()}
+                onTranslate={jest.fn()}
+                localizations={[]}
+                translationLanguages={[]}
             />,
         );
 
@@ -223,6 +232,9 @@ describe('PartnerSectionForm', () => {
                 onChange={onChange}
                 onDelete={jest.fn()}
                 onPublish={jest.fn()}
+                onTranslate={jest.fn()}
+                localizations={[]}
+                translationLanguages={[]}
             />,
         );
 
@@ -259,6 +271,9 @@ describe('PartnerSectionForm', () => {
                 onChange={onChange}
                 onDelete={jest.fn()}
                 onPublish={jest.fn()}
+                onTranslate={jest.fn()}
+                localizations={[]}
+                translationLanguages={[]}
             />,
         );
 
@@ -293,6 +308,9 @@ describe('PartnerSectionForm', () => {
                 onChange={onChange}
                 onDelete={jest.fn()}
                 onPublish={jest.fn()}
+                onTranslate={jest.fn()}
+                localizations={[]}
+                translationLanguages={[]}
             />,
         );
 
@@ -320,6 +338,9 @@ describe('PartnerSectionForm', () => {
                 onChange={jest.fn()}
                 onDelete={jest.fn()}
                 onPublish={jest.fn()}
+                onTranslate={jest.fn()}
+                localizations={[]}
+                translationLanguages={[]}
             />,
         );
 
@@ -336,6 +357,9 @@ describe('PartnerSectionForm', () => {
                 onChange={jest.fn()}
                 onDelete={jest.fn()}
                 onPublish={jest.fn()}
+                onTranslate={jest.fn()}
+                localizations={[]}
+                translationLanguages={[]}
             />,
         );
 
@@ -354,6 +378,9 @@ describe('PartnerSectionForm', () => {
                 onChange={jest.fn()}
                 onDelete={jest.fn()}
                 onPublish={jest.fn()}
+                onTranslate={jest.fn()}
+                localizations={[]}
+                translationLanguages={[]}
             />,
         );
 
@@ -376,6 +403,9 @@ describe('PartnerSectionForm', () => {
                 onChange={jest.fn()}
                 onDelete={jest.fn()}
                 onPublish={jest.fn()}
+                onTranslate={jest.fn()}
+                localizations={[]}
+                translationLanguages={[]}
             />,
         );
 
@@ -394,6 +424,9 @@ describe('PartnerSectionForm', () => {
                 onChange={jest.fn()}
                 onDelete={jest.fn()}
                 onPublish={jest.fn()}
+                onTranslate={jest.fn()}
+                localizations={[]}
+                translationLanguages={[]}
             />,
         );
 
@@ -410,6 +443,9 @@ describe('PartnerSectionForm', () => {
                 onChange={jest.fn()}
                 onDelete={jest.fn()}
                 onPublish={jest.fn()}
+                onTranslate={jest.fn()}
+                localizations={[]}
+                translationLanguages={[]}
             />,
         );
 
@@ -431,6 +467,9 @@ describe('PartnerSectionForm', () => {
                 onChange={jest.fn()}
                 onDelete={onDelete}
                 onPublish={onPublish}
+                onTranslate={jest.fn()}
+                localizations={[]}
+                translationLanguages={[]}
             />,
         );
 
@@ -454,6 +493,9 @@ describe('PartnerSectionForm', () => {
                 onChange={onChange}
                 onDelete={jest.fn()}
                 onPublish={jest.fn()}
+                onTranslate={jest.fn()}
+                localizations={[]}
+                translationLanguages={[]}
             />,
         );
 
@@ -472,6 +514,9 @@ describe('PartnerSectionForm', () => {
                 onChange={jest.fn()}
                 onDelete={jest.fn()}
                 onPublish={jest.fn()}
+                onTranslate={jest.fn()}
+                localizations={[]}
+                translationLanguages={[]}
             />,
         );
         expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED })).toBeDisabled();
@@ -487,6 +532,9 @@ describe('PartnerSectionForm', () => {
                 onChange={jest.fn()}
                 onDelete={jest.fn()}
                 onPublish={jest.fn()}
+                onTranslate={jest.fn()}
+                localizations={[]}
+                translationLanguages={[]}
             />,
         );
         expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED })).toBeDisabled();
@@ -500,6 +548,9 @@ describe('PartnerSectionForm', () => {
                 onChange={jest.fn()}
                 onDelete={jest.fn()}
                 onPublish={jest.fn()}
+                onTranslate={jest.fn()}
+                localizations={[]}
+                translationLanguages={[]}
             />,
         );
         expect(screen.getByRole('button', { name: COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED })).toBeEnabled();

--- a/src/pages/admin/partners/components/partner-section/PartnerSectionForm.tsx
+++ b/src/pages/admin/partners/components/partner-section/PartnerSectionForm.tsx
@@ -13,6 +13,8 @@ import { IconButton } from '@/components/admin/icon-button/IconButton';
 import { LocalizationStatuses } from '@/components/admin/localization-statuses/LocalizationStatuses';
 import { ACTION_ICONS } from '@/const/common/action-icons';
 import { EntityLocalization, LocalizationLanguage } from '@/types/common/language';
+import { PartnerSectionLocalizationDto } from '@/types/admin/partners';
+import { DEFAULT_LOCALE } from '@/const/common/locales';
 import styles from './PartnerSectionForm.module.scss';
 import './PartnerSectionForm.scss';
 
@@ -42,6 +44,9 @@ export interface PartnerSectionProps {
     isDirty: boolean;
     localizations: EntityLocalization[];
     translationLanguages: LocalizationLanguage[];
+    language: LocalizationLanguage;
+    translatedContent: PartnerSectionLocalizationDto | null;
+    disableStructuralActions?: boolean;
 }
 
 const PartnerSectionComponent = ({
@@ -55,28 +60,39 @@ const PartnerSectionComponent = ({
     isDirty,
     localizations,
     translationLanguages,
+    language,
+    translatedContent,
+    disableStructuralActions = false,
 }: PartnerSectionProps) => {
+    const isBaseLanguage = language.code === DEFAULT_LOCALE;
+    const displayedTitle = isBaseLanguage ? value.title : (translatedContent?.title ?? '');
+    const displayedDescription = isBaseLanguage ? value.description : (translatedContent?.description ?? '');
+
     const handleTitleChange = useCallback(
         (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+            if (!isBaseLanguage) return;
             const newTitle = e.target.value;
             const error = PARTNER_SECTION_VALIDATION_FUNCTIONS.validateTitle(newTitle);
 
             onChange({ ...value, title: newTitle }, { ...errors, title: error });
         },
-        [value, errors, onChange],
+        [value, errors, onChange, isBaseLanguage],
     );
 
     const handleDescriptionChange = useCallback(
         (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+            if (!isBaseLanguage) return;
             const newDescription = e.target.value;
             const error = PARTNER_SECTION_VALIDATION_FUNCTIONS.validateDescription(newDescription);
 
             onChange({ ...value, description: newDescription }, { ...errors, description: error });
         },
-        [value, errors, onChange],
+        [value, errors, onChange, isBaseLanguage],
     );
 
     const handleAddPartner = useCallback(() => {
+        if (disableStructuralActions) return;
+
         const newPartner: PartnerFormValues = {
             localId: crypto.randomUUID(),
             partnerId: null,
@@ -89,7 +105,7 @@ const PartnerSectionComponent = ({
         const newPartnerErrors = [...errors.partners, {}];
 
         onChange({ ...value, partners: newPartners }, { ...errors, partners: newPartnerErrors });
-    }, [value, errors, onChange]);
+    }, [value, errors, onChange, disableStructuralActions]);
 
     const handlePartnerChange = useCallback(
         (partnerValues: PartnerFormValues, partnerErrors: PartnerFormErrors) => {
@@ -113,6 +129,8 @@ const PartnerSectionComponent = ({
 
     const handlePartnerDelete = useCallback(
         (localId: string) => {
+            if (disableStructuralActions) return;
+
             const indexToDelete = value.partners.findIndex((p) => p.localId === localId);
             if (indexToDelete === -1) return;
 
@@ -131,12 +149,13 @@ const PartnerSectionComponent = ({
                 { ...errors, partners: newPartnerErrors },
             );
         },
-        [value, errors, onChange],
+        [value, errors, onChange, disableStructuralActions],
     );
 
     const handleDelete = useCallback(() => {
+        if (disableStructuralActions) return;
         onDelete(value.localId);
-    }, [onDelete, value.localId]);
+    }, [onDelete, value.localId, disableStructuralActions]);
 
     const handlePublish = useCallback(() => {
         onPublish(value.localId, value);
@@ -185,13 +204,13 @@ const PartnerSectionComponent = ({
                 <div className={styles['title-group']}>
                     <TextAreaWithCharacterLimitGroup
                         label={PARTNERS_TEXT.FORM.LABEL.TITLE}
-                        value={value.title}
+                        value={displayedTitle}
                         error={errors.title}
                         onChange={handleTitleChange}
                         name={`partner-section-title-${value.localId}`}
                         id={`partner-section-title-${value.localId}`}
                         isRequired={true}
-                        disabled={disabled}
+                        disabled={disabled || !isBaseLanguage}
                         placeholder={PARTNERS_TEXT.SECTION.TITLE_PLACEHOLDER}
                         maxLength={PARTNER_SECTION_VALIDATION.title.max}
                         rows={3}
@@ -200,13 +219,13 @@ const PartnerSectionComponent = ({
                 <div className={styles['description-group']}>
                     <TextAreaWithCharacterLimitGroup
                         label={PARTNERS_TEXT.FORM.LABEL.DESCRIPTION}
-                        value={value.description}
+                        value={displayedDescription}
                         error={errors.description}
                         onChange={handleDescriptionChange}
                         name={`partner-section-description-${value.localId}`}
                         id={`partner-section-description-${value.localId}`}
                         isRequired={true}
-                        disabled={disabled}
+                        disabled={disabled || !isBaseLanguage}
                         placeholder={PARTNERS_TEXT.SECTION.DESCRIPTION_PLACEHOLDER}
                         maxLength={PARTNER_SECTION_VALIDATION.description.max}
                         rows={3}
@@ -223,13 +242,22 @@ const PartnerSectionComponent = ({
                         disabled={disabled}
                         onValuesChange={handlePartnerChange}
                         onDelete={handlePartnerDelete}
+                        language={language}
+                        translatedDescription={
+                            translatedContent?.partners.find((p) => p.partnerId === partner.partnerId)?.description
+                        }
+                        disableStructuralActions={disableStructuralActions}
                     />
                 ))}
                 <div className={styles['add-card']}>
                     <button
                         type="button"
                         onClick={handleAddPartner}
-                        disabled={disabled || value.partners.length >= PARTNER_SECTION_VALIDATION.partners.max}
+                        disabled={
+                            disabled ||
+                            disableStructuralActions ||
+                            value.partners.length >= PARTNER_SECTION_VALIDATION.partners.max
+                        }
                     >
                         <span>{PARTNERS_TEXT.BUTTON.ADD_PARTNER}</span>
                     </button>
@@ -243,12 +271,18 @@ const PartnerSectionComponent = ({
             )}
 
             <div className={styles['actions']}>
-                <Button buttonStyle="secondary" onClick={handleDelete} disabled={disabled}>
+                <Button buttonStyle="secondary" onClick={handleDelete} disabled={disabled || disableStructuralActions}>
                     {PARTNERS_TEXT.SECTION.DELETE_SECTION}
                 </Button>
-                <Button buttonStyle="primary" onClick={handlePublish} disabled={disabled || !isDirty || !isFormValid()}>
-                    {COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED}
-                </Button>
+                {isBaseLanguage && (
+                    <Button
+                        buttonStyle="primary"
+                        onClick={handlePublish}
+                        disabled={disabled || !isDirty || !isFormValid()}
+                    >
+                        {COMMON_TEXT_ADMIN.BUTTON.SAVE_AS_PUBLISHED}
+                    </Button>
+                )}
             </div>
         </div>
     );

--- a/src/pages/admin/partners/components/partner-section/PartnerSectionForm.tsx
+++ b/src/pages/admin/partners/components/partner-section/PartnerSectionForm.tsx
@@ -9,6 +9,10 @@ import { TextAreaWithCharacterLimitGroup } from '@/components/admin/input-groups
 import { PartnerForm, PartnerFormErrors, PartnerFormValues } from '../partner-form/PartnerForm';
 import { InlineLoader } from '@/components/common/inline-loader/InlineLoader';
 import { Button } from '@/components/admin/button/Button';
+import { IconButton } from '@/components/admin/icon-button/IconButton';
+import { LocalizationStatuses } from '@/components/admin/localization-statuses/LocalizationStatuses';
+import { ACTION_ICONS } from '@/const/common/action-icons';
+import { EntityLocalization, LocalizationLanguage } from '@/types/common/language';
 import styles from './PartnerSectionForm.module.scss';
 import './PartnerSectionForm.scss';
 
@@ -34,7 +38,10 @@ export interface PartnerSectionProps {
     onChange: (value: PartnerSectionFormValues, errors: PartnerSectionErrors) => void;
     onDelete: (localId: string) => void;
     onPublish: (localId: string, sectionData: PartnerSectionFormValues) => void;
+    onTranslate: (sectionId: number) => void;
     isDirty: boolean;
+    localizations: EntityLocalization[];
+    translationLanguages: LocalizationLanguage[];
 }
 
 const PartnerSectionComponent = ({
@@ -42,9 +49,12 @@ const PartnerSectionComponent = ({
     onChange,
     onDelete,
     onPublish,
+    onTranslate,
     disabled = false,
     errors,
     isDirty,
+    localizations,
+    translationLanguages,
 }: PartnerSectionProps) => {
     const handleTitleChange = useCallback(
         (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -132,6 +142,11 @@ const PartnerSectionComponent = ({
         onPublish(value.localId, value);
     }, [onPublish, value]);
 
+    const handleTranslate = useCallback(() => {
+        if (value.sectionId === null) return;
+        onTranslate(value.sectionId);
+    }, [onTranslate, value.sectionId]);
+
     const isFormValid = (): boolean => {
         if (PARTNER_SECTION_VALIDATION_FUNCTIONS.validateTitle(value.title)) {
             return false;
@@ -155,6 +170,17 @@ const PartnerSectionComponent = ({
 
     return (
         <div className={styles.root}>
+            <div className={styles['status-bar']}>
+                <LocalizationStatuses languages={translationLanguages} localizedEntity={{ localizations }} />
+                <IconButton
+                    aria-label={COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION}
+                    type="button"
+                    onClick={handleTranslate}
+                    DefaultIcon={ACTION_ICONS.translate.default}
+                    disabled={disabled || isDirty || value.sectionId === null}
+                />
+            </div>
+
             <div className={styles.inputs}>
                 <div className={styles['title-group']}>
                     <TextAreaWithCharacterLimitGroup

--- a/src/pages/admin/partners/components/partner-section/PartnerSectionForm.tsx
+++ b/src/pages/admin/partners/components/partner-section/PartnerSectionForm.tsx
@@ -42,6 +42,7 @@ export interface PartnerSectionProps {
     onPublish: (localId: string, sectionData: PartnerSectionFormValues) => void;
     onTranslate: (sectionId: number) => void;
     isDirty: boolean;
+    isTextDirty: boolean;
     localizations: EntityLocalization[];
     translationLanguages: LocalizationLanguage[];
     language: LocalizationLanguage;
@@ -58,6 +59,7 @@ const PartnerSectionComponent = ({
     disabled = false,
     errors,
     isDirty,
+    isTextDirty,
     localizations,
     translationLanguages,
     language,
@@ -196,7 +198,7 @@ const PartnerSectionComponent = ({
                     type="button"
                     onClick={handleTranslate}
                     DefaultIcon={ACTION_ICONS.translate.default}
-                    disabled={disabled || isDirty || value.sectionId === null}
+                    disabled={disabled || isTextDirty || value.sectionId === null}
                 />
             </div>
 

--- a/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.test.tsx
+++ b/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.test.tsx
@@ -10,7 +10,7 @@ import { PARTNERS_TEXT } from '@/const/admin/partners';
 import { ToastType } from '@/types/admin/toast';
 
 const mockPartnerSectionFormRender = jest.fn((props: any) => {
-    const { value, errors, disabled, onChange, onDelete, onPublish } = props;
+    const { value, errors, disabled, onChange, onDelete, onPublish, onTranslate } = props;
     return (
         <div data-testid={`partner-section-${value.localId}`} data-disabled={disabled}>
             <span>{value.title}</span>
@@ -37,6 +37,14 @@ const mockPartnerSectionFormRender = jest.fn((props: any) => {
                 disabled={disabled}
             >
                 Publish Section
+            </button>
+            <button
+                type="button"
+                data-testid={`section-translate-${value.localId}`}
+                onClick={() => onTranslate(value.sectionId)}
+                disabled={disabled}
+            >
+                Translate Section
             </button>
         </div>
     );
@@ -73,6 +81,31 @@ jest.mock('@/hooks/common/use-data-fetch/useDataFetch');
 jest.mock('@/services/api/admin/partners/partners-api');
 jest.mock('@/hooks/admin/use-admin-client/useAdminClient');
 jest.mock('@/contexts/admin/toast-context-provider/ToastContextProvider');
+
+const mockTranslationLanguages = [{ id: 2, code: 'en', name: 'English' }];
+
+jest.mock('@/hooks/admin/use-localization-toolkit/useLocalizationToolkit', () => ({
+    useLocalizationToolkit: () => ({
+        allLanguages: mockTranslationLanguages,
+        translationLanguages: mockTranslationLanguages,
+        selectedLanguage: mockTranslationLanguages[0],
+        onLanguageChange: jest.fn(),
+        translationStatusFilter: undefined,
+        onTranslationStatusFilterChange: jest.fn(),
+        retryFetchLanguages: jest.fn(),
+    }),
+}));
+
+jest.mock('../translate-partner-section-modal/TranslatePartnerSectionModal', () => ({
+    TranslatePartnerSectionModal: ({ isOpen, onClose, section, onTranslated }: any) =>
+        isOpen ? (
+            <div data-testid="translate-partner-section-modal">
+                <span data-testid="translate-section-id">{section?.id ?? 'none'}</span>
+                <button onClick={onTranslated}>mock-translated-success</button>
+                <button onClick={onClose}>mock-translate-close</button>
+            </div>
+        ) : null,
+}));
 
 const mockedUseDataFetch = useDataFetch as jest.Mock;
 const mockedPartnersApi = PartnersApi as jest.Mocked<typeof PartnersApi>;
@@ -113,6 +146,7 @@ beforeEach(() => {
                 imageId: 301,
             },
         ],
+        localizations: [],
     });
 
     mockedPartnersApi.updateSection.mockResolvedValue({
@@ -127,6 +161,7 @@ beforeEach(() => {
                 imageId: 20,
             },
         ],
+        localizations: [],
     });
 
     mockedPartnersApi.deleteSection.mockResolvedValue();
@@ -565,6 +600,63 @@ describe('PartnerSectionsEditor', () => {
         await waitFor(() => {
             expect(addToastMock).toHaveBeenCalledWith(PARTNERS_TEXT.MESSAGE.FAIL_TO_DELETE_SECTION, ToastType.Error);
         });
+    });
+
+    it('opens the translate modal for the clicked section and closes it', async () => {
+        const refetchMock = jest.fn();
+        mockSections(
+            [
+                {
+                    id: 4,
+                    title: 'Translatable section',
+                    description: 'Desc',
+                    partners: [],
+                },
+            ],
+            { refetch: refetchMock },
+        );
+
+        await renderEditor();
+
+        expect(screen.queryByTestId('translate-partner-section-modal')).not.toBeInTheDocument();
+
+        const props = getLatestFormProps();
+        act(() => {
+            props.onTranslate(props.value.sectionId);
+        });
+
+        expect(screen.getByTestId('translate-partner-section-modal')).toBeInTheDocument();
+        expect(screen.getByTestId('translate-section-id')).toHaveTextContent('4');
+
+        fireEvent.click(screen.getByText('mock-translate-close'));
+
+        expect(screen.queryByTestId('translate-partner-section-modal')).not.toBeInTheDocument();
+    });
+
+    it('refetches sections when a translation is saved', async () => {
+        const refetchMock = jest.fn();
+        mockSections(
+            [
+                {
+                    id: 4,
+                    title: 'Translatable section',
+                    description: 'Desc',
+                    partners: [],
+                },
+            ],
+            { refetch: refetchMock },
+        );
+
+        await renderEditor();
+
+        const props = getLatestFormProps();
+        act(() => {
+            props.onTranslate(props.value.sectionId);
+        });
+
+        fireEvent.click(screen.getByText('mock-translated-success'));
+
+        expect(refetchMock).toHaveBeenCalledTimes(1);
     });
 
     it('does not add section while sections are loading', async () => {

--- a/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.test.tsx
+++ b/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.test.tsx
@@ -6,6 +6,7 @@ import { useDataFetch } from '@/hooks/common/use-data-fetch/useDataFetch';
 import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
 import { useToast } from '@/contexts/admin/toast-context-provider/ToastContextProvider';
 import { PartnersApi } from '@/services/api/admin/partners/partners-api';
+import { PartnerSectionLocalizationApi } from '@/services/api/admin/partners/partner-section-localizations-api';
 import { PARTNERS_TEXT } from '@/const/admin/partners';
 import { ToastType } from '@/types/admin/toast';
 
@@ -79,22 +80,13 @@ jest.mock('@/components/admin/confirmation-modal/ConfirmationModal', () => ({
 
 jest.mock('@/hooks/common/use-data-fetch/useDataFetch');
 jest.mock('@/services/api/admin/partners/partners-api');
+jest.mock('@/services/api/admin/partners/partner-section-localizations-api');
 jest.mock('@/hooks/admin/use-admin-client/useAdminClient');
 jest.mock('@/contexts/admin/toast-context-provider/ToastContextProvider');
 
-const mockTranslationLanguages = [{ id: 2, code: 'en', name: 'English' }];
-
-jest.mock('@/hooks/admin/use-localization-toolkit/useLocalizationToolkit', () => ({
-    useLocalizationToolkit: () => ({
-        allLanguages: mockTranslationLanguages,
-        translationLanguages: mockTranslationLanguages,
-        selectedLanguage: mockTranslationLanguages[0],
-        onLanguageChange: jest.fn(),
-        translationStatusFilter: undefined,
-        onTranslationStatusFilterChange: jest.fn(),
-        retryFetchLanguages: jest.fn(),
-    }),
-}));
+const UK_LANGUAGE = { id: 1, code: 'uk', name: 'Ukrainian' };
+const EN_LANGUAGE = { id: 2, code: 'en', name: 'English' };
+const mockTranslationLanguages = [EN_LANGUAGE];
 
 jest.mock('../translate-partner-section-modal/TranslatePartnerSectionModal', () => ({
     TranslatePartnerSectionModal: ({ isOpen, onClose, section, onTranslated }: any) =>
@@ -109,6 +101,9 @@ jest.mock('../translate-partner-section-modal/TranslatePartnerSectionModal', () 
 
 const mockedUseDataFetch = useDataFetch as jest.Mock;
 const mockedPartnersApi = PartnersApi as jest.Mocked<typeof PartnersApi>;
+const mockedPartnerSectionLocalizationApi = PartnerSectionLocalizationApi as jest.Mocked<
+    typeof PartnerSectionLocalizationApi
+>;
 const mockedUseAdminClient = useAdminClient as jest.Mock;
 const mockedUseToast = useToast as jest.Mock;
 
@@ -165,6 +160,7 @@ beforeEach(() => {
     });
 
     mockedPartnersApi.deleteSection.mockResolvedValue();
+    mockedPartnerSectionLocalizationApi.get.mockResolvedValue(null);
 });
 
 function mockSections(sections: any[], overrides: { isLoading?: boolean; error?: any; refetch?: jest.Mock } = {}) {
@@ -177,7 +173,11 @@ function mockSections(sections: any[], overrides: { isLoading?: boolean; error?:
     });
 }
 
-async function renderEditor(ui: React.ReactElement = <PartnerSectionsEditor />) {
+async function renderEditor(
+    ui: React.ReactElement = (
+        <PartnerSectionsEditor language={UK_LANGUAGE} translationLanguages={mockTranslationLanguages} />
+    ),
+) {
     render(ui);
     await waitFor(() => expect(mockPartnerSectionFormRender).toHaveBeenCalled());
 }
@@ -209,7 +209,7 @@ describe('PartnerSectionsEditor', () => {
     it('shows loader when sections are loading and none are rendered yet', () => {
         mockSections([], { isLoading: true });
 
-        render(<PartnerSectionsEditor />);
+        render(<PartnerSectionsEditor language={UK_LANGUAGE} translationLanguages={mockTranslationLanguages} />);
 
         expect(screen.getByTestId('inline-loader-2')).toBeInTheDocument();
         expect(mockPartnerSectionFormRender).not.toHaveBeenCalled();
@@ -219,7 +219,7 @@ describe('PartnerSectionsEditor', () => {
         const refetchMock = jest.fn();
         mockSections([], { error: new Error('load error'), refetch: refetchMock });
 
-        render(<PartnerSectionsEditor />);
+        render(<PartnerSectionsEditor language={UK_LANGUAGE} translationLanguages={mockTranslationLanguages} />);
 
         expect(screen.getByText(PARTNERS_TEXT.MESSAGE.FAIL_TO_LOAD_PARTNERS)).toBeInTheDocument();
         fireEvent.click(screen.getByRole('button', { name: 'Спробувати ще' }));
@@ -284,7 +284,9 @@ describe('PartnerSectionsEditor', () => {
         mockSections([]);
 
         const ref = createRef<PartnerSectionsEditorRef>();
-        render(<PartnerSectionsEditor ref={ref} />);
+        render(
+            <PartnerSectionsEditor ref={ref} language={UK_LANGUAGE} translationLanguages={mockTranslationLanguages} />,
+        );
 
         await act(async () => {
             ref.current?.addSection();
@@ -303,7 +305,9 @@ describe('PartnerSectionsEditor', () => {
         mockSections([]);
 
         const ref = createRef<PartnerSectionsEditorRef>();
-        render(<PartnerSectionsEditor ref={ref} />);
+        render(
+            <PartnerSectionsEditor ref={ref} language={UK_LANGUAGE} translationLanguages={mockTranslationLanguages} />,
+        );
 
         await act(async () => {
             ref.current?.addSection();
@@ -496,7 +500,9 @@ describe('PartnerSectionsEditor', () => {
         mockSections([]);
 
         const ref = createRef<PartnerSectionsEditorRef>();
-        render(<PartnerSectionsEditor ref={ref} />);
+        render(
+            <PartnerSectionsEditor ref={ref} language={UK_LANGUAGE} translationLanguages={mockTranslationLanguages} />,
+        );
 
         await act(async () => {
             ref.current?.addSection();
@@ -523,7 +529,7 @@ describe('PartnerSectionsEditor', () => {
     it('does not toast when fetch error is a cancellation', () => {
         mockSections([], { error: { name: 'AbortError' } });
 
-        render(<PartnerSectionsEditor />);
+        render(<PartnerSectionsEditor language={UK_LANGUAGE} translationLanguages={mockTranslationLanguages} />);
 
         expect(addToastMock).not.toHaveBeenCalled();
     });
@@ -539,7 +545,9 @@ describe('PartnerSectionsEditor', () => {
         ]);
 
         const ref = createRef<PartnerSectionsEditorRef>();
-        render(<PartnerSectionsEditor ref={ref} />);
+        render(
+            <PartnerSectionsEditor ref={ref} language={UK_LANGUAGE} translationLanguages={mockTranslationLanguages} />,
+        );
 
         await waitFor(() => expect(mockPartnerSectionFormRender).toHaveBeenCalledTimes(1));
 
@@ -583,7 +591,7 @@ describe('PartnerSectionsEditor', () => {
             },
         ]);
 
-        render(<PartnerSectionsEditor />);
+        render(<PartnerSectionsEditor language={UK_LANGUAGE} translationLanguages={mockTranslationLanguages} />);
 
         const props = mockPartnerSectionFormRender.mock.calls[0][0];
 
@@ -659,6 +667,58 @@ describe('PartnerSectionsEditor', () => {
         expect(refetchMock).toHaveBeenCalledTimes(1);
     });
 
+    it('does not fetch section translations when the base language is selected', async () => {
+        mockSections([{ id: 1, title: 'Section', description: 'Desc', partners: [] }]);
+
+        await renderEditor();
+
+        expect(mockedPartnerSectionLocalizationApi.get).not.toHaveBeenCalled();
+
+        const props = getLatestFormProps();
+        expect(props.language).toEqual(UK_LANGUAGE);
+        expect(props.translatedContent).toBeNull();
+        expect(props.disableStructuralActions).toBe(false);
+    });
+
+    it("fetches each visible section's translation when a non-base language is selected", async () => {
+        mockedPartnerSectionLocalizationApi.get.mockImplementation(async (_client: any, sectionId: number) => {
+            if (sectionId === 1) {
+                return {
+                    entityId: 1,
+                    title: 'Section 1 EN',
+                    description: 'Description 1 EN',
+                    partners: [],
+                    localizationInfoDto: { id: EN_LANGUAGE.id, code: EN_LANGUAGE.code },
+                    translationStatus: 1,
+                };
+            }
+            return null;
+        });
+
+        mockSections([
+            { id: 1, title: 'Section 1', description: 'Desc 1', partners: [] },
+            { id: 2, title: 'Section 2', description: 'Desc 2', partners: [] },
+        ]);
+
+        render(<PartnerSectionsEditor language={EN_LANGUAGE} translationLanguages={mockTranslationLanguages} />);
+
+        await waitFor(() => {
+            expect(mockedPartnerSectionLocalizationApi.get).toHaveBeenCalledWith('mock-client', 1, EN_LANGUAGE.id);
+            expect(mockedPartnerSectionLocalizationApi.get).toHaveBeenCalledWith('mock-client', 2, EN_LANGUAGE.id);
+        });
+
+        await waitFor(() => {
+            const calls = mockPartnerSectionFormRender.mock.calls;
+            const propsForSection1 = [...calls].reverse().find((call) => call[0].value.sectionId === 1)?.[0];
+            const propsForSection2 = [...calls].reverse().find((call) => call[0].value.sectionId === 2)?.[0];
+
+            expect(propsForSection1.language).toEqual(EN_LANGUAGE);
+            expect(propsForSection1.translatedContent?.title).toBe('Section 1 EN');
+            expect(propsForSection1.disableStructuralActions).toBe(true);
+            expect(propsForSection2.translatedContent).toBeNull();
+        });
+    });
+
     it('does not add section while sections are loading', async () => {
         mockSections(
             [
@@ -673,7 +733,9 @@ describe('PartnerSectionsEditor', () => {
         );
 
         const ref = createRef<PartnerSectionsEditorRef>();
-        render(<PartnerSectionsEditor ref={ref} />);
+        render(
+            <PartnerSectionsEditor ref={ref} language={UK_LANGUAGE} translationLanguages={mockTranslationLanguages} />,
+        );
 
         await waitFor(() => expect(mockPartnerSectionFormRender).toHaveBeenCalledTimes(1));
 

--- a/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.tsx
+++ b/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.tsx
@@ -78,6 +78,38 @@ const isSectionDirty = (section: PartnerSectionFormValues, fetchedSections: Part
     return false;
 };
 
+const isSectionTextDirty = (section: PartnerSectionFormValues, fetchedSections: PartnerSection[]): boolean => {
+    if (section.sectionId === null) return true;
+
+    const originalSection = fetchedSections.find((s) => s.id === section.sectionId);
+    if (!originalSection) return true;
+
+    if (section.title !== originalSection.title) return true;
+    if (section.description !== originalSection.description) return true;
+
+    const originalPartnersMap = new Map(originalSection.partners.map((p) => [p.id, p]));
+
+    for (const partner of section.partners) {
+        if (partner.partnerId === null) continue;
+
+        const originalPartner = originalPartnersMap.get(partner.partnerId);
+        if (!originalPartner) continue;
+
+        if (partner.description !== originalPartner.description) return true;
+    }
+
+    return false;
+};
+
+const isCancelError = (error: unknown): boolean => {
+    if (axios.isCancel?.(error)) return true;
+    if (typeof error === 'object' && error !== null && 'name' in error) {
+        const { name } = error as { name?: unknown };
+        return name === 'CanceledError' || name === 'AbortError';
+    }
+    return false;
+};
+
 export interface PartnerSectionsEditorRef {
     addSection: () => void;
 }
@@ -221,13 +253,8 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef, Partne
                     if (hasFailure) {
                         addToast(PARTNERS_TEXT.MESSAGE.FAIL_TO_LOAD_PARTNERS, ToastType.Error);
                     }
-                } catch (error: any) {
-                    if (
-                        cancelled ||
-                        axios.isCancel?.(error) ||
-                        error.name === 'CanceledError' ||
-                        error.name === 'AbortError'
-                    ) {
+                } catch (error: unknown) {
+                    if (cancelled || isCancelError(error)) {
                         return;
                     }
                     addToast(PARTNERS_TEXT.MESSAGE.FAIL_TO_LOAD_PARTNERS, ToastType.Error);
@@ -348,8 +375,8 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef, Partne
                     }
                     return [...currentArray, savedSection];
                 });
-            } catch (error: any) {
-                if (axios.isCancel?.(error) || error.name === 'CanceledError' || error.name === 'AbortError') {
+            } catch (error: unknown) {
+                if (isCancelError(error)) {
                     return;
                 }
                 addToast(PARTNERS_TEXT.MESSAGE.FAIL_TO_PUBLISH_SECTION, ToastType.Error);
@@ -413,8 +440,8 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef, Partne
                 }
 
                 addToast(PARTNERS_TEXT.MESSAGE.SECTION_DELETED, ToastType.Success);
-            } catch (error: any) {
-                if (axios.isCancel?.(error) || error.name === 'CanceledError' || error.name === 'AbortError') {
+            } catch (error: unknown) {
+                if (isCancelError(error)) {
                     return;
                 }
                 addToast(PARTNERS_TEXT.MESSAGE.FAIL_TO_DELETE_SECTION, ToastType.Error);
@@ -472,6 +499,11 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef, Partne
             [localSections, fetchedSections],
         );
 
+        const sectionTextDirtyStates = React.useMemo(
+            () => localSections.map((section) => isSectionTextDirty(section, fetchedSections)),
+            [localSections, fetchedSections],
+        );
+
         if (isSectionsLoading && localSections.length === 0) {
             return (
                 <div className={styles.loader}>
@@ -500,6 +532,7 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef, Partne
                         errors={errors[index] || { partners: [] }}
                         disabled={isSectionsLoading || isPublishing || (!isBaseLanguage && isLoadingTranslations)}
                         isDirty={sectionDirtyStates[index]}
+                        isTextDirty={sectionTextDirtyStates[index]}
                         onChange={handleChange}
                         onDelete={handleDeleteRequest}
                         onPublish={handlePublishRequest}

--- a/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.tsx
+++ b/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback, useImperativeHandle, useState, useEffect, useRef } from 'react';
+import React, { forwardRef, useCallback, useImperativeHandle, useState, useEffect, useMemo, useRef } from 'react';
 import {
     PartnerSectionForm,
     PartnerSectionErrors,
@@ -21,6 +21,8 @@ import {
     PartnersSectionCreateRequest,
     PartnersSectionUpdateRequest,
 } from '@/types/admin/partners';
+import { useLocalizationToolkit } from '@/hooks/admin/use-localization-toolkit/useLocalizationToolkit';
+import { TranslatePartnerSectionModal } from '../translate-partner-section-modal/TranslatePartnerSectionModal';
 import styles from './PartnerSectionsEditor.module.scss';
 
 const isPartnerEmpty = (partner: PartnerFormValues): boolean => {
@@ -94,7 +96,17 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef>((_, re
     const [sectionToPublishId, setSectionToPublishId] = useState<string | null>(null);
     const [sectionToPublishData, setSectionToPublishData] = useState<PartnerSectionFormValues | null>(null);
     const [localSections, setLocalSections] = useState<PartnerSectionFormValues[]>([]);
+    const [translatingSectionId, setTranslatingSectionId] = useState<number | null>(null);
     const scrollAnchorRef = useRef<HTMLDivElement>(null);
+
+    const handleLocalizationError = useCallback(
+        (message: string) => {
+            addToast(message, ToastType.Error);
+        },
+        [addToast],
+    );
+
+    const { translationLanguages } = useLocalizationToolkit({ setErrorState: handleLocalizationError });
 
     const fetchSectionsHandler = useCallback(
         async (options: RequestOptions): Promise<PartnerSection[]> => {
@@ -267,6 +279,23 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef>((_, re
         }
     }, [sectionToPublishData, addToast, client, setLocalSections, sectionToPublishId, setFetchedSections]);
 
+    const handleOpenTranslate = useCallback((sectionId: number) => {
+        setTranslatingSectionId(sectionId);
+    }, []);
+
+    const handleCloseTranslate = useCallback(() => {
+        setTranslatingSectionId(null);
+    }, []);
+
+    const handleTranslated = useCallback(() => {
+        refetchSections();
+    }, [refetchSections]);
+
+    const sectionToTranslate = useMemo(
+        () => fetchedSections.find((s) => s.id === translatingSectionId) ?? null,
+        [fetchedSections, translatingSectionId],
+    );
+
     const handleDeleteRequest = useCallback((localId: string) => {
         setSectionToDeleteId(localId);
         setDeletePhase(DeletePhase.CONFIRM_SECTION);
@@ -393,6 +422,9 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef>((_, re
                     onChange={handleChange}
                     onDelete={handleDeleteRequest}
                     onPublish={handlePublishRequest}
+                    onTranslate={handleOpenTranslate}
+                    localizations={fetchedSections.find((s) => s.id === section.sectionId)?.localizations ?? []}
+                    translationLanguages={translationLanguages}
                 />
             ))}
             <div ref={scrollAnchorRef} />
@@ -418,6 +450,14 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef>((_, re
                 title={PARTNERS_TEXT.FORM.TITLE.PUBLISH_SECTION}
                 onConfirm={handleConfirmPublish}
                 onCancel={handleClosePublishModal}
+            />
+
+            <TranslatePartnerSectionModal
+                isOpen={translatingSectionId !== null}
+                onClose={handleCloseTranslate}
+                section={sectionToTranslate}
+                translatedLanguages={translationLanguages}
+                onTranslated={handleTranslated}
             />
         </div>
     );

--- a/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.tsx
+++ b/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.tsx
@@ -7,6 +7,7 @@ import {
 import { RequestOptions } from '@/types/common/api';
 import { ToastType } from '@/types/admin/toast';
 import { PARTNERS_TEXT } from '@/const/admin/partners';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import axios from 'axios';
 import { PartnerFormValues } from '../partner-form/PartnerForm';
 import { PartnersApi } from '@/services/api/admin/partners/partners-api';
@@ -397,7 +398,8 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef, Partne
 
         const handleTranslated = useCallback(() => {
             refetchSections();
-        }, [refetchSections]);
+            addToast(COMMON_TEXT_ADMIN.MESSAGE.TRANSLATION_SAVED_SUCCESS, ToastType.Success);
+        }, [refetchSections, addToast]);
 
         const sectionToTranslate = useMemo(
             () => fetchedSections.find((s) => s.id === translatingSectionId) ?? null,

--- a/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.tsx
+++ b/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.tsx
@@ -18,10 +18,13 @@ import { InlineLoader } from '@/components/common/inline-loader/InlineLoader';
 import {
     Partner,
     PartnerSection,
+    PartnerSectionLocalizationDto,
     PartnersSectionCreateRequest,
     PartnersSectionUpdateRequest,
 } from '@/types/admin/partners';
-import { useLocalizationToolkit } from '@/hooks/admin/use-localization-toolkit/useLocalizationToolkit';
+import { LocalizationLanguage } from '@/types/common/language';
+import { DEFAULT_LOCALE } from '@/const/common/locales';
+import { PartnerSectionLocalizationApi } from '@/services/api/admin/partners/partner-section-localizations-api';
 import { TranslatePartnerSectionModal } from '../translate-partner-section-modal/TranslatePartnerSectionModal';
 import styles from './PartnerSectionsEditor.module.scss';
 
@@ -85,382 +88,445 @@ enum DeletePhase {
     CONFIRM_PARTNERS = 'confirm_partners',
 }
 
-export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef>((_, ref) => {
-    const client = useAdminClient();
-    const { addToast } = useToast();
-    const [errors, setErrors] = useState<PartnerSectionErrors[]>([]);
-    const [isPublishing, setIsPublishing] = useState<boolean>(false);
-    const [deletePhase, setDeletePhase] = useState<DeletePhase>(DeletePhase.IDLE);
-    const [sectionToDeleteId, setSectionToDeleteId] = useState<string | null>(null);
-    const [isPublishModalOpen, setIsPublishModalOpen] = useState(false);
-    const [sectionToPublishId, setSectionToPublishId] = useState<string | null>(null);
-    const [sectionToPublishData, setSectionToPublishData] = useState<PartnerSectionFormValues | null>(null);
-    const [localSections, setLocalSections] = useState<PartnerSectionFormValues[]>([]);
-    const [translatingSectionId, setTranslatingSectionId] = useState<number | null>(null);
-    const scrollAnchorRef = useRef<HTMLDivElement>(null);
+export interface PartnerSectionsEditorProps {
+    language: LocalizationLanguage;
+    translationLanguages: LocalizationLanguage[];
+}
 
-    const handleLocalizationError = useCallback(
-        (message: string) => {
-            addToast(message, ToastType.Error);
-        },
-        [addToast],
-    );
+export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef, PartnerSectionsEditorProps>(
+    ({ language, translationLanguages }, ref) => {
+        const client = useAdminClient();
+        const { addToast } = useToast();
+        const [errors, setErrors] = useState<PartnerSectionErrors[]>([]);
+        const [isPublishing, setIsPublishing] = useState<boolean>(false);
+        const [deletePhase, setDeletePhase] = useState<DeletePhase>(DeletePhase.IDLE);
+        const [sectionToDeleteId, setSectionToDeleteId] = useState<string | null>(null);
+        const [isPublishModalOpen, setIsPublishModalOpen] = useState(false);
+        const [sectionToPublishId, setSectionToPublishId] = useState<string | null>(null);
+        const [sectionToPublishData, setSectionToPublishData] = useState<PartnerSectionFormValues | null>(null);
+        const [localSections, setLocalSections] = useState<PartnerSectionFormValues[]>([]);
+        const [translatingSectionId, setTranslatingSectionId] = useState<number | null>(null);
+        const [sectionTranslations, setSectionTranslations] = useState<
+            Record<number, PartnerSectionLocalizationDto | null>
+        >({});
+        const [isLoadingTranslations, setIsLoadingTranslations] = useState(false);
+        const scrollAnchorRef = useRef<HTMLDivElement>(null);
 
-    const { translationLanguages } = useLocalizationToolkit({ setErrorState: handleLocalizationError });
+        const isBaseLanguage = language.code === DEFAULT_LOCALE;
 
-    const fetchSectionsHandler = useCallback(
-        async (options: RequestOptions): Promise<PartnerSection[]> => {
-            return await PartnersApi.getSections(client, options);
-        },
-        [client],
-    );
+        const fetchSectionsHandler = useCallback(
+            async (options: RequestOptions): Promise<PartnerSection[]> => {
+                return await PartnersApi.getSections(client, options);
+            },
+            [client],
+        );
 
-    const {
-        data: fetchedSections,
-        isLoading: isSectionsLoading,
-        error: sectionsFetchError,
-        refetch: refetchSections,
-        setData: setFetchedSections,
-    } = useDataFetch<PartnerSection[]>({
-        initialData: [],
-        fetchHandler: fetchSectionsHandler,
-        autoFetchDisabled: false,
-    });
+        const {
+            data: fetchedSections,
+            isLoading: isSectionsLoading,
+            error: sectionsFetchError,
+            refetch: refetchSections,
+            setData: setFetchedSections,
+        } = useDataFetch<PartnerSection[]>({
+            initialData: [],
+            fetchHandler: fetchSectionsHandler,
+            autoFetchDisabled: false,
+        });
 
-    useEffect(() => {
-        setLocalSections(
-            fetchedSections.map((section: PartnerSection) => ({
-                localId: crypto.randomUUID(),
-                sectionId: section.id,
-                title: section.title,
-                description: section.description,
-                deletedPartnerIds: [],
-                partners: section.partners.map((p) => ({
+        useEffect(() => {
+            setLocalSections(
+                fetchedSections.map((section: PartnerSection) => ({
+                    localId: crypto.randomUUID(),
+                    sectionId: section.id,
+                    title: section.title,
+                    description: section.description,
+                    deletedPartnerIds: [],
+                    partners: section.partners.map((p) => ({
+                        localId: crypto.randomUUID(),
+                        partnerId: p.id,
+                        description: p.description,
+                        image: p.image,
+                        imageId: p.imageId,
+                    })),
+                })),
+            );
+            setErrors(
+                fetchedSections.map((section: PartnerSection) => ({
+                    partners: section.partners.map(() => ({})),
+                })),
+            );
+        }, [fetchedSections]);
+
+        useEffect(() => {
+            if (sectionsFetchError) {
+                if (
+                    axios.isCancel?.(sectionsFetchError) ||
+                    sectionsFetchError.name === 'CanceledError' ||
+                    sectionsFetchError.name === 'AbortError'
+                ) {
+                    return;
+                }
+                addToast(PARTNERS_TEXT.MESSAGE.FAIL_TO_LOAD_PARTNERS, ToastType.Error);
+            }
+        }, [sectionsFetchError, addToast]);
+
+        useEffect(() => {
+            if (isBaseLanguage) {
+                setSectionTranslations({});
+                setIsLoadingTranslations(false);
+                return;
+            }
+
+            let cancelled = false;
+
+            const fetchTranslations = async () => {
+                setIsLoadingTranslations(true);
+                try {
+                    const sectionIds = fetchedSections.map((section) => section.id);
+                    const results = await Promise.all(
+                        sectionIds.map((sectionId) =>
+                            PartnerSectionLocalizationApi.get(client, sectionId, language.id),
+                        ),
+                    );
+
+                    if (cancelled) return;
+
+                    setSectionTranslations(
+                        sectionIds.reduce<Record<number, PartnerSectionLocalizationDto | null>>(
+                            (acc, sectionId, index) => {
+                                acc[sectionId] = results[index];
+                                return acc;
+                            },
+                            {},
+                        ),
+                    );
+                } catch (error: any) {
+                    if (
+                        cancelled ||
+                        axios.isCancel?.(error) ||
+                        error.name === 'CanceledError' ||
+                        error.name === 'AbortError'
+                    ) {
+                        return;
+                    }
+                    addToast(PARTNERS_TEXT.MESSAGE.FAIL_TO_LOAD_PARTNERS, ToastType.Error);
+                } finally {
+                    if (!cancelled) {
+                        setIsLoadingTranslations(false);
+                    }
+                }
+            };
+
+            fetchTranslations();
+
+            return () => {
+                cancelled = true;
+            };
+        }, [isBaseLanguage, language, fetchedSections, client, addToast]);
+
+        const handleChange = useCallback(
+            (updatedSection: PartnerSectionFormValues, sectionErrors: PartnerSectionErrors) => {
+                setLocalSections((currentSections) =>
+                    currentSections.map((s) => (s.localId === updatedSection.localId ? updatedSection : s)),
+                );
+
+                setErrors((currentErrors) => {
+                    const index = localSections.findIndex((s) => s.localId === updatedSection.localId);
+                    if (index === -1) return currentErrors;
+
+                    const newErrors = [...currentErrors];
+                    newErrors[index] = sectionErrors;
+                    return newErrors;
+                });
+            },
+            [localSections, setLocalSections],
+        );
+
+        const handlePublishRequest = useCallback((localId: string, sectionData: PartnerSectionFormValues) => {
+            setSectionToPublishId(localId);
+            setSectionToPublishData(sectionData);
+            setIsPublishModalOpen(true);
+        }, []);
+
+        const handleClosePublishModal = useCallback(() => {
+            setIsPublishModalOpen(false);
+            setSectionToPublishId(null);
+            setSectionToPublishData(null);
+        }, []);
+
+        const handleConfirmPublish = useCallback(async () => {
+            if (!sectionToPublishId || !sectionToPublishData) return;
+
+            setIsPublishing(true);
+            setIsPublishModalOpen(false);
+            try {
+                const sectionToPublish = sectionToPublishData;
+
+                let savedSection: PartnerSection;
+
+                if (sectionToPublish.sectionId === null) {
+                    const createRequest: PartnersSectionCreateRequest = {
+                        title: sectionToPublish.title,
+                        description: sectionToPublish.description,
+                        partners: sectionToPublish.partners.map((p) => ({
+                            description: p.description,
+                            image: p.image,
+                            imageId: p.imageId,
+                        })),
+                    };
+
+                    savedSection = await PartnersApi.postSection(client, createRequest);
+                    addToast(PARTNERS_TEXT.MESSAGE.SECTION_CREATED, ToastType.Success);
+                } else {
+                    const updateRequest: PartnersSectionUpdateRequest = {
+                        title: sectionToPublish.title,
+                        description: sectionToPublish.description,
+                        partnersToUpdate: sectionToPublish.partners.map((p) => ({
+                            id: p.partnerId,
+                            description: p.description,
+                            image: p.image,
+                            imageId: p.imageId,
+                        })),
+                        partnerIdsToDelete: sectionToPublish.deletedPartnerIds || [],
+                    };
+
+                    savedSection = await PartnersApi.updateSection(client, sectionToPublish.sectionId, updateRequest);
+                    addToast(PARTNERS_TEXT.MESSAGE.SECTION_PUBLISHED, ToastType.Success);
+                }
+
+                const mapPartnerToFormValue = (p: Partner) => ({
                     localId: crypto.randomUUID(),
                     partnerId: p.id,
                     description: p.description,
                     image: p.image,
                     imageId: p.imageId,
-                })),
-            })),
-        );
-        setErrors(
-            fetchedSections.map((section: PartnerSection) => ({
-                partners: section.partners.map(() => ({})),
-            })),
-        );
-    }, [fetchedSections]);
+                });
 
-    useEffect(() => {
-        if (sectionsFetchError) {
-            if (
-                axios.isCancel?.(sectionsFetchError) ||
-                sectionsFetchError.name === 'CanceledError' ||
-                sectionsFetchError.name === 'AbortError'
-            ) {
+                const updateSectionInList = (s: PartnerSectionFormValues) => {
+                    if (s.localId === sectionToPublishId) {
+                        return {
+                            ...s,
+                            sectionId: savedSection.id,
+                            title: savedSection.title,
+                            description: savedSection.description,
+                            deletedPartnerIds: [],
+                            partners: savedSection.partners.map(mapPartnerToFormValue),
+                        };
+                    }
+                    return s;
+                };
+
+                setLocalSections((currentSections) => currentSections.map(updateSectionInList));
+                setFetchedSections((current) => {
+                    const currentArray = current || [];
+                    const existingIndex = currentArray.findIndex((s) => s.id === savedSection.id);
+                    if (existingIndex >= 0) {
+                        const newArray = [...currentArray];
+                        newArray[existingIndex] = savedSection;
+                        return newArray;
+                    }
+                    return [...currentArray, savedSection];
+                });
+            } catch (error: any) {
+                if (axios.isCancel?.(error) || error.name === 'CanceledError' || error.name === 'AbortError') {
+                    return;
+                }
+                addToast(PARTNERS_TEXT.MESSAGE.FAIL_TO_PUBLISH_SECTION, ToastType.Error);
+            } finally {
+                setIsPublishing(false);
+                setSectionToPublishId(null);
+                setSectionToPublishData(null);
+            }
+        }, [sectionToPublishData, addToast, client, setLocalSections, sectionToPublishId, setFetchedSections]);
+
+        const handleOpenTranslate = useCallback((sectionId: number) => {
+            setTranslatingSectionId(sectionId);
+        }, []);
+
+        const handleCloseTranslate = useCallback(() => {
+            setTranslatingSectionId(null);
+        }, []);
+
+        const handleTranslated = useCallback(() => {
+            refetchSections();
+        }, [refetchSections]);
+
+        const sectionToTranslate = useMemo(
+            () => fetchedSections.find((s) => s.id === translatingSectionId) ?? null,
+            [fetchedSections, translatingSectionId],
+        );
+
+        const handleDeleteRequest = useCallback((localId: string) => {
+            setSectionToDeleteId(localId);
+            setDeletePhase(DeletePhase.CONFIRM_SECTION);
+        }, []);
+
+        const handleCloseModal = useCallback(() => {
+            setDeletePhase(DeletePhase.IDLE);
+            setSectionToDeleteId(null);
+        }, []);
+
+        const handleFirstConfirm = useCallback(() => {
+            setDeletePhase(DeletePhase.CONFIRM_PARTNERS);
+        }, []);
+
+        const handleFinalConfirmDelete = useCallback(async () => {
+            if (!sectionToDeleteId) return;
+
+            setIsPublishing(true);
+            setDeletePhase(DeletePhase.IDLE);
+
+            try {
+                const sectionToDelete = localSections.find((s) => s.localId === sectionToDeleteId);
+
+                if (sectionToDelete && sectionToDelete.sectionId) {
+                    await PartnersApi.deleteSection(client, sectionToDelete.sectionId);
+                }
+
+                const indexToDelete = localSections.findIndex((s) => s.localId === sectionToDeleteId);
+                setLocalSections((current) => current.filter((s) => s.localId !== sectionToDeleteId));
+                setErrors((current) => current.filter((_, i) => i !== indexToDelete));
+
+                if (sectionToDelete && sectionToDelete.sectionId) {
+                    setFetchedSections((current) => (current || []).filter((s) => s.id !== sectionToDelete.sectionId));
+                }
+
+                addToast(PARTNERS_TEXT.MESSAGE.SECTION_DELETED, ToastType.Success);
+            } catch (error: any) {
+                if (axios.isCancel?.(error) || error.name === 'CanceledError' || error.name === 'AbortError') {
+                    return;
+                }
+                addToast(PARTNERS_TEXT.MESSAGE.FAIL_TO_DELETE_SECTION, ToastType.Error);
+            } finally {
+                setIsPublishing(false);
+                setSectionToDeleteId(null);
+            }
+        }, [localSections, client, setLocalSections, sectionToDeleteId, addToast, setFetchedSections]);
+
+        const addSection = useCallback(() => {
+            if (isPublishing || isSectionsLoading || !isBaseLanguage) {
                 return;
             }
-            addToast(PARTNERS_TEXT.MESSAGE.FAIL_TO_LOAD_PARTNERS, ToastType.Error);
-        }
-    }, [sectionsFetchError, addToast]);
-
-    const handleChange = useCallback(
-        (updatedSection: PartnerSectionFormValues, sectionErrors: PartnerSectionErrors) => {
-            setLocalSections((currentSections) =>
-                currentSections.map((s) => (s.localId === updatedSection.localId ? updatedSection : s)),
-            );
-
-            setErrors((currentErrors) => {
-                const index = localSections.findIndex((s) => s.localId === updatedSection.localId);
-                if (index === -1) return currentErrors;
-
-                const newErrors = [...currentErrors];
-                newErrors[index] = sectionErrors;
-                return newErrors;
-            });
-        },
-        [localSections, setLocalSections],
-    );
-
-    const handlePublishRequest = useCallback((localId: string, sectionData: PartnerSectionFormValues) => {
-        setSectionToPublishId(localId);
-        setSectionToPublishData(sectionData);
-        setIsPublishModalOpen(true);
-    }, []);
-
-    const handleClosePublishModal = useCallback(() => {
-        setIsPublishModalOpen(false);
-        setSectionToPublishId(null);
-        setSectionToPublishData(null);
-    }, []);
-
-    const handleConfirmPublish = useCallback(async () => {
-        if (!sectionToPublishId || !sectionToPublishData) return;
-
-        setIsPublishing(true);
-        setIsPublishModalOpen(false);
-        try {
-            const sectionToPublish = sectionToPublishData;
-
-            let savedSection: PartnerSection;
-
-            if (sectionToPublish.sectionId === null) {
-                const createRequest: PartnersSectionCreateRequest = {
-                    title: sectionToPublish.title,
-                    description: sectionToPublish.description,
-                    partners: sectionToPublish.partners.map((p) => ({
-                        description: p.description,
-                        image: p.image,
-                        imageId: p.imageId,
-                    })),
-                };
-
-                savedSection = await PartnersApi.postSection(client, createRequest);
-                addToast(PARTNERS_TEXT.MESSAGE.SECTION_CREATED, ToastType.Success);
-            } else {
-                const updateRequest: PartnersSectionUpdateRequest = {
-                    title: sectionToPublish.title,
-                    description: sectionToPublish.description,
-                    partnersToUpdate: sectionToPublish.partners.map((p) => ({
-                        id: p.partnerId,
-                        description: p.description,
-                        image: p.image,
-                        imageId: p.imageId,
-                    })),
-                    partnerIdsToDelete: sectionToPublish.deletedPartnerIds || [],
-                };
-
-                savedSection = await PartnersApi.updateSection(client, sectionToPublish.sectionId, updateRequest);
-                addToast(PARTNERS_TEXT.MESSAGE.SECTION_PUBLISHED, ToastType.Success);
+            if (localSections.length > 0) {
+                const lastSection = localSections[localSections.length - 1];
+                if (isSectionEmpty(lastSection)) {
+                    return;
+                }
             }
 
-            const mapPartnerToFormValue = (p: Partner) => ({
+            const newSection: PartnerSectionFormValues = {
                 localId: crypto.randomUUID(),
-                partnerId: p.id,
-                description: p.description,
-                image: p.image,
-                imageId: p.imageId,
-            });
-
-            const updateSectionInList = (s: PartnerSectionFormValues) => {
-                if (s.localId === sectionToPublishId) {
-                    return {
-                        ...s,
-                        sectionId: savedSection.id,
-                        title: savedSection.title,
-                        description: savedSection.description,
-                        deletedPartnerIds: [],
-                        partners: savedSection.partners.map(mapPartnerToFormValue),
-                    };
-                }
-                return s;
+                sectionId: null,
+                title: '',
+                description: '',
+                partners: [
+                    {
+                        localId: crypto.randomUUID(),
+                        partnerId: null,
+                        description: '',
+                        image: null,
+                        imageId: null,
+                    },
+                ],
+                deletedPartnerIds: [],
             };
 
-            setLocalSections((currentSections) => currentSections.map(updateSectionInList));
-            setFetchedSections((current) => {
-                const currentArray = current || [];
-                const existingIndex = currentArray.findIndex((s) => s.id === savedSection.id);
-                if (existingIndex >= 0) {
-                    const newArray = [...currentArray];
-                    newArray[existingIndex] = savedSection;
-                    return newArray;
-                }
-                return [...currentArray, savedSection];
-            });
-        } catch (error: any) {
-            if (axios.isCancel?.(error) || error.name === 'CanceledError' || error.name === 'AbortError') {
-                return;
-            }
-            addToast(PARTNERS_TEXT.MESSAGE.FAIL_TO_PUBLISH_SECTION, ToastType.Error);
-        } finally {
-            setIsPublishing(false);
-            setSectionToPublishId(null);
-            setSectionToPublishData(null);
-        }
-    }, [sectionToPublishData, addToast, client, setLocalSections, sectionToPublishId, setFetchedSections]);
+            setLocalSections((current) => [...current, newSection]);
+            setErrors((current) => [...current, { partners: [] }]);
+            setTimeout(() => {
+                scrollAnchorRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'start' });
+            }, 0);
+        }, [isPublishing, isSectionsLoading, isBaseLanguage, localSections, setLocalSections, setErrors]);
 
-    const handleOpenTranslate = useCallback((sectionId: number) => {
-        setTranslatingSectionId(sectionId);
-    }, []);
-
-    const handleCloseTranslate = useCallback(() => {
-        setTranslatingSectionId(null);
-    }, []);
-
-    const handleTranslated = useCallback(() => {
-        refetchSections();
-    }, [refetchSections]);
-
-    const sectionToTranslate = useMemo(
-        () => fetchedSections.find((s) => s.id === translatingSectionId) ?? null,
-        [fetchedSections, translatingSectionId],
-    );
-
-    const handleDeleteRequest = useCallback((localId: string) => {
-        setSectionToDeleteId(localId);
-        setDeletePhase(DeletePhase.CONFIRM_SECTION);
-    }, []);
-
-    const handleCloseModal = useCallback(() => {
-        setDeletePhase(DeletePhase.IDLE);
-        setSectionToDeleteId(null);
-    }, []);
-
-    const handleFirstConfirm = useCallback(() => {
-        setDeletePhase(DeletePhase.CONFIRM_PARTNERS);
-    }, []);
-
-    const handleFinalConfirmDelete = useCallback(async () => {
-        if (!sectionToDeleteId) return;
-
-        setIsPublishing(true);
-        setDeletePhase(DeletePhase.IDLE);
-
-        try {
-            const sectionToDelete = localSections.find((s) => s.localId === sectionToDeleteId);
-
-            if (sectionToDelete && sectionToDelete.sectionId) {
-                await PartnersApi.deleteSection(client, sectionToDelete.sectionId);
-            }
-
-            const indexToDelete = localSections.findIndex((s) => s.localId === sectionToDeleteId);
-            setLocalSections((current) => current.filter((s) => s.localId !== sectionToDeleteId));
-            setErrors((current) => current.filter((_, i) => i !== indexToDelete));
-
-            if (sectionToDelete && sectionToDelete.sectionId) {
-                setFetchedSections((current) => (current || []).filter((s) => s.id !== sectionToDelete.sectionId));
-            }
-
-            addToast(PARTNERS_TEXT.MESSAGE.SECTION_DELETED, ToastType.Success);
-        } catch (error: any) {
-            if (axios.isCancel?.(error) || error.name === 'CanceledError' || error.name === 'AbortError') {
-                return;
-            }
-            addToast(PARTNERS_TEXT.MESSAGE.FAIL_TO_DELETE_SECTION, ToastType.Error);
-        } finally {
-            setIsPublishing(false);
-            setSectionToDeleteId(null);
-        }
-    }, [localSections, client, setLocalSections, sectionToDeleteId, addToast, setFetchedSections]);
-
-    const addSection = useCallback(() => {
-        if (isPublishing || isSectionsLoading) {
-            return;
-        }
-        if (localSections.length > 0) {
-            const lastSection = localSections[localSections.length - 1];
-            if (isSectionEmpty(lastSection)) {
-                return;
-            }
-        }
-
-        const newSection: PartnerSectionFormValues = {
-            localId: crypto.randomUUID(),
-            sectionId: null,
-            title: '',
-            description: '',
-            partners: [
-                {
-                    localId: crypto.randomUUID(),
-                    partnerId: null,
-                    description: '',
-                    image: null,
-                    imageId: null,
-                },
-            ],
-            deletedPartnerIds: [],
-        };
-
-        setLocalSections((current) => [...current, newSection]);
-        setErrors((current) => [...current, { partners: [] }]);
-        setTimeout(() => {
-            scrollAnchorRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'start' });
-        }, 0);
-    }, [isPublishing, isSectionsLoading, localSections, setLocalSections, setErrors]);
-
-    useImperativeHandle(
-        ref,
-        () => ({
-            addSection: addSection,
-        }),
-        [addSection],
-    );
-
-    const sectionDirtyStates = React.useMemo(
-        () => localSections.map((section) => isSectionDirty(section, fetchedSections)),
-        [localSections, fetchedSections],
-    );
-
-    if (isSectionsLoading && localSections.length === 0) {
-        return (
-            <div className={styles.loader}>
-                <InlineLoader size={2} />
-            </div>
+        useImperativeHandle(
+            ref,
+            () => ({
+                addSection: addSection,
+            }),
+            [addSection],
         );
-    }
 
-    if (sectionsFetchError && localSections.length === 0) {
-        return (
-            <div className={styles.error}>
-                <p className={styles['error-text']}>{PARTNERS_TEXT.MESSAGE.FAIL_TO_LOAD_PARTNERS}</p>
-                <button onClick={() => refetchSections()} className={styles['error-text-button']}>
-                    {PARTNERS_TEXT.BUTTON.TRY_AGAIN}
-                </button>
-            </div>
+        const sectionDirtyStates = React.useMemo(
+            () => localSections.map((section) => isSectionDirty(section, fetchedSections)),
+            [localSections, fetchedSections],
         );
-    }
 
-    return (
-        <div className={styles.root}>
-            {localSections.map((section, index) => (
-                <PartnerSectionForm
-                    key={section.localId}
-                    value={section}
-                    errors={errors[index] || { partners: [] }}
-                    disabled={isSectionsLoading || isPublishing}
-                    isDirty={sectionDirtyStates[index]}
-                    onChange={handleChange}
-                    onDelete={handleDeleteRequest}
-                    onPublish={handlePublishRequest}
-                    onTranslate={handleOpenTranslate}
-                    localizations={fetchedSections.find((s) => s.id === section.sectionId)?.localizations ?? []}
-                    translationLanguages={translationLanguages}
+        if (isSectionsLoading && localSections.length === 0) {
+            return (
+                <div className={styles.loader}>
+                    <InlineLoader size={2} />
+                </div>
+            );
+        }
+
+        if (sectionsFetchError && localSections.length === 0) {
+            return (
+                <div className={styles.error}>
+                    <p className={styles['error-text']}>{PARTNERS_TEXT.MESSAGE.FAIL_TO_LOAD_PARTNERS}</p>
+                    <button onClick={() => refetchSections()} className={styles['error-text-button']}>
+                        {PARTNERS_TEXT.BUTTON.TRY_AGAIN}
+                    </button>
+                </div>
+            );
+        }
+
+        return (
+            <div className={styles.root}>
+                {localSections.map((section, index) => (
+                    <PartnerSectionForm
+                        key={section.localId}
+                        value={section}
+                        errors={errors[index] || { partners: [] }}
+                        disabled={isSectionsLoading || isPublishing || (!isBaseLanguage && isLoadingTranslations)}
+                        isDirty={sectionDirtyStates[index]}
+                        onChange={handleChange}
+                        onDelete={handleDeleteRequest}
+                        onPublish={handlePublishRequest}
+                        onTranslate={handleOpenTranslate}
+                        localizations={fetchedSections.find((s) => s.id === section.sectionId)?.localizations ?? []}
+                        translationLanguages={translationLanguages}
+                        language={language}
+                        translatedContent={
+                            section.sectionId !== null ? (sectionTranslations[section.sectionId] ?? null) : null
+                        }
+                        disableStructuralActions={!isBaseLanguage}
+                    />
+                ))}
+                <div ref={scrollAnchorRef} />
+
+                <ConfirmationModal
+                    isOpen={deletePhase === DeletePhase.CONFIRM_SECTION}
+                    onClose={handleCloseModal}
+                    title={PARTNERS_TEXT.FORM.TITLE.DELETE_SECTION}
+                    onConfirm={handleFirstConfirm}
+                    onCancel={handleCloseModal}
                 />
-            ))}
-            <div ref={scrollAnchorRef} />
+                <ConfirmationModal
+                    isOpen={deletePhase === DeletePhase.CONFIRM_PARTNERS}
+                    onClose={handleCloseModal}
+                    title={PARTNERS_TEXT.FORM.MESSAGE.DELETE_SECTION_WARNING}
+                    onConfirm={handleFinalConfirmDelete}
+                    onCancel={handleCloseModal}
+                />
 
-            <ConfirmationModal
-                isOpen={deletePhase === DeletePhase.CONFIRM_SECTION}
-                onClose={handleCloseModal}
-                title={PARTNERS_TEXT.FORM.TITLE.DELETE_SECTION}
-                onConfirm={handleFirstConfirm}
-                onCancel={handleCloseModal}
-            />
-            <ConfirmationModal
-                isOpen={deletePhase === DeletePhase.CONFIRM_PARTNERS}
-                onClose={handleCloseModal}
-                title={PARTNERS_TEXT.FORM.MESSAGE.DELETE_SECTION_WARNING}
-                onConfirm={handleFinalConfirmDelete}
-                onCancel={handleCloseModal}
-            />
+                <ConfirmationModal
+                    isOpen={isPublishModalOpen}
+                    onClose={handleClosePublishModal}
+                    title={PARTNERS_TEXT.FORM.TITLE.PUBLISH_SECTION}
+                    onConfirm={handleConfirmPublish}
+                    onCancel={handleClosePublishModal}
+                />
 
-            <ConfirmationModal
-                isOpen={isPublishModalOpen}
-                onClose={handleClosePublishModal}
-                title={PARTNERS_TEXT.FORM.TITLE.PUBLISH_SECTION}
-                onConfirm={handleConfirmPublish}
-                onCancel={handleClosePublishModal}
-            />
-
-            <TranslatePartnerSectionModal
-                isOpen={translatingSectionId !== null}
-                onClose={handleCloseTranslate}
-                section={sectionToTranslate}
-                translatedLanguages={translationLanguages}
-                onTranslated={handleTranslated}
-            />
-        </div>
-    );
-});
+                <TranslatePartnerSectionModal
+                    isOpen={translatingSectionId !== null}
+                    onClose={handleCloseTranslate}
+                    section={sectionToTranslate}
+                    translatedLanguages={translationLanguages}
+                    onTranslated={handleTranslated}
+                />
+            </div>
+        );
+    },
+);
 
 PartnerSectionsEditor.displayName = 'PartnerSectionsEditor';

--- a/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.tsx
+++ b/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.tsx
@@ -179,11 +179,13 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef, Partne
 
             let cancelled = false;
 
+            setSectionTranslations({});
+
             const fetchTranslations = async () => {
                 setIsLoadingTranslations(true);
                 try {
                     const sectionIds = fetchedSections.map((section) => section.id);
-                    const results = await Promise.all(
+                    const results = await Promise.allSettled(
                         sectionIds.map((sectionId) =>
                             PartnerSectionLocalizationApi.get(client, sectionId, language.id),
                         ),
@@ -191,15 +193,34 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef, Partne
 
                     if (cancelled) return;
 
+                    let hasFailure = false;
+
                     setSectionTranslations(
                         sectionIds.reduce<Record<number, PartnerSectionLocalizationDto | null>>(
                             (acc, sectionId, index) => {
-                                acc[sectionId] = results[index];
+                                const result = results[index];
+                                if (result.status === 'fulfilled') {
+                                    acc[sectionId] = result.value;
+                                } else {
+                                    const error = result.reason;
+                                    const isCancelError =
+                                        axios.isCancel?.(error) ||
+                                        error?.name === 'CanceledError' ||
+                                        error?.name === 'AbortError';
+                                    if (!isCancelError) {
+                                        hasFailure = true;
+                                    }
+                                    acc[sectionId] = null;
+                                }
                                 return acc;
                             },
                             {},
                         ),
                     );
+
+                    if (hasFailure) {
+                        addToast(PARTNERS_TEXT.MESSAGE.FAIL_TO_LOAD_PARTNERS, ToastType.Error);
+                    }
                 } catch (error: any) {
                     if (
                         cancelled ||

--- a/src/pages/admin/partners/components/translate-partner-banner-form/TranslatePartnerBannerForm.test.tsx
+++ b/src/pages/admin/partners/components/translate-partner-banner-form/TranslatePartnerBannerForm.test.tsx
@@ -1,0 +1,213 @@
+import React, { createRef } from 'react';
+import { createEvent, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+    TranslatePartnerBannerForm,
+    TranslatePartnerBannerFormRef,
+    TranslatePartnerBannerFormValues,
+} from './TranslatePartnerBannerForm';
+import { VisibilityStatus } from '@/types/admin/common';
+import { PARTNER_BANNER_VALIDATION_FUNCTIONS } from '@/validation/admin/partner-schema/partner-schema';
+
+jest.mock('@/validation/admin/partner-schema/partner-schema', () => ({
+    PARTNER_BANNER_VALIDATION_FUNCTIONS: {
+        validateTitle: jest.fn(() => undefined),
+        validateDescription: jest.fn(() => undefined),
+    },
+}));
+
+jest.mock('@/components/admin/input-groups/rich-text-input-group/RichTextInputGroup', () => ({
+    RichTextInputGroup: ({ value, onChange, onBlur, disabled, id, error }: any) => (
+        <div>
+            <div
+                data-testid={`richtext-${id}`}
+                contentEditable={!disabled}
+                onInput={(e: any) => onChange(e.target.textContent)}
+                onBlur={onBlur}
+                suppressContentEditableWarning
+            >
+                {value}
+            </div>
+            {error && <span data-testid={`error-${id}`}>{error}</span>}
+        </div>
+    ),
+}));
+
+jest.mock('@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup', () => ({
+    InputWithCharacterLimitGroup: ({ value, onChange, onBlur, disabled, name, id, error }: any) => (
+        <div>
+            <input
+                data-testid={`input-${name ?? id}`}
+                value={value}
+                onChange={onChange}
+                onBlur={onBlur}
+                disabled={disabled}
+            />
+            {error && <span data-testid={`error-${name ?? id}`}>{error}</span>}
+        </div>
+    ),
+}));
+
+const validationMock = PARTNER_BANNER_VALIDATION_FUNCTIONS as jest.Mocked<typeof PARTNER_BANNER_VALIDATION_FUNCTIONS>;
+
+describe('TranslatePartnerBannerForm', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        validationMock.validateTitle.mockReturnValue(undefined);
+        validationMock.validateDescription.mockReturnValue(undefined);
+    });
+
+    const renderForm = (props: Partial<React.ComponentProps<typeof TranslatePartnerBannerForm>> = {}) => {
+        const ref = createRef<TranslatePartnerBannerFormRef>();
+        const defaultProps: React.ComponentProps<typeof TranslatePartnerBannerForm> = {
+            onSubmit: jest.fn(),
+        };
+
+        const view = render(<TranslatePartnerBannerForm ref={ref} {...defaultProps} {...props} />);
+
+        return {
+            ref,
+            onSubmit: props.onSubmit ?? defaultProps.onSubmit,
+            ...view,
+        };
+    };
+
+    it('renders title and description fields', () => {
+        renderForm();
+
+        expect(screen.getByTestId('richtext-translate-banner-title')).toBeInTheDocument();
+        expect(screen.getByTestId('input-description')).toBeInTheDocument();
+    });
+
+    it('fields are empty by default', () => {
+        renderForm();
+
+        expect(screen.getByTestId('richtext-translate-banner-title')).toHaveTextContent('');
+        expect(screen.getByTestId('input-description')).toHaveValue('');
+    });
+
+    it('fills fields from initialData', () => {
+        const initialData: TranslatePartnerBannerFormValues = {
+            title: 'Existing title',
+            description: 'Existing description',
+        };
+
+        renderForm({ initialData });
+
+        expect(screen.getByTestId('richtext-translate-banner-title')).toHaveTextContent('Existing title');
+        expect(screen.getByTestId('input-description')).toHaveValue('Existing description');
+    });
+
+    it('updates title and description values on change', () => {
+        renderForm();
+
+        fireEvent.input(screen.getByTestId('richtext-translate-banner-title'), {
+            target: { textContent: 'Translated title' },
+        });
+        fireEvent.change(screen.getByTestId('input-description'), {
+            target: { value: 'Translated description' },
+        });
+
+        expect(screen.getByTestId('richtext-translate-banner-title')).toHaveTextContent('Translated title');
+        expect(screen.getByTestId('input-description')).toHaveValue('Translated description');
+    });
+
+    it('validates title and description on blur', () => {
+        renderForm();
+
+        fireEvent.blur(screen.getByTestId('richtext-translate-banner-title'));
+        fireEvent.blur(screen.getByTestId('input-description'));
+
+        expect(validationMock.validateTitle).toHaveBeenCalled();
+        expect(validationMock.validateDescription).toHaveBeenCalled();
+    });
+
+    it('shows validation errors returned by validation functions', async () => {
+        validationMock.validateTitle.mockReturnValue('Title error');
+        validationMock.validateDescription.mockReturnValue('Description error');
+
+        renderForm();
+
+        fireEvent.blur(screen.getByTestId('richtext-translate-banner-title'));
+        fireEvent.blur(screen.getByTestId('input-description'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('error-translate-banner-title')).toHaveTextContent('Title error');
+            expect(screen.getByTestId('error-description')).toHaveTextContent('Description error');
+        });
+    });
+
+    it('calls onValidationChange from form manager updates', async () => {
+        const onValidationChange = jest.fn();
+
+        renderForm({ onValidationChange });
+
+        await waitFor(() => {
+            expect(onValidationChange).toHaveBeenCalledWith(true);
+        });
+    });
+
+    it('reports dirty state relative to initialData', async () => {
+        const onDirtyChange = jest.fn();
+        const initialData: TranslatePartnerBannerFormValues = {
+            title: 'Base title',
+            description: 'Base description',
+        };
+
+        renderForm({ initialData, onDirtyChange });
+
+        await waitFor(() => {
+            expect(onDirtyChange).toHaveBeenCalledWith(false);
+        });
+
+        fireEvent.change(screen.getByTestId('input-description'), { target: { value: 'Changed description' } });
+
+        await waitFor(() => {
+            expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+        });
+    });
+
+    it('submits data via ref.submit and forwards only form data to onSubmit', async () => {
+        const onSubmit = jest.fn();
+        const { ref } = renderForm({ onSubmit });
+
+        fireEvent.input(screen.getByTestId('richtext-translate-banner-title'), {
+            target: { textContent: 'Final title' },
+        });
+        fireEvent.change(screen.getByTestId('input-description'), {
+            target: { value: 'Final description' },
+        });
+
+        await ref.current?.submit(VisibilityStatus.Draft);
+
+        expect(onSubmit).toHaveBeenCalledWith({
+            title: 'Final title',
+            description: 'Final description',
+        });
+    });
+
+    it('exposes isValid and isDirty through ref', () => {
+        const { ref } = renderForm();
+
+        expect(ref.current?.isValid()).toBe(true);
+        expect(ref.current?.isDirty()).toBe(false);
+    });
+
+    it('disables fields when formDisabled is true', () => {
+        renderForm({ formDisabled: true });
+
+        expect(screen.getByTestId('input-description')).toBeDisabled();
+    });
+
+    it('prevents default form submission behavior', () => {
+        const { container } = renderForm();
+        const form = container.querySelector('#translate-partner-banner-form') as HTMLFormElement;
+
+        const event = createEvent.submit(form);
+        event.preventDefault = jest.fn();
+
+        fireEvent(form, event);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+});

--- a/src/pages/admin/partners/components/translate-partner-banner-form/TranslatePartnerBannerForm.tsx
+++ b/src/pages/admin/partners/components/translate-partner-banner-form/TranslatePartnerBannerForm.tsx
@@ -1,0 +1,123 @@
+import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
+import { RichTextInputGroup } from '@/components/admin/input-groups/rich-text-input-group/RichTextInputGroup';
+import { PARTNERS_TEXT, PARTNER_BANNER_VALIDATION } from '@/const/admin/partners';
+import { useFormManager } from '@/hooks/admin/use-form-manager/useFormManager';
+import { VisibilityStatus } from '@/types/admin/common';
+import { PARTNER_BANNER_VALIDATION_FUNCTIONS } from '@/validation/admin/partner-schema/partner-schema';
+import { getPlainTextFromHtml } from '@/utils/functions/get-plain-text-from-html/get-plain-text-from-html';
+import { forwardRef, useEffect } from 'react';
+
+export interface TranslatePartnerBannerFormValues {
+    title: string;
+    description: string;
+}
+
+export interface TranslatePartnerBannerFormErrorState {
+    title: string | undefined;
+    description: string | undefined;
+    [key: string]: string | undefined;
+}
+
+export interface TranslatePartnerBannerFormRef {
+    submit: (status?: VisibilityStatus) => Promise<void>;
+    isValid: () => boolean;
+    isDirty: () => boolean;
+}
+
+export interface TranslatePartnerBannerFormProps {
+    onSubmit: (data: TranslatePartnerBannerFormValues, status?: VisibilityStatus) => void | Promise<void>;
+    initialData?: TranslatePartnerBannerFormValues | null;
+    formDisabled?: boolean;
+    onValidationChange?: (isValid: boolean) => void;
+    onDirtyChange?: (isDirty: boolean) => void;
+}
+
+const DEFAULT_FORM_STATE: TranslatePartnerBannerFormValues = {
+    title: '',
+    description: '',
+};
+
+const validateForm = (
+    formState: TranslatePartnerBannerFormValues,
+    _isPublishing: boolean,
+): TranslatePartnerBannerFormErrorState => {
+    return {
+        title: PARTNER_BANNER_VALIDATION_FUNCTIONS.validateTitle(getPlainTextFromHtml(formState.title)),
+        description: PARTNER_BANNER_VALIDATION_FUNCTIONS.validateDescription(formState.description),
+    };
+};
+
+export const TranslatePartnerBannerForm = forwardRef<TranslatePartnerBannerFormRef, TranslatePartnerBannerFormProps>(
+    ({ initialData = null, onSubmit, formDisabled, onValidationChange, onDirtyChange }, ref) => {
+        const { formState, setFormState, errors, setErrors, isSubmitting } = useFormManager<
+            TranslatePartnerBannerFormValues,
+            TranslatePartnerBannerFormErrorState
+        >({
+            defaultFormState: DEFAULT_FORM_STATE,
+            initialData,
+            validateForm,
+            onValidationChange,
+            ref,
+            onSubmit: (data, _status) => onSubmit(data),
+        });
+
+        useEffect(() => {
+            const isDirty = JSON.stringify(formState) !== JSON.stringify(initialData ?? DEFAULT_FORM_STATE);
+            onDirtyChange?.(isDirty);
+        }, [formState, initialData, onDirtyChange]);
+
+        const handleTitleChange = (value: string) => {
+            setFormState((prev) => ({ ...prev, title: value }));
+        };
+
+        const handleTitleBlur = () => {
+            const error = PARTNER_BANNER_VALIDATION_FUNCTIONS.validateTitle(getPlainTextFromHtml(formState.title));
+            setErrors((prev) => ({ ...prev, title: error }));
+        };
+
+        const handleDescriptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+            setFormState((prev) => ({ ...prev, description: e.target.value }));
+        };
+
+        const handleDescriptionBlur = () => {
+            const error = PARTNER_BANNER_VALIDATION_FUNCTIONS.validateDescription(formState.description);
+            setErrors((prev) => ({ ...prev, description: error }));
+        };
+
+        return (
+            <form
+                onSubmit={(e) => e.preventDefault()}
+                className="translate-partner-banner-form"
+                id={'translate-partner-banner-form'}
+                noValidate
+            >
+                <RichTextInputGroup
+                    label={PARTNERS_TEXT.FORM.LABEL.TITLE}
+                    isRequired
+                    value={formState.title}
+                    error={errors.title}
+                    onChange={handleTitleChange}
+                    onBlur={handleTitleBlur}
+                    disabled={isSubmitting || formDisabled}
+                    maxLength={PARTNER_BANNER_VALIDATION.title.max}
+                    name={'title'}
+                    id={'translate-banner-title'}
+                    trimOnBlur
+                />
+
+                <InputWithCharacterLimitGroup
+                    label={PARTNERS_TEXT.FORM.LABEL.DESCRIPTION}
+                    isRequired
+                    error={errors.description}
+                    value={formState.description}
+                    onChange={handleDescriptionChange}
+                    onBlur={handleDescriptionBlur}
+                    disabled={isSubmitting || formDisabled}
+                    maxLength={PARTNER_BANNER_VALIDATION.description.max}
+                    name={'description'}
+                    id={'translate-banner-description'}
+                />
+            </form>
+        );
+    },
+);

--- a/src/pages/admin/partners/components/translate-partner-banner-modal/TranslatePartnerBannerModal.test.tsx
+++ b/src/pages/admin/partners/components/translate-partner-banner-modal/TranslatePartnerBannerModal.test.tsx
@@ -1,0 +1,308 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { ModalMode } from '@/types/admin/common';
+import { PartnerBanner } from '@/types/admin/partners';
+import { TranslationStatus, LocalizationLanguage } from '@/types/common/language';
+import { useTranslatePartnerBanner } from '@/hooks/admin/use-translate-partner-banner/useTranslatePartnerBanner';
+import { TranslatePartnerBannerModal } from './TranslatePartnerBannerModal';
+
+let mockFormIsValid = true;
+let mockFormIsDirty = true;
+
+const mockTranslateBanner = jest.fn();
+
+jest.mock('@/components/admin/localization-modal/LocalizationModal', () => ({
+    LocalizationModal: (props: unknown) => require('@/utils/test-mocks/test-mocks').MockLocalizationModal(props),
+}));
+
+jest.mock('@/components/admin/translation-controls/TranslationControls', () => ({
+    TranslationControls: ({ selectedLanguage, languages, onLanguageChange, isSubmitting }: any) => (
+        <div data-testid="translation-controls">
+            <span data-testid="selected-language">{selectedLanguage?.code ?? 'none'}</span>
+            <span data-testid="is-submitting">{String(isSubmitting)}</span>
+            <span data-testid="languages-count">{String(languages?.length ?? 0)}</span>
+            <button
+                data-testid="choose-last-language"
+                onClick={() => onLanguageChange?.(languages?.[languages.length - 1] ?? null)}
+            >
+                choose last language
+            </button>
+        </div>
+    ),
+}));
+
+jest.mock('../translate-partner-banner-form/TranslatePartnerBannerForm', () => {
+    const React = require('react');
+
+    return {
+        TranslatePartnerBannerForm: React.forwardRef(
+            ({ onSubmit, onValidationChange, onDirtyChange, initialData, formDisabled }: any, ref: React.Ref<any>) => {
+                React.useImperativeHandle(ref, () => ({
+                    submit: () =>
+                        onSubmit({
+                            title: 'Translated banner title',
+                            description: 'Translated banner description',
+                        }),
+                    isValid: () => mockFormIsValid,
+                    isDirty: () => mockFormIsDirty,
+                }));
+
+                React.useEffect(() => {
+                    onValidationChange?.(true);
+                    onDirtyChange?.(mockFormIsDirty);
+                }, [onValidationChange, onDirtyChange]);
+
+                return (
+                    <div
+                        data-testid="translate-partner-banner-form"
+                        data-initial={initialData ? JSON.stringify(initialData) : 'null'}
+                        data-disabled={String(Boolean(formDisabled))}
+                    />
+                );
+            },
+        ),
+    };
+});
+
+jest.mock('@/hooks/admin/use-translate-partner-banner/useTranslatePartnerBanner', () => ({
+    useTranslatePartnerBanner: jest.fn(() => ({
+        translateBanner: mockTranslateBanner,
+        isSubmitting: false,
+        error: '',
+        clearError: jest.fn(),
+    })),
+}));
+
+const mockUseTranslatePartnerBanner = jest.mocked(useTranslatePartnerBanner);
+
+const UK_LANGUAGE: LocalizationLanguage = {
+    id: 1,
+    code: 'uk',
+    name: 'Ukrainian',
+};
+
+const EN_LANGUAGE: LocalizationLanguage = {
+    id: 2,
+    code: 'en',
+    name: 'English',
+};
+
+const PL_LANGUAGE: LocalizationLanguage = {
+    id: 3,
+    code: 'pl',
+    name: 'Polish',
+};
+
+const BANNER_WITHOUT_LOCALIZATION: PartnerBanner = {
+    id: 10,
+    title: 'Banner title',
+    description: 'Banner description',
+    image: null,
+    imageId: null,
+    localizations: [],
+};
+
+const BANNER_WITH_EN_LOCALIZATION: PartnerBanner = {
+    id: 10,
+    title: 'Banner title',
+    description: 'Banner description',
+    image: null,
+    imageId: null,
+    localizations: [
+        {
+            title: 'Banner title EN',
+            description: 'Banner description EN',
+            language: {
+                id: EN_LANGUAGE.id,
+                code: EN_LANGUAGE.code,
+            },
+            translationStatus: TranslationStatus.Relevant,
+        },
+    ],
+};
+
+describe('TranslatePartnerBannerModal', () => {
+    const renderModal = (props: Partial<React.ComponentProps<typeof TranslatePartnerBannerModal>> = {}) => {
+        const defaultProps: React.ComponentProps<typeof TranslatePartnerBannerModal> = {
+            isOpen: true,
+            onClose: jest.fn(),
+            banner: BANNER_WITHOUT_LOCALIZATION,
+            onTranslateBanner: jest.fn(),
+            translatedLanguages: [UK_LANGUAGE, EN_LANGUAGE],
+        };
+
+        return render(<TranslatePartnerBannerModal {...defaultProps} {...props} />);
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockFormIsValid = true;
+        mockFormIsDirty = true;
+
+        mockTranslateBanner.mockResolvedValue(undefined);
+        mockUseTranslatePartnerBanner.mockReturnValue({
+            translateBanner: mockTranslateBanner,
+            isSubmitting: false,
+            error: '',
+            clearError: jest.fn(),
+        });
+    });
+
+    it('returns null when banner is null', () => {
+        renderModal({ banner: null });
+
+        expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+    });
+
+    it('uses first non-default language as selected language by default', () => {
+        renderModal({ translatedLanguages: [UK_LANGUAGE, EN_LANGUAGE, PL_LANGUAGE] });
+
+        expect(screen.getByTestId('selected-language')).toHaveTextContent('en');
+    });
+
+    it('falls back to first language when only default locale exists', () => {
+        renderModal({ translatedLanguages: [UK_LANGUAGE] });
+
+        expect(screen.getByTestId('selected-language')).toHaveTextContent('uk');
+    });
+
+    it('uses null selected language when translatedLanguages is empty', () => {
+        renderModal({ translatedLanguages: [] });
+
+        expect(screen.getByTestId('selected-language')).toHaveTextContent('none');
+        expect(mockUseTranslatePartnerBanner).toHaveBeenCalledWith(expect.objectContaining({ language: null }));
+    });
+
+    it('starts in add mode when banner has no localization for selected language', () => {
+        renderModal({ banner: BANNER_WITHOUT_LOCALIZATION, translatedLanguages: [UK_LANGUAGE, EN_LANGUAGE] });
+
+        expect(mockUseTranslatePartnerBanner).toHaveBeenCalledWith(expect.objectContaining({ mode: ModalMode.Add }));
+        expect(screen.getByTestId('modal-title')).toHaveTextContent(
+            COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION,
+        );
+    });
+
+    it('starts in edit mode when banner has localization for selected language', async () => {
+        renderModal({ banner: BANNER_WITH_EN_LOCALIZATION, translatedLanguages: [UK_LANGUAGE, EN_LANGUAGE] });
+
+        await waitFor(() => {
+            expect(mockUseTranslatePartnerBanner).toHaveBeenCalledWith(
+                expect.objectContaining({ mode: ModalMode.Edit }),
+            );
+        });
+        expect(screen.getByTestId('modal-title')).toHaveTextContent(
+            COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.UPDATE_TRANSLATION,
+        );
+    });
+
+    it('passes initialData to form in edit mode', async () => {
+        renderModal({ banner: BANNER_WITH_EN_LOCALIZATION, translatedLanguages: [UK_LANGUAGE, EN_LANGUAGE] });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('translate-partner-banner-form')).toHaveAttribute(
+                'data-initial',
+                JSON.stringify({
+                    title: 'Banner title EN',
+                    description: 'Banner description EN',
+                }),
+            );
+        });
+    });
+
+    it('submits translation and executes success callback flow', async () => {
+        const onTranslateBanner = jest.fn();
+        const onClose = jest.fn();
+
+        mockTranslateBanner.mockImplementation(async () => {
+            const firstCallArgs = mockUseTranslatePartnerBanner.mock.calls[0][0];
+            firstCallArgs.onSuccess(BANNER_WITH_EN_LOCALIZATION);
+        });
+
+        renderModal({ onTranslateBanner, onClose });
+
+        fireEvent.click(screen.getByTestId('save-localization-btn'));
+
+        await waitFor(() => {
+            expect(mockTranslateBanner).toHaveBeenCalledWith({
+                title: 'Translated banner title',
+                description: 'Translated banner description',
+            });
+        });
+
+        expect(onTranslateBanner).toHaveBeenCalledWith(BANNER_WITH_EN_LOCALIZATION);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not submit when form is invalid', () => {
+        mockFormIsValid = false;
+        renderModal();
+
+        fireEvent.click(screen.getByTestId('save-localization-btn'));
+
+        expect(mockTranslateBanner).not.toHaveBeenCalled();
+    });
+
+    it('shows confirmation modal when closing dirty form and closes immediately for clean form', () => {
+        const onClose = jest.fn();
+
+        mockFormIsDirty = true;
+        const { rerender } = render(
+            <TranslatePartnerBannerModal
+                isOpen={true}
+                onClose={onClose}
+                banner={BANNER_WITHOUT_LOCALIZATION}
+                onTranslateBanner={jest.fn()}
+                translatedLanguages={[UK_LANGUAGE, EN_LANGUAGE]}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('modal'));
+        expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument();
+        expect(onClose).not.toHaveBeenCalled();
+
+        mockFormIsDirty = false;
+        rerender(
+            <TranslatePartnerBannerModal
+                isOpen={true}
+                onClose={onClose}
+                banner={BANNER_WITHOUT_LOCALIZATION}
+                onTranslateBanner={jest.fn()}
+                translatedLanguages={[UK_LANGUAGE, EN_LANGUAGE]}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('modal'));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders error message and passes submitting state to controls and form', () => {
+        mockUseTranslatePartnerBanner.mockReturnValue({
+            translateBanner: mockTranslateBanner,
+            isSubmitting: true,
+            error: 'Translation failed',
+            clearError: jest.fn(),
+        });
+
+        renderModal();
+
+        expect(screen.getByText('Translation failed')).toBeInTheDocument();
+        expect(screen.getByTestId('is-submitting')).toHaveTextContent('true');
+        expect(screen.getByTestId('translate-partner-banner-form')).toHaveAttribute('data-disabled', 'true');
+        expect(screen.getByTestId('save-localization-btn')).toBeDisabled();
+    });
+
+    it('changes language through translation controls and keeps add mode if localization is missing', async () => {
+        renderModal({ translatedLanguages: [UK_LANGUAGE, EN_LANGUAGE, PL_LANGUAGE] });
+
+        fireEvent.click(screen.getByTestId('choose-last-language'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('selected-language')).toHaveTextContent('pl');
+        });
+        expect(screen.getByTestId('modal-title')).toHaveTextContent(
+            COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION,
+        );
+    });
+});

--- a/src/pages/admin/partners/components/translate-partner-banner-modal/TranslatePartnerBannerModal.test.tsx
+++ b/src/pages/admin/partners/components/translate-partner-banner-modal/TranslatePartnerBannerModal.test.tsx
@@ -168,6 +168,32 @@ describe('TranslatePartnerBannerModal', () => {
         expect(screen.getByTestId('selected-language')).toHaveTextContent('uk');
     });
 
+    it('selects a language once it arrives after the modal has already mounted with no languages', () => {
+        const { rerender } = render(
+            <TranslatePartnerBannerModal
+                isOpen={true}
+                onClose={jest.fn()}
+                banner={BANNER_WITHOUT_LOCALIZATION}
+                onTranslateBanner={jest.fn()}
+                translatedLanguages={[]}
+            />,
+        );
+
+        expect(screen.getByTestId('selected-language')).toHaveTextContent('none');
+
+        rerender(
+            <TranslatePartnerBannerModal
+                isOpen={true}
+                onClose={jest.fn()}
+                banner={BANNER_WITHOUT_LOCALIZATION}
+                onTranslateBanner={jest.fn()}
+                translatedLanguages={[UK_LANGUAGE, EN_LANGUAGE]}
+            />,
+        );
+
+        expect(screen.getByTestId('selected-language')).toHaveTextContent('en');
+    });
+
     it('uses null selected language when translatedLanguages is empty', () => {
         renderModal({ translatedLanguages: [] });
 

--- a/src/pages/admin/partners/components/translate-partner-banner-modal/TranslatePartnerBannerModal.tsx
+++ b/src/pages/admin/partners/components/translate-partner-banner-modal/TranslatePartnerBannerModal.tsx
@@ -1,7 +1,6 @@
 import { LocalizationModal } from '@/components/admin/localization-modal/LocalizationModal';
 import { TranslationControls } from '@/components/admin/translation-controls/TranslationControls';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
-import { DEFAULT_LOCALE } from '@/const/common/locales';
 import { useTranslatePartnerBanner } from '@/hooks/admin/use-translate-partner-banner/useTranslatePartnerBanner';
 import { ModalMode } from '@/types/admin/common';
 import { PartnerBanner } from '@/types/admin/partners';
@@ -32,10 +31,7 @@ export const TranslatePartnerBannerModal = ({
     const [isFormValid, setIsFormValid] = useState(false);
     const [isDirty, setIsDirty] = useState(false);
 
-    const [language, setLanguage] = useState<LocalizationLanguage | null>(() => {
-        if (!translatedLanguages?.length) return null;
-        return translatedLanguages.find((l) => l.code !== DEFAULT_LOCALE) || translatedLanguages[0];
-    });
+    const [language, setLanguage] = useState<LocalizationLanguage | null>(() => translatedLanguages?.[0] ?? null);
 
     const existingLocalization = useMemo(() => {
         if (!banner?.localizations || !language) return null;
@@ -56,7 +52,7 @@ export const TranslatePartnerBannerModal = ({
 
     const { translateBanner, isSubmitting, error } = useTranslatePartnerBanner({
         banner,
-        language: language as LocalizationLanguage,
+        language,
         onSuccess: (updatedBanner) => {
             onTranslateBanner(updatedBanner);
             onClose();

--- a/src/pages/admin/partners/components/translate-partner-banner-modal/TranslatePartnerBannerModal.tsx
+++ b/src/pages/admin/partners/components/translate-partner-banner-modal/TranslatePartnerBannerModal.tsx
@@ -6,7 +6,7 @@ import { useTranslatePartnerBanner } from '@/hooks/admin/use-translate-partner-b
 import { ModalMode } from '@/types/admin/common';
 import { PartnerBanner } from '@/types/admin/partners';
 import { LocalizationLanguage } from '@/types/common/language';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
     TranslatePartnerBannerForm,
     TranslatePartnerBannerFormRef,
@@ -36,6 +36,11 @@ export const TranslatePartnerBannerModal = ({
         if (!translatedLanguages?.length) return null;
         return translatedLanguages.find((l) => l.code !== DEFAULT_LOCALE) ?? translatedLanguages[0];
     });
+
+    useEffect(() => {
+        if (language || !translatedLanguages?.length) return;
+        setLanguage(translatedLanguages.find((l) => l.code !== DEFAULT_LOCALE) || translatedLanguages[0]);
+    }, [translatedLanguages, language]);
 
     const existingLocalization = useMemo(() => {
         if (!banner?.localizations || !language) return null;

--- a/src/pages/admin/partners/components/translate-partner-banner-modal/TranslatePartnerBannerModal.tsx
+++ b/src/pages/admin/partners/components/translate-partner-banner-modal/TranslatePartnerBannerModal.tsx
@@ -1,6 +1,7 @@
 import { LocalizationModal } from '@/components/admin/localization-modal/LocalizationModal';
 import { TranslationControls } from '@/components/admin/translation-controls/TranslationControls';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { DEFAULT_LOCALE } from '@/const/common/locales';
 import { useTranslatePartnerBanner } from '@/hooks/admin/use-translate-partner-banner/useTranslatePartnerBanner';
 import { ModalMode } from '@/types/admin/common';
 import { PartnerBanner } from '@/types/admin/partners';
@@ -31,7 +32,10 @@ export const TranslatePartnerBannerModal = ({
     const [isFormValid, setIsFormValid] = useState(false);
     const [isDirty, setIsDirty] = useState(false);
 
-    const [language, setLanguage] = useState<LocalizationLanguage | null>(() => translatedLanguages?.[0] ?? null);
+    const [language, setLanguage] = useState<LocalizationLanguage | null>(() => {
+        if (!translatedLanguages?.length) return null;
+        return translatedLanguages.find((l) => l.code !== DEFAULT_LOCALE) ?? translatedLanguages[0];
+    });
 
     const existingLocalization = useMemo(() => {
         if (!banner?.localizations || !language) return null;

--- a/src/pages/admin/partners/components/translate-partner-banner-modal/TranslatePartnerBannerModal.tsx
+++ b/src/pages/admin/partners/components/translate-partner-banner-modal/TranslatePartnerBannerModal.tsx
@@ -1,0 +1,114 @@
+import { LocalizationModal } from '@/components/admin/localization-modal/LocalizationModal';
+import { TranslationControls } from '@/components/admin/translation-controls/TranslationControls';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { DEFAULT_LOCALE } from '@/const/common/locales';
+import { useTranslatePartnerBanner } from '@/hooks/admin/use-translate-partner-banner/useTranslatePartnerBanner';
+import { ModalMode } from '@/types/admin/common';
+import { PartnerBanner } from '@/types/admin/partners';
+import { LocalizationLanguage } from '@/types/common/language';
+import { useMemo, useRef, useState } from 'react';
+import {
+    TranslatePartnerBannerForm,
+    TranslatePartnerBannerFormRef,
+    TranslatePartnerBannerFormValues,
+} from '../translate-partner-banner-form/TranslatePartnerBannerForm';
+
+interface TranslatePartnerBannerModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    banner: PartnerBanner | null;
+    onTranslateBanner: (banner: PartnerBanner) => void;
+    translatedLanguages: LocalizationLanguage[];
+}
+
+export const TranslatePartnerBannerModal = ({
+    isOpen,
+    onClose,
+    banner,
+    onTranslateBanner,
+    translatedLanguages,
+}: TranslatePartnerBannerModalProps) => {
+    const formRef = useRef<TranslatePartnerBannerFormRef>(null);
+    const [isFormValid, setIsFormValid] = useState(false);
+    const [isDirty, setIsDirty] = useState(false);
+
+    const [language, setLanguage] = useState<LocalizationLanguage | null>(() => {
+        if (!translatedLanguages?.length) return null;
+        return translatedLanguages.find((l) => l.code !== DEFAULT_LOCALE) || translatedLanguages[0];
+    });
+
+    const existingLocalization = useMemo(() => {
+        if (!banner?.localizations || !language) return null;
+        return banner.localizations.find((loc) => loc.language.id === language.id);
+    }, [banner, language]);
+
+    const mode = existingLocalization ? ModalMode.Edit : ModalMode.Add;
+    const isEditMode = mode === ModalMode.Edit;
+
+    const initialData = useMemo<TranslatePartnerBannerFormValues | null>(() => {
+        if (!isEditMode || !existingLocalization) return null;
+
+        return {
+            title: existingLocalization.title,
+            description: existingLocalization.description,
+        };
+    }, [existingLocalization, isEditMode]);
+
+    const { translateBanner, isSubmitting, error } = useTranslatePartnerBanner({
+        banner,
+        language: language as LocalizationLanguage,
+        onSuccess: (updatedBanner) => {
+            onTranslateBanner(updatedBanner);
+            onClose();
+        },
+        mode,
+    });
+
+    const handleSaveClick = () => {
+        if (!formRef.current?.isValid()) return;
+        formRef.current.submit();
+    };
+
+    const checkIsDirty = () => {
+        return formRef.current?.isDirty() ?? false;
+    };
+
+    const handleFormSubmit = async (data: TranslatePartnerBannerFormValues) => {
+        await translateBanner(data);
+    };
+
+    if (!banner) return null;
+
+    const modalTitle = isEditMode
+        ? COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.UPDATE_TRANSLATION
+        : COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION;
+
+    return (
+        <LocalizationModal
+            isOpen={isOpen}
+            onClose={onClose}
+            title={modalTitle}
+            onSave={handleSaveClick}
+            isSubmitting={isSubmitting}
+            isFormValid={isFormValid}
+            checkIsDirty={checkIsDirty}
+            isDirty={isDirty}
+        >
+            <TranslationControls
+                selectedLanguage={language}
+                isSubmitting={isSubmitting}
+                languages={translatedLanguages}
+                onLanguageChange={setLanguage}
+            />
+            {error && <div className="translate-partner-banner-error">{error}</div>}
+            <TranslatePartnerBannerForm
+                ref={formRef}
+                initialData={initialData}
+                onValidationChange={setIsFormValid}
+                onSubmit={handleFormSubmit}
+                formDisabled={isSubmitting}
+                onDirtyChange={setIsDirty}
+            />
+        </LocalizationModal>
+    );
+};

--- a/src/pages/admin/partners/components/translate-partner-section-form/TranslatePartnerSectionForm.module.scss
+++ b/src/pages/admin/partners/components/translate-partner-section-form/TranslatePartnerSectionForm.module.scss
@@ -1,0 +1,14 @@
+.partners-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.875rem;
+    align-items: flex-start;
+    margin-top: 1.5rem;
+}
+
+.partner-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    width: 13.125rem;
+}

--- a/src/pages/admin/partners/components/translate-partner-section-form/TranslatePartnerSectionForm.module.scss
+++ b/src/pages/admin/partners/components/translate-partner-section-form/TranslatePartnerSectionForm.module.scss
@@ -1,14 +1,14 @@
 .partners-grid {
     display: flex;
     flex-wrap: wrap;
-    gap: 1.875rem;
+    gap: 30px;
     align-items: flex-start;
-    margin-top: 1.5rem;
+    margin-top: 24px;
 }
 
 .partner-row {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
-    width: 13.125rem;
+    gap: 8px;
+    width: 210px;
 }

--- a/src/pages/admin/partners/components/translate-partner-section-form/TranslatePartnerSectionForm.test.tsx
+++ b/src/pages/admin/partners/components/translate-partner-section-form/TranslatePartnerSectionForm.test.tsx
@@ -1,0 +1,262 @@
+import React, { createRef } from 'react';
+import { createEvent, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TranslatePartnerSectionForm, TranslatePartnerSectionFormRef } from './TranslatePartnerSectionForm';
+import { TranslatePartnerSectionFormValues } from '@/hooks/admin/use-translate-partner-section/useTranslatePartnerSection';
+import { VisibilityStatus } from '@/types/admin/common';
+import { Partner } from '@/types/admin/partners';
+import {
+    PARTNER_SECTION_VALIDATION_FUNCTIONS,
+    PARTNER_VALIDATION_FUNCTIONS,
+} from '@/validation/admin/partner-schema/partner-schema';
+
+jest.mock('@/validation/admin/partner-schema/partner-schema', () => ({
+    PARTNER_SECTION_VALIDATION_FUNCTIONS: {
+        validateTitle: jest.fn(() => undefined),
+        validateDescription: jest.fn(() => undefined),
+    },
+    PARTNER_VALIDATION_FUNCTIONS: {
+        validateDescription: jest.fn(() => undefined),
+    },
+}));
+
+jest.mock(
+    '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup',
+    () => ({
+        TextAreaWithCharacterLimitGroup: ({ value, onChange, disabled, name, id, error }: any) => (
+            <div>
+                <textarea
+                    data-testid={`textarea-${name ?? id}`}
+                    value={value}
+                    onChange={onChange}
+                    disabled={disabled}
+                />
+                {error && <span data-testid={`error-${name ?? id}`}>{error}</span>}
+            </div>
+        ),
+    }),
+);
+
+jest.mock('@/components/admin/image-input/ImageInput', () => ({
+    ImageInput: ({ id, disabled }: any) => <div data-testid={id} data-disabled={String(Boolean(disabled))} />,
+}));
+
+const validationMock = PARTNER_SECTION_VALIDATION_FUNCTIONS as jest.Mocked<typeof PARTNER_SECTION_VALIDATION_FUNCTIONS>;
+const partnerValidationMock = PARTNER_VALIDATION_FUNCTIONS as jest.Mocked<typeof PARTNER_VALIDATION_FUNCTIONS>;
+
+const mockPartners: Partner[] = [
+    { id: 5, description: 'Live partner 1', image: null, imageId: null },
+    { id: 6, description: 'Live partner 2', image: null, imageId: null },
+];
+
+const emptyInitialData: TranslatePartnerSectionFormValues = {
+    title: '',
+    description: '',
+    partners: [
+        { partnerId: 5, description: '' },
+        { partnerId: 6, description: '' },
+    ],
+};
+
+describe('TranslatePartnerSectionForm', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        validationMock.validateTitle.mockReturnValue(undefined);
+        validationMock.validateDescription.mockReturnValue(undefined);
+        partnerValidationMock.validateDescription.mockReturnValue(undefined);
+    });
+
+    const renderForm = (props: Partial<React.ComponentProps<typeof TranslatePartnerSectionForm>> = {}) => {
+        const ref = createRef<TranslatePartnerSectionFormRef>();
+        const defaultProps: React.ComponentProps<typeof TranslatePartnerSectionForm> = {
+            onSubmit: jest.fn(),
+            partners: mockPartners,
+            initialData: emptyInitialData,
+        };
+
+        const view = render(<TranslatePartnerSectionForm ref={ref} {...defaultProps} {...props} />);
+
+        return {
+            ref,
+            onSubmit: props.onSubmit ?? defaultProps.onSubmit,
+            ...view,
+        };
+    };
+
+    it('renders title, description and one row per partner', () => {
+        renderForm();
+
+        expect(screen.getByTestId('textarea-title')).toBeInTheDocument();
+        expect(screen.getByTestId('textarea-description')).toBeInTheDocument();
+        expect(screen.getByTestId('translate-partner-image-5')).toBeInTheDocument();
+        expect(screen.getByTestId('translate-partner-image-6')).toBeInTheDocument();
+        expect(screen.getByTestId('textarea-translate-partner-description-5')).toBeInTheDocument();
+        expect(screen.getByTestId('textarea-translate-partner-description-6')).toBeInTheDocument();
+    });
+
+    it('fills fields from initialData', () => {
+        const initialData: TranslatePartnerSectionFormValues = {
+            title: 'Existing title',
+            description: 'Existing description',
+            partners: [
+                { partnerId: 5, description: 'Existing partner 1' },
+                { partnerId: 6, description: 'Existing partner 2' },
+            ],
+        };
+
+        renderForm({ initialData });
+
+        expect(screen.getByTestId('textarea-title')).toHaveValue('Existing title');
+        expect(screen.getByTestId('textarea-description')).toHaveValue('Existing description');
+        expect(screen.getByTestId('textarea-translate-partner-description-5')).toHaveValue('Existing partner 1');
+        expect(screen.getByTestId('textarea-translate-partner-description-6')).toHaveValue('Existing partner 2');
+    });
+
+    it('renders partner images as disabled (read-only)', () => {
+        renderForm();
+
+        expect(screen.getByTestId('translate-partner-image-5')).toHaveAttribute('data-disabled', 'true');
+    });
+
+    it('updates title, description and partner description values on change', () => {
+        renderForm();
+
+        fireEvent.change(screen.getByTestId('textarea-title'), { target: { value: 'Translated title' } });
+        fireEvent.change(screen.getByTestId('textarea-description'), {
+            target: { value: 'Translated description' },
+        });
+        fireEvent.change(screen.getByTestId('textarea-translate-partner-description-5'), {
+            target: { value: 'Translated partner 1' },
+        });
+
+        expect(screen.getByTestId('textarea-title')).toHaveValue('Translated title');
+        expect(screen.getByTestId('textarea-description')).toHaveValue('Translated description');
+        expect(screen.getByTestId('textarea-translate-partner-description-5')).toHaveValue('Translated partner 1');
+        expect(screen.getByTestId('textarea-translate-partner-description-6')).toHaveValue('');
+    });
+
+    it('validates title, description and partner description on change', () => {
+        renderForm();
+
+        fireEvent.change(screen.getByTestId('textarea-title'), { target: { value: 'x' } });
+        fireEvent.change(screen.getByTestId('textarea-description'), { target: { value: 'y' } });
+        fireEvent.change(screen.getByTestId('textarea-translate-partner-description-5'), { target: { value: 'z' } });
+
+        expect(validationMock.validateTitle).toHaveBeenCalledWith('x');
+        expect(validationMock.validateDescription).toHaveBeenCalledWith('y');
+        expect(partnerValidationMock.validateDescription).toHaveBeenCalledWith('z');
+    });
+
+    it('shows validation errors returned by validation functions', async () => {
+        validationMock.validateTitle.mockReturnValue('Title error');
+        partnerValidationMock.validateDescription.mockReturnValue('Partner error');
+
+        renderForm();
+
+        fireEvent.change(screen.getByTestId('textarea-title'), { target: { value: 'x' } });
+        fireEvent.change(screen.getByTestId('textarea-translate-partner-description-5'), { target: { value: 'z' } });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('error-title')).toHaveTextContent('Title error');
+            expect(screen.getByTestId('error-translate-partner-description-5')).toHaveTextContent('Partner error');
+        });
+    });
+
+    it('calls onValidationChange from form manager updates', async () => {
+        const onValidationChange = jest.fn();
+
+        renderForm({ onValidationChange });
+
+        await waitFor(() => {
+            expect(onValidationChange).toHaveBeenCalledWith(true);
+        });
+    });
+
+    it('reports invalid only while a partner actually has an error', async () => {
+        const onValidationChange = jest.fn();
+        partnerValidationMock.validateDescription.mockReturnValue(undefined);
+
+        renderForm({ onValidationChange });
+
+        await waitFor(() => {
+            expect(onValidationChange).toHaveBeenLastCalledWith(true);
+        });
+
+        partnerValidationMock.validateDescription.mockReturnValue('Partner error');
+        fireEvent.change(screen.getByTestId('textarea-translate-partner-description-5'), {
+            target: { value: 'bad' },
+        });
+
+        await waitFor(() => {
+            expect(onValidationChange).toHaveBeenLastCalledWith(false);
+        });
+    });
+
+    it('reports dirty state relative to initialData', async () => {
+        const onDirtyChange = jest.fn();
+
+        renderForm({ onDirtyChange });
+
+        await waitFor(() => {
+            expect(onDirtyChange).toHaveBeenCalledWith(false);
+        });
+
+        fireEvent.change(screen.getByTestId('textarea-title'), { target: { value: 'Changed title' } });
+
+        await waitFor(() => {
+            expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+        });
+    });
+
+    it('submits data via ref.submit and forwards only form data to onSubmit', async () => {
+        const onSubmit = jest.fn();
+        const { ref } = renderForm({ onSubmit });
+
+        fireEvent.change(screen.getByTestId('textarea-title'), { target: { value: 'Final title' } });
+        fireEvent.change(screen.getByTestId('textarea-description'), { target: { value: 'Final description' } });
+        fireEvent.change(screen.getByTestId('textarea-translate-partner-description-5'), {
+            target: { value: 'Final partner 1' },
+        });
+        fireEvent.change(screen.getByTestId('textarea-translate-partner-description-6'), {
+            target: { value: 'Final partner 2' },
+        });
+
+        await ref.current?.submit(VisibilityStatus.Draft);
+
+        expect(onSubmit).toHaveBeenCalledWith({
+            title: 'Final title',
+            description: 'Final description',
+            partners: [
+                { partnerId: 5, description: 'Final partner 1' },
+                { partnerId: 6, description: 'Final partner 2' },
+            ],
+        });
+    });
+
+    it('exposes isValid and isDirty through ref', () => {
+        const { ref } = renderForm();
+
+        expect(ref.current?.isValid()).toBe(true);
+        expect(ref.current?.isDirty()).toBe(false);
+    });
+
+    it('disables all fields when formDisabled is true', () => {
+        renderForm({ formDisabled: true });
+
+        expect(screen.getByTestId('textarea-title')).toBeDisabled();
+        expect(screen.getByTestId('textarea-description')).toBeDisabled();
+        expect(screen.getByTestId('textarea-translate-partner-description-5')).toBeDisabled();
+    });
+
+    it('prevents default form submission behavior', () => {
+        const { container } = renderForm();
+        const form = container.querySelector('#translate-partner-section-form') as HTMLFormElement;
+
+        const event = createEvent.submit(form);
+        event.preventDefault = jest.fn();
+
+        fireEvent(form, event);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+});

--- a/src/pages/admin/partners/components/translate-partner-section-form/TranslatePartnerSectionForm.tsx
+++ b/src/pages/admin/partners/components/translate-partner-section-form/TranslatePartnerSectionForm.tsx
@@ -1,0 +1,175 @@
+import { forwardRef, useEffect } from 'react';
+import { ImageInput } from '@/components/admin/image-input/ImageInput';
+import { TextAreaWithCharacterLimitGroup } from '@/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup';
+import { PARTNERS_TEXT, PARTNER_SECTION_VALIDATION, PARTNER_VALIDATION } from '@/const/admin/partners';
+import { useFormManager } from '@/hooks/admin/use-form-manager/useFormManager';
+import { VisibilityStatus } from '@/types/admin/common';
+import { Partner } from '@/types/admin/partners';
+import {
+    PARTNER_SECTION_VALIDATION_FUNCTIONS,
+    PARTNER_VALIDATION_FUNCTIONS,
+} from '@/validation/admin/partner-schema/partner-schema';
+import { TranslatePartnerSectionFormValues } from '@/hooks/admin/use-translate-partner-section/useTranslatePartnerSection';
+import styles from './TranslatePartnerSectionForm.module.scss';
+
+export interface TranslatePartnerSectionFormErrorState {
+    title: string | undefined;
+    description: string | undefined;
+    partners: Array<{ description?: string }> | undefined;
+    [key: string]: string | undefined | Array<{ description?: string }>;
+}
+
+export interface TranslatePartnerSectionFormRef {
+    submit: (status?: VisibilityStatus) => Promise<void>;
+    isValid: () => boolean;
+    isDirty: () => boolean;
+}
+
+export interface TranslatePartnerSectionFormProps {
+    onSubmit: (data: TranslatePartnerSectionFormValues, status?: VisibilityStatus) => void | Promise<void>;
+    partners: Partner[];
+    initialData: TranslatePartnerSectionFormValues;
+    formDisabled?: boolean;
+    onValidationChange?: (isValid: boolean) => void;
+    onDirtyChange?: (isDirty: boolean) => void;
+}
+
+const validateForm = (
+    formState: TranslatePartnerSectionFormValues,
+    _isPublishing: boolean,
+): TranslatePartnerSectionFormErrorState => {
+    const partnerErrors = formState.partners.map((partner) => ({
+        description: PARTNER_VALIDATION_FUNCTIONS.validateDescription(partner.description),
+    }));
+    const hasPartnerErrors = partnerErrors.some((partnerError) => partnerError.description !== undefined);
+
+    return {
+        title: PARTNER_SECTION_VALIDATION_FUNCTIONS.validateTitle(formState.title),
+        description: PARTNER_SECTION_VALIDATION_FUNCTIONS.validateDescription(formState.description),
+        partners: hasPartnerErrors ? partnerErrors : undefined,
+    };
+};
+
+export const TranslatePartnerSectionForm = forwardRef<TranslatePartnerSectionFormRef, TranslatePartnerSectionFormProps>(
+    ({ initialData, onSubmit, partners, formDisabled, onValidationChange, onDirtyChange }, ref) => {
+        const { formState, setFormState, errors, setErrors, isSubmitting } = useFormManager<
+            TranslatePartnerSectionFormValues,
+            TranslatePartnerSectionFormErrorState
+        >({
+            defaultFormState: initialData,
+            initialData,
+            validateForm,
+            onValidationChange,
+            ref,
+            onSubmit: (data, _status) => onSubmit(data),
+        });
+
+        useEffect(() => {
+            const isDirty = JSON.stringify(formState) !== JSON.stringify(initialData);
+            onDirtyChange?.(isDirty);
+        }, [formState, initialData, onDirtyChange]);
+
+        const handleTitleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+            const value = e.target.value;
+            setFormState((prev) => ({ ...prev, title: value }));
+            setErrors((prev) => ({ ...prev, title: PARTNER_SECTION_VALIDATION_FUNCTIONS.validateTitle(value) }));
+        };
+
+        const handleDescriptionChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+            const value = e.target.value;
+            setFormState((prev) => ({ ...prev, description: value }));
+            setErrors((prev) => ({
+                ...prev,
+                description: PARTNER_SECTION_VALIDATION_FUNCTIONS.validateDescription(value),
+            }));
+        };
+
+        const handlePartnerDescriptionChange = (index: number, value: string) => {
+            setFormState((prev) => ({
+                ...prev,
+                partners: prev.partners.map((partner, i) =>
+                    i === index ? { ...partner, description: value } : partner,
+                ),
+            }));
+            setErrors((prev) => {
+                const partnerErrors = prev.partners?.length ? [...prev.partners] : formState.partners.map(() => ({}));
+                partnerErrors[index] = { description: PARTNER_VALIDATION_FUNCTIONS.validateDescription(value) };
+                return { ...prev, partners: partnerErrors };
+            });
+        };
+
+        const disabled = isSubmitting || formDisabled;
+        const partnerErrors = errors.partners ?? [];
+
+        return (
+            <form
+                onSubmit={(e) => e.preventDefault()}
+                className="translate-partner-section-form"
+                id={'translate-partner-section-form'}
+                noValidate
+            >
+                <TextAreaWithCharacterLimitGroup
+                    label={PARTNERS_TEXT.FORM.LABEL.TITLE}
+                    value={formState.title}
+                    error={errors.title}
+                    onChange={handleTitleChange}
+                    isRequired
+                    disabled={disabled}
+                    maxLength={PARTNER_SECTION_VALIDATION.title.max}
+                    name={'title'}
+                    id={'translate-section-title'}
+                    rows={3}
+                />
+
+                <TextAreaWithCharacterLimitGroup
+                    label={PARTNERS_TEXT.FORM.LABEL.DESCRIPTION}
+                    value={formState.description}
+                    error={errors.description}
+                    onChange={handleDescriptionChange}
+                    isRequired
+                    disabled={disabled}
+                    maxLength={PARTNER_SECTION_VALIDATION.description.max}
+                    name={'description'}
+                    id={'translate-section-description'}
+                    rows={3}
+                />
+
+                <div className={styles['partners-grid']}>
+                    {formState.partners.map((partnerValue, index) => {
+                        const partner = partners[index];
+                        const partnerError = partnerErrors[index]?.description;
+
+                        return (
+                            <div key={partnerValue.partnerId} className={styles['partner-row']}>
+                                <ImageInput
+                                    value={partner?.image ?? null}
+                                    onChange={() => undefined}
+                                    setError={() => undefined}
+                                    disabled
+                                    id={`translate-partner-image-${partnerValue.partnerId}`}
+                                    name={`translate-partner-image-${partnerValue.partnerId}`}
+                                    cropWidth={PARTNER_VALIDATION.image.width}
+                                    cropHeight={PARTNER_VALIDATION.image.height}
+                                    style={{ width: '13rem', height: '13rem' }}
+                                />
+
+                                <TextAreaWithCharacterLimitGroup
+                                    label={PARTNERS_TEXT.PARTNER.DESCRIPTION_LABEL}
+                                    value={partnerValue.description}
+                                    error={partnerError}
+                                    onChange={(e) => handlePartnerDescriptionChange(index, e.target.value)}
+                                    isRequired
+                                    disabled={disabled}
+                                    maxLength={PARTNER_VALIDATION.description.max}
+                                    name={`translate-partner-description-${partnerValue.partnerId}`}
+                                    id={`translate-partner-description-${partnerValue.partnerId}`}
+                                    rows={3}
+                                />
+                            </div>
+                        );
+                    })}
+                </div>
+            </form>
+        );
+    },
+);

--- a/src/pages/admin/partners/components/translate-partner-section-modal/TranslatePartnerSectionModal.module.scss
+++ b/src/pages/admin/partners/components/translate-partner-section-modal/TranslatePartnerSectionModal.module.scss
@@ -4,7 +4,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    min-height: 12.5rem;
+    min-height: 200px;
 }
 
 .error {

--- a/src/pages/admin/partners/components/translate-partner-section-modal/TranslatePartnerSectionModal.module.scss
+++ b/src/pages/admin/partners/components/translate-partner-section-modal/TranslatePartnerSectionModal.module.scss
@@ -1,0 +1,12 @@
+@use '@/assets/sass/variables/colors' as c;
+
+.loader {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 12.5rem;
+}
+
+.error {
+    color: c.$error;
+}

--- a/src/pages/admin/partners/components/translate-partner-section-modal/TranslatePartnerSectionModal.test.tsx
+++ b/src/pages/admin/partners/components/translate-partner-section-modal/TranslatePartnerSectionModal.test.tsx
@@ -1,0 +1,333 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { PartnerSection, PartnerSectionLocalizationDto } from '@/types/admin/partners';
+import { LocalizationLanguage } from '@/types/common/language';
+import { useTranslatePartnerSection } from '@/hooks/admin/use-translate-partner-section/useTranslatePartnerSection';
+import { TranslatePartnerSectionModal } from './TranslatePartnerSectionModal';
+
+let mockFormIsValid = true;
+let mockFormIsDirty = true;
+
+const mockTranslateSection = jest.fn();
+
+jest.mock('@/components/admin/localization-modal/LocalizationModal', () => ({
+    LocalizationModal: (props: unknown) => require('@/utils/test-mocks/test-mocks').MockLocalizationModal(props),
+}));
+
+jest.mock('@/components/admin/translation-controls/TranslationControls', () => ({
+    TranslationControls: ({ selectedLanguage, languages, onLanguageChange, isSubmitting }: any) => (
+        <div data-testid="translation-controls">
+            <span data-testid="selected-language">{selectedLanguage?.code ?? 'none'}</span>
+            <span data-testid="is-submitting">{String(isSubmitting)}</span>
+            <button
+                data-testid="choose-last-language"
+                onClick={() => onLanguageChange?.(languages?.[languages.length - 1] ?? null)}
+            >
+                choose last language
+            </button>
+        </div>
+    ),
+}));
+
+jest.mock('@/components/common/inline-loader/InlineLoader', () => ({
+    InlineLoader: ({ size }: { size: number }) => <div data-testid={`inline-loader-${size}`} />,
+}));
+
+jest.mock('../translate-partner-section-form/TranslatePartnerSectionForm', () => {
+    const React = require('react');
+
+    return {
+        TranslatePartnerSectionForm: React.forwardRef(
+            ({ onSubmit, onValidationChange, onDirtyChange, initialData, formDisabled }: any, ref: React.Ref<any>) => {
+                React.useImperativeHandle(ref, () => ({
+                    submit: () =>
+                        onSubmit({
+                            title: 'Translated section title',
+                            description: 'Translated section description',
+                            partners: initialData.partners,
+                        }),
+                    isValid: () => mockFormIsValid,
+                    isDirty: () => mockFormIsDirty,
+                }));
+
+                React.useEffect(() => {
+                    onValidationChange?.(true);
+                    onDirtyChange?.(mockFormIsDirty);
+                }, [onValidationChange, onDirtyChange]);
+
+                return (
+                    <div
+                        data-testid="translate-partner-section-form"
+                        data-initial={JSON.stringify(initialData)}
+                        data-disabled={String(Boolean(formDisabled))}
+                    />
+                );
+            },
+        ),
+    };
+});
+
+jest.mock('@/hooks/admin/use-translate-partner-section/useTranslatePartnerSection', () => ({
+    useTranslatePartnerSection: jest.fn(() => ({
+        translateSection: mockTranslateSection,
+        isSubmitting: false,
+        error: '',
+        clearError: jest.fn(),
+        isEditMode: false,
+        existingTranslation: null,
+        isLoadingTranslation: false,
+        translationFetchError: '',
+    })),
+}));
+
+const mockUseTranslatePartnerSection = jest.mocked(useTranslatePartnerSection);
+
+const UK_LANGUAGE: LocalizationLanguage = { id: 1, code: 'uk', name: 'Ukrainian' };
+const EN_LANGUAGE: LocalizationLanguage = { id: 2, code: 'en', name: 'English' };
+const PL_LANGUAGE: LocalizationLanguage = { id: 3, code: 'pl', name: 'Polish' };
+
+const SECTION: PartnerSection = {
+    id: 10,
+    title: 'Section title',
+    description: 'Section description',
+    partners: [
+        { id: 5, description: 'Partner 1', image: null, imageId: null },
+        { id: 6, description: 'Partner 2', image: null, imageId: null },
+    ],
+    localizations: [],
+};
+
+const EXISTING_TRANSLATION: PartnerSectionLocalizationDto = {
+    entityId: 10,
+    title: 'Section title EN',
+    description: 'Section description EN',
+    partners: [{ partnerId: 5, description: 'Partner 1 EN' }],
+    localizationInfoDto: { id: EN_LANGUAGE.id, code: EN_LANGUAGE.code },
+    translationStatus: 1,
+};
+
+const defaultHookReturn = () => ({
+    translateSection: mockTranslateSection,
+    isSubmitting: false,
+    error: '',
+    clearError: jest.fn(),
+    isEditMode: false,
+    existingTranslation: null as PartnerSectionLocalizationDto | null,
+    isLoadingTranslation: false,
+    translationFetchError: '',
+});
+
+describe('TranslatePartnerSectionModal', () => {
+    const renderModal = (props: Partial<React.ComponentProps<typeof TranslatePartnerSectionModal>> = {}) => {
+        const defaultProps: React.ComponentProps<typeof TranslatePartnerSectionModal> = {
+            isOpen: true,
+            onClose: jest.fn(),
+            section: SECTION,
+            translatedLanguages: [UK_LANGUAGE, EN_LANGUAGE],
+            onTranslated: jest.fn(),
+        };
+
+        return render(<TranslatePartnerSectionModal {...defaultProps} {...props} />);
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockFormIsValid = true;
+        mockFormIsDirty = true;
+
+        mockTranslateSection.mockResolvedValue(undefined);
+        mockUseTranslatePartnerSection.mockReturnValue(defaultHookReturn());
+    });
+
+    it('returns null when section is null', () => {
+        renderModal({ section: null });
+
+        expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+    });
+
+    it('uses first non-default language as selected language by default', () => {
+        renderModal({ translatedLanguages: [UK_LANGUAGE, EN_LANGUAGE, PL_LANGUAGE] });
+
+        expect(screen.getByTestId('selected-language')).toHaveTextContent('en');
+    });
+
+    it('falls back to first language when only default locale exists', () => {
+        renderModal({ translatedLanguages: [UK_LANGUAGE] });
+
+        expect(screen.getByTestId('selected-language')).toHaveTextContent('uk');
+    });
+
+    it('selects a language once it arrives after the modal has already mounted with no languages', () => {
+        const { rerender } = render(
+            <TranslatePartnerSectionModal
+                isOpen={true}
+                onClose={jest.fn()}
+                section={SECTION}
+                translatedLanguages={[]}
+                onTranslated={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByTestId('selected-language')).toHaveTextContent('none');
+
+        rerender(
+            <TranslatePartnerSectionModal
+                isOpen={true}
+                onClose={jest.fn()}
+                section={SECTION}
+                translatedLanguages={[UK_LANGUAGE, EN_LANGUAGE]}
+                onTranslated={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByTestId('selected-language')).toHaveTextContent('en');
+    });
+
+    it('shows a loader while the translation is being fetched', () => {
+        mockUseTranslatePartnerSection.mockReturnValue({
+            ...defaultHookReturn(),
+            isLoadingTranslation: true,
+        });
+
+        renderModal();
+
+        expect(screen.getByTestId('inline-loader-2')).toBeInTheDocument();
+        expect(screen.queryByTestId('translate-partner-section-form')).not.toBeInTheDocument();
+    });
+
+    it('shows Add mode title and empty rows when no translation exists yet', () => {
+        mockUseTranslatePartnerSection.mockReturnValue({
+            ...defaultHookReturn(),
+            isEditMode: false,
+            existingTranslation: null,
+        });
+
+        renderModal();
+
+        expect(screen.getByTestId('modal-title')).toHaveTextContent(
+            COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION,
+        );
+
+        const initial = JSON.parse(screen.getByTestId('translate-partner-section-form').getAttribute('data-initial')!);
+        expect(initial).toEqual({
+            title: '',
+            description: '',
+            partners: [
+                { partnerId: 5, description: '' },
+                { partnerId: 6, description: '' },
+            ],
+        });
+    });
+
+    it('shows Edit mode and pre-fills from the existing translation, defaulting untranslated partners to empty', () => {
+        mockUseTranslatePartnerSection.mockReturnValue({
+            ...defaultHookReturn(),
+            isEditMode: true,
+            existingTranslation: EXISTING_TRANSLATION,
+        });
+
+        renderModal();
+
+        expect(screen.getByTestId('modal-title')).toHaveTextContent(
+            COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.UPDATE_TRANSLATION,
+        );
+
+        const initial = JSON.parse(screen.getByTestId('translate-partner-section-form').getAttribute('data-initial')!);
+        expect(initial).toEqual({
+            title: 'Section title EN',
+            description: 'Section description EN',
+            partners: [
+                { partnerId: 5, description: 'Partner 1 EN' },
+                { partnerId: 6, description: '' },
+            ],
+        });
+    });
+
+    it('submits translation and executes success callback flow', async () => {
+        const onTranslated = jest.fn();
+        const onClose = jest.fn();
+
+        mockTranslateSection.mockImplementation(async () => {
+            onTranslated();
+            onClose();
+        });
+
+        renderModal({ onTranslated, onClose });
+
+        fireEvent.click(screen.getByTestId('save-localization-btn'));
+
+        await waitFor(() => {
+            expect(mockTranslateSection).toHaveBeenCalled();
+        });
+
+        expect(onTranslated).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not submit when form is invalid', () => {
+        mockFormIsValid = false;
+        renderModal();
+
+        fireEvent.click(screen.getByTestId('save-localization-btn'));
+
+        expect(mockTranslateSection).not.toHaveBeenCalled();
+    });
+
+    it('shows confirmation modal when closing dirty form and closes immediately for clean form', () => {
+        const onClose = jest.fn();
+
+        mockFormIsDirty = true;
+        const { rerender } = render(
+            <TranslatePartnerSectionModal
+                isOpen={true}
+                onClose={onClose}
+                section={SECTION}
+                translatedLanguages={[UK_LANGUAGE, EN_LANGUAGE]}
+                onTranslated={jest.fn()}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('modal'));
+        expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument();
+        expect(onClose).not.toHaveBeenCalled();
+
+        mockFormIsDirty = false;
+        rerender(
+            <TranslatePartnerSectionModal
+                isOpen={true}
+                onClose={onClose}
+                section={SECTION}
+                translatedLanguages={[UK_LANGUAGE, EN_LANGUAGE]}
+                onTranslated={jest.fn()}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('modal'));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders translate error and translation fetch error messages', () => {
+        mockUseTranslatePartnerSection.mockReturnValue({
+            ...defaultHookReturn(),
+            error: 'Translate failed',
+            translationFetchError: 'Fetch failed',
+        });
+
+        renderModal();
+
+        expect(screen.getByText('Translate failed')).toBeInTheDocument();
+        expect(screen.getByText('Fetch failed')).toBeInTheDocument();
+    });
+
+    it('changes language through translation controls', async () => {
+        renderModal({ translatedLanguages: [UK_LANGUAGE, EN_LANGUAGE, PL_LANGUAGE] });
+
+        fireEvent.click(screen.getByTestId('choose-last-language'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('selected-language')).toHaveTextContent('pl');
+        });
+    });
+});

--- a/src/pages/admin/partners/components/translate-partner-section-modal/TranslatePartnerSectionModal.tsx
+++ b/src/pages/admin/partners/components/translate-partner-section-modal/TranslatePartnerSectionModal.tsx
@@ -117,9 +117,10 @@ export const TranslatePartnerSectionModal = ({
             />
 
             {error && <div className={styles.error}>{error}</div>}
-            {translationFetchError && <div className={styles.error}>{translationFetchError}</div>}
 
-            {isLoadingTranslation || !initialData ? (
+            {translationFetchError ? (
+                <div className={styles.error}>{translationFetchError}</div>
+            ) : isLoadingTranslation || !initialData ? (
                 <div className={styles.loader}>
                     <InlineLoader size={2} />
                 </div>

--- a/src/pages/admin/partners/components/translate-partner-section-modal/TranslatePartnerSectionModal.tsx
+++ b/src/pages/admin/partners/components/translate-partner-section-modal/TranslatePartnerSectionModal.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { LocalizationModal } from '@/components/admin/localization-modal/LocalizationModal';
+import { TranslationControls } from '@/components/admin/translation-controls/TranslationControls';
+import { InlineLoader } from '@/components/common/inline-loader/InlineLoader';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { DEFAULT_LOCALE } from '@/const/common/locales';
+import {
+    TranslatePartnerSectionFormValues,
+    useTranslatePartnerSection,
+} from '@/hooks/admin/use-translate-partner-section/useTranslatePartnerSection';
+import { PartnerSection } from '@/types/admin/partners';
+import { LocalizationLanguage } from '@/types/common/language';
+import {
+    TranslatePartnerSectionForm,
+    TranslatePartnerSectionFormRef,
+} from '../translate-partner-section-form/TranslatePartnerSectionForm';
+import styles from './TranslatePartnerSectionModal.module.scss';
+
+interface TranslatePartnerSectionModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    section: PartnerSection | null;
+    translatedLanguages: LocalizationLanguage[];
+    onTranslated: () => void;
+}
+
+export const TranslatePartnerSectionModal = ({
+    isOpen,
+    onClose,
+    section,
+    translatedLanguages,
+    onTranslated,
+}: TranslatePartnerSectionModalProps) => {
+    const formRef = useRef<TranslatePartnerSectionFormRef>(null);
+    const [isFormValid, setIsFormValid] = useState(false);
+    const [isDirty, setIsDirty] = useState(false);
+
+    const [language, setLanguage] = useState<LocalizationLanguage | null>(() => {
+        if (!translatedLanguages?.length) return null;
+        return translatedLanguages.find((l) => l.code !== DEFAULT_LOCALE) || translatedLanguages[0];
+    });
+
+    useEffect(() => {
+        if (language || !translatedLanguages?.length) return;
+        setLanguage(translatedLanguages.find((l) => l.code !== DEFAULT_LOCALE) || translatedLanguages[0]);
+    }, [translatedLanguages, language]);
+
+    const {
+        translateSection,
+        isSubmitting,
+        error,
+        isEditMode,
+        existingTranslation,
+        isLoadingTranslation,
+        translationFetchError,
+    } = useTranslatePartnerSection({
+        section,
+        language,
+        isOpen,
+        onSuccess: () => {
+            onTranslated();
+            onClose();
+        },
+    });
+
+    const initialData = useMemo<TranslatePartnerSectionFormValues | null>(() => {
+        if (!section || isLoadingTranslation) return null;
+
+        return {
+            title: existingTranslation?.title ?? '',
+            description: existingTranslation?.description ?? '',
+            partners: section.partners.map((partner) => ({
+                partnerId: partner.id,
+                description:
+                    existingTranslation?.partners.find((translated) => translated.partnerId === partner.id)
+                        ?.description ?? '',
+            })),
+        };
+    }, [section, existingTranslation, isLoadingTranslation]);
+
+    const handleSaveClick = () => {
+        if (!formRef.current?.isValid()) return;
+        formRef.current.submit();
+    };
+
+    const checkIsDirty = () => {
+        return formRef.current?.isDirty() ?? false;
+    };
+
+    const handleFormSubmit = async (data: TranslatePartnerSectionFormValues) => {
+        await translateSection(data);
+    };
+
+    if (!section) return null;
+
+    const modalTitle = isEditMode
+        ? COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.UPDATE_TRANSLATION
+        : COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION;
+
+    return (
+        <LocalizationModal
+            isOpen={isOpen}
+            onClose={onClose}
+            title={modalTitle}
+            onSave={handleSaveClick}
+            isSubmitting={isSubmitting}
+            isFormValid={isFormValid}
+            checkIsDirty={checkIsDirty}
+            isDirty={isDirty}
+            maxWidth="1200px"
+        >
+            <TranslationControls
+                selectedLanguage={language}
+                isSubmitting={isSubmitting}
+                languages={translatedLanguages}
+                onLanguageChange={setLanguage}
+            />
+
+            {error && <div className={styles.error}>{error}</div>}
+            {translationFetchError && <div className={styles.error}>{translationFetchError}</div>}
+
+            {isLoadingTranslation || !initialData ? (
+                <div className={styles.loader}>
+                    <InlineLoader size={2} />
+                </div>
+            ) : (
+                <TranslatePartnerSectionForm
+                    ref={formRef}
+                    partners={section.partners}
+                    initialData={initialData}
+                    onValidationChange={setIsFormValid}
+                    onSubmit={handleFormSubmit}
+                    formDisabled={isSubmitting}
+                    onDirtyChange={setIsDirty}
+                />
+            )}
+        </LocalizationModal>
+    );
+};

--- a/src/pages/public/partners-page/partners-sections/intro-section/IntroSection.test.tsx
+++ b/src/pages/public/partners-page/partners-sections/intro-section/IntroSection.test.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { IntroSection } from './IntroSection';
-import { PartnersBanner } from '@/types/public/partners-page';
+import { PartnersBanner, PartnersBannerLocalizationDto } from '@/types/public/partners-page';
+
+jest.mock('react-router-dom', () => ({
+    useLocation: jest.fn(),
+    useNavigate: jest.fn(),
+}));
 
 jest.mock('@/assets/images/horses.webp', () => 'fallback-background-image.png');
 
@@ -18,6 +24,11 @@ jest.mock('@/const/public/partners-page', () => ({
 }));
 
 describe('IntroSection', () => {
+    beforeEach(() => {
+        (useLocation as jest.Mock).mockReturnValue({ pathname: '/', search: '' });
+        (useNavigate as jest.Mock).mockReturnValue(jest.fn());
+    });
+
     describe('when banner prop is provided', () => {
         const mockBanner: PartnersBanner = {
             title: 'Test Title',
@@ -61,6 +72,28 @@ describe('IntroSection', () => {
             const { container } = render(<IntroSection banner={null} />);
 
             expect(container).toBeEmptyDOMElement();
+        });
+
+        it('should render the localized title and description when a localization matches the current language', () => {
+            const bannerWithLocalization: PartnersBanner = {
+                ...mockBanner,
+                localizations: [
+                    {
+                        entityId: 1,
+                        title: 'Localized Title',
+                        description: 'Localized Description',
+                        translationStatus: 1,
+                        localizationInfoDto: { id: 2, code: 'uk' },
+                    } as PartnersBannerLocalizationDto,
+                ],
+            };
+
+            render(<IntroSection banner={bannerWithLocalization} />);
+
+            const title = screen.getByRole('heading', { level: 1 });
+            expect(title).toHaveTextContent('Localized Title');
+            expect(screen.getByText('Localized Description')).toBeInTheDocument();
+            expect(screen.queryByText('Test Description')).not.toBeInTheDocument();
         });
     });
 });

--- a/src/pages/public/partners-page/partners-sections/intro-section/IntroSection.tsx
+++ b/src/pages/public/partners-page/partners-sections/intro-section/IntroSection.tsx
@@ -1,21 +1,33 @@
+import { useMemo } from 'react';
 import styles from './IntroSection.module.scss';
 import background from '@/assets/images/horses.webp';
 import { PartnersBanner } from '@/types/public/partners-page';
 import DOMPurify from 'dompurify';
 import { SafeHtml } from '@/components/common/safe-html';
 import { getImageSrc } from '@/utils/functions/image-helper/image-helper';
+import { useGetLocalization } from '@/hooks/common/use-get-localization/useGetLocalization';
+import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/localization/localization-mappers';
 
 export interface IntroSectionProps {
     banner: PartnersBanner | null;
 }
 
 export const IntroSection = ({ banner }: IntroSectionProps) => {
+    const normalizedLocalizations = useMemo(
+        () => (banner?.localizations ?? []).map((localization) => mapLocalizationDtoToModel(localization)),
+        [banner?.localizations],
+    );
+
+    const { title, description } = useGetLocalization(normalizedLocalizations, {
+        title: banner?.title ?? '',
+        description: banner?.description ?? '',
+    });
+
     if (!banner) {
         return null;
     }
 
-    const { title, description, image } = banner;
-    const imageUrl = getImageSrc(image) || background;
+    const imageUrl = getImageSrc(banner.image) || background;
 
     const sanitizedTitle = DOMPurify.sanitize(title, {
         ALLOWED_TAGS: ['strong', 'em', 'b', 'i', 'br'],

--- a/src/pages/public/partners-page/partners-sections/partners-section/PartnersSection.test.tsx
+++ b/src/pages/public/partners-page/partners-sections/partners-section/PartnersSection.test.tsx
@@ -1,10 +1,25 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { PartnersSection } from './PartnersSection';
-import { PartnerSection as PartnerSectionType } from '@/types/public/partners-page';
+import {
+    PartnerSection as PartnerSectionType,
+    PartnerSectionLocalizationDto,
+    PartnerLocalizationDto,
+} from '@/types/public/partners-page';
+
+jest.mock('react-router-dom', () => ({
+    useLocation: jest.fn(),
+    useNavigate: jest.fn(),
+}));
 
 describe('PartnersSection', () => {
+    beforeEach(() => {
+        (useLocation as jest.Mock).mockReturnValue({ pathname: '/', search: '' });
+        (useNavigate as jest.Mock).mockReturnValue(jest.fn());
+    });
+
     const mockSection: PartnerSectionType = {
         id: 1,
         title: 'Our partners',
@@ -63,5 +78,41 @@ describe('PartnersSection', () => {
 
         const logos = screen.queryAllByRole('img');
         expect(logos).toHaveLength(0);
+    });
+
+    it('should render the localized title, description and partner descriptions when a localization matches the current language', () => {
+        const sectionLocalization: PartnerSectionLocalizationDto = {
+            entityId: 1,
+            title: 'Localized title',
+            description: 'Localized description',
+            translationStatus: 1,
+            localizationInfoDto: { id: 2, code: 'uk' },
+        };
+
+        const partnerLocalization: PartnerLocalizationDto = {
+            entityId: 1,
+            description: 'Localized Partner One',
+            translationStatus: 1,
+            localizationInfoDto: { id: 2, code: 'uk' },
+        };
+
+        const sectionWithLocalization: PartnerSectionType = {
+            ...mockSection,
+            localizations: [sectionLocalization],
+            partners: mockSection.partners.map((partner) =>
+                partner.id === 1 ? { ...partner, localizations: [partnerLocalization] } : partner,
+            ),
+        };
+
+        render(<PartnersSection section={sectionWithLocalization} />);
+
+        expect(screen.getByRole('heading', { name: 'Localized title' })).toBeInTheDocument();
+        expect(screen.getByText('Localized description')).toBeInTheDocument();
+        expect(screen.getByText('Localized Partner One')).toBeInTheDocument();
+
+        expect(screen.getByText('Partner Two')).toBeInTheDocument();
+
+        expect(screen.queryByText('Our partners')).not.toBeInTheDocument();
+        expect(screen.queryByText('Partner One')).not.toBeInTheDocument();
     });
 });

--- a/src/pages/public/partners-page/partners-sections/partners-section/PartnersSection.tsx
+++ b/src/pages/public/partners-page/partners-sections/partners-section/PartnersSection.tsx
@@ -1,13 +1,28 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { PartnerSection } from '@/types/public/partners-page';
 import styles from './PartnersSection.module.scss';
 import { getImageSrc } from '@/utils/functions/image-helper/image-helper';
+import { useGetLocalization } from '@/hooks/common/use-get-localization/useGetLocalization';
+import { useLocale } from '@/hooks/common/use-locale/useLocale';
+import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/localization/localization-mappers';
 
 interface PartnersSectionProps {
     section: PartnerSection | null;
 }
 
 export const PartnersSection = ({ section }: PartnersSectionProps) => {
+    const { currentLanguage } = useLocale();
+
+    const normalizedLocalizations = useMemo(
+        () => (section?.localizations ?? []).map((localization) => mapLocalizationDtoToModel(localization)),
+        [section?.localizations],
+    );
+
+    const { title, description } = useGetLocalization(normalizedLocalizations, {
+        title: section?.title ?? '',
+        description: section?.description ?? '',
+    });
+
     if (!section) {
         return null;
     }
@@ -16,20 +31,26 @@ export const PartnersSection = ({ section }: PartnersSectionProps) => {
         <section className={styles['partners-content-section']}>
             <div className={styles.container}>
                 <div className={styles['partners-header']}>
-                    <h2 className={styles['section-title']}>{section.title}</h2>
-                    <p className={styles['section-description']}>{section.description}</p>
+                    <h2 className={styles['section-title']}>{title}</h2>
+                    <p className={styles['section-description']}>{description}</p>
                 </div>
                 <div className={styles['partners-logos']}>
-                    {section.partners.map((partner) => (
-                        <div key={partner.id} className={styles['partner-item']}>
-                            <img
-                                src={getImageSrc(partner.image)}
-                                alt={`${partner.id} logo`}
-                                className={styles['partner-logo']}
-                            />
-                            <p className={styles['partner-name']}>{partner.description}</p>
-                        </div>
-                    ))}
+                    {section.partners.map((partner) => {
+                        const translatedDescription = partner.localizations?.find(
+                            (localization) => localization.localizationInfoDto.code === currentLanguage,
+                        )?.description;
+
+                        return (
+                            <div key={partner.id} className={styles['partner-item']}>
+                                <img
+                                    src={getImageSrc(partner.image)}
+                                    alt={`${partner.id} logo`}
+                                    className={styles['partner-logo']}
+                                />
+                                <p className={styles['partner-name']}>{translatedDescription ?? partner.description}</p>
+                            </div>
+                        );
+                    })}
                 </div>
             </div>
         </section>

--- a/src/pages/public/partners-page/partners-sections/partners-section/PartnersSection.tsx
+++ b/src/pages/public/partners-page/partners-sections/partners-section/PartnersSection.tsx
@@ -37,7 +37,7 @@ export const PartnersSection = ({ section }: PartnersSectionProps) => {
                 <div className={styles['partners-logos']}>
                     {section.partners.map((partner) => {
                         const translatedDescription = partner.localizations?.find(
-                            (localization) => localization.localizationInfoDto.code === currentLanguage,
+                            (localization) => localization.localizationInfoDto?.code === currentLanguage,
                         )?.description;
 
                         return (

--- a/src/services/api/admin/partners/partner-section-localizations-api.test.ts
+++ b/src/services/api/admin/partners/partner-section-localizations-api.test.ts
@@ -1,0 +1,159 @@
+import { PartnerSectionLocalizationApi } from './partner-section-localizations-api';
+import { API_ROUTES } from '@/const/common/api-routes/main-api';
+import {
+    CreatePartnerSectionLocalizationDto,
+    PartnerSectionLocalizationDto,
+    UpdatePartnerSectionLocalizationDto,
+} from '@/types/admin/partners';
+import { LocalizationInfo, TranslationStatus } from '@/types/common/language';
+
+describe('PartnerSectionLocalizationApi.get', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should call client.get with correct url and return response data', async () => {
+        const mockClient = {
+            get: jest.fn(),
+        };
+
+        const mockResponseData: PartnerSectionLocalizationDto = {
+            entityId: 1,
+            title: 'Section title',
+            description: 'Translated section description',
+            partners: [{ partnerId: 5, description: 'Translated partner description' }],
+            localizationInfoDto: {
+                id: 2,
+                code: 'en',
+                name: 'English',
+            } as LocalizationInfo,
+            translationStatus: TranslationStatus.Relevant,
+        };
+
+        mockClient.get.mockResolvedValueOnce({ data: mockResponseData });
+
+        const result = await PartnerSectionLocalizationApi.get(mockClient as any, 1, 2);
+
+        expect(mockClient.get).toHaveBeenCalledTimes(1);
+        expect(mockClient.get).toHaveBeenCalledWith(`${API_ROUTES.PARTNER_SECTION_LOCALIZATIONS.BASE}/1/2`);
+        expect(result).toEqual(mockResponseData);
+    });
+
+    it('should return null when the API responds with 404', async () => {
+        const mockClient = {
+            get: jest.fn(),
+        };
+
+        const notFoundError = {
+            isAxiosError: true,
+            response: { status: 404 },
+        };
+
+        mockClient.get.mockRejectedValueOnce(notFoundError);
+
+        const result = await PartnerSectionLocalizationApi.get(mockClient as any, 1, 2);
+
+        expect(result).toBeNull();
+    });
+
+    it('should rethrow when the error is not a 404', async () => {
+        const mockClient = {
+            get: jest.fn(),
+        };
+
+        const serverError = {
+            isAxiosError: true,
+            response: { status: 500 },
+        };
+
+        mockClient.get.mockRejectedValueOnce(serverError);
+
+        await expect(PartnerSectionLocalizationApi.get(mockClient as any, 1, 2)).rejects.toEqual(serverError);
+    });
+});
+
+describe('PartnerSectionLocalizationApi.create', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should call client.post with correct url and payload and return response data', async () => {
+        const mockClient = {
+            post: jest.fn(),
+        };
+
+        const payload: CreatePartnerSectionLocalizationDto = {
+            entityId: 1,
+            languageId: 2,
+            title: 'Section title',
+            description: 'Translated section description',
+            partners: [{ partnerId: 5, description: 'Translated partner description' }],
+        };
+
+        const mockResponseData: PartnerSectionLocalizationDto = {
+            entityId: 1,
+            title: 'Section title',
+            description: 'Translated section description',
+            partners: [{ partnerId: 5, description: 'Translated partner description' }],
+            localizationInfoDto: {
+                id: 2,
+                code: 'en',
+                name: 'English',
+            } as LocalizationInfo,
+            translationStatus: TranslationStatus.Relevant,
+        };
+
+        mockClient.post.mockResolvedValueOnce({ data: mockResponseData });
+
+        const result = await PartnerSectionLocalizationApi.create(mockClient as any, payload);
+
+        expect(mockClient.post).toHaveBeenCalledTimes(1);
+        expect(mockClient.post).toHaveBeenCalledWith(API_ROUTES.PARTNER_SECTION_LOCALIZATIONS.BASE, payload);
+        expect(result).toEqual(mockResponseData);
+    });
+});
+
+describe('PartnerSectionLocalizationApi.update', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should call client.put with correct url and payload and return response data', async () => {
+        const mockClient = {
+            put: jest.fn(),
+        };
+
+        const entityId = 1;
+        const languageId = 2;
+
+        const payload: UpdatePartnerSectionLocalizationDto = {
+            title: 'Updated section title',
+            description: 'Updated section description',
+            partners: [{ partnerId: 5, description: 'Updated partner description' }],
+        };
+
+        const mockResponseData: PartnerSectionLocalizationDto = {
+            entityId,
+            title: 'Updated section title',
+            description: 'Updated section description',
+            partners: [{ partnerId: 5, description: 'Updated partner description' }],
+            localizationInfoDto: {
+                id: languageId,
+                code: 'en',
+                name: 'English',
+            } as LocalizationInfo,
+            translationStatus: TranslationStatus.Relevant,
+        };
+
+        mockClient.put.mockResolvedValueOnce({ data: mockResponseData });
+
+        const result = await PartnerSectionLocalizationApi.update(mockClient as any, entityId, languageId, payload);
+
+        expect(mockClient.put).toHaveBeenCalledTimes(1);
+        expect(mockClient.put).toHaveBeenCalledWith(
+            `${API_ROUTES.PARTNER_SECTION_LOCALIZATIONS.BASE}/${entityId}/${languageId}`,
+            payload,
+        );
+        expect(result).toEqual(mockResponseData);
+    });
+});

--- a/src/services/api/admin/partners/partner-section-localizations-api.ts
+++ b/src/services/api/admin/partners/partner-section-localizations-api.ts
@@ -1,0 +1,52 @@
+import { AxiosInstance } from 'axios';
+import axios from 'axios';
+import { API_ROUTES } from '@/const/common/api-routes/main-api';
+import {
+    CreatePartnerSectionLocalizationDto,
+    PartnerSectionLocalizationDto,
+    UpdatePartnerSectionLocalizationDto,
+} from '@/types/admin/partners';
+
+export const PartnerSectionLocalizationApi = {
+    get: async (
+        client: AxiosInstance,
+        entityId: number,
+        languageId: number,
+    ): Promise<PartnerSectionLocalizationDto | null> => {
+        try {
+            const response = await client.get<PartnerSectionLocalizationDto>(
+                `${API_ROUTES.PARTNER_SECTION_LOCALIZATIONS.BASE}/${entityId}/${languageId}`,
+            );
+            return response.data;
+        } catch (error) {
+            if (axios.isAxiosError(error) && error.response?.status === 404) {
+                return null;
+            }
+            throw error;
+        }
+    },
+
+    create: async (
+        client: AxiosInstance,
+        data: CreatePartnerSectionLocalizationDto,
+    ): Promise<PartnerSectionLocalizationDto> => {
+        const response = await client.post<PartnerSectionLocalizationDto>(
+            API_ROUTES.PARTNER_SECTION_LOCALIZATIONS.BASE,
+            data,
+        );
+        return response.data;
+    },
+
+    update: async (
+        client: AxiosInstance,
+        entityId: number,
+        languageId: number,
+        data: UpdatePartnerSectionLocalizationDto,
+    ): Promise<PartnerSectionLocalizationDto> => {
+        const response = await client.put<PartnerSectionLocalizationDto>(
+            `${API_ROUTES.PARTNER_SECTION_LOCALIZATIONS.BASE}/${entityId}/${languageId}`,
+            data,
+        );
+        return response.data;
+    },
+};

--- a/src/services/api/admin/partners/partners-api.test.ts
+++ b/src/services/api/admin/partners/partners-api.test.ts
@@ -170,6 +170,7 @@ describe('PartnersApi (admin)', () => {
                                 imageId: dto.sections[0].partners[0].image?.id ?? null,
                             },
                         ],
+                        localizations: [],
                     },
                 ],
             };
@@ -204,6 +205,7 @@ describe('PartnersApi (admin)', () => {
                     title: 'First',
                     description: 'Desc',
                     partners: [{ id: 2, description: 'Partner', image: sectionsDto[0].partners[0].image, imageId: 3 }],
+                    localizations: [],
                 },
             ];
             expect(result).toEqual(expected);
@@ -269,6 +271,7 @@ describe('PartnersApi (admin)', () => {
                         imageId: responseDto.partners[0].image?.id ?? null,
                     },
                 ],
+                localizations: [],
             };
             expect(result).toEqual(expected);
         });
@@ -336,6 +339,7 @@ describe('PartnersApi (admin)', () => {
                     image: partner.image,
                     imageId: partner.image?.id ?? null,
                 })),
+                localizations: [],
             };
             expect(updated).toEqual(expected);
         });

--- a/src/services/api/admin/partners/partners-api.test.ts
+++ b/src/services/api/admin/partners/partners-api.test.ts
@@ -34,6 +34,7 @@ describe('PartnersApi (admin)', () => {
                 title: 'Banner title',
                 description: 'Banner description',
                 image: { id: 5, url: 'https://img', mimeType: 'image/png' },
+                localizations: [],
             };
 
             mockClient.get.mockResolvedValueOnce({ data: bannerDto });
@@ -42,10 +43,12 @@ describe('PartnersApi (admin)', () => {
 
             expect(mockClient.get).toHaveBeenCalledWith(API_ROUTES.PARTNERS.BANNER);
             const expected: PartnerBanner = {
+                id: bannerDto.id,
                 title: bannerDto.title,
                 description: bannerDto.description,
                 image: bannerDto.image,
                 imageId: bannerDto.image?.id ?? null,
+                localizations: [],
             };
             expect(result).toEqual(expected);
         });
@@ -67,6 +70,7 @@ describe('PartnersApi (admin)', () => {
                 title: request.title,
                 description: request.description,
                 image: { id: 7, url: 'https://new-image', mimeType: 'image/png' },
+                localizations: [],
             };
             mockClient.put.mockResolvedValueOnce({ data: responseDto });
 
@@ -81,10 +85,12 @@ describe('PartnersApi (admin)', () => {
             expect(mockedImageApi.delete).toHaveBeenCalledWith(mockClient, 3);
 
             const expected: PartnerBanner = {
+                id: responseDto.id,
                 title: responseDto.title,
                 description: responseDto.description,
                 image: responseDto.image,
                 imageId: responseDto.image?.id ?? null,
+                localizations: [],
             };
             expect(result).toEqual(expected);
         });
@@ -144,10 +150,12 @@ describe('PartnersApi (admin)', () => {
 
             const expected: PartnersPageData = {
                 banner: {
+                    id: dto.banner.id,
                     title: dto.banner.title,
                     description: dto.banner.description,
                     image: dto.banner.image,
                     imageId: dto.banner.image?.id ?? null,
+                    localizations: [],
                 },
                 sections: [
                     {

--- a/src/services/api/admin/partners/partners-banner-localizations-api.test.ts
+++ b/src/services/api/admin/partners/partners-banner-localizations-api.test.ts
@@ -1,0 +1,94 @@
+import { PartnerBannerLocalizationApi } from './partners-banner-localizations-api';
+import { API_ROUTES } from '@/const/common/api-routes/main-api';
+import {
+    CreatePartnerBannerLocalizationDto,
+    PartnerBannerLocalizationDto,
+    UpdatePartnerBannerLocalizationDto,
+} from '@/types/admin/partners';
+import { LocalizationInfo, TranslationStatus } from '@/types/common/language';
+
+describe('PartnerBannerLocalizationApi.create', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should call client.post with correct url and payload and return response data', async () => {
+        const mockClient = {
+            post: jest.fn(),
+        };
+
+        const payload: CreatePartnerBannerLocalizationDto = {
+            entityId: 1,
+            languageId: 2,
+            title: 'Banner title',
+            description: 'Translated banner description',
+        };
+
+        const mockResponseData: PartnerBannerLocalizationDto = {
+            entityId: 1,
+            title: 'Banner title',
+            description: 'Translated banner description',
+            localizationInfoDto: {
+                id: 2,
+                code: 'en',
+                name: 'English',
+            } as LocalizationInfo,
+            translationStatus: TranslationStatus.Relevant,
+        };
+
+        mockClient.post.mockResolvedValueOnce({
+            data: mockResponseData,
+        });
+
+        const result = await PartnerBannerLocalizationApi.create(mockClient as any, payload);
+
+        expect(mockClient.post).toHaveBeenCalledTimes(1);
+        expect(mockClient.post).toHaveBeenCalledWith(API_ROUTES.PARTNERS_PAGE_BANNER_LOCALIZATIONS.BASE, payload);
+        expect(result).toEqual(mockResponseData);
+    });
+});
+
+describe('PartnerBannerLocalizationApi.update', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should call client.put with correct url and payload and return response data', async () => {
+        const mockClient = {
+            put: jest.fn(),
+        };
+
+        const entityId = 1;
+        const languageId = 2;
+
+        const payload: UpdatePartnerBannerLocalizationDto = {
+            title: 'Updated banner title',
+            description: 'Updated banner description',
+        };
+
+        const mockResponseData: PartnerBannerLocalizationDto = {
+            entityId,
+            title: 'Updated banner title',
+            description: 'Updated banner description',
+            localizationInfoDto: {
+                id: languageId,
+                code: 'en',
+                name: 'English',
+            } as LocalizationInfo,
+            translationStatus: TranslationStatus.Relevant,
+        };
+
+        mockClient.put.mockResolvedValueOnce({
+            data: mockResponseData,
+        });
+
+        const result = await PartnerBannerLocalizationApi.update(mockClient as any, entityId, languageId, payload);
+
+        expect(mockClient.put).toHaveBeenCalledTimes(1);
+        expect(mockClient.put).toHaveBeenCalledWith(
+            `${API_ROUTES.PARTNERS_PAGE_BANNER_LOCALIZATIONS.BASE}/${entityId}/${languageId}`,
+            payload,
+        );
+        expect(result).toEqual(mockResponseData);
+    });
+});

--- a/src/services/api/admin/partners/partners-banner-localizations-api.ts
+++ b/src/services/api/admin/partners/partners-banner-localizations-api.ts
@@ -1,0 +1,33 @@
+import { API_ROUTES } from '@/const/common/api-routes/main-api';
+import {
+    CreatePartnerBannerLocalizationDto,
+    PartnerBannerLocalizationDto,
+    UpdatePartnerBannerLocalizationDto,
+} from '@/types/admin/partners';
+import { AxiosInstance } from 'axios';
+
+export const PartnerBannerLocalizationApi = {
+    create: async (
+        client: AxiosInstance,
+        data: CreatePartnerBannerLocalizationDto,
+    ): Promise<PartnerBannerLocalizationDto> => {
+        const response = await client.post<PartnerBannerLocalizationDto>(
+            API_ROUTES.PARTNERS_PAGE_BANNER_LOCALIZATIONS.BASE,
+            data,
+        );
+        return response.data;
+    },
+
+    update: async (
+        client: AxiosInstance,
+        entityId: number,
+        languageId: number,
+        data: UpdatePartnerBannerLocalizationDto,
+    ): Promise<PartnerBannerLocalizationDto> => {
+        const response = await client.put<PartnerBannerLocalizationDto>(
+            `${API_ROUTES.PARTNERS_PAGE_BANNER_LOCALIZATIONS.BASE}/${entityId}/${languageId}`,
+            data,
+        );
+        return response.data;
+    },
+};

--- a/src/types/admin/partners.ts
+++ b/src/types/admin/partners.ts
@@ -26,7 +26,7 @@ export type PartnerSection = {
     title: string;
     description: string;
     partners: Partner[];
-};
+} & EntityWithLocalizations<EntityLocalization>;
 
 export type PartnersPageData = {
     banner: PartnerBanner;
@@ -131,11 +131,42 @@ export interface PartnerDto {
     image: Image;
 }
 
-export interface PartnersSectionDto {
+export interface PartnersSectionDto extends EntityWithDtoLocalizations<EntityLocalizationDto> {
     id: number;
     title: string;
     description: string;
     partners: PartnerDto[];
+}
+
+export interface PartnerLocalizationDto {
+    partnerId: number;
+    description: string;
+}
+
+export interface PartnerLocalization {
+    entityId: number;
+    description: string;
+}
+
+export interface PartnerSectionLocalizationDto extends EntityLocalizationDto {
+    entityId: number;
+    title: string;
+    description: string;
+    partners: PartnerLocalizationDto[];
+}
+
+export interface CreatePartnerSectionLocalizationDto {
+    entityId: number;
+    languageId: number;
+    title: string;
+    description: string;
+    partners: PartnerLocalizationDto[];
+}
+
+export interface UpdatePartnerSectionLocalizationDto {
+    title: string;
+    description: string;
+    partners: PartnerLocalizationDto[];
 }
 
 export interface PartnersPageDataDto {

--- a/src/types/admin/partners.ts
+++ b/src/types/admin/partners.ts
@@ -1,11 +1,18 @@
+import {
+    EntityLocalization,
+    EntityLocalizationDto,
+    EntityWithDtoLocalizations,
+    EntityWithLocalizations,
+} from '../common/language';
 import { Image, ImageValues } from '../common/image';
 
 export type PartnerBanner = {
+    id: number;
     title: string;
     description: string;
     image: Image | ImageValues | null;
     imageId: number | null;
-};
+} & EntityWithLocalizations<PartnerBannerLocalization>;
 
 export type Partner = {
     id: number;
@@ -88,11 +95,34 @@ export interface UpdatePartnerBannerDto {
 }
 
 // Response DTO
-export interface PartnerBannerDto {
+export interface PartnerBannerDto extends EntityWithDtoLocalizations<PartnerBannerLocalizationDto> {
     id: number;
     title: string;
     description: string;
     image: Image | null;
+}
+
+export interface PartnerBannerLocalization extends EntityLocalization {
+    title: string;
+    description: string;
+}
+
+export interface PartnerBannerLocalizationDto extends EntityLocalizationDto {
+    entityId: number;
+    title: string;
+    description: string;
+}
+
+export interface CreatePartnerBannerLocalizationDto {
+    entityId: number;
+    languageId: number;
+    title: string;
+    description: string;
+}
+
+export interface UpdatePartnerBannerLocalizationDto {
+    title: string;
+    description: string;
 }
 
 export interface PartnerDto {

--- a/src/types/public/partners-page.ts
+++ b/src/types/public/partners-page.ts
@@ -24,10 +24,23 @@ export interface PartnerSection {
     title: string;
     description: string;
     partners: Partner[];
+    localizations?: PartnerSectionLocalizationDto[];
 }
 
 export interface Partner {
     id: number;
     description: string;
     image: Image;
+    localizations?: PartnerLocalizationDto[];
+}
+
+export interface PartnerLocalizationDto extends EntityLocalizationDto {
+    entityId: number;
+    description: string;
+}
+
+export interface PartnerSectionLocalizationDto extends EntityLocalizationDto {
+    entityId: number;
+    title: string;
+    description: string;
 }

--- a/src/types/public/partners-page.ts
+++ b/src/types/public/partners-page.ts
@@ -1,14 +1,22 @@
 import { Image } from '../common/image';
+import { EntityLocalizationDto } from '../common/language';
 
 export interface PartnerPage {
     banner: PartnersBanner;
     sections: PartnerSection[];
 }
 
+export interface PartnersBannerLocalizationDto extends EntityLocalizationDto {
+    entityId: number;
+    title: string;
+    description: string;
+}
+
 export interface PartnersBanner {
     title: string;
     description: string;
     image?: Image;
+    localizations?: PartnersBannerLocalizationDto[];
 }
 
 export interface PartnerSection {

--- a/src/utils/functions/mappers/admin/partner-mappers/partner-mappers.test.ts
+++ b/src/utils/functions/mappers/admin/partner-mappers/partner-mappers.test.ts
@@ -186,6 +186,7 @@ describe('partner-mapper', () => {
                         image: mockImage2,
                     },
                 ],
+                localizations: [],
             };
 
             const result = mapSectionDtoToSection(dto);
@@ -208,6 +209,7 @@ describe('partner-mapper', () => {
                         imageId: 2,
                     },
                 ],
+                localizations: [],
             });
         });
 
@@ -217,6 +219,7 @@ describe('partner-mapper', () => {
                 title: 'Empty Section',
                 description: 'Section with no partners',
                 partners: [],
+                localizations: [],
             };
 
             const result = mapSectionDtoToSection(dto);
@@ -226,7 +229,32 @@ describe('partner-mapper', () => {
                 title: 'Empty Section',
                 description: 'Section with no partners',
                 partners: [],
+                localizations: [],
             });
+        });
+
+        it('maps localizations from EntityLocalizationDto to EntityLocalization', () => {
+            const dto: PartnersSectionDto = {
+                id: 3,
+                title: 'Section Title',
+                description: 'Section description',
+                partners: [],
+                localizations: [
+                    {
+                        localizationInfoDto: { id: 2, code: 'en' },
+                        translationStatus: TranslationStatus.Relevant,
+                    },
+                ],
+            };
+
+            const result = mapSectionDtoToSection(dto);
+
+            expect(result.localizations).toEqual([
+                {
+                    language: { id: 2, code: 'en' },
+                    translationStatus: TranslationStatus.Relevant,
+                },
+            ]);
         });
     });
 
@@ -252,6 +280,7 @@ describe('partner-mapper', () => {
                                 image: mockImage,
                             },
                         ],
+                        localizations: [],
                     },
                     {
                         id: 2,
@@ -264,6 +293,7 @@ describe('partner-mapper', () => {
                                 image: mockImage2,
                             },
                         ],
+                        localizations: [],
                     },
                 ],
             };
@@ -292,6 +322,7 @@ describe('partner-mapper', () => {
                                 imageId: 1,
                             },
                         ],
+                        localizations: [],
                     },
                     {
                         id: 2,
@@ -305,6 +336,7 @@ describe('partner-mapper', () => {
                                 imageId: 2,
                             },
                         ],
+                        localizations: [],
                     },
                 ],
             });

--- a/src/utils/functions/mappers/admin/partner-mappers/partner-mappers.test.ts
+++ b/src/utils/functions/mappers/admin/partner-mappers/partner-mappers.test.ts
@@ -6,6 +6,7 @@ import {
 } from './partner-mappers';
 import { PartnerBannerDto, PartnerDto, PartnersPageDataDto, PartnersSectionDto } from '@/types/admin/partners';
 import { Image } from '@/types/common/image';
+import { TranslationStatus } from '@/types/common/language';
 
 describe('partner-mapper', () => {
     const mockImage: Image = {
@@ -71,15 +72,18 @@ describe('partner-mapper', () => {
                 title: 'Banner Title',
                 description: 'Banner description',
                 image: mockImage,
+                localizations: [],
             };
 
             const result = mapBannerDtoToBanner(dto);
 
             expect(result).toEqual({
+                id: 1,
                 title: 'Banner Title',
                 description: 'Banner description',
                 image: mockImage,
                 imageId: 1,
+                localizations: [],
             });
         });
 
@@ -89,15 +93,18 @@ describe('partner-mapper', () => {
                 title: 'Banner without image',
                 description: 'Banner description',
                 image: null,
+                localizations: [],
             };
 
             const result = mapBannerDtoToBanner(dto);
 
             expect(result).toEqual({
+                id: 2,
                 title: 'Banner without image',
                 description: 'Banner description',
                 image: null,
                 imageId: null,
+                localizations: [],
             });
         });
 
@@ -111,11 +118,13 @@ describe('partner-mapper', () => {
                     url: 'https://example.com/image.jpg',
                     mimeType: 'image/jpeg',
                 },
+                localizations: [],
             };
 
             const result = mapBannerDtoToBanner(dto);
 
             expect(result).toEqual({
+                id: 3,
                 title: 'Banner Title',
                 description: 'Banner description',
                 image: {
@@ -124,7 +133,38 @@ describe('partner-mapper', () => {
                     mimeType: 'image/jpeg',
                 },
                 imageId: null,
+                localizations: [],
             });
+        });
+
+        it('maps localizations from PartnerBannerLocalizationDto to PartnerBannerLocalization', () => {
+            const dto: PartnerBannerDto = {
+                id: 4,
+                title: 'Banner Title',
+                description: 'Banner description',
+                image: mockImage,
+                localizations: [
+                    {
+                        entityId: 4,
+                        title: 'Banner Title EN',
+                        description: 'Banner description EN',
+                        localizationInfoDto: { id: 2, code: 'en' },
+                        translationStatus: TranslationStatus.Relevant,
+                    },
+                ],
+            };
+
+            const result = mapBannerDtoToBanner(dto);
+
+            expect(result.localizations).toEqual([
+                {
+                    entityId: 4,
+                    title: 'Banner Title EN',
+                    description: 'Banner description EN',
+                    language: { id: 2, code: 'en' },
+                    translationStatus: TranslationStatus.Relevant,
+                },
+            ]);
         });
     });
 
@@ -198,6 +238,7 @@ describe('partner-mapper', () => {
                     title: 'Banner Title',
                     description: 'Banner description',
                     image: mockImage,
+                    localizations: [],
                 },
                 sections: [
                     {
@@ -231,10 +272,12 @@ describe('partner-mapper', () => {
 
             expect(result).toEqual({
                 banner: {
+                    id: 1,
                     title: 'Banner Title',
                     description: 'Banner description',
                     image: mockImage,
                     imageId: 1,
+                    localizations: [],
                 },
                 sections: [
                     {
@@ -274,6 +317,7 @@ describe('partner-mapper', () => {
                     title: 'Banner Title',
                     description: 'Banner description',
                     image: null,
+                    localizations: [],
                 },
                 sections: [],
             };
@@ -282,10 +326,12 @@ describe('partner-mapper', () => {
 
             expect(result).toEqual({
                 banner: {
+                    id: 1,
                     title: 'Banner Title',
                     description: 'Banner description',
                     image: null,
                     imageId: null,
+                    localizations: [],
                 },
                 sections: [],
             });
@@ -298,6 +344,7 @@ describe('partner-mapper', () => {
                     title: 'Banner Title',
                     description: 'Banner description',
                     image: mockImage,
+                    localizations: [],
                 },
                 sections: [],
             };
@@ -306,10 +353,12 @@ describe('partner-mapper', () => {
 
             expect(result).toEqual({
                 banner: {
+                    id: 1,
                     title: 'Banner Title',
                     description: 'Banner description',
                     image: mockImage,
                     imageId: 1,
+                    localizations: [],
                 },
                 sections: [],
             });

--- a/src/utils/functions/mappers/admin/partner-mappers/partner-mappers.ts
+++ b/src/utils/functions/mappers/admin/partner-mappers/partner-mappers.ts
@@ -22,6 +22,7 @@ export const mapSectionDtoToSection = (dto: PartnersSectionDto): PartnerSection 
     title: dto.title,
     description: dto.description,
     partners: dto.partners.map(mapPartnerDtoToPartner),
+    localizations: (dto.localizations ?? []).map(mapLocalizationDtoToModel),
 });
 
 export const mapBannerDtoToBanner = (dto: PartnerBannerDto): PartnerBanner => ({

--- a/src/utils/functions/mappers/admin/partner-mappers/partner-mappers.ts
+++ b/src/utils/functions/mappers/admin/partner-mappers/partner-mappers.ts
@@ -8,6 +8,7 @@ import {
     Partner,
     PartnerSection,
 } from '@/types/admin/partners';
+import { mapLocalizationDtoToModel } from '@/utils/functions/mappers/common/localization/localization-mappers';
 
 export const mapPartnerDtoToPartner = (dto: PartnerDto): Partner => ({
     id: dto.id,
@@ -24,10 +25,12 @@ export const mapSectionDtoToSection = (dto: PartnersSectionDto): PartnerSection 
 });
 
 export const mapBannerDtoToBanner = (dto: PartnerBannerDto): PartnerBanner => ({
+    id: dto.id,
     title: dto.title,
     description: dto.description,
     image: dto.image,
     imageId: dto.image?.id ?? null,
+    localizations: (dto.localizations ?? []).map(mapLocalizationDtoToModel),
 });
 
 export const mapPartnerPageDataDtoToPageData = (dto: PartnersPageDataDto): PartnersPageData => ({


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2542)
*  [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2543)
*  [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2544)
*  [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2545)
*  [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2547)
*  [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2548)
*  [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2549)
*  [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2550)
*  [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2551)
*  [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2553)
*  [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2554)
* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2585)

## Description

This PR adds full translation support to the Партнери (Partners) admin page: dedicated translate modals for the banner and each partner section, plus a page-level language switcher that renders the whole page in a read-only translated view — bringing Partners in line with how Team, Programs, and other content pages already handle localization.

## Summary of change

*   **Banner Translation Modal (`TranslatePartnerBannerModal.tsx`, `useTranslatePartnerBanner.ts`)**: Add/edit a title + description translation for the Partners banner via the existing `PartnersPageBannerLocalizations` endpoints.
*   **Partner Section Translation Modal (`TranslatePartnerSectionModal.tsx`, `useTranslatePartnerSection.ts`, `partner-section-localizations-api.ts`)**: Bundles a section's title/description and every partner's description into one save, using the new `PartnerSectionLocalizations` endpoints — a `404` on fetch drives Add vs. Edit mode.
*   **"Мова" Language Dropdown (`PartnerPageToolbar.tsx`, `PartnerPanelContent.tsx`)**: Page-level language selector (defaults to Українська). Selecting a translated language shows banner/section/partner content read-only across the whole page — fields and images disabled, rich-text toolbar hidden, **"Опублікувати"** hidden — and disables structural actions (Add Section / Add Partner / Delete Section) so admins cannot create blank cards they cannot yet fill in.
*   **Test Coverage Expansion (`*.test.tsx`)**: New and updated tests across all touched components and hooks covering translation flows, language-gating, and the section-translation fetch behavior, keeping project coverage thresholds intact.

## How to recreate changes

1. Log into the Admin panel and navigate to **"Партнери"**.
2. **Banner translation**: Click the translate icon on the banner's top row, fill in EN title/description , save, verify the status badge turns green and a success toast appears.
3. **Section translation**: Click the translate icon on a saved section, fill in the section and partner descriptions, save, verify the badge updates. Add a new partner to the section, publish it, then reopen the translate modal and confirm the new partner's row is empty while existing rows stay pre-filled.
4. Open the **"Мова"** dropdown, select **"Англійська"**, verify banner/section/partner fields and images are disabled, the rich-text toolbar is gone, **"Опублікувати"** is hidden, and the Add Section / Add Partner / Delete Section buttons are disabled.
5. Switch back to **"Українська"** ,verify all fields re-enable and publish buttons reappear.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multilingual editing and translation workflows for partner banners and sections.
  * Added language selection, translation status indicators, and translation forms.
  * Restricted structural editing and publishing to the base language.
  * Added retry actions when language data fails to load.

* **Bug Fixes**
  * Preserved existing localizations during updates.
  * Improved loading, validation, disabled-state, and error handling.
  * Added user-facing translation and localization error messages.

* **Tests**
  * Expanded coverage for multilingual editing, translation flows, and error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->