### PR TITLE
Fix/issue 2704 [Programs][Public] The full name of the program is not displayed when you hover over the program tile

### DIFF
--- a/src/components/public/program-card/ProgramCardProgramsPage.module.scss
+++ b/src/components/public/program-card/ProgramCardProgramsPage.module.scss
@@ -23,6 +23,12 @@
             transition: all 0.5s ease;
         }
 
+        .name {
+            white-space: normal;
+            overflow: visible;
+            text-overflow: unset;
+        }
+
         .description {
             opacity: 1;
             max-height: 200px;


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2704)

## Description

This PR fixes the hover behavior for program tiles on the public Programs page. Program cards with long names stayed truncated with an ellipsis (...) even on hover, instead of expanding to show the full title as the design specifies.

## How it looks

<img width="1202" height="563" alt="image" src="https://github.com/user-attachments/assets/6a1c132a-ff20-43ca-b969-44aa9c2e50ca" />

## Summary of change

*   **Hover State Override (`ProgramCardProgramsPage.module.scss`)**: Added a `.name` override inside the existing `.root:hover` block. This switches the title from its default clamped state (`white-space: nowrap`, `overflow: hidden`, `text-overflow: ellipsis`) to `white-space: normal`, `overflow: visible`, `text-overflow: unset` on hover — allowing the full program name to wrap and display instead of staying truncated with `...`.

## How to recreate changes

1. Navigate to the public **"Програми"** page.
2. Find a program tile whose name is long enough to be truncated with `...` in its default state.
3. Hover over the tile.
4. Observe the full program name now wraps across multiple lines instead of remaining truncated with an ellipsis.


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions
