### PR TITLE
fix/issue-2872 [Team Page] [Admin Panel] [Add Category] The "Опис" field validates a minimum length of 10 characters instead of 5

### DIFF
--- a/src/const/admin/team.ts
+++ b/src/const/admin/team.ts
@@ -107,7 +107,7 @@ export const TEAM_IMAGE_PLACEHOLDER = {
 
 export const TEAM_CATEGORY_VALIDATION = {
     name: {
-        min: 5,
+        min: 10,
         max: 20,
         getRequiredError: () => 'Назва обов’язкова',
         getMinError: () => `Не менше ${TEAM_CATEGORY_VALIDATION.name.min} символів`,


### PR DESCRIPTION
## Github ticket

* [2872](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2872)

## Description

The main goal of this PR is to update the minimum character length validation for team category names in the admin panel.

## How it looks

<img width="577" height="507" alt="image" src="https://github.com/user-attachments/assets/dadad7cd-14e7-4a17-9997-9cff02ec7d3c" />

## Summary of change

* Updated the `TEAM_CATEGORY_VALIDATION` constant in `src/const/admin/team.ts`.
* Increased the `min` length constraint for the `name` field from `5` to `10`.

## How to recreate changes

1. Pull the changes and run the application locally.
2. Log in and navigate to the Admin panel.
3. Go to the Team Categories management section.
4. Attempt to add a team category using a name with fewer than 10 characters.
5. Verify that a validation error is displayed, indicating the new minimum length requirement.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions