### PR TITLE
Fix: About Us CTA should open in a new tab (PR #531 review fixes)

### DIFF
--- a/src/pages/public/main-page/about-us/AboutUsSection.test.tsx
+++ b/src/pages/public/main-page/about-us/AboutUsSection.test.tsx
@@ -1,6 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { useNavigate } from 'react-router-dom';
 import { AboutUsSection } from './AboutUsSection';
 import { PUBLIC_ROUTES } from '@/const/public/routes';
 import { PublicMainAboutUsDto, PublicMainPageLocalizationDto } from '@/types/public/main-page';
@@ -28,8 +26,6 @@ jest.mock('@/hooks/common/use-locale/useLocale', () => ({
 }));
 
 const mockedUseLocale = useLocale as jest.Mock;
-const mockedUseNavigate = useNavigate as jest.Mock;
-const mockNavigate = jest.fn();
 
 const createLocalization = (overrides: Partial<PublicMainPageLocalizationDto> = {}): PublicMainPageLocalizationDto => ({
     entityId: 1,
@@ -50,7 +46,6 @@ describe('AboutUsSection', () => {
         jest.clearAllMocks();
         mockT.mockImplementation((key: string) => translations[key] ?? key);
         mockedUseLocale.mockReturnValue({ currentLanguage: 'uk' });
-        mockedUseNavigate.mockReturnValue(mockNavigate);
     });
 
     it('renders the title as a level 2 heading and the description as a paragraph', () => {
@@ -97,16 +92,15 @@ describe('AboutUsSection', () => {
 
         expect(screen.queryByRole('heading', { level: 2 })).not.toBeInTheDocument();
         expect(container.querySelector('p')).not.toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Get to know more' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Get to know more' })).toBeInTheDocument();
     });
 
-    it('navigates to the about us page when the button is clicked', async () => {
-        const user = userEvent.setup();
+    it('opens the about us page in a new tab and keeps the current page intact', () => {
         render(<AboutUsSection mainAboutUs={createAboutUs()} />);
 
-        await user.click(screen.getByRole('button', { name: 'Get to know more' }));
-
-        expect(mockNavigate).toHaveBeenCalledTimes(1);
-        expect(mockNavigate).toHaveBeenCalledWith(PUBLIC_ROUTES.ABOUT_US.FULL);
+        const link = screen.getByRole('link', { name: 'Get to know more' });
+        expect(link).toHaveAttribute('href', PUBLIC_ROUTES.ABOUT_US.FULL);
+        expect(link).toHaveAttribute('target', '_blank');
+        expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     });
 });

--- a/src/pages/public/main-page/about-us/AboutUsSection.tsx
+++ b/src/pages/public/main-page/about-us/AboutUsSection.tsx
@@ -2,7 +2,6 @@ import { PublicMainAboutUsDto } from '@/types/public/main-page';
 import { SafeHtml } from '@/components/common/safe-html';
 import { useTranslation } from 'react-i18next';
 import { useLocale } from '@/hooks/common/use-locale/useLocale';
-import { useNavigate } from 'react-router-dom';
 import { PUBLIC_ROUTES } from '@/const/public/routes';
 import { Button } from '@/components/public/ui/button/Button';
 import { ReactComponent as ArrowIcon } from '@/assets/icons/arrow-up-right.svg';
@@ -26,7 +25,6 @@ const getLocalizedAboutUsDescription = (mainAboutUs: PublicMainAboutUsDto, curre
 export const AboutUsSection = ({ mainAboutUs }: PublicMainAboutUsProps) => {
     const { t } = useTranslation('mainPage');
     const { currentLanguage } = useLocale();
-    const navigate = useNavigate();
 
     const title = mainAboutUs ? getLocalizedAboutUsTitle(mainAboutUs, currentLanguage) : '';
     const description = mainAboutUs ? getLocalizedAboutUsDescription(mainAboutUs, currentLanguage) : '';
@@ -38,7 +36,9 @@ export const AboutUsSection = ({ mainAboutUs }: PublicMainAboutUsProps) => {
             <div className={styles['description-content']}>
                 {description && <SafeHtml as="p" className={styles.description} html={description} />}
                 <Button
-                    onClick={() => navigate(PUBLIC_ROUTES.ABOUT_US.FULL)}
+                    href={PUBLIC_ROUTES.ABOUT_US.FULL}
+                    target="_blank"
+                    rel="noopener noreferrer"
                     icon={ArrowIcon}
                     iconPosition="right"
                     variant="tertiary"


### PR DESCRIPTION
## JIRA or Github ticker

- Issue #2489 (backend repo) — "[Main] View about us"
- Follows up on #531

## Description

This PR addresses a code review finding on #531 (About Us section on the Main page). The CTA button "Дізнатися більше" used `react-router-dom`'s `useNavigate()` in its `onClick`, performing an in-tab SPA route change. Issue #2489's acceptance criteria require the button to open the "Хто ми" page **in a new tab** while the **Main page stays open** — neither was true, so AC #2 and AC #3 were silently unmet despite the existing test suite passing (the test asserted the incorrect behavior rather than the specified one).

## How it looks

No visual/UI change — the CTA looks identical. The only behavioral change is that clicking it now opens a new browser tab instead of navigating away from the Main page in the current tab.

## Summary of change

- `AboutUsSection.tsx`: replaced the `useNavigate()`/`onClick` navigation with `href={PUBLIC_ROUTES.ABOUT_US.FULL}`, `target="_blank"`, `rel="noopener noreferrer"` on the CTA `Button`, matching the existing pattern already used by `IntroSection` and `DonationSection` on the same page. Removed the now-unused `useNavigate` import.
- `AboutUsSection.test.tsx`: updated queries from `role: button` to `role: link` (the CTA now renders as a real anchor), and replaced the click/navigate assertion with attribute checks on `href`/`target`/`rel`, mirroring `DonationSection.test.tsx`. Removed the now-unused `useNavigate` mock and `userEvent` import.

## How to recreate changes

1. Run `npm start` and open the Main page.
2. Click "Дізнатись більше" under the About Us section.
3. Before this fix: the Main page navigates away in the same tab to `/about-us`.
4. After this fix: a new browser tab opens to `/about-us`, and the original Main page tab remains open and unchanged.

## CHECK LIST

- [x] New tests were added or existing were modified
- [ ] Changes have severe impact on users
- [ ] Changes have medium impact on users
- [x] Changes have light impact on users
- [x] Test coverage was updated
- [x] PR meets all conventions

---
🤖 Generated with a multi-agent Claude Code review of #531 (fetch/scan agents on Haiku, review/fix agents on Sonnet). Validated locally: `npm run lint` (0 errors), `npm run test:cover` (499/499 suites, 95.95% lines / 87.23% branches, both above threshold), `npm run build` (success).