### PR TITLE
Fix/issue-2465 [Single Program] [UI] Clean-up icon does not update on-the-fly after entering valid input in text fields

### DIFF
--- a/src/hooks/admin/use-field-handlers/useFieldHandlers.test.ts
+++ b/src/hooks/admin/use-field-handlers/useFieldHandlers.test.ts
@@ -91,6 +91,29 @@ describe('useFieldHandlers', () => {
         expect(managerResult.current.errors.name).toBeUndefined();
     });
 
+    it('keeps the error on change while the value is still invalid', () => {
+        const validateName = jest.fn((value: string) => (value.length >= 5 ? undefined : 'Too short'));
+        const { result: managerResult } = makeManager();
+
+        const { result: fieldsResult } = renderHook(() =>
+            useFieldHandlers(managerResult.current, [{ name: 'name', validateFn: validateName }]),
+        );
+
+        act(() => {
+            fieldsResult.current.name.onBlur();
+        });
+
+        expect(managerResult.current.errors.name).toBe('Too short');
+
+        act(() => {
+            fieldsResult.current.name.onChange({
+                target: { value: 'abc' },
+            } as React.ChangeEvent<HTMLInputElement>);
+        });
+
+        expect(managerResult.current.errors.name).toBe('Too short');
+    });
+
     it('calls validateFn and sets error on onBlur', () => {
         const validateName = jest.fn((value: string) => (value ? undefined : 'Required'));
         const { result: managerResult } = makeManager();

--- a/src/hooks/admin/use-field-handlers/useFieldHandlers.test.ts
+++ b/src/hooks/admin/use-field-handlers/useFieldHandlers.test.ts
@@ -51,6 +51,46 @@ describe('useFieldHandlers', () => {
         expect(managerResult.current.formState.name).toBe('Bob');
     });
 
+    it('does NOT set an error on change when no error is shown yet', () => {
+        const validateName = jest.fn((value: string) => (value.length >= 5 ? undefined : 'Too short'));
+        const { result: managerResult } = makeManager();
+
+        const { result: fieldsResult } = renderHook(() =>
+            useFieldHandlers(managerResult.current, [{ name: 'name', validateFn: validateName }]),
+        );
+
+        act(() => {
+            fieldsResult.current.name.onChange({
+                target: { value: 'ab' },
+            } as React.ChangeEvent<HTMLInputElement>);
+        });
+
+        expect(managerResult.current.errors.name).toBeUndefined();
+    });
+
+    it('clears the error on change when error is already shown', () => {
+        const validateName = jest.fn((value: string) => (value.length >= 5 ? undefined : 'Too short'));
+        const { result: managerResult } = makeManager();
+
+        const { result: fieldsResult } = renderHook(() =>
+            useFieldHandlers(managerResult.current, [{ name: 'name', validateFn: validateName }]),
+        );
+
+        act(() => {
+            fieldsResult.current.name.onBlur();
+        });
+
+        expect(managerResult.current.errors.name).toBe('Too short');
+
+        act(() => {
+            fieldsResult.current.name.onChange({
+                target: { value: 'abcde' },
+            } as React.ChangeEvent<HTMLInputElement>);
+        });
+
+        expect(managerResult.current.errors.name).toBeUndefined();
+    });
+
     it('calls validateFn and sets error on onBlur', () => {
         const validateName = jest.fn((value: string) => (value ? undefined : 'Required'));
         const { result: managerResult } = makeManager();

--- a/src/hooks/admin/use-field-handlers/useFieldHandlers.ts
+++ b/src/hooks/admin/use-field-handlers/useFieldHandlers.ts
@@ -27,7 +27,17 @@ export function useFieldHandlers<TFormValues, TFormErrors, TConfig extends Field
             const binding: FieldBinding = {
                 value,
                 onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-                    setFormState((prev) => ({ ...prev, [name]: e.target.value }) as TFormValues);
+                    const targetValue = e.target.value;
+                    setFormState((prev) => ({ ...prev, [name]: targetValue }) as TFormValues);
+                    if (validateFn) {
+                        const error = validateFn(targetValue, false);
+                        setErrors((prev) => {
+                            const currentError = (prev as Record<string, string | undefined>)[name];
+                            if (!currentError) return prev;
+
+                            return { ...prev, [name]: error } as TFormErrors;
+                        });
+                    }
                 },
                 onBlur: () => {
                     if (validateFn) {

--- a/src/hooks/admin/use-field-handlers/useFieldHandlers.ts
+++ b/src/hooks/admin/use-field-handlers/useFieldHandlers.ts
@@ -34,6 +34,7 @@ export function useFieldHandlers<TFormValues, TFormErrors, TConfig extends Field
                         setErrors((prev) => {
                             const currentError = (prev as Record<string, string | undefined>)[name];
                             if (!currentError) return prev;
+                            if (currentError === error) return prev;
 
                             return { ...prev, [name]: error } as TFormErrors;
                         });


### PR DESCRIPTION
## Github ticket

* [#2465](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2465)

## Description

The clean-up icon, the red border and the error message in the "Додати програму" modal didn't update while the user was typing. Once a validation error appeared (after the first blur), it stayed on screen until the user left the field again - even after the entered value had already become valid.

## How it looks


https://github.com/user-attachments/assets/32d7365d-ae56-4130-9f43-111f24ff9fea


## Summary of change

`useFieldHandlers.ts` - the `onChange` handler now re-validates the field and updates errors, but only when an error is already displayed for that field. If no error is shown, the previous errors object is returned unchanged, so on extra re-render happens and the min-length error doesn't appear before the first blur.

`onBlur` is unchanged - it remains the trigger for the first appearance of the error.

Max-length validation and the live character counter were not touched: they work through a separate mechanism and already behaved in real time.

`useFieldHandlers.test.ts` - two cases added: an error is NOT created on change when none is shown, and an existing error is cleared on change once the value becomes valid.

## How to recreate changes

1. Log in to the admin panel, go to Програми -> "Додати програму";
2. Click the "Назва" field, enter 1 character, then click outside the field -> the error "Не менше 5 символів", the red border and the red clean-up icon appear;
3. Click back into the field and type until it contains 5 or more characters;
4. Expected: the error message, the red border and the red icon disappear immediately, without leaving the field;
5. The same applies to "Опис" (min 10) "Локація" (min 2).


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated form fields to validate changes immediately when applicable.
  * Existing field errors are now cleared as soon as the entered value becomes valid.
  * Existing errors are preserved when changed values remain invalid.

* **Tests**
  * Added coverage for validation behavior when changing field values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->