### PR TITLE
Feature/issue-1853 [Programs] Validate program category translation

### DIFF
--- a/src/const/admin/programs.ts
+++ b/src/const/admin/programs.ts
@@ -113,9 +113,9 @@ export const PROGRAM_VALIDATION = {
 
 export const PROGRAM_CATEGORY_VALIDATION = {
     name: {
-        min: 5,
+        min: 2,
         max: 20,
-        getRequiredError: () => "Назва обов'язкова",
+        getRequiredError: () => "Поле обов'язкове",
         getCategoryWithThisNameAlreadyExistsError: () =>
             COMMON_TEXT_ADMIN.CATEGORIES.FORM.MESSAGE.ALREADY_CONTAIN_CATEGORY_WITH_NAME,
     },

--- a/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.test.ts
+++ b/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.test.ts
@@ -194,7 +194,7 @@ describe('useProgramExpenseRecordForm', () => {
         const { result } = renderUseProgramExpenseForm();
 
         act(() => {
-            result.current.handleProgramInputChange('ab');
+            result.current.handleProgramInputChange('a');
         });
         act(() => {
             result.current.handleProgramBlur();

--- a/src/pages/admin/programs/components/program-category-modals/ProgramCategoryModal.test.tsx
+++ b/src/pages/admin/programs/components/program-category-modals/ProgramCategoryModal.test.tsx
@@ -191,7 +191,7 @@ describe('ProgramCategoryModal - Add Mode', () => {
     it('prevents submit when validation errors exist (e.g., too short)', () => {
         renderModal();
 
-        typeName('Abc');
+        typeName('A');
         fireEvent.click(getSaveButton());
 
         // Save does not proceed due to validation, API should not be called


### PR DESCRIPTION
## Github ticket

  * https://github.com/ita-social-projects/VictoryCenter-Back/issues/1853

  ## Description

  Updated the program category name validation rules and error messages in accordance with acceptance criteria so
  that category name inputs are validated consistently in real-time and on focus shift.

  ## Summary of change

  • Updated PROGRAM_CATEGORY_VALIDATION.name.min to 2 characters (previously 5).
  • Updated PROGRAM_CATEGORY_VALIDATION.name.getRequiredError to return "Поле обов'язкове".
  • Updated unit test assertions in ProgramCategoryModal.test.tsx for minimum length checks.

  ## How to recreate changes

  1. Open the Admin Programs page.
  2. Open the Category modal ("Додати категорію" or "Редагувати категорію").
  3. Type a 1-character name and shift focus or submit -> observe error message "Не менше 2 символів".
  4. Clear the field -> observe error message "Поле обов'язкове".
  5. Enter more than 20 characters -> observe real-time error message "Не більше 20 символів".

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Category names can now be as short as two characters.
  * Updated the required-field validation message in Ukrainian.
  * Prevented saving categories with names shorter than the minimum length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->