### PR TITLE
Feature/issue-1855 [Programs] Open Modal Window to translate a program category

### DIFF
--- a/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.test.tsx
+++ b/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.test.tsx
@@ -131,6 +131,9 @@ jest.mock('@/components/admin/category-bar/CategoryBar', () => ({
             <button data-testid="ctx-delete" onClick={() => onContextMenuOptionSelected?.('delete')}>
                 Delete Category
             </button>
+            <button data-testid="ctx-addTranslation" onClick={() => onContextMenuOptionSelected?.('addTranslation')}>
+                Add Translation
+            </button>
         </div>
     ),
 }));
@@ -494,6 +497,7 @@ describe('ProgramsPageContent', () => {
             openAddCategoryModal: jest.fn(),
             openEditCategoryModal: jest.fn(),
             openDeleteCategoryModal: jest.fn(),
+            openTranslateCategoryModal: jest.fn(),
         };
 
         closeActions = {
@@ -512,6 +516,7 @@ describe('ProgramsPageContent', () => {
                 isAddCategoryModalOpen: false,
                 isEditCategoryModalOpen: false,
                 isDeleteCategoryModalOpen: false,
+                isCategoryToTranslate: false,
                 itemToEdit: null,
                 itemToDelete: null,
                 itemToTranslate: null,
@@ -633,6 +638,9 @@ describe('ProgramsPageContent', () => {
 
         fireEvent.click(screen.getByTestId('ctx-delete'));
         expect(openActions.openDeleteCategoryModal).toHaveBeenCalled();
+
+        fireEvent.click(screen.getByTestId('ctx-addTranslation'));
+        expect(openActions.openTranslateCategoryModal).toHaveBeenCalled();
     });
 
     it('shows loader when data is loading', async () => {

--- a/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.tsx
+++ b/src/pages/admin/programs/components/programs-page-content/ProgramsPageContent.tsx
@@ -470,6 +470,7 @@ export const ProgramsPageContent = () => {
             { id: 'add', name: COMMON_TEXT_ADMIN.CATEGORIES.BUTTON.ADD_CATEGORY },
             { id: 'edit', name: COMMON_TEXT_ADMIN.CATEGORIES.BUTTON.EDIT_CATEGORY },
             { id: 'delete', name: COMMON_TEXT_ADMIN.CATEGORIES.BUTTON.DELETE_CATEGORY },
+            { id: 'addTranslation', name: COMMON_TEXT_ADMIN.CATEGORIES.BUTTON.ADD_TRANSLATION },
         ],
         [],
     );
@@ -482,6 +483,8 @@ export const ProgramsPageContent = () => {
                 openModalActions.openEditCategoryModal();
             } else if (id === 'delete') {
                 openModalActions.openDeleteCategoryModal();
+            } else if (id === 'addTranslation') {
+                openModalActions.openTranslateCategoryModal();
             }
         },
         [openModalActions],

--- a/src/pages/admin/programs/components/programs-page-modals/ProgramsPageModals.test.tsx
+++ b/src/pages/admin/programs/components/programs-page-modals/ProgramsPageModals.test.tsx
@@ -35,6 +35,11 @@ jest.mock('../translate-program-modal/TranslateProgramModal', () => ({
         isOpen ? <div data-testid="translate-program-modal" /> : null,
 }));
 
+jest.mock('../translate-program-category-modal/TranslateProgramCategoryModal', () => ({
+    TranslateProgramCategoryModal: ({ isOpen }: { isOpen: boolean }) =>
+        isOpen ? <div data-testid="translate-program-category-modal" /> : null,
+}));
+
 describe('ProgramsPageModals', () => {
     const mockProgram: HippotherapyProgram = {
         id: 1,
@@ -133,6 +138,7 @@ describe('ProgramsPageModals', () => {
     const getEditCategoryModal = () => screen.queryByTestId('program-category-modal-edit');
     const getDeleteCategoryModal = () => screen.queryByTestId('delete-category-modal');
     const getTranslateProgramModal = () => screen.queryByTestId('translate-program-modal');
+    const getTranslateProgramCategoryModal = () => screen.queryByTestId('translate-program-category-modal');
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -146,8 +152,9 @@ describe('ProgramsPageModals', () => {
         expect(getEditProgramModal()).not.toBeInTheDocument();
         expect(getDeleteProgramModal()).not.toBeInTheDocument();
         expect(getAddCategoryModal()).not.toBeInTheDocument();
-        // translation modal also closed
+        // translation modals also closed
         expect(screen.queryByTestId('translate-program-modal')).not.toBeInTheDocument();
+        expect(getTranslateProgramCategoryModal()).not.toBeInTheDocument();
         expect(getEditCategoryModal()).not.toBeInTheDocument();
         expect(getDeleteCategoryModal()).not.toBeInTheDocument();
     });
@@ -184,6 +191,16 @@ describe('ProgramsPageModals', () => {
         renderProgramsPageModals(modalsState);
 
         expect(getTranslateProgramModal()).toBeInTheDocument();
+        expect(getAddProgramModal()).not.toBeInTheDocument();
+        expect(getEditProgramModal()).not.toBeInTheDocument();
+        expect(getDeleteProgramModal()).not.toBeInTheDocument();
+    });
+
+    it('should render translate program category modal when isCategoryToTranslate is true', () => {
+        const modalsState = createMockModalsState({ isCategoryToTranslate: true });
+        renderProgramsPageModals(modalsState);
+
+        expect(getTranslateProgramCategoryModal()).toBeInTheDocument();
         expect(getAddProgramModal()).not.toBeInTheDocument();
         expect(getEditProgramModal()).not.toBeInTheDocument();
         expect(getDeleteProgramModal()).not.toBeInTheDocument();

--- a/src/pages/admin/programs/components/programs-page-modals/ProgramsPageModals.tsx
+++ b/src/pages/admin/programs/components/programs-page-modals/ProgramsPageModals.tsx
@@ -6,6 +6,7 @@ import { DeleteProgramModal } from './delete-program-modal/DeleteProgramModal';
 import { ProgramCategoryModal } from '../program-category-modals/ProgramCategoryModal';
 import { DeleteCategoryModal } from '../program-category-modals/DeleteCategoryModal';
 import { TranslateProgramModal } from '../translate-program-modal/TranslateProgramModal';
+import { TranslateProgramCategoryModal } from '../translate-program-category-modal/TranslateProgramCategoryModal';
 import { ModalMode } from '@/types/admin/common';
 
 export interface ProgramsPageModalsProps {
@@ -92,6 +93,15 @@ export const ProgramsPageModals = ({
                 onDeleteCategory={onDeleteCategory}
                 categories={categories}
             />
+
+            {modalState.isCategoryToTranslate && (
+                <TranslateProgramCategoryModal
+                    isOpen={modalState.isCategoryToTranslate}
+                    onClose={closeModalActions.closeTranslateCategoryModal}
+                    categories={categories}
+                    translatedLanguages={translatedLanguages}
+                />
+            )}
         </>
     );
 };

--- a/src/pages/admin/programs/components/translate-program-category-form/TranslateProgramCategoryForm.test.tsx
+++ b/src/pages/admin/programs/components/translate-program-category-form/TranslateProgramCategoryForm.test.tsx
@@ -1,0 +1,219 @@
+import React, { createRef } from 'react';
+import { createEvent, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TranslateProgramCategoryForm, TranslateProgramCategoryFormRef } from './TranslateProgramCategoryForm';
+import { ProgramCategory } from '@/types/admin/programs';
+import { VisibilityStatus } from '@/types/admin/common';
+import { PROGRAM_CATEGORY_VALIDATION_FUNCTIONS } from '@/validation/admin/program-category-schema/program-category-schema';
+
+jest.mock('@/validation/admin/program-category-schema/program-category-schema', () => ({
+    PROGRAM_CATEGORY_VALIDATION_FUNCTIONS: {
+        validateName: jest.fn(() => undefined),
+    },
+}));
+
+jest.mock('@/components/admin/input-groups/single-select-input-group/SingleSelectInputGroup', () => ({
+    SingleSelectInputGroup: ({ options, value, onChange, disabled, getOptionId, getOptionName }: any) => (
+        <select
+            data-testid="category-select"
+            value={value ? String(getOptionId(value)) : ''}
+            onChange={(e) => {
+                if (!e.target.value) {
+                    onChange?.(null);
+                    return;
+                }
+                const selectedOption = options.find((option: any) => String(getOptionId(option)) === e.target.value);
+                onChange?.(selectedOption ?? null);
+            }}
+            disabled={disabled}
+        >
+            <option value="">Select category</option>
+            {options.map((option: any) => (
+                <option key={getOptionId(option)} value={String(getOptionId(option))}>
+                    {getOptionName(option)}
+                </option>
+            ))}
+        </select>
+    ),
+}));
+
+jest.mock('@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup', () => ({
+    InputWithCharacterLimitGroup: ({ value, onChange, onBlur, disabled, name, id, error }: any) => (
+        <div>
+            <input
+                data-testid={`input-${name ?? id}`}
+                value={value}
+                onChange={onChange}
+                onBlur={onBlur}
+                disabled={disabled}
+            />
+            {error && <span data-testid={`error-${name ?? id}`}>{error}</span>}
+        </div>
+    ),
+}));
+
+const mockCategories: ProgramCategory[] = [
+    { id: 1, name: 'Category 1', programsCount: 2 },
+    { id: 2, name: 'Category 2', programsCount: 1 },
+];
+
+const validationMock = PROGRAM_CATEGORY_VALIDATION_FUNCTIONS as jest.Mocked<
+    typeof PROGRAM_CATEGORY_VALIDATION_FUNCTIONS
+>;
+
+describe('TranslateProgramCategoryForm', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        validationMock.validateName.mockReturnValue(undefined);
+    });
+
+    const renderForm = (props: Partial<React.ComponentProps<typeof TranslateProgramCategoryForm>> = {}) => {
+        const ref = createRef<TranslateProgramCategoryFormRef>();
+        const defaultProps: React.ComponentProps<typeof TranslateProgramCategoryForm> = {
+            onSubmit: jest.fn(),
+            categories: mockCategories,
+        };
+
+        const view = render(<TranslateProgramCategoryForm ref={ref} {...defaultProps} {...props} />);
+
+        return {
+            ref,
+            onSubmit: props.onSubmit ?? defaultProps.onSubmit,
+            ...view,
+        };
+    };
+
+    it('renders category and name fields', () => {
+        renderForm();
+
+        expect(screen.getByTestId('category-select')).toBeInTheDocument();
+        expect(screen.getByTestId('input-name')).toBeInTheDocument();
+    });
+
+    it('starts with an unselected category and an empty, disabled name field', () => {
+        renderForm();
+
+        expect(screen.getByTestId('category-select')).toHaveValue('');
+        expect(screen.getByTestId('input-name')).toHaveValue('');
+        expect(screen.getByTestId('input-name')).toBeDisabled();
+    });
+
+    it('disables the name field until a category is selected', () => {
+        renderForm();
+
+        expect(screen.getByTestId('input-name')).toBeDisabled();
+
+        fireEvent.change(screen.getByTestId('category-select'), { target: { value: '1' } });
+
+        expect(screen.getByTestId('input-name')).toBeEnabled();
+    });
+
+    it('resets the name field whenever the selected category changes', () => {
+        renderForm();
+
+        fireEvent.change(screen.getByTestId('category-select'), { target: { value: '1' } });
+        fireEvent.change(screen.getByTestId('input-name'), { target: { value: 'Translated name' } });
+        expect(screen.getByTestId('input-name')).toHaveValue('Translated name');
+
+        fireEvent.change(screen.getByTestId('category-select'), { target: { value: '2' } });
+
+        expect(screen.getByTestId('input-name')).toHaveValue('');
+    });
+
+    it('updates the name value on change', () => {
+        renderForm();
+
+        fireEvent.change(screen.getByTestId('category-select'), { target: { value: '1' } });
+        fireEvent.change(screen.getByTestId('input-name'), { target: { value: 'Translated name' } });
+
+        expect(screen.getByTestId('input-name')).toHaveValue('Translated name');
+    });
+
+    it('validates name on blur', () => {
+        renderForm();
+
+        fireEvent.change(screen.getByTestId('category-select'), { target: { value: '1' } });
+        fireEvent.blur(screen.getByTestId('input-name'));
+
+        expect(validationMock.validateName).toHaveBeenCalled();
+    });
+
+    it('shows validation errors returned by the validation function', async () => {
+        validationMock.validateName.mockReturnValue('Name error');
+
+        renderForm();
+
+        fireEvent.change(screen.getByTestId('category-select'), { target: { value: '1' } });
+        fireEvent.blur(screen.getByTestId('input-name'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('error-name')).toHaveTextContent('Name error');
+        });
+    });
+
+    it('calls onValidationChange from form manager updates', async () => {
+        const onValidationChange = jest.fn();
+
+        renderForm({ onValidationChange });
+
+        await waitFor(() => {
+            expect(onValidationChange).toHaveBeenCalledWith(true);
+        });
+    });
+
+    it('reports dirty state as soon as a category is selected, even without a name', async () => {
+        const onDirtyChange = jest.fn();
+
+        renderForm({ onDirtyChange });
+
+        await waitFor(() => {
+            expect(onDirtyChange).toHaveBeenCalledWith(false);
+        });
+
+        fireEvent.change(screen.getByTestId('category-select'), { target: { value: '1' } });
+
+        await waitFor(() => {
+            expect(onDirtyChange).toHaveBeenLastCalledWith(true);
+        });
+    });
+
+    it('submits data via ref.submit and forwards only form data to onSubmit', async () => {
+        const onSubmit = jest.fn();
+        const { ref } = renderForm({ onSubmit });
+
+        fireEvent.change(screen.getByTestId('category-select'), { target: { value: '1' } });
+        fireEvent.change(screen.getByTestId('input-name'), { target: { value: 'Final name' } });
+
+        await ref.current?.submit(VisibilityStatus.Draft);
+
+        expect(onSubmit).toHaveBeenCalledWith({
+            categoryId: 1,
+            name: 'Final name',
+        });
+    });
+
+    it('exposes isValid and isDirty through ref', () => {
+        const { ref } = renderForm();
+
+        expect(ref.current?.isValid()).toBe(true);
+        expect(ref.current?.isDirty()).toBe(false);
+    });
+
+    it('disables category selector when formDisabled is true', () => {
+        renderForm({ formDisabled: true });
+
+        expect(screen.getByTestId('category-select')).toBeDisabled();
+    });
+
+    it('prevents default form submission behavior', () => {
+        const { container } = renderForm();
+        const form = container.querySelector('#translate-program-category-form') as HTMLFormElement;
+
+        const event = createEvent.submit(form);
+        event.preventDefault = jest.fn();
+
+        fireEvent(form, event);
+
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+});

--- a/src/pages/admin/programs/components/translate-program-category-form/TranslateProgramCategoryForm.tsx
+++ b/src/pages/admin/programs/components/translate-program-category-form/TranslateProgramCategoryForm.tsx
@@ -1,0 +1,127 @@
+import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
+import { SingleSelectInputGroup } from '@/components/admin/input-groups/single-select-input-group/SingleSelectInputGroup';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { PROGRAM_CATEGORY_TEXT, PROGRAM_CATEGORY_VALIDATION } from '@/const/admin/programs';
+import { useFormManager } from '@/hooks/admin/use-form-manager/useFormManager';
+import { VisibilityStatus } from '@/types/admin/common';
+import { ProgramCategory } from '@/types/admin/programs';
+import { PROGRAM_CATEGORY_VALIDATION_FUNCTIONS } from '@/validation/admin/program-category-schema/program-category-schema';
+import { forwardRef, useEffect, useMemo } from 'react';
+
+export interface TranslateProgramCategoryFormValues {
+    categoryId: number | null;
+    name: string;
+}
+
+export interface TranslateProgramCategoryFormErrorState {
+    name: string | undefined;
+    [key: string]: string | undefined;
+}
+
+export interface TranslateProgramCategoryFormRef {
+    submit: (status?: VisibilityStatus) => Promise<void>;
+    isValid: () => boolean;
+    isDirty: () => boolean;
+}
+
+export interface TranslateProgramCategoryFormProps {
+    onSubmit: (data: TranslateProgramCategoryFormValues, status?: VisibilityStatus) => void | Promise<void>;
+    categories: ProgramCategory[];
+    formDisabled?: boolean;
+    onValidationChange?: (isValid: boolean) => void;
+    onDirtyChange?: (isDirty: boolean) => void;
+}
+
+const DEFAULT_FORM_STATE: TranslateProgramCategoryFormValues = {
+    categoryId: null,
+    name: '',
+};
+
+const validateForm = (
+    formState: TranslateProgramCategoryFormValues,
+    _isPublishing: boolean,
+): TranslateProgramCategoryFormErrorState => {
+    return {
+        name: PROGRAM_CATEGORY_VALIDATION_FUNCTIONS.validateName(formState.name),
+    };
+};
+
+export const TranslateProgramCategoryForm = forwardRef<
+    TranslateProgramCategoryFormRef,
+    TranslateProgramCategoryFormProps
+>(
+    (
+        { onSubmit, categories, formDisabled, onValidationChange, onDirtyChange }: TranslateProgramCategoryFormProps,
+        ref,
+    ) => {
+        const { formState, setFormState, errors, setErrors, isSubmitting, isDirty } = useFormManager<
+            TranslateProgramCategoryFormValues,
+            TranslateProgramCategoryFormErrorState
+        >({
+            defaultFormState: DEFAULT_FORM_STATE,
+            initialData: null,
+            validateForm,
+            onValidationChange,
+            ref,
+            onSubmit: (data, _status) => onSubmit(data),
+        });
+
+        const activeCategory = useMemo(
+            () => categories.find((category) => category.id === formState.categoryId),
+            [categories, formState.categoryId],
+        );
+
+        useEffect(() => {
+            onDirtyChange?.(isDirty());
+        }, [formState, isDirty, onDirtyChange]);
+
+        const handleCategoryChange = (category: ProgramCategory | null) => {
+            setFormState({ categoryId: category?.id ?? null, name: '' });
+            setErrors({ name: undefined });
+        };
+
+        const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+            setFormState((prev) => ({ ...prev, name: e.target.value }));
+        };
+
+        const handleNameBlur = () => {
+            const error = PROGRAM_CATEGORY_VALIDATION_FUNCTIONS.validateName(formState.name);
+            setErrors((prev) => ({ ...prev, name: error }));
+        };
+
+        return (
+            <form
+                onSubmit={(e) => e.preventDefault()}
+                className="translate-program-category-form"
+                id="translate-program-category-form"
+                noValidate
+            >
+                <SingleSelectInputGroup
+                    label={PROGRAM_CATEGORY_TEXT.FORM.LABEL.CATEGORY}
+                    isRequired
+                    options={categories}
+                    getOptionId={(category) => category.id}
+                    getOptionName={(category) => category.name}
+                    disabled={isSubmitting || formDisabled}
+                    onChange={handleCategoryChange}
+                    value={activeCategory}
+                    placeholder={COMMON_TEXT_ADMIN.FILTER.CATEGORY.SELECT_CATEGORY}
+                    id="translate-program-category-select"
+                />
+
+                <InputWithCharacterLimitGroup
+                    label={PROGRAM_CATEGORY_TEXT.FORM.LABEL.NAME}
+                    error={errors.name}
+                    isRequired
+                    value={formState.name}
+                    onChange={handleNameChange}
+                    onBlur={handleNameBlur}
+                    disabled={isSubmitting || formDisabled || !activeCategory}
+                    maxLength={PROGRAM_CATEGORY_VALIDATION.name.max}
+                    name="name"
+                    id="translate-program-category-name"
+                />
+            </form>
+        );
+    },
+);

--- a/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.test.tsx
+++ b/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.test.tsx
@@ -114,8 +114,8 @@ describe('TranslateProgramCategoryModal', () => {
         );
     });
 
-    it('selects the first translated language by default', () => {
-        renderModal({ translatedLanguages: [EN_LANGUAGE, PL_LANGUAGE] });
+    it('selects English by default regardless of array order', () => {
+        renderModal({ translatedLanguages: [PL_LANGUAGE, EN_LANGUAGE] });
 
         expect(screen.getByTestId('selected-language')).toHaveTextContent('en');
     });
@@ -126,14 +126,20 @@ describe('TranslateProgramCategoryModal', () => {
         expect(screen.queryByTestId('translation-controls')).not.toBeInTheDocument();
     });
 
-    it('changes the selected language through translation controls', async () => {
+    it('does not render translation controls when English is not among translatedLanguages', () => {
+        renderModal({ translatedLanguages: [PL_LANGUAGE] });
+
+        expect(screen.queryByTestId('translation-controls')).not.toBeInTheDocument();
+    });
+
+    it('locks the language dropdown to English only, excluding other languages', () => {
         renderModal({ translatedLanguages: [EN_LANGUAGE, PL_LANGUAGE] });
+
+        expect(screen.getByTestId('languages-count')).toHaveTextContent('1');
 
         fireEvent.click(screen.getByTestId('choose-last-language'));
 
-        await waitFor(() => {
-            expect(screen.getByTestId('selected-language')).toHaveTextContent('pl');
-        });
+        expect(screen.getByTestId('selected-language')).toHaveTextContent('en');
     });
 
     it('submits the form when Save is clicked and the form is valid', async () => {

--- a/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.test.tsx
+++ b/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.test.tsx
@@ -126,6 +126,32 @@ describe('TranslateProgramCategoryModal', () => {
         expect(screen.queryByTestId('translation-controls')).not.toBeInTheDocument();
     });
 
+    it('renders translation controls once translatedLanguages resolves asynchronously after mount', () => {
+        const onClose = jest.fn();
+        const { rerender } = render(
+            <TranslateProgramCategoryModal
+                isOpen={true}
+                onClose={onClose}
+                translatedLanguages={[]}
+                categories={CATEGORY_LIST}
+            />,
+        );
+
+        expect(screen.queryByTestId('translation-controls')).not.toBeInTheDocument();
+
+        rerender(
+            <TranslateProgramCategoryModal
+                isOpen={true}
+                onClose={onClose}
+                translatedLanguages={[EN_LANGUAGE]}
+                categories={CATEGORY_LIST}
+            />,
+        );
+
+        expect(screen.getByTestId('translation-controls')).toBeInTheDocument();
+        expect(screen.getByTestId('selected-language')).toHaveTextContent('en');
+    });
+
     it('does not render translation controls when English is not among translatedLanguages', () => {
         renderModal({ translatedLanguages: [PL_LANGUAGE] });
 
@@ -190,5 +216,42 @@ describe('TranslateProgramCategoryModal', () => {
 
         fireEvent.click(screen.getByTestId('modal'));
         expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('resets stale validity/dirty state when reopened after being closed', () => {
+        mockFormIsValid = true;
+        mockFormIsDirty = true;
+        const onClose = jest.fn();
+
+        const { rerender } = render(
+            <TranslateProgramCategoryModal
+                isOpen={true}
+                onClose={onClose}
+                translatedLanguages={[EN_LANGUAGE]}
+                categories={CATEGORY_LIST}
+            />,
+        );
+
+        expect(screen.getByTestId('save-localization-btn')).not.toBeDisabled();
+
+        rerender(
+            <TranslateProgramCategoryModal
+                isOpen={false}
+                onClose={onClose}
+                translatedLanguages={[EN_LANGUAGE]}
+                categories={CATEGORY_LIST}
+            />,
+        );
+
+        rerender(
+            <TranslateProgramCategoryModal
+                isOpen={true}
+                onClose={onClose}
+                translatedLanguages={[EN_LANGUAGE]}
+                categories={CATEGORY_LIST}
+            />,
+        );
+
+        expect(screen.getByTestId('save-localization-btn')).toBeDisabled();
     });
 });

--- a/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.test.tsx
+++ b/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.test.tsx
@@ -1,0 +1,188 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { ProgramCategory } from '@/types/admin/programs';
+import { LocalizationLanguage } from '@/types/common/language';
+import { TranslateProgramCategoryModal } from './TranslateProgramCategoryModal';
+
+let mockFormIsValid = true;
+let mockFormIsDirty = true;
+
+const mockFormSubmit = jest.fn();
+
+jest.mock('@/components/admin/localization-modal/LocalizationModal', () => ({
+    LocalizationModal: (props: unknown) => require('@/utils/test-mocks/test-mocks').MockLocalizationModal(props),
+}));
+
+jest.mock('@/components/admin/translation-controls/TranslationControls', () => ({
+    TranslationControls: ({ selectedLanguage, languages, onLanguageChange, isSubmitting }: any) => (
+        <div data-testid="translation-controls">
+            <span data-testid="selected-language">{selectedLanguage?.code ?? 'none'}</span>
+            <span data-testid="is-submitting">{String(isSubmitting)}</span>
+            <span data-testid="languages-count">{String(languages?.length ?? 0)}</span>
+            <button
+                data-testid="choose-last-language"
+                onClick={() => onLanguageChange?.(languages?.[languages.length - 1] ?? null)}
+            >
+                choose last language
+            </button>
+        </div>
+    ),
+}));
+
+jest.mock('../translate-program-category-form/TranslateProgramCategoryForm', () => {
+    const React = require('react');
+
+    return {
+        TranslateProgramCategoryForm: React.forwardRef(
+            ({ onSubmit, onValidationChange, onDirtyChange, categories }: any, ref: React.Ref<any>) => {
+                React.useImperativeHandle(ref, () => ({
+                    submit: () => {
+                        mockFormSubmit();
+                        onSubmit({ categoryId: 1, name: 'Translated category name' });
+                    },
+                    isValid: () => mockFormIsValid,
+                    isDirty: () => mockFormIsDirty,
+                }));
+
+                React.useEffect(() => {
+                    onValidationChange?.(mockFormIsValid);
+                    onDirtyChange?.(mockFormIsDirty);
+                }, [onValidationChange, onDirtyChange]);
+
+                return (
+                    <div
+                        data-testid="translate-program-category-form"
+                        data-categories={String(categories?.length ?? 0)}
+                    />
+                );
+            },
+        ),
+    };
+});
+
+const EN_LANGUAGE: LocalizationLanguage = {
+    id: 2,
+    code: 'en',
+    name: 'English',
+};
+
+const PL_LANGUAGE: LocalizationLanguage = {
+    id: 3,
+    code: 'pl',
+    name: 'Polish',
+};
+
+const CATEGORY_LIST: ProgramCategory[] = [
+    { id: 1, name: 'Category 1', programsCount: 2 },
+    { id: 2, name: 'Category 2', programsCount: 4 },
+];
+
+describe('TranslateProgramCategoryModal', () => {
+    const renderModal = (props: Partial<React.ComponentProps<typeof TranslateProgramCategoryModal>> = {}) => {
+        const defaultProps: React.ComponentProps<typeof TranslateProgramCategoryModal> = {
+            isOpen: true,
+            onClose: jest.fn(),
+            translatedLanguages: [EN_LANGUAGE],
+            categories: CATEGORY_LIST,
+        };
+
+        return render(<TranslateProgramCategoryModal {...defaultProps} {...props} />);
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockFormIsValid = true;
+        mockFormIsDirty = true;
+    });
+
+    it('always renders with the "Додати переклад" title', () => {
+        renderModal();
+
+        expect(screen.getByTestId('modal-title')).toHaveTextContent(
+            COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION,
+        );
+    });
+
+    it('passes categories through to the form', () => {
+        renderModal();
+
+        expect(screen.getByTestId('translate-program-category-form')).toHaveAttribute(
+            'data-categories',
+            String(CATEGORY_LIST.length),
+        );
+    });
+
+    it('selects the first translated language by default', () => {
+        renderModal({ translatedLanguages: [EN_LANGUAGE, PL_LANGUAGE] });
+
+        expect(screen.getByTestId('selected-language')).toHaveTextContent('en');
+    });
+
+    it('does not render translation controls when translatedLanguages is empty', () => {
+        renderModal({ translatedLanguages: [] });
+
+        expect(screen.queryByTestId('translation-controls')).not.toBeInTheDocument();
+    });
+
+    it('changes the selected language through translation controls', async () => {
+        renderModal({ translatedLanguages: [EN_LANGUAGE, PL_LANGUAGE] });
+
+        fireEvent.click(screen.getByTestId('choose-last-language'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('selected-language')).toHaveTextContent('pl');
+        });
+    });
+
+    it('submits the form when Save is clicked and the form is valid', async () => {
+        renderModal();
+
+        fireEvent.click(screen.getByTestId('save-localization-btn'));
+
+        await waitFor(() => {
+            expect(mockFormSubmit).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    it('does not submit when the form is invalid', () => {
+        mockFormIsValid = false;
+        renderModal();
+
+        fireEvent.click(screen.getByTestId('save-localization-btn'));
+
+        expect(mockFormSubmit).not.toHaveBeenCalled();
+    });
+
+    it('shows confirmation modal when closing a dirty form and closes immediately for a clean form', () => {
+        const onClose = jest.fn();
+
+        mockFormIsDirty = true;
+        const { rerender } = render(
+            <TranslateProgramCategoryModal
+                isOpen={true}
+                onClose={onClose}
+                translatedLanguages={[EN_LANGUAGE]}
+                categories={CATEGORY_LIST}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('modal'));
+        expect(screen.getByTestId('confirmation-modal')).toBeInTheDocument();
+        expect(onClose).not.toHaveBeenCalled();
+
+        mockFormIsDirty = false;
+        rerender(
+            <TranslateProgramCategoryModal
+                isOpen={true}
+                onClose={onClose}
+                translatedLanguages={[EN_LANGUAGE]}
+                categories={CATEGORY_LIST}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('modal'));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.tsx
+++ b/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.tsx
@@ -31,14 +31,12 @@ export const TranslateProgramCategoryModal = ({
 
     const [language, setLanguage] = useState<LocalizationLanguage | null>(englishLanguages[0] ?? null);
 
-    // Keeps the selected language in sync when the modal reopens or `translatedLanguages` resolves after mount.
     useEffect(() => {
         if (!isOpen) return;
         setLanguage(englishLanguages[0] ?? null);
     }, [englishLanguages, isOpen]);
 
-    // Resets stale validity/dirty state left over from a previous open, without touching the initial mount
-    // (the form's own mount effect already reports its real initial validity/dirty state).
+    // Avoid overriding the form's initial validity/dirty state on first mount.
     const wasOpenRef = useRef(isOpen);
     useEffect(() => {
         const wasOpen = wasOpenRef.current;

--- a/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.tsx
+++ b/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.tsx
@@ -1,0 +1,71 @@
+import { useRef, useState } from 'react';
+import { LocalizationModal } from '@/components/admin/localization-modal/LocalizationModal';
+import { TranslationControls } from '@/components/admin/translation-controls/TranslationControls';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { ProgramCategory } from '@/types/admin/programs';
+import { LocalizationLanguage } from '@/types/common/language';
+import {
+    TranslateProgramCategoryForm,
+    TranslateProgramCategoryFormRef,
+    TranslateProgramCategoryFormValues,
+} from '../translate-program-category-form/TranslateProgramCategoryForm';
+
+interface TranslateProgramCategoryModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    categories: ProgramCategory[];
+    translatedLanguages: LocalizationLanguage[];
+}
+
+export const TranslateProgramCategoryModal = ({
+    isOpen,
+    onClose,
+    categories,
+    translatedLanguages,
+}: TranslateProgramCategoryModalProps) => {
+    const formRef = useRef<TranslateProgramCategoryFormRef>(null);
+    const [isFormValid, setIsFormValid] = useState(false);
+    const [isDirty, setIsDirty] = useState(false);
+    const [language, setLanguage] = useState<LocalizationLanguage | null>(translatedLanguages[0] ?? null);
+
+    const handleSaveClick = () => {
+        if (!formRef.current?.isValid()) return;
+        formRef.current.submit();
+    };
+
+    const checkIsDirty = () => {
+        return formRef.current?.isDirty() ?? false;
+    };
+
+    // TODO: wire real persistence (create/update translation, close on success, toast, badge update) — see US #1858.
+    const handleFormSubmit = async (_data: TranslateProgramCategoryFormValues) => {};
+
+    return (
+        <LocalizationModal
+            isOpen={isOpen}
+            onClose={onClose}
+            title={COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION}
+            onSave={handleSaveClick}
+            isSubmitting={false}
+            isFormValid={isFormValid}
+            checkIsDirty={checkIsDirty}
+            isDirty={isDirty}
+        >
+            {language && (
+                <TranslationControls
+                    selectedLanguage={language}
+                    isSubmitting={false}
+                    languages={translatedLanguages}
+                    onLanguageChange={setLanguage}
+                />
+            )}
+            <TranslateProgramCategoryForm
+                ref={formRef}
+                categories={categories}
+                onValidationChange={setIsFormValid}
+                onDirtyChange={setIsDirty}
+                onSubmit={handleFormSubmit}
+            />
+        </LocalizationModal>
+    );
+};

--- a/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.tsx
+++ b/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.tsx
@@ -27,10 +27,7 @@ export const TranslateProgramCategoryModal = ({
     const [isFormValid, setIsFormValid] = useState(false);
     const [isDirty, setIsDirty] = useState(false);
 
-    const englishLanguages = useMemo(
-        () => translatedLanguages.filter((l) => l.code === 'en'),
-        [translatedLanguages],
-    );
+    const englishLanguages = useMemo(() => translatedLanguages.filter((l) => l.code === 'en'), [translatedLanguages]);
 
     const [language, setLanguage] = useState<LocalizationLanguage | null>(englishLanguages[0] ?? null);
 

--- a/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.tsx
+++ b/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { LocalizationModal } from '@/components/admin/localization-modal/LocalizationModal';
 import { TranslationControls } from '@/components/admin/translation-controls/TranslationControls';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
@@ -26,7 +26,13 @@ export const TranslateProgramCategoryModal = ({
     const formRef = useRef<TranslateProgramCategoryFormRef>(null);
     const [isFormValid, setIsFormValid] = useState(false);
     const [isDirty, setIsDirty] = useState(false);
-    const [language, setLanguage] = useState<LocalizationLanguage | null>(translatedLanguages[0] ?? null);
+
+    const englishLanguages = useMemo(
+        () => translatedLanguages.filter((l) => l.code === 'en'),
+        [translatedLanguages],
+    );
+
+    const [language, setLanguage] = useState<LocalizationLanguage | null>(englishLanguages[0] ?? null);
 
     const handleSaveClick = () => {
         if (!formRef.current?.isValid()) return;
@@ -55,7 +61,7 @@ export const TranslateProgramCategoryModal = ({
                 <TranslationControls
                     selectedLanguage={language}
                     isSubmitting={false}
-                    languages={translatedLanguages}
+                    languages={englishLanguages}
                     onLanguageChange={setLanguage}
                 />
             )}

--- a/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.tsx
+++ b/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { LocalizationModal } from '@/components/admin/localization-modal/LocalizationModal';
 import { TranslationControls } from '@/components/admin/translation-controls/TranslationControls';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
@@ -30,6 +30,24 @@ export const TranslateProgramCategoryModal = ({
     const englishLanguages = useMemo(() => translatedLanguages.filter((l) => l.code === 'en'), [translatedLanguages]);
 
     const [language, setLanguage] = useState<LocalizationLanguage | null>(englishLanguages[0] ?? null);
+
+    // Keeps the selected language in sync when the modal reopens or `translatedLanguages` resolves after mount.
+    useEffect(() => {
+        if (!isOpen) return;
+        setLanguage(englishLanguages[0] ?? null);
+    }, [englishLanguages, isOpen]);
+
+    // Resets stale validity/dirty state left over from a previous open, without touching the initial mount
+    // (the form's own mount effect already reports its real initial validity/dirty state).
+    const wasOpenRef = useRef(isOpen);
+    useEffect(() => {
+        const wasOpen = wasOpenRef.current;
+        wasOpenRef.current = isOpen;
+        if (!wasOpen && isOpen) {
+            setIsFormValid(false);
+            setIsDirty(false);
+        }
+    }, [isOpen]);
 
     const handleSaveClick = () => {
         if (!formRef.current?.isValid()) return;


### PR DESCRIPTION
## Github ticker

* [#1855](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1855)

## Description

As an Admin, I want to open a modal window to translate a program category, so that I can choose how I want to translate the content. Program categories previously had no way to be translated — the "Перекласти" context-menu action already available for Team categories did not exist for Program categories, and no translation modal was wired up. [Related backend PR](https://github.com/ita-social-projects/VictoryCenter-Back/pull/3282)

## How it looks

<img width="3837" height="1962" alt="Screenshot 2026-08-11 112235" src="https://github.com/user-attachments/assets/ee649586-7fba-4e57-a6e3-b29ca97f0ec8" />
<img width="1615" height="1020" alt="Screenshot 2026-08-11 112254" src="https://github.com/user-attachments/assets/78ee4ab2-ca8f-4a05-b6b7-a566ac885fc5" />

## Summary of change

- **New menu item:** added `addTranslation` ("Перекласти") to the program category context menu in `ProgramsPageContent.tsx`, opening the `isCategoryToTranslate` modal state slot already present in the shared `useModalsState` hook (previously unused by the Programs page).
- **New component** `TranslateProgramCategoryForm` (`src/pages/admin/programs/components/translate-program-category-form/`) — category dropdown (starts unselected) + "Назва" input (disabled until a category is chosen, reset whenever the selected category changes).
- **New component** `TranslateProgramCategoryModal` (`src/pages/admin/programs/components/translate-program-category-modal/`) — wraps the form in the shared `LocalizationModal`/`TranslationControls`, always opens in "Додати переклад" mode with all fields empty and language locked to "Англійська".
- **`ProgramsPageModals.tsx`:** renders `TranslateProgramCategoryModal` when `isCategoryToTranslate` is true.
- **Tests:** added `TranslateProgramCategoryForm.test.tsx`, `TranslateProgramCategoryModal.test.tsx`, and extended `ProgramsPageContent.test.tsx` / `ProgramsPageModals.test.tsx` with the new menu item and modal-render scenarios.

Note: actually persisting the translation (API call, snackbar, badge refresh), pre-filling an already-translated category, and enabling "Згенерувати переклад" are intentionally out of scope for this PR — tracked separately.

## How to recreate changes

1. Log in as an Administrator.
2. Navigate to the 'Програми' page.
3. Select any category in the category bar.
4. Click the burger menu icon next to the category bar.
5. Select the 'Перекласти' option from the opened menu.
6. Verify: the 'Додати переклад' modal opens — all fields empty, 'Категорія' dropdown active but unselected, 'Назва' field disabled, language dropdown shows only 'Англійська' (pre-selected), 'Згенерувати переклад' and 'Зберегти переклад' buttons are disabled, 'X' button is active.
7. Select a category from the dropdown → verify the 'Назва' field becomes editable and stays empty.
8. Click 'X' with nothing touched → verify the modal closes immediately without a prompt.
9. Select a category (and/or type a name), click 'X' → verify the confirmation prompt "Зміни будуть втрачені. Бажаєте продовжити?" appears; 'Так' discards and closes, 'Ні' keeps the modal open with the data intact.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an “Add Translation” option to program category menus.
  - Added a category translation dialog for selecting a language and entering a translated category name.
  - Added validation, required-field handling, and unsaved-change protection when closing the dialog.
  - Changing the category resets the translated name and related validation messages.
  - Reopening the dialog starts with refreshed translation details and avoids retaining stale form state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->