### PR TITLE
fix: [Partners] address code review findings from PR #520 (translate flows)

### DIFF
--- a/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.tsx
+++ b/src/pages/admin/partners/components/partner-sections-editor/PartnerSectionsEditor.tsx
@@ -7,6 +7,7 @@ import {
 import { RequestOptions } from '@/types/common/api';
 import { ToastType } from '@/types/admin/toast';
 import { PARTNERS_TEXT } from '@/const/admin/partners';
+import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import axios from 'axios';
 import { PartnerFormValues } from '../partner-form/PartnerForm';
 import { PartnersApi } from '@/services/api/admin/partners/partners-api';
@@ -397,7 +398,8 @@ export const PartnerSectionsEditor = forwardRef<PartnerSectionsEditorRef, Partne
 
         const handleTranslated = useCallback(() => {
             refetchSections();
-        }, [refetchSections]);
+            addToast(COMMON_TEXT_ADMIN.MESSAGE.TRANSLATION_SAVED_SUCCESS, ToastType.Success);
+        }, [refetchSections, addToast]);
 
         const sectionToTranslate = useMemo(
             () => fetchedSections.find((s) => s.id === translatingSectionId) ?? null,

--- a/src/pages/admin/partners/components/translate-partner-banner-modal/TranslatePartnerBannerModal.test.tsx
+++ b/src/pages/admin/partners/components/translate-partner-banner-modal/TranslatePartnerBannerModal.test.tsx
@@ -168,6 +168,32 @@ describe('TranslatePartnerBannerModal', () => {
         expect(screen.getByTestId('selected-language')).toHaveTextContent('uk');
     });
 
+    it('selects a language once it arrives after the modal has already mounted with no languages', () => {
+        const { rerender } = render(
+            <TranslatePartnerBannerModal
+                isOpen={true}
+                onClose={jest.fn()}
+                banner={BANNER_WITHOUT_LOCALIZATION}
+                onTranslateBanner={jest.fn()}
+                translatedLanguages={[]}
+            />,
+        );
+
+        expect(screen.getByTestId('selected-language')).toHaveTextContent('none');
+
+        rerender(
+            <TranslatePartnerBannerModal
+                isOpen={true}
+                onClose={jest.fn()}
+                banner={BANNER_WITHOUT_LOCALIZATION}
+                onTranslateBanner={jest.fn()}
+                translatedLanguages={[UK_LANGUAGE, EN_LANGUAGE]}
+            />,
+        );
+
+        expect(screen.getByTestId('selected-language')).toHaveTextContent('en');
+    });
+
     it('uses null selected language when translatedLanguages is empty', () => {
         renderModal({ translatedLanguages: [] });
 

--- a/src/pages/admin/partners/components/translate-partner-banner-modal/TranslatePartnerBannerModal.tsx
+++ b/src/pages/admin/partners/components/translate-partner-banner-modal/TranslatePartnerBannerModal.tsx
@@ -6,7 +6,7 @@ import { useTranslatePartnerBanner } from '@/hooks/admin/use-translate-partner-b
 import { ModalMode } from '@/types/admin/common';
 import { PartnerBanner } from '@/types/admin/partners';
 import { LocalizationLanguage } from '@/types/common/language';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
     TranslatePartnerBannerForm,
     TranslatePartnerBannerFormRef,
@@ -36,6 +36,11 @@ export const TranslatePartnerBannerModal = ({
         if (!translatedLanguages?.length) return null;
         return translatedLanguages.find((l) => l.code !== DEFAULT_LOCALE) ?? translatedLanguages[0];
     });
+
+    useEffect(() => {
+        if (language || !translatedLanguages?.length) return;
+        setLanguage(translatedLanguages.find((l) => l.code !== DEFAULT_LOCALE) || translatedLanguages[0]);
+    }, [translatedLanguages, language]);
 
     const existingLocalization = useMemo(() => {
         if (!banner?.localizations || !language) return null;


### PR DESCRIPTION
## JIRA or Github ticker

- Follow-up to [#2543](https://github.com/ita-social-projects/VictoryCenter-Client/issues/2543), review of [#520](https://github.com/ita-social-projects/VictoryCenter-Client/pull/520)

## Description

This PR contains fixes found during a code review of #520 (Partners page title/section translation). Two Medium-severity issues were identified by comparing the PR's diff against acceptance criteria for #2543 and against established conventions used by the other `useTranslateX` flows in the codebase (FAQ, Programs, Team, Reports).

## Summary of change

- **Show a success toast after translating a partner section.** `PartnerSectionsEditor`'s `handleTranslated` callback only refetched sections after a save, giving no confirmation to the admin. Every other translate flow (FAQ, Programs, Team, Reports, and this same PR's own banner-translation handler) shows a `TRANSLATION_SAVED_SUCCESS` toast on success — the section flow was the odd one out. Added the matching `addToast` call.
- **Fix translate-banner modal losing track of the target language.** `TranslatePartnerBannerModal` picked its `language` state once via a lazy `useState` initializer over the `translatedLanguages` prop. Since this component stays mounted for the page's lifetime (only `isOpen` toggles visibility), if `translatedLanguages` was still empty on first render and populated afterward, `language` stayed `null` forever and the modal could never show a selected language. The sibling `TranslatePartnerSectionModal` (added in the same PR) already guards against exactly this with a `useEffect`; applied the same fix here for consistency, plus a test covering the new branch.

A third, Minor finding was noted but not fixed (out of scope per Critical/Medium-only fix policy): `useTranslatePartnerBanner`/`useTranslatePartnerSection` swallow errors in their `catch` blocks instead of re-throwing, unlike other `useTranslateX` hooks (e.g. `useTranslateFaq`). Currently harmless since nothing downstream depends on the throw, but worth aligning for consistency in a future pass.

## How to recreate changes

1. On the Partners admin page, switch to a non-base language and open "Add translation" on a partner section, fill in the fields, and save — a success toast now appears (previously none did).
2. To exercise the language-recovery fix: it only manifests if `translatedLanguages` loads after `TranslatePartnerBannerModal` first mounts; covered directly by the added unit test (`TranslatePartnerBannerModal.test.tsx`) rather than being easy to reproduce manually.

## CHECK LIST

- [x] New tests were added or existing were modified
- [ ] Changes have severe impact on users
- [ ] Changes have medium impact on users
- [x] Changes have light impact on users
- [x] Test coverage was updated
- [x] PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Translation dialogs now automatically select an available language when translation options load.
  * Saving translated partner sections now displays a confirmation message after the updates are refreshed.

* **Bug Fixes**
  * Improved translation workflows when language options become available after the dialog opens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->