### PR TITLE
Fix/issue 2899 [Partners] [Admin] The snack-bar notification displays incorrect text after saving changes in the title section

### DIFF
--- a/src/const/admin/partners.ts
+++ b/src/const/admin/partners.ts
@@ -45,7 +45,7 @@ export const PARTNERS_TEXT = {
         SECTION_UPDATED: 'Секція успішно оновлена',
         SECTION_DELETED: 'Секція успішно видалена',
         SECTION_PUBLISHED: 'Секція успішно опублікована',
-        BANNER_SAVED: 'Банер успішно збережено',
+        BANNER_PUBLISHED: 'Зміни успішно опубліковано',
         FAIL_TO_LOAD_PARTNERS: 'Виникла помилка, не вдалося завантажити партнерів',
         FAIL_TO_UPDATE_BANNER: 'Виникла помилка під час оновлення банера',
         FAIL_TO_CREATE_SECTION: 'Виникла помилка під час створення секції',

--- a/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.test.tsx
+++ b/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.test.tsx
@@ -315,7 +315,7 @@ describe('PartnerBanner', () => {
         });
 
         await waitFor(() => {
-            expect(mockAddToast).toHaveBeenCalledWith(PARTNERS_TEXT.MESSAGE.BANNER_SAVED, ToastType.Success);
+            expect(mockAddToast).toHaveBeenCalledWith(PARTNERS_TEXT.MESSAGE.BANNER_PUBLISHED, ToastType.Success, 3000);
         });
 
         await waitFor(() => {

--- a/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.tsx
+++ b/src/pages/admin/partners/components/partner-banner-form/PartnerBannerForm.tsx
@@ -190,7 +190,7 @@ export const PartnerBanner = () => {
             setFormState({ values: updatedBanner, savedValues: updatedBanner });
             setTouched({});
             setErrors({});
-            addToast(PARTNERS_TEXT.MESSAGE.BANNER_SAVED, ToastType.Success);
+            addToast(PARTNERS_TEXT.MESSAGE.BANNER_PUBLISHED, ToastType.Success, 3000);
         } catch (error: any) {
             if (axios.isCancel?.(error) || error.name === 'CanceledError' || error.name === 'AbortError') {
                 return;


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2899)

## Description

This PR fixes a mismatched toast (snack-bar) message on the Partners page. After confirming publish via the "Так" button in the confirmation pop-up, the banner section displayed "Банер успішно збережено" instead of the standardized "Зміни успішно опубліковано" message that the UI kit mock-up specifies.

## How it looks
<img width="968" height="312" alt="image" src="https://github.com/user-attachments/assets/155791b6-dcbf-41f5-b4c1-68e27901ccdd" />

## Summary of change

*   **Corrected Toast Message (`partners.ts`)**: Replaced the `BANNER_SAVED` constant ('Банер успішно збережено') with `BANNER_PUBLISHED` ('Зміни успішно опубліковано'), aligning the Partners banner publish flow with the UI kit mock-up and with the message used by other admin publish flows.
*   **Aligned Toast Duration (`PartnerBannerForm.tsx`)**: Updated the `addToast` call in `handlePublishConfirm` to pass an explicit 3000ms duration, matching the convention used in Reports/Company Profile/Main Page (previously omitted here).

## How to recreate changes
1. Log into the Admin panel and navigate to the **Partners** page.
2. Click **"Опублікувати"** (Publish) in the banner title section.
3. In the opened pop-up, click **"Так"** (Yes).
4. Observe the snack-bar now displays *"Зміни успішно опубліковано"* instead of *"Банер успішно збережено"*.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions
