### PR TITLE
Fix/issue 3115 [Records] [Admin] The field 'Курс USD/UAH' accepts an integer starting with zero

### DIFF
--- a/src/validation/admin/reports-schema/funds-expenditures-exchange-rate-schema/funds-expenditures-exchange-rate-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-exchange-rate-schema/funds-expenditures-exchange-rate-schema.test.ts
@@ -45,6 +45,22 @@ describe('funds-expenditures-exchange-rate-schema', () => {
             );
         });
 
+        it('returns numeric validation for integer with a leading zero', () => {
+            expect(validateFundsExpendituresExchangeRate('012345678')).toBe(
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.EXCHANGE_RATE_ONLY_NUMERIC,
+            );
+        });
+
+        it('returns numeric validation for decimal with a leading zero before the comma', () => {
+            expect(validateFundsExpendituresExchangeRate('01,5')).toBe(
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.EXCHANGE_RATE_ONLY_NUMERIC,
+            );
+        });
+
+        it('accepts a single zero integer part followed by a decimal', () => {
+            expect(validateFundsExpendituresExchangeRate('0,5')).toBeUndefined();
+        });
+
         it('returns gt-zero validation for zero', () => {
             expect(validateFundsExpendituresExchangeRate('0')).toBe(
                 FUNDS_EXPENDITURES_TEXT.VALIDATION.EXCHANGE_RATE_GT_ZERO,

--- a/src/validation/admin/reports-schema/funds-expenditures-exchange-rate-schema/funds-expenditures-exchange-rate-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-exchange-rate-schema/funds-expenditures-exchange-rate-schema.ts
@@ -29,7 +29,7 @@ export const validateFundsExpendituresExchangeRate = (
         return trigger === 'blur' ? COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED : undefined;
     }
 
-    if (!/^\d+(?:,\d+)?$/.test(normalized)) {
+    if (!/^(0|[1-9]\d*)(?:,\d+)?$/.test(normalized)) {
         return FUNDS_EXPENDITURES_TEXT.VALIDATION.EXCHANGE_RATE_ONLY_NUMERIC;
     }
 

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
@@ -39,6 +39,22 @@ describe('FUNDS_EXPENDITURES_RECORD_VALIDATION_FUNCTIONS', () => {
             );
         });
 
+        it('should return numeric error for integer with a leading zero', () => {
+            expect(validateFundsExpendituresAmount('012345678', 'change')).toBe(
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER,
+            );
+        });
+
+        it('should return numeric error for decimal with a leading zero before the comma', () => {
+            expect(validateFundsExpendituresAmount('01,50', 'change')).toBe(
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER,
+            );
+        });
+
+        it('should accept a single zero integer part followed by a decimal', () => {
+            expect(validateFundsExpendituresAmount('0,50', 'change')).toBeUndefined();
+        });
+
         it('should return max digits error when integer part is too long', () => {
             expect(validateFundsExpendituresAmount('1234567890', 'change')).toBe(
                 FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DIGITS,

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
@@ -36,19 +36,27 @@ export const normalizeFundsExpendituresAmountInput = (value: string | undefined 
     return trimEnd ? normalized.trim() : normalized;
 };
 
+const exceedsMaxDecimalDigits = (value: string): boolean => {
+    if (!value) {
+        return false;
+    }
+
+    const withCommaSeparator = value.replaceAll(/\s+/g, ' ').trimStart().replaceAll('.', ',');
+    const firstCommaIndex = withCommaSeparator.indexOf(',');
+    if (firstCommaIndex === -1) {
+        return false;
+    }
+
+    const rawDecimalPart = withCommaSeparator.slice(firstCommaIndex + 1).replace(/[^\d]/g, '');
+    return rawDecimalPart.length > 2;
+};
+
 export const validateFundsExpendituresAmount = (
     value: string,
     trigger: FundsExpendituresAmountValidationTrigger = 'change',
 ): string | undefined => {
-    if (value) {
-        const withCommaSeparator = value.replaceAll(/\s+/g, ' ').trimStart().replaceAll('.', ',');
-        const firstCommaIndex = withCommaSeparator.indexOf(',');
-        if (firstCommaIndex !== -1) {
-            const rawDecimalPart = withCommaSeparator.slice(firstCommaIndex + 1).replace(/[^\d]/g, '');
-            if (rawDecimalPart.length > 2) {
-                return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DECIMALS;
-            }
-        }
+    if (exceedsMaxDecimalDigits(value)) {
+        return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DECIMALS;
     }
 
     const normalized = normalizeFundsExpendituresAmountInput(value, true);

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
@@ -63,7 +63,7 @@ export const validateFundsExpendituresAmount = (
         return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_NEGATIVE;
     }
 
-    if (!/^\d+(?:,\d{1,2})?$/.test(compact)) {
+    if (!/^(0|[1-9]\d*)(?:,\d{1,2})?$/.test(compact)) {
         return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_ONLY_NUMBER;
     }
 


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3115)

## Description

This PR fixes the numeric validation for the "Курс USD/UAH" field and the "Сума UAH"/"Сума USD" row fields. Both fields accepted integers with a leading zero (e.g. 012345678) without showing an error, leaving "Витрати", "Надходження", "Опублікувати" and the row Edit/Delete icons active when they should have been disabled.

## How it looks
<img width="1543" height="310" alt="image" src="https://github.com/user-attachments/assets/7e66e821-4d4f-4148-82aa-1bf159e55c0c" />

## Summary of change

*   **`funds-expenditures-exchange-rate-schema.ts`**: Fixed the "only numeric" regex in `validateFundsExpendituresExchangeRate` from `/^\d+(?:,\d+)?$/` to `/^(0|[1-9]\d*)(?:,\d+)?$/` so an integer part with a leading zero is rejected as `EXCHANGE_RATE_ONLY_NUMERIC` instead of silently passing through.
*   **`funds-expenditures-record-schema.ts`**: Applied the same fix to `validateFundsExpendituresAmount`, which backs the per-row **"Сума UAH"** / **"Сума USD"** edit fields.
*   **Testing**: Added regression tests to both test files covering: leading-zero integer, leading-zero before a decimal comma, and the legitimate `0,x` case.

## How to recreate changes

1. Log into the Admin panel, navigate to **"Звітність"** and **"Звіт та аналітика"** tab. 
2. Click **"Редагувати Доходи та витрати"**.
3. Type `012345678` into the **"Курс USD/UAH"** field (or into a row's **"Сума UAH"** field via the row edit pencil icon).
4. Observe the error message now appears and the **"Витрати"**, **"Надходження"**, and **"Опублікувати"** buttons, along with the row Edit/Delete icons, become disabled, except for **"Відмінити"**.


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for exchange rates and expenditure amounts.
  * Leading-zero values such as `01` are now rejected.
  * Valid zero and decimal values, including `0,5` and `0,50`, remain accepted.
  * Existing numeric, digit-limit, and greater-than-zero validation rules are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->