### PR TITLE
fix/issue-2937 [Programs] "Видалити категорію?" pop up contains incorrect button labels

### DIFF
--- a/src/pages/admin/programs/components/program-category-modals/DeleteCategoryConfirmModal.test.tsx
+++ b/src/pages/admin/programs/components/program-category-modals/DeleteCategoryConfirmModal.test.tsx
@@ -31,8 +31,8 @@ describe('DeleteCategoryConfirmModal', () => {
     const renderModal = (overrideProps = {}) =>
         render(<DeleteCategoryConfirmModal {...defaultProps} {...overrideProps} />);
 
-    const getDeleteButton = () => screen.getByText(COMMON_TEXT_ADMIN.BUTTON.DELETE);
-    const getCancelButton = () => screen.getByText(COMMON_TEXT_ADMIN.BUTTON.CANCEL);
+    const getDeleteButton = () => screen.getByText(COMMON_TEXT_ADMIN.BUTTON.YES);
+    const getCancelButton = () => screen.getByText(COMMON_TEXT_ADMIN.BUTTON.NO);
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/src/pages/admin/programs/components/program-category-modals/DeleteCategoryConfirmModal.tsx
+++ b/src/pages/admin/programs/components/program-category-modals/DeleteCategoryConfirmModal.tsx
@@ -21,10 +21,10 @@ export const DeleteCategoryConfirmModal = ({
             <Modal.Title>{COMMON_TEXT_ADMIN.CATEGORIES.FORM.TITLE.DELETE_CATEGORY_CONFIRM}</Modal.Title>
             <Modal.Actions>
                 <Button buttonStyle="secondary" onClick={onClose} disabled={isSubmitting}>
-                    {COMMON_TEXT_ADMIN.BUTTON.CANCEL}
+                    {COMMON_TEXT_ADMIN.BUTTON.NO}
                 </Button>
                 <Button buttonStyle="primary" onClick={onConfirm} disabled={isSubmitting}>
-                    {COMMON_TEXT_ADMIN.BUTTON.DELETE}
+                    {COMMON_TEXT_ADMIN.BUTTON.YES}
                 </Button>
             </Modal.Actions>
         </Modal>


### PR DESCRIPTION
## Github ticket

* [2937](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2937)

## Description

The main goal of this PR is to update the button labels in the delete category confirmation modal to use "Yes" and "No" instead of "Delete" and "Cancel", providing a clearer and more conversational user experience.

## How it looks

<img width="572" height="168" alt="image" src="https://github.com/user-attachments/assets/b6e83f71-16de-4e5e-bbb4-0dd269a4df5a" />

## Summary of change

* Updated `DeleteCategoryConfirmModal.tsx` to use `COMMON_TEXT_ADMIN.BUTTON.NO` and `COMMON_TEXT_ADMIN.BUTTON.YES` constants instead of `CANCEL` and `DELETE`.
* Updated the corresponding test file `DeleteCategoryConfirmModal.test.tsx` to query for the new "Yes" and "No" button texts, ensuring the tests match the updated component.

## How to recreate changes

1. Pull the changes and run the application locally.
2. Log in and navigate to the Admin panel.
3. Go to the Programs -> Categories section.
4. Click the delete action for any category to trigger the confirmation modal.
5. Verify that the buttons on the modal now display as "Yes" (for confirm) and "No" (for cancel).
6. Run the test suite to ensure `DeleteCategoryConfirmModal.test.tsx` passes successfully.

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the category deletion confirmation dialog buttons to use clearer “Yes” and “No” labels.
  * Existing button behavior and disabled states remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->