### PR TITLE
Fix/issue 2625 [Programs] The layout of elements and paragraps in Small desktop screens (1024px – 1280px) doesnot match the Mock-up.

### DIFF
--- a/src/components/public/header/Header.scss
+++ b/src/components/public/header/Header.scss
@@ -22,8 +22,14 @@ $header-height: 4rem;
         justify-content: space-between;
         align-items: center;
         height: 100%;
-        padding-left: 3.5rem;
-        padding-right: 3.5rem;
+
+        padding-left: 1rem;
+        padding-right: 1rem;
+
+        @media (min-width: 1025px) {
+            padding-left: 3.5rem;
+            padding-right: 3.5rem;
+        }
 
         .logo-container {
             .logo {
@@ -143,6 +149,22 @@ $header-height: 4rem;
     }
 }
 
+@media (min-width: 768px) and (max-width: 1024px) {
+    .header-block {
+        .header-content-container {
+            .button-container {
+                .language-switcher {
+                    margin-right: 0.75rem;
+                }
+
+                .burger-menu-icon {
+                    margin-left: 0.75rem;
+                }
+            }
+        }
+    }
+}
+
 @media (max-width: 559px) {
     .header-block {
         .header-content-container {
@@ -168,6 +190,8 @@ $header-height: 4rem;
 
         .mobile-language-switcher {
             display: flex;
+
+            width: auto;
             padding: 1rem;
             border-top: 1px solid colors.$blue-50;
         }
@@ -178,7 +202,6 @@ $header-height: 4rem;
     .header-block {
         .header-content-container {
             .button-container {
-
                 .contact-us-button,
                 .language-switcher {
                     display: none;

--- a/src/components/public/header/Header.tsx
+++ b/src/components/public/header/Header.tsx
@@ -73,7 +73,7 @@ export const Header = () => {
 
                         <Button
                             variant="tertiary"
-                            size="large"
+                            size="medium"
                             icon={BurgerIcon}
                             ariaLabel="Open menu"
                             onClick={toggleMenu}

--- a/src/components/public/language-switcher/LanguageSwitcher.scss
+++ b/src/components/public/language-switcher/LanguageSwitcher.scss
@@ -1,12 +1,26 @@
 .language-switcher {
-    width: 5.25rem;
+    width: 3.5rem;
     &-head {
-        width: 5.25rem;
+        width: 3.5rem;
+
+        padding-left: 0;
+        padding-right: 0;
         border: none;
         background-color: transparent;
 
         &:hover {
             background-color: transparent;
+        }
+    }
+
+    .language-switcher-option {
+        padding-left: 0;
+        padding-right: 0;
+        justify-content: center;
+
+        span {
+            white-space: nowrap;
+            overflow-wrap: normal;
         }
     }
 }

--- a/src/components/public/language-switcher/LanguageSwitcher.tsx
+++ b/src/components/public/language-switcher/LanguageSwitcher.tsx
@@ -31,6 +31,7 @@ export const LanguageSwitcher = ({ onValueChange, className, openOnHover = false
             placeholder="lng"
             className={classNames('language-switcher', className)}
             headClassName="language-switcher-head"
+            optionClassName="language-switcher-option"
             openOnHover={openOnHover}
         >
             {LOCALES.map((lng) => (

--- a/src/pages/public/programs-page/intro-section/IntroSection.module.scss
+++ b/src/pages/public/programs-page/intro-section/IntroSection.module.scss
@@ -139,16 +139,16 @@
         max-width: 100%;
 
         @media (min-width: 768px) {
+            flex-direction: row;
+            align-items: flex-start;
             font-size: 18px;
             line-height: 26px;
             gap: 16px;
         }
 
         @media (min-width: 1024px) {
-            flex-direction: row;
             font-size: 20px;
             line-height: 28px;
-            align-items: flex-start;
         }
 
         p {


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2625)

## Description

This PR fixes responsive header and layout issues on the public Programs page at tablet breakpoints (768px–1024px). At these widths, the header's button spacing didn't match the design, the language switcher was oversized, and the intro section's two description paragraphs stacked vertically instead of displaying side by side as the design specifies.

## How it looks
**Before**
<img width="482" height="553" alt="image" src="https://github.com/user-attachments/assets/c50ded96-9d88-427d-ad6d-99e92b8e2bdc" />

**After**
<img width="480" height="531" alt="image" src="https://github.com/user-attachments/assets/6bbd7bb2-abaa-447d-a9d1-05a4bc7b0ef5" />

## Summary of change

*   **Header spacing (`Header.scss`)**: Header padding now stays at 16px through 1024px and only steps out to 56px at 1025px+, instead of jumping to 56px at every width. Added a 768px–1024px-scoped rule giving the language switcher and burger menu 12px offsets, producing the design's 20px / 8px / 20px gap rhythm across the button cluster.
*   **Language switcher size (`LanguageSwitcher.scss`, `LanguageSwitcher.tsx`)**: Reduced the switcher's fixed width from 84px to 56px and removed its horizontal padding to match. Added an `optionClassName` prop so the dropdown's UA/EN options keep the narrower width without the text wrapping onto two lines.
*   **Burger menu size (`Header.tsx`)**: Changed the burger button from `size="large"` (40×48) to `size="medium"` (40×40), matching the header cluster's uniform button height.
*   **Mobile menu switcher (`Header.scss`)**: Set `width: auto` on the switcher inside the collapsed mobile menu (≤559px) so it isn't constrained by the header's fixed 56px width and no longer wraps.
*   **Paragraph layout (`IntroSection.module.scss`)**: Moved `flex-direction: row` from the 1024px breakpoint down to 768px, so the two description paragraphs sit side by side starting at tablet width instead of only on desktop.

## How to recreate changes

1. Navigate to the public **"Програми"** page.
2. Open DevTools and set the viewport to 768×1024.
3. Confirm the header buttons (language switcher, **"Зв'язатись"**, **"Донатити"**, burger icon) are evenly spaced with no overlap, and the two description paragraphs below the title display side by side instead of stacked.


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions
