### PR TITLE
Fix/issue 2267 [Single Program] [UI] Input field does not resize and shows scrollbar at max character limit

### DIFF
--- a/src/pages/admin/programs/components/program-form/ProgramForm.test.tsx
+++ b/src/pages/admin/programs/components/program-form/ProgramForm.test.tsx
@@ -57,8 +57,10 @@ jest.mock(
             onBlur,
             error,
             id,
+            autoGrow,
+            maxRows,
         }: TextAreaWithCharacterLimitGroupProps) => (
-            <div data-testid={`group-${id}`}>
+            <div data-testid={`group-${id}`} data-auto-grow={String(autoGrow)} data-max-rows={String(maxRows)}>
                 <label htmlFor={id}>{label}</label>
                 <textarea id={id} data-testid={`input-${id}`} value={value} onChange={onChange} onBlur={onBlur} />
                 {error && <span data-testid={`error-${id}`}>{error}</span>}
@@ -322,6 +324,15 @@ describe('ProgramForm', () => {
             expect(screen.getByTestId('input-description')).toHaveValue('');
             expect(screen.getByTestId('value-backgroundImage')).toHaveTextContent('NoImage');
             expect(screen.getByTestId('value-previewImage')).toHaveTextContent('NoImage');
+        });
+
+        it('should render name and description as uncapped auto-growing textareas', () => {
+            renderProgramForm();
+
+            expect(screen.getByTestId('group-name')).toHaveAttribute('data-auto-grow', 'true');
+            expect(screen.getByTestId('group-name')).toHaveAttribute('data-max-rows', '0');
+            expect(screen.getByTestId('group-description')).toHaveAttribute('data-auto-grow', 'true');
+            expect(screen.getByTestId('group-description')).toHaveAttribute('data-max-rows', '0');
         });
 
         it('should render with initial data when provided', () => {

--- a/src/pages/admin/programs/components/program-form/ProgramForm.tsx
+++ b/src/pages/admin/programs/components/program-form/ProgramForm.tsx
@@ -617,7 +617,7 @@ export const ProgramForm = forwardRef<ProgramFormRef, ProgramFormProps>(
                                     PROGRAM_VALIDATION.name.max,
                                 )}
                                 autoGrow={true}
-                                maxRows={12}
+                                maxRows={0}
                             />
 
                             <InputWithCharacterLimitGroup
@@ -686,7 +686,7 @@ export const ProgramForm = forwardRef<ProgramFormRef, ProgramFormProps>(
                                     PROGRAM_VALIDATION.description.max,
                                 )}
                                 autoGrow={true}
-                                maxRows={16}
+                                maxRows={0}
                             />
 
                             <PhotoInputGroup


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2267)

## Description

This PR fixes the "Назва" and "Опис" fields in the admin Add/Edit Program modal, where entering text near the character limit caused an internal scrollbar to appear instead of the field growing to show the full text — even though the character count hadn't reached its max (90/400). The fields grow with content but stop growing once they hit `maxRows` rows, switching to an internal scrollbar. Because each line break (not just each character) counts toward the row cap, a field could run out of rows well before it ran out of allowed characters, so text got clipped behind a scrollbar instead of being fully visible.

## How it looks

<img width="1280" height="586" alt="image" src="https://github.com/user-attachments/assets/d386f9b8-b936-4cfc-90c0-1fb33b6ddecf" />

## Summary of change

*   **`ProgramForm.tsx`**: Changed `maxRows` from 12/16 to 0 on the Name and Description fields. `TextAreaWithCharacterLimit` already treats `maxRows={0}` as "no cap" (grow to fit content, no internal scroll).

## How to recreate changes

1. Navigate to the admin **"Програми"** page and open Add/Edit Program.
2. In the **"Назва"** or **"Опис"** field, type or paste text (with line breaks) approaching the character limit.
3. **Before this fix**: The field stops growing and shows an internal scrollbar, hiding part of the text.
4. **After this fix**: The field keeps expanding to show all entered text, up to the character limit, with no internal scrollbar.


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Program name and description fields now expand without a row limit, making longer content easier to enter and review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->