### PR TITLE
fix/issue-2641 [Programs] The placeholder in the search field does not match the mockup

### DIFF
--- a/src/const/admin/programs.ts
+++ b/src/const/admin/programs.ts
@@ -5,7 +5,7 @@ export const PROGRAMS_TEXT = {
         ADD_PROGRAM: 'Додати програму',
     },
     PLACEHOLDER: {
-        SEARCH_PROGRAMS: 'Шукати програми...',
+        SEARCH_PROGRAMS: 'Введіть назву',
         INSERT_PROGRAM_NAME: 'Введіть назву програми',
         INSERT_PROGRAM_LOCATION: 'Введіть місце проведення',
         INSERT_PROGRAM_PARTICIPANTS_COUNT: 'Введіть кількість учасників',


### PR DESCRIPTION
## Github ticket

* [2641](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2641)

## Description

The main goal of this PR is to update the placeholder text for the program search input field in the admin panel to provide a more accurate instruction to the user.

## How it looks

<img width="1891" height="145" alt="image" src="https://github.com/user-attachments/assets/f88fb4fd-425c-4a81-9871-920cb74dd82a" />

## Summary of change

* Updated the `SEARCH_PROGRAMS` property within the `PROGRAMS_TEXT.PLACEHOLDER` constant in `src/const/admin/programs.ts`.
* Changed the placeholder string from `'Шукати програми...'` to `'Введіть назву'`.

## How to recreate changes

1. Pull the changes and run the application locally.
2. Log in and navigate to the Admin panel.
3. Go to the "Programs" page/section.
4. Locate the search input field and verify that the placeholder text now displays as "Введіть назву".

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions
