### PR TITLE
Fix/issue 3109 [Reports] Math rounding rule violation: system incorrectly rounds up 'Сума (USD)' amount to 2 decimal places

### DIFF
--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.test.tsx
@@ -446,7 +446,7 @@ describe('AddProgramExpenseRecordModal', () => {
                     programName: 'Program A',
                     reportingYear: '2025',
                     amountUah: '200',
-                    amountUsd: '4,75', // auto calculated based on rate 42.15 and rounded up
+                    amountUsd: '4,74', // auto calculated based on rate 42.15 and rounded to two decimals
                 });
             });
         });

--- a/src/utils/functions/get-converted-amount/get-converted-amount.test.ts
+++ b/src/utils/functions/get-converted-amount/get-converted-amount.test.ts
@@ -25,6 +25,10 @@ describe('getConvertedAmount', () => {
         expect(getConvertedAmount('100', '45')).toBe('2,22');
     });
 
+    it('rounds half up when floating-point division introduces representation error (100.5 / 100 = 1.005)', () => {
+        expect(getConvertedAmount('100.5', '100')).toBe('1,01');
+    });
+
     it('should return null for empty or invalid source amount', () => {
         expect(getConvertedAmount('', '40')).toBeNull();
         expect(getConvertedAmount('   ', '40')).toBeNull();

--- a/src/utils/functions/get-converted-amount/get-converted-amount.test.ts
+++ b/src/utils/functions/get-converted-amount/get-converted-amount.test.ts
@@ -2,7 +2,7 @@ import { getConvertedAmount } from '@/utils/functions/get-converted-amount/get-c
 
 describe('getConvertedAmount', () => {
     it('returns USD when converting from UAH', () => {
-        expect(getConvertedAmount('500000', '42')).toBe('11904,77');
+        expect(getConvertedAmount('500000', '42')).toBe('11904,76');
     });
 
     it('returns null when exchange rate is empty', () => {
@@ -13,8 +13,16 @@ describe('getConvertedAmount', () => {
         expect(getConvertedAmount('1000', '0')).toBeNull();
     });
 
-    it('returns value rounded up to two decimals for UAH to USD conversion', () => {
-        expect(getConvertedAmount('100', '3')).toBe('33,34');
+    it('returns value rounded to two decimals for UAH to USD conversion', () => {
+        expect(getConvertedAmount('100', '3')).toBe('33,33');
+    });
+
+    it('rounds half up when the third decimal is exactly 5', () => {
+        expect(getConvertedAmount('89', '40')).toBe('2,23');
+    });
+
+    it('rounds down when the third decimal is less than 5', () => {
+        expect(getConvertedAmount('100', '45')).toBe('2,22');
     });
 
     it('should return null for empty or invalid source amount', () => {

--- a/src/utils/functions/get-converted-amount/get-converted-amount.ts
+++ b/src/utils/functions/get-converted-amount/get-converted-amount.ts
@@ -1,7 +1,7 @@
 import { parseAmount } from '@/utils/functions/parse-amount/parse-amount';
 import { formatNumberDecimalComma } from '@/utils/functions/formatters/format-number';
 
-const roundToTwoDecimals = (value: number): number => Math.round(value * 100) / 100;
+const roundToTwoDecimals = (value: number): number => Math.round((value + Number.EPSILON) * 100) / 100;
 
 export const getConvertedAmount = (value: string, exchangeRate: string | null | undefined): string | null => {
     const parsedExchangeRate = parseAmount(exchangeRate ?? '');

--- a/src/utils/functions/get-converted-amount/get-converted-amount.ts
+++ b/src/utils/functions/get-converted-amount/get-converted-amount.ts
@@ -1,7 +1,7 @@
 import { parseAmount } from '@/utils/functions/parse-amount/parse-amount';
 import { formatNumberDecimalComma } from '@/utils/functions/formatters/format-number';
 
-const roundUpToTwoDecimals = (value: number): number => Math.ceil(value * 100) / 100;
+const roundToTwoDecimals = (value: number): number => Math.round(value * 100) / 100;
 
 export const getConvertedAmount = (value: string, exchangeRate: string | null | undefined): string | null => {
     const parsedExchangeRate = parseAmount(exchangeRate ?? '');
@@ -17,7 +17,7 @@ export const getConvertedAmount = (value: string, exchangeRate: string | null | 
     const parsedCurrentAmount = parseAmount(value);
     const convertedAmount = parsedCurrentAmount / parsedExchangeRate;
 
-    const roundedConvertedAmount = roundUpToTwoDecimals(convertedAmount);
+    const roundedConvertedAmount = roundToTwoDecimals(convertedAmount);
 
     return Number.isFinite(roundedConvertedAmount) ? formatNumberDecimalComma(roundedConvertedAmount) : null;
 };

--- a/src/utils/functions/validate-usd-amount-mismatch/validate-usd-amount-mismatch.test.ts
+++ b/src/utils/functions/validate-usd-amount-mismatch/validate-usd-amount-mismatch.test.ts
@@ -1,8 +1,8 @@
 import { isUsdAmountMismatch } from '@/utils/functions/validate-usd-amount-mismatch/validate-usd-amount-mismatch';
 
 describe('isUsdAmountMismatch', () => {
-    it('returns false when USD matches UAH conversion rounded up to two decimals', () => {
-        expect(isUsdAmountMismatch('100', '2.39', '42')).toBe(false);
+    it('returns false when USD matches UAH conversion rounded to two decimals', () => {
+        expect(isUsdAmountMismatch('100', '2.38', '42')).toBe(false);
     });
 
     it('returns true when USD does not match UAH conversion', () => {
@@ -17,6 +17,6 @@ describe('isUsdAmountMismatch', () => {
     });
 
     it('supports spaces and comma decimal separator', () => {
-        expect(isUsdAmountMismatch('1 000,5', '23,83', '42')).toBe(false);
+        expect(isUsdAmountMismatch('1 000,5', '23,82', '42')).toBe(false);
     });
 });


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3109)

## Description

This PR fixes a rounding bug in the "Додати витрату" modal (Program Expenses and Funds Expenditures) where the auto-calculated Сума (USD) field used ceiling rounding instead of standard mathematical rounding. Any UAH amount whose conversion produced a third decimal digit below 5 was incorrectly rounded up, inflating the displayed USD amount.

## How it looks
<img width="538" height="667" alt="image" src="https://github.com/user-attachments/assets/7b61cd0c-e66f-46a4-8ada-c013b63e0520" />

## Summary of change

*   **Fixed rounding logic (`get-converted-amount.ts`)**: Replaced `Math.ceil(value * 100) / 100` with `Math.round(value * 100) / 100`, renaming `roundUpToTwoDecimals` → `roundToTwoDecimals` to reflect the corrected behavior. This function backs both the Program Expenses and Funds Expenditures record modals via the shared `updateFundsAmounts` utility, so the fix applies to both.
*   **Updated test expectations**: Corrected hardcoded expected USD values in `get-converted-amount.test.ts`, `validate-usd-amount-mismatch.test.ts`, and `AddProgramExpenseRecordModal.test.tsx` that had baked in the old ceiling behavior, and added explicit test cases for round-down (2.2222 → 2.22) and round-half-up (2.225 → 2.23) scenarios.

## How to recreate changes

1. Log into the Admin panel and open the **Reports** page, navigate to**Program Expenses** (or Funds Expenditures) and click **"Додати витрату"**.
2. Ensure the exchange rate shown is 45, then enter `100` in **Сума (UAH)**.
3. Observe that **Сума (USD)** now correctly displays `2.22` instead of the previous `2.23`.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved currency conversion rounding to use standard two-decimal rounding.
  * Corrected converted USD amounts and mismatch validation results for greater accuracy.
  * Updated expense editing behavior to reflect precise exchange-rate calculations.

* **Tests**
  * Expanded coverage for decimal precision, half-up rounding, and values below five.
  * Updated validation scenarios to match corrected conversion results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->