### PR TITLE
Fix/issue 3237 [Reports][Admin panel] Error message is displayed when attempting to enter a 3rd decimal digit in 'Сума (UAH)' and 'Сума (USD)' fields

### DIFF
--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
@@ -87,10 +87,8 @@ describe('FUNDS_EXPENDITURES_RECORD_VALIDATION_FUNCTIONS', () => {
             expect(validateFundsExpendituresAmount('1 200,50', 'save')).toBeUndefined();
         });
 
-        it('should return error when user types more than two decimal digits', () => {
-            expect(validateFundsExpendituresAmount('1 200,123', 'change')).toBe(
-                FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DECIMALS,
-            );
+        it('should accept value with more than two decimal digits because they will be normalized', () => {
+            expect(validateFundsExpendituresAmount('1 200,123', 'change')).toBeUndefined();
         });
 
         it('should ignore spaces when counting fractional digits', () => {

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
@@ -89,6 +89,7 @@ describe('FUNDS_EXPENDITURES_RECORD_VALIDATION_FUNCTIONS', () => {
 
         it('should accept value with more than two decimal digits because they will be normalized', () => {
             expect(validateFundsExpendituresAmount('1 200,123', 'change')).toBeUndefined();
+            expect(normalizeFundsExpendituresAmountInput('1 200,123', true)).toBe('1 200,12');
         });
 
         it('should ignore spaces when counting fractional digits', () => {

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
@@ -36,29 +36,10 @@ export const normalizeFundsExpendituresAmountInput = (value: string | undefined 
     return trimEnd ? normalized.trim() : normalized;
 };
 
-const exceedsMaxDecimalDigits = (value: string): boolean => {
-    if (!value) {
-        return false;
-    }
-
-    const withCommaSeparator = value.replaceAll(/\s+/g, ' ').trimStart().replaceAll('.', ',');
-    const firstCommaIndex = withCommaSeparator.indexOf(',');
-    if (firstCommaIndex === -1) {
-        return false;
-    }
-
-    const rawDecimalPart = withCommaSeparator.slice(firstCommaIndex + 1).replace(/[^\d]/g, '');
-    return rawDecimalPart.length > 2;
-};
-
 export const validateFundsExpendituresAmount = (
     value: string,
     trigger: FundsExpendituresAmountValidationTrigger = 'change',
 ): string | undefined => {
-    if (exceedsMaxDecimalDigits(value)) {
-        return FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DECIMALS;
-    }
-
     const normalized = normalizeFundsExpendituresAmountInput(value, true);
 
     if (!normalized) {


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3237)

## Description
This PR fixes the 'Сума (UAH)' and 'Сума (USD)' fields in 'Додати витрату по програмі' modal window. Entering a 3rd decimal digit caused an unnecessary error message to appear, instead of simply preventing the 3rd digit input.
<!--- Please decripe the main goal of this PR and why it was created --->

## How it looks

https://github.com/user-attachments/assets/6772cec0-5e7a-4786-a451-27136e92b328

The amount fields (both UAH and USD) now normalize extra decimal digits by trimming them to two places instead of showing a validation error.
<!--- Please provide iamges(screenshots or screen recording) of changes --->

## Summary of change

- `funds-expenditures-record-schema.ts` : Removed the `exceedsMaxDecimalDigits` helper, which which validated the decimal digits limit before normalization. Now decimal digits limit is handled during normalization.
- `funds-expenditures-record-schema.test.ts`: Updated tests to reflect that values with more than two decimal digits are accepted and normalized instead of triggering a validation error.

<!--- Please specify what was changed --->

## How to recreate changes

1. Log in as an admin.
2. Navigate to the 'Звіт та аналітика' -> 'Доходи та витрати' tab.
3. Open the 'Додати надходження' (or expense) modal.
4. Focus on the Amount (UAH or USD) field.
5. Attempt to type or past a number containing 3 or more extra decimal digits.
6. Observe that extra decimal digits are trimmed to two places immediately and no validation error is shown.

<!--- Please provide short instruction step-by-step how to see changes that was implemented by this PR --->


## CHECK LIST
- [X]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [X]  Changes has light impact on users
- [ ]  Test covetage was updated
- [X]  PR meets all conventions

Closes #3237


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Amount fields now accept values with more than two decimal places during editing.
  * Extra fractional digits are automatically truncated to two decimal places during normalization.
  * Updated validation behavior ensures normalized amounts continue through the standard formatting checks without triggering an unnecessary maximum-decimals error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->