### PR TITLE
Fix/issue-3229-3230 [Admin panel][Reports] Decimal without zero before the dot is not accepted by the 'Сума (UAH)' field

### DIFF
--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
@@ -40,6 +40,9 @@ describe('FUNDS_EXPENDITURES_RECORD_VALIDATION_FUNCTIONS', () => {
         it('should prepend zero for negative values starting with a comma', () => {
             expect(normalizeFundsExpendituresAmountInput('-,12')).toBe('-0,12');
         });
+        it('should handle dot with spaces before decimal digits', () => {
+            expect(normalizeFundsExpendituresAmountInput('. 12')).toBe('0,12');
+        });
     });
 
     describe('validateFundsExpendituresAmount', () => {
@@ -104,6 +107,11 @@ describe('FUNDS_EXPENDITURES_RECORD_VALIDATION_FUNCTIONS', () => {
 
         it('should pass valid value when user types dot and decimal digits without leading zero', () => {
             expect(validateFundsExpendituresAmount('.12', 'change')).toBeUndefined();
+        });
+        it('should validate negative comma-starting input and return negative error', () => {
+            expect(validateFundsExpendituresAmount('-,12', 'change')).toBe(
+                FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_NEGATIVE,
+            );
         });
     });
 

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
@@ -24,6 +24,22 @@ describe('FUNDS_EXPENDITURES_RECORD_VALIDATION_FUNCTIONS', () => {
         it('should keep only first two digits after comma', () => {
             expect(normalizeFundsExpendituresAmountInput('1200,5678')).toBe('1200,56');
         });
+
+        it('should prepend zero if input starts with a dot', () => {
+            expect(normalizeFundsExpendituresAmountInput('.12')).toBe('0,12');
+        });
+
+        it('should prepend zero if input starts with a comma', () => {
+            expect(normalizeFundsExpendituresAmountInput(',12')).toBe('0,12');
+        });
+
+        it('should prepend zero for negative values starting with a dot', () => {
+            expect(normalizeFundsExpendituresAmountInput('-.12')).toBe('-0,12');
+        });
+
+        it('should prepend zero for negative values starting with a comma', () => {
+            expect(normalizeFundsExpendituresAmountInput('-,12')).toBe('-0,12');
+        });
     });
 
     describe('validateFundsExpendituresAmount', () => {
@@ -84,6 +100,10 @@ describe('FUNDS_EXPENDITURES_RECORD_VALIDATION_FUNCTIONS', () => {
 
         it('should support dot input by normalizing it to comma', () => {
             expect(validateFundsExpendituresAmount('1 200.50', 'save')).toBeUndefined();
+        });
+
+        it('should pass valid value when user types dot and decimal digits without leading zero', () => {
+            expect(validateFundsExpendituresAmount('.12', 'change')).toBeUndefined();
         });
     });
 

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
@@ -21,11 +21,13 @@ export const normalizeFundsExpendituresAmountInput = (value: string | undefined 
     const withNormalizedSpaces = value.replaceAll(/\s+/g, ' ').trimStart();
     let withCommaSeparator = withNormalizedSpaces.replaceAll('.', ',');
 
-    if (withCommaSeparator.startsWith(',')) {
-        withCommaSeparator = `0${withCommaSeparator}`;
-    } else if (withCommaSeparator.startsWith('-,')) {
-        withCommaSeparator = `-0,${withCommaSeparator.slice(2)}`;
-    }
+    withCommaSeparator = withCommaSeparator.replace(/^-\s+/, '-');
+
+    const isNegative = withCommaSeparator.startsWith('-');
+    const absoluteValue = isNegative ? withCommaSeparator.slice(1) : withCommaSeparator;
+    const normalizedPrefix = absoluteValue.startsWith(',') ? `0${absoluteValue}` : absoluteValue;
+
+    withCommaSeparator = isNegative ? `-${normalizedPrefix}` : normalizedPrefix;
 
     const firstCommaIndex = withCommaSeparator.indexOf(',');
 

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
@@ -19,7 +19,14 @@ export const normalizeFundsExpendituresAmountInput = (value: string | undefined 
         return '';
     }
     const withNormalizedSpaces = value.replaceAll(/\s+/g, ' ').trimStart();
-    const withCommaSeparator = withNormalizedSpaces.replaceAll('.', ',');
+    let withCommaSeparator = withNormalizedSpaces.replaceAll('.', ',');
+
+    if (withCommaSeparator.startsWith(',')) {
+        withCommaSeparator = `0${withCommaSeparator}`;
+    } else if (withCommaSeparator.startsWith('-,')) {
+        withCommaSeparator = `-0,${withCommaSeparator.slice(2)}`;
+    }
+
     const firstCommaIndex = withCommaSeparator.indexOf(',');
 
     if (firstCommaIndex === -1) {


### PR DESCRIPTION
## Github ticket

* [3229](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3229)
* [3230](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3230)

## Description

The main goal of this PR is to improve the user experience when entering monetary amounts. It automatically formats inputs that start with a decimal separator (a dot or a comma) by prepending a leading zero, preventing unnecessary validation errors for valid shorthand inputs like `.12` or `,50`.

## Summary of change

* Updated the `normalizeFundsExpendituresAmountInput` function to automatically prepend `0` if the value starts with `,` (or `.` normalized to `,`).
* Added support for negative shorthand values (e.g., prepending `-0,` if the input starts with `-,`).
* Added 4 new unit test cases in `funds-expenditures-record-schema.test.ts` to verify the new normalization logic for positive and negative shorthand inputs.
* Added 1 new unit test case to ensure that shorthand decimal inputs successfully pass the `validateFundsExpendituresAmount` check.

## How to recreate changes

1. Navigate to the page with the Add/Edit Funds Expenditures Record Modal.
2. Open the modal and focus on the Amount (UAH or USD) input field.
3. Type a shorthand decimal value, for example: `.12`, `,12`, or `-.12`.
4. Verify that the input is automatically formatted to `0,12` or `-0,12` respectively.
5. Confirm that no validation errors (such as "Amount must be a number") are triggered for these specific inputs upon change or blur.

## CHECK LIST
- [x] New tests was added or existing was modified
- [ ] Changes has severe impact on users
- [ ] Changes has medium impact on users
- [x] Changes has light impact on users
- [x] Test covetage was updated
- [x] PR meets all conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of decimal amount inputs without a leading zero, such as `.12` and `-.12`.
  * Decimal values using either commas or periods are now normalized consistently during validation.

* **Tests**
  * Added coverage for positive and negative decimal formats and validation of leading-decimal amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->