### PR TITLE
Fix/issue-3117 [Team][Admin Panel] An error message 'Зображення завелике. Це може вплинути на якість. Обріжте до рекомендованого.' appears after uploading an uncropped image

### DIFF
--- a/src/components/admin/image-input/ImageInput.tsx
+++ b/src/components/admin/image-input/ImageInput.tsx
@@ -171,7 +171,7 @@ export const ImageInput = ({
     const handleCropCancel = async () => {
         setShowCropperModal(false);
 
-        if (!previewImage && rawImage && 'base64' in rawImage) {
+        if (rawImage && 'base64' in rawImage) {
             setPreviewImage(rawImage);
             onChange(rawImage);
 

--- a/src/pages/admin/team/components/member-form/MemberForm.tsx
+++ b/src/pages/admin/team/components/member-form/MemberForm.tsx
@@ -43,7 +43,6 @@ export interface MemberFormProps {
 }
 
 const mapImageInputError = (error: string | null): string | undefined => {
-    // Removing only ImageDimensionsTooLargeError
     if (!error || error === IMAGE_VALIDATION.ImageDimensionsTooLargeError) {
         return undefined;
     }

--- a/src/pages/admin/team/components/member-form/MemberForm.tsx
+++ b/src/pages/admin/team/components/member-form/MemberForm.tsx
@@ -5,6 +5,7 @@ import { ImageValues, Image } from '@/types/common/image';
 import { InputLabel } from '@/components/admin/input-label/InputLabel';
 import { SingleSelectInput } from '@/components/common/single-select-input/SingleSelectInput';
 import { TEAM_IMAGE_PLACEHOLDER, TEAM_MEMBER_VALIDATION, TEAM_MEMBERS_TEXT } from '@/const/admin/team';
+import { IMAGE_VALIDATION } from '@/const/admin/image';
 import { ImageInput } from '@/components/admin/image-input/ImageInput';
 import './MemberForm.scss';
 import { useFormManager } from '@/hooks/admin/use-form-manager/useFormManager';
@@ -40,6 +41,15 @@ export interface MemberFormProps {
     categories: TeamCategory[];
     onValidationChange?: (isValid: boolean) => void;
 }
+
+const mapImageInputError = (error: string | null): string | undefined => {
+    // Removing only ImageDimensionsTooLargeError
+    if (!error || error === IMAGE_VALIDATION.ImageDimensionsTooLargeError) {
+        return undefined;
+    }
+
+    return error;
+};
 
 const validateForm = (formState: TeamMemberFormValues, isPublishing: boolean): TeamMemberFormErrorState => {
     return {
@@ -164,7 +174,7 @@ export const MemberForm = forwardRef<TeamMemberFormRef, MemberFormProps>(
                         setError={(error) =>
                             setErrors((prev) => ({
                                 ...prev,
-                                image: error || undefined,
+                                image: mapImageInputError(error),
                             }))
                         }
                     />


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3117)

## Description

This PR resolves an issue where a false-positive error message ("Зображення завелике. Це може вплинути на якість. Обріжте до рекомендованого.") appeared below the photo when an admin uploaded an uncropped image in the Team Member modal. 

Although the record could still be published normally, displaying this error message created a misleading UI state for the admin user.

## How it looks

<img width="428" alt="Screenshot 2026-08-13 001145" src="https://github.com/user-attachments/assets/41634aa9-6b48-41df-acbf-d47224a5d4e3" />

## Summary of change

* **Validation Error Filtering (`mapImageInputError`)**: Added `mapImageInputError` helper function to filter out `ImageDimensionsTooLargeError` from the image validation error state. This prevents displaying the "image too large" error when an uncropped image is uploaded, ensuring a clean UI while keeping all other critical validation checks intact.
* **Crop Cancel Handler Update**: Ensured that declining the crop modal applies the newly uploaded `rawImage` even when editing an existing team member with a pre-existing image preview.

## How to recreate changes

1. Log in as an Admin and navigate to the **"Команда"** page.
2. Open either **"Додати в команду"** or **"Редагувати члена команди"** modal.
3. Upload an image larger than the designed display area (e.g., 800x600 px).
4. In the crop modal, decline cropping (click 'Ні' or 'X').
5. Observe that the image is set without any error message below the photo.
6. Click **"Опублікувати"** — the team member record is published successfully.

## CHECK LIST
- [ ] New tests was added or existing was modified
- [ ] Changes has severe impact on users
- [ ] Changes has medium impact on users
- [x] Changes has light impact on users
- [ ] Test coverage was updated
- [x] PR meets all conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image upload error handling in the member form.
  * Empty validation messages and large image-dimension errors are now suppressed to reduce unnecessary alerts.
  * Other image upload errors continue to be displayed so users can address genuine validation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->