### PR TITLE
Fix/issue-3217 [Admin] Dropdowns in modal windows and page header are not working accoding to UI/UX requirements

### DIFF
--- a/src/components/common/select/Select.test.tsx
+++ b/src/components/common/select/Select.test.tsx
@@ -481,6 +481,43 @@ describe('Select Component', () => {
         expect(selectContainer).toHaveClass('select-closed');
         expect(selectContainer).toHaveClass('select-disabled');
     });
+
+    it('closes the dropdown when a click outside occurs', () => {
+        const { container } = render(
+            <div>
+                <Select {...defaultProps} />
+                <button data-testid="outside-button">Click Me</button>
+            </div>,
+        );
+        const selectContainer = container.querySelector('.select') as HTMLElement;
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
+        const outsideButton = screen.getByTestId('outside-button');
+
+        fireEvent.click(selectButton);
+        expect(selectContainer).toHaveClass('select-opened');
+
+        fireEvent.mouseDown(outsideButton);
+        expect(selectContainer).toHaveClass('select-closed');
+    });
+
+    it('closes the dropdown when focus is lost (blur) to an outside element', () => {
+        const { container } = render(
+            <div>
+                <Select {...defaultProps} />
+                <button data-testid="outside-button">Focus Me</button>
+            </div>,
+        );
+        const selectContainer = container.querySelector('.select') as HTMLElement;
+        const selectButton = container.querySelector('.select-head') as HTMLElement;
+        const outsideButton = screen.getByTestId('outside-button');
+
+        fireEvent.click(selectButton);
+        expect(selectContainer).toHaveClass('select-opened');
+
+        fireEvent.blur(selectContainer, { relatedTarget: outsideButton });
+
+        expect(selectContainer).toHaveClass('select-closed');
+    });
 });
 
 describe('Select Component (openOnHover coverage)', () => {

--- a/src/components/common/select/Select.tsx
+++ b/src/components/common/select/Select.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useEffect, useState } from 'react';
+import React, { RefObject, useEffect, useState, useRef } from 'react';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { ReactComponent as ArrowDown } from '@/assets/icons/chevron-down.svg';
 import { ReactComponent as ArrowUp } from '@/assets/icons/chevron-up.svg';
@@ -40,11 +40,30 @@ export const Select = <TValue,>({
 
     const [isOpen, setIsOpen] = useState(false);
 
+    const internalRef = useRef<HTMLDivElement>(null);
+    const containerRef = selectContainerRef || internalRef;
+
     useEffect(() => {
         if (disabled) {
             setIsOpen(false);
         }
     }, [disabled]);
+
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (isOpen && containerRef.current && !containerRef.current.contains(event.target as Node)) {
+                setIsOpen(false);
+            }
+        };
+
+        if (isOpen) {
+            document.addEventListener('mousedown', handleClickOutside);
+        }
+
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, [isOpen, containerRef]);
 
     const selectedOption = options.find((opt) => opt.props.value === value);
     const hasValue = value !== null && value !== undefined;
@@ -77,7 +96,7 @@ export const Select = <TValue,>({
 
     return (
         <div
-            ref={selectContainerRef}
+            ref={containerRef}
             className={classNames('select', className, {
                 'select-opened': isOpen,
                 'select-closed': !isOpen,

--- a/src/components/common/select/Select.tsx
+++ b/src/components/common/select/Select.tsx
@@ -65,6 +65,12 @@ export const Select = <TValue,>({
         };
     }, [isOpen, containerRef]);
 
+    const handleBlur = (e: React.FocusEvent<HTMLDivElement>) => {
+        if (isOpen && containerRef.current && !containerRef.current.contains(e.relatedTarget as Node)) {
+            setIsOpen(false);
+        }
+    };
+
     const selectedOption = options.find((opt) => opt.props.value === value);
     const hasValue = value !== null && value !== undefined;
     const displayLabel =
@@ -104,6 +110,7 @@ export const Select = <TValue,>({
             })}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
+            onBlurCapture={handleBlur}
         >
             <button
                 type="button"

--- a/src/components/common/select/Select.tsx
+++ b/src/components/common/select/Select.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject, useEffect, useState, useRef } from 'react';
+import React, { RefObject, useEffect, useState, useRef, useMemo } from 'react';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { ReactComponent as ArrowDown } from '@/assets/icons/chevron-down.svg';
 import { ReactComponent as ArrowUp } from '@/assets/icons/chevron-up.svg';
@@ -41,7 +41,7 @@ export const Select = <TValue,>({
     const [isOpen, setIsOpen] = useState(false);
 
     const internalRef = useRef<HTMLDivElement>(null);
-    const containerRef = selectContainerRef || internalRef;
+    const containerRef = useMemo(() => selectContainerRef || internalRef, [selectContainerRef]);
 
     useEffect(() => {
         if (disabled) {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-record-modal/AddFundsExpendituresRecordModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-record-modal/AddFundsExpendituresRecordModal.module.scss
@@ -76,7 +76,7 @@
         min-width: 100%;
         max-height: 120px;
         overflow-y: scroll;
-        scrollbar-color: #a4a49b transparent;
+        scrollbar-color: c.$grey-700 transparent;
         border-radius: 8px;
         border: 1px solid c.$grey-700;
         margin-top: 4px;
@@ -91,11 +91,11 @@
         }
 
         &::-webkit-scrollbar-thumb {
-            background-color: #a4a49b;
+            background-color: c.$grey-700;
             border-radius: 8px;
 
             &:hover {
-                background-color: #8c8c84;
+                background-color: c.$grey-800;
             }
         }
     }

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-record-modal/AddFundsExpendituresRecordModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-record-modal/AddFundsExpendituresRecordModal.module.scss
@@ -74,6 +74,36 @@
 
     :global(.select-options) {
         min-width: 100%;
+        max-height: 120px;
+        overflow-y: scroll;
+        scrollbar-color: #a4a49b transparent;
+        border-radius: 8px;
+        border: 1px solid c.$grey-700;
+        margin-top: 4px;
+
+        &::-webkit-scrollbar {
+            width: 8px;
+        }
+
+        &::-webkit-scrollbar-track {
+            background: transparent;
+            border-radius: 8px;
+        }
+
+        &::-webkit-scrollbar-thumb {
+            background-color: #a4a49b;
+            border-radius: 8px;
+
+            &:hover {
+                background-color: #8c8c84;
+            }
+        }
+    }
+}
+
+.select-error {
+    :global(.select-head) {
+        border-color: c.$error;
     }
 }
 

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-record-modal/AddFundsExpendituresRecordModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-record-modal/AddFundsExpendituresRecordModal.test.tsx
@@ -44,27 +44,29 @@ jest.mock('@/components/admin/input-with-character-limit/InputWithCharacterLimit
 jest.mock('@/components/common/select/Select', () => {
     const React = require('react');
 
-    const Select = ({ value, onValueChange, placeholder, children }: any) => {
+    const Select = ({ value, onValueChange, placeholder, children, className }: any) => {
         const options = React.Children.toArray(children)
             .filter((child: any) => child?.props)
             .map((child: any) => ({ value: child.props.value, name: child.props.name }));
 
         return (
-            <select
-                data-testid={placeholder}
-                value={value ?? ''}
-                onChange={(event) => {
-                    const selected = options.find((item: any) => String(item.value) === event.target.value);
-                    onValueChange(selected?.value);
-                }}
-            >
-                <option value="">placeholder</option>
-                {options.map((option: any) => (
-                    <option key={String(option.value)} value={option.value}>
-                        {option.name}
-                    </option>
-                ))}
-            </select>
+            <div data-testid={`select-wrapper-${placeholder}`} className={className}>
+                <select
+                    data-testid={placeholder}
+                    value={value ?? ''}
+                    onChange={(event) => {
+                        const selected = options.find((item: any) => String(item.value) === event.target.value);
+                        onValueChange(selected?.value);
+                    }}
+                >
+                    <option value="">placeholder</option>
+                    {options.map((option: any) => (
+                        <option key={String(option.value)} value={option.value}>
+                            {option.name}
+                        </option>
+                    ))}
+                </select>
+            </div>
         );
     };
 
@@ -163,7 +165,7 @@ describe('AddFundsExpendituresRecordModal', () => {
         expect(screen.getByTestId('record-category-disabled-placeholder')).toBeInTheDocument();
     });
 
-    it('renders field errors and usd mismatch message', () => {
+    it('renders field errors and applies select-error class to dropdowns when errors exist', () => {
         mockedHook.mockReturnValue({
             ...baseHookResult,
             usdMismatchMessage: 'Mismatch',
@@ -178,13 +180,45 @@ describe('AddFundsExpendituresRecordModal', () => {
             },
         } as any);
 
-        renderComponent();
+        renderComponent('income');
 
         expect(screen.getByText('year error')).toBeInTheDocument();
         expect(screen.getByText('category error')).toBeInTheDocument();
         expect(screen.getByText('uah error')).toBeInTheDocument();
         expect(screen.getByText('usd error')).toBeInTheDocument();
         expect(screen.getByText('Mismatch')).toBeInTheDocument();
+
+        const yearSelectWrapper = screen.getByTestId(
+            `select-wrapper-${FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER}`,
+        );
+        expect(yearSelectWrapper.className).toContain('select-error');
+
+        const categorySelectWrapper = screen.getByTestId(
+            `select-wrapper-${FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.CATEGORY_PLACEHOLDER}`,
+        );
+        expect(categorySelectWrapper.className).toContain('select-error');
+    });
+
+    it('does not apply select-error class to dropdowns when no errors exist', () => {
+        mockedHook.mockReturnValue({
+            ...baseHookResult,
+            formState: {
+                ...baseHookResult.formState,
+                errors: {},
+            },
+        } as any);
+
+        renderComponent('income');
+
+        const yearSelectWrapper = screen.getByTestId(
+            `select-wrapper-${FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER}`,
+        );
+        expect(yearSelectWrapper.className).not.toContain('select-error');
+
+        const categorySelectWrapper = screen.getByTestId(
+            `select-wrapper-${FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.CATEGORY_PLACEHOLDER}`,
+        );
+        expect(categorySelectWrapper.className).not.toContain('select-error');
     });
 
     it('calls handlers from hook on interactions', () => {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-record-modal/AddFundsExpendituresRecordModal.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-record-modal/AddFundsExpendituresRecordModal.test.tsx
@@ -50,23 +50,22 @@ jest.mock('@/components/common/select/Select', () => {
             .map((child: any) => ({ value: child.props.value, name: child.props.name }));
 
         return (
-            <div data-testid={`select-wrapper-${placeholder}`} className={className}>
-                <select
-                    data-testid={placeholder}
-                    value={value ?? ''}
-                    onChange={(event) => {
-                        const selected = options.find((item: any) => String(item.value) === event.target.value);
-                        onValueChange(selected?.value);
-                    }}
-                >
-                    <option value="">placeholder</option>
-                    {options.map((option: any) => (
-                        <option key={String(option.value)} value={option.value}>
-                            {option.name}
-                        </option>
-                    ))}
-                </select>
-            </div>
+            <select
+                data-testid={placeholder}
+                className={className}
+                value={value ?? ''}
+                onChange={(event) => {
+                    const selected = options.find((item: any) => String(item.value) === event.target.value);
+                    onValueChange(selected?.value);
+                }}
+            >
+                <option value="">placeholder</option>
+                {options.map((option: any) => (
+                    <option key={String(option.value)} value={option.value}>
+                        {option.name}
+                    </option>
+                ))}
+            </select>
         );
     };
 
@@ -188,15 +187,11 @@ describe('AddFundsExpendituresRecordModal', () => {
         expect(screen.getByText('usd error')).toBeInTheDocument();
         expect(screen.getByText('Mismatch')).toBeInTheDocument();
 
-        const yearSelectWrapper = screen.getByTestId(
-            `select-wrapper-${FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER}`,
-        );
-        expect(yearSelectWrapper.className).toContain('select-error');
+        const yearSelect = screen.getByTestId(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER);
+        expect(yearSelect.className).toContain('select-error');
 
-        const categorySelectWrapper = screen.getByTestId(
-            `select-wrapper-${FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.CATEGORY_PLACEHOLDER}`,
-        );
-        expect(categorySelectWrapper.className).toContain('select-error');
+        const categorySelect = screen.getByTestId(FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.CATEGORY_PLACEHOLDER);
+        expect(categorySelect.className).toContain('select-error');
     });
 
     it('does not apply select-error class to dropdowns when no errors exist', () => {
@@ -210,15 +205,11 @@ describe('AddFundsExpendituresRecordModal', () => {
 
         renderComponent('income');
 
-        const yearSelectWrapper = screen.getByTestId(
-            `select-wrapper-${FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER}`,
-        );
-        expect(yearSelectWrapper.className).not.toContain('select-error');
+        const yearSelect = screen.getByTestId(FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER);
+        expect(yearSelect.className).not.toContain('select-error');
 
-        const categorySelectWrapper = screen.getByTestId(
-            `select-wrapper-${FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.CATEGORY_PLACEHOLDER}`,
-        );
-        expect(categorySelectWrapper.className).not.toContain('select-error');
+        const categorySelect = screen.getByTestId(FUNDS_EXPENDITURES_TEXT.MODAL.INCOME.CATEGORY_PLACEHOLDER);
+        expect(categorySelect.className).not.toContain('select-error');
     });
 
     it('calls handlers from hook on interactions', () => {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-record-modal/AddFundsExpendituresRecordModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-record-modal/AddFundsExpendituresRecordModal.tsx
@@ -116,7 +116,7 @@ export const AddFundsExpendituresRecordModal = ({
                             onValueChange={handleReportingYearChange}
                             selectContainerRef={reportingYearSelectRef}
                             placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER}
-                            className={styles.select}
+                            className={`${styles.select} ${formState.errors.reportingYear ? styles['select-error'] : ''}`}
                             optionClassName={styles['select-option']}
                         >
                             {yearOptions.map((year) => (
@@ -146,7 +146,7 @@ export const AddFundsExpendituresRecordModal = ({
                                 onValueChange={handleCategoryChange}
                                 selectContainerRef={categorySelectRef}
                                 placeholder={modalConfig.CATEGORY_PLACEHOLDER}
-                                className={styles.select}
+                                className={`${styles.select} ${formState.errors.categoryId ? styles['select-error'] : ''}`}
                                 optionClassName={styles['select-option']}
                             >
                                 {filteredCategories.map((category) => (

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-record-modal/AddFundsExpendituresRecordModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-record-modal/AddFundsExpendituresRecordModal.tsx
@@ -1,4 +1,5 @@
 import { FocusEvent, useMemo, useRef } from 'react';
+import classNames from 'classnames';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
 import { ConfirmationModal } from '@/components/admin/confirmation-modal/ConfirmationModal';
@@ -116,7 +117,9 @@ export const AddFundsExpendituresRecordModal = ({
                             onValueChange={handleReportingYearChange}
                             selectContainerRef={reportingYearSelectRef}
                             placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.SHARED.REPORTING_YEAR_PLACEHOLDER}
-                            className={`${styles.select} ${formState.errors.reportingYear ? styles['select-error'] : ''}`}
+                            className={classNames(styles.select, {
+                                [styles['select-error']]: formState.errors.reportingYear,
+                            })}
                             optionClassName={styles['select-option']}
                         >
                             {yearOptions.map((year) => (
@@ -146,7 +149,9 @@ export const AddFundsExpendituresRecordModal = ({
                                 onValueChange={handleCategoryChange}
                                 selectContainerRef={categorySelectRef}
                                 placeholder={modalConfig.CATEGORY_PLACEHOLDER}
-                                className={`${styles.select} ${formState.errors.categoryId ? styles['select-error'] : ''}`}
+                                className={classNames(styles.select, {
+                                    [styles['select-error']]: formState.errors.categoryId,
+                                })}
                                 optionClassName={styles['select-option']}
                             >
                                 {filteredCategories.map((category) => (


### PR DESCRIPTION
## Github ticket

* [3217](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3217)

## Description

The main goal of this PR is to improve the user experience and styling of the `Select` component, specifically within the Add Funds/Expenditures modal. It introduces a "click outside to close" behavior for the dropdown menus, refines the dropdown UI with custom scrollbars and borders, and adds visual error states (red borders) for better form validation feedback.

## How it looks

<img width="618" height="763" alt="image" src="https://github.com/user-attachments/assets/92519ce6-0e44-4be0-8e2f-3e620cf3b667" />

## Summary of change

* **`src/components/common/select/Select.tsx`:** Implemented a `mousedown` event listener to close the dropdown when a user clicks outside of the component wrapper. Added internal `useRef` handling to ensure the component always has a valid reference for the click-outside logic, even if `selectContainerRef` is not provided.
* **`AddFundsExpendituresRecordModal.module.scss`:** Added styling for the `:global(.select-options)` dropdown container, including a `max-height` of `120px`, a custom styled scrollbar, an `8px` border radius, and a matching border. Created a `.select-error` class that applies a red border to the select head when validation fails.
* **`AddFundsExpendituresRecordModal.tsx`:** Added conditional rendering to the `className` prop of the "Reporting Year" and "Category" `Select` components. This applies the `.select-error` styling dynamically when `formState.errors.reportingYear` or `formState.errors.categoryId` are present.

## How to recreate changes

1. Navigate to the page containing the Add Funds/Expenditures modal.
2. Click on the "Reporting Year" or "Category" dropdown. You should see the new border radius and custom scrollbar styles for the options list.
3. Click anywhere else on the screen outside the open dropdown. The dropdown should close automatically.
4. Leave the required select fields empty and trigger form validation (e.g., by blurring the field or attempting to submit). The dropdowns should display a red border to indicate an error state.

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Select menus now close when clicking outside the open menu.
  * Select controls display a clear error-state border when validation fails.

* **Style**
  * Select option lists now have bounded scrolling, improved spacing, hover states, and customized scrollbars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->