### PR TITLE
fix:/issue-2938 [Partners] Application displays wrong pop up label when Admin clicks on "Опублікувати" button

### DIFF
--- a/src/const/admin/partners.ts
+++ b/src/const/admin/partners.ts
@@ -12,7 +12,7 @@ export const PARTNERS_TEXT = {
         },
         TITLE: {
             DELETE_SECTION: 'Видалити секцію',
-            PUBLISH_SECTION: 'Опублікувати зміни?',
+            PUBLISH_SECTION: 'Опублікувати нову секцію?',
         },
         MESSAGE: {
             FAIL_TO_DELETE_PARTNER_SECTION: 'Виникла помилка під час видалення секції партнерів',


### PR DESCRIPTION
## Github ticket

* [2938](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2938)

## Description

The main goal of this PR is to update the title text for the publish action within the admin partners section. It clarifies the user interface by changing the prompt from a generic "Publish changes?" to a more specific "Publish new section?".

## How it looks

<img width="580" height="306" alt="image" src="https://github.com/user-attachments/assets/02c29592-4b0c-4be5-babc-0ef6e79d8acc" />

## Summary of change

* Modified `src/const/admin/partners.ts`.
* Updated the `PUBLISH_SECTION` constant inside `PARTNERS_TEXT.TITLE` from `'Опублікувати зміни?'` to `'Опублікувати нову секцію?'`.

## How to recreate changes

1. Log into the Admin panel.
2. Navigate to the Partners section.
3. Initiate the action to publish a section.
4. Observe the updated title text in the publish confirmation prompt, which should now display "Опублікувати нову секцію?".

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions