### PR TITLE
fix/issue-2703 [Programs] Incorrect default filter label displayed on Programs page ("Усі" instead of "ВСІ")

### DIFF
--- a/src/locales/uk/programs.json
+++ b/src/locales/uk/programs.json
@@ -5,7 +5,7 @@
     "PROGRAMS": "Програми",
     "PROGRAMS_FOR_KIDS": "Дитячі",
     "PROGRAMS_FOR_VETERANS": "Ветеранські",
-    "PROGRAMS_ALL": "Усі",
+    "PROGRAMS_ALL": "Всі",
     "CONTACT": "Зв'язатись",
     "ABOUT_PROGRAMS": "Наші програми — це про повернення до себе і віднайдення внутрішньої сили. Через коня, через тіло, через простір, у якому можна знову довіряти — собі й життю.",
     "VICTORY_CENTER_BELIEF.FIRST_LINE": "У Victory Center ми віримо: зцілення починається не зі слів, а з тиші, ",


### PR DESCRIPTION
## Github ticket

* [2703](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2703)

## Description

The main goal of this PR is to fix a grammatical issue in the Ukrainian localization. It corrects the translation for the "All" button in the Programs section to ensure better natural language flow.

## How it looks

The button text on the UI for selecting all programs now displays "Всі" instead of "Усі" when the Ukrainian language is active.
<img width="1300" height="87" alt="image" src="https://github.com/user-attachments/assets/282baeb1-245b-45e6-89a9-0a5b56691f73" />

## Summary of change

* Updated the `PROGRAMS_ALL` translation key in `src/locales/uk/programs.json` from `"Усі"` to `"Всі"`.

## How to recreate changes

1. Run the application locally.
2. Set the application language to Ukrainian.
3. Navigate to the Programs page/section.
4. Verify that the filter button for all programs now says "Всі".

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Ukrainian language localization with translation refinement for enhanced linguistic accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->