### PR TITLE
Fix/issue 2803 [Partners][Admin panel] Uploaded image doesn't dim on hover in the Title section

### DIFF
--- a/src/assets/sass/variables/z-index.scss
+++ b/src/assets/sass/variables/z-index.scss
@@ -31,6 +31,7 @@ $admin-layout: (
     search-bar-suggestions: 10,
     select: 10,
     who-we-are-page-image-preview: 1,
+    image-input-hover-overlay: 1,
     image-input-action-buttons: 2,
 );
 

--- a/src/components/admin/image-input/ImageInput.module.scss
+++ b/src/components/admin/image-input/ImageInput.module.scss
@@ -48,7 +48,22 @@
         border-radius: 4px;
         overflow: hidden;
 
+        &::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            z-index: z-index.admin('image-input-hover-overlay');
+            background: c.$white;
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.3s ease;
+        }
+
         &:hover {
+            &::after {
+                opacity: 0.5;
+            }
+
             .delete-button,
             .crop-button {
                 opacity: 1;


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2803)

## Description

This PR fixes the hover behavior for the uploaded image in the title section on the admin Партнери page. The image did not dim or change state in any way on hover, instead staying visually identical to its resting state — instead of dimming to indicate it's clickable, as the design mock-up specifies.


## How it looks

<img width="1280" height="596" alt="image" src="https://github.com/user-attachments/assets/fcbcbd7f-5b78-4529-b397-6baa0c1b00a3" />

## Summary of change

*   **Hover Dim Overlay (`ImageInput.module.scss`)**: Added a `::after` overlay inside the shared `.image-preview` block, which fades from `opacity: 0` to `opacity: 0.5` on hover. This dims the uploaded image on hover to match the design mock-up, while the existing delete/crop icon buttons continue to fade in above it.
*   **Z-index token (`z-index.scss`)**: Registered a new `image-input-hover-overlay` token so the dim overlay stacks below the delete/crop action buttons but above the image itself.

## How to recreate changes

1. Navigate to the admin **"Партнери"** page.
2. Go to the title section with a previously uploaded image.
3. Hover over the uploaded image.
4. Observe the image now dims while the delete/crop icons fade in, matching the mock-up.


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved image preview hover feedback with a subtle white overlay.
  * Preserved existing controls for deleting and cropping images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->