### PR TITLE
Fix/issue-3302 [Reports][Admin panel] Grammatical error 'Звітній' instead of 'Звітний' in both the field label and dropdown placeholder on the 'Додати витрату по програмі' modal

### DIFF
--- a/src/const/admin/reports.ts
+++ b/src/const/admin/reports.ts
@@ -202,8 +202,8 @@ export const FUNDS_EXPENDITURES_TEXT = {
     },
     MODAL: {
         SHARED: {
-            REPORTING_YEAR_LABEL: 'Звітній рік',
-            REPORTING_YEAR_PLACEHOLDER: 'Оберіть звітній рік',
+            REPORTING_YEAR_LABEL: 'Звітний рік',
+            REPORTING_YEAR_PLACEHOLDER: 'Оберіть звітний рік',
             AMOUNT_UAH_LABEL: 'Сума (UAH)',
             AMOUNT_USD_LABEL: 'Сума (USD)',
             CONFIRM_CLOSE_TITLE: 'Зміни будуть втрачені. Бажаєте продовжити?',
@@ -302,7 +302,7 @@ export const FUNDS_EXPENDITURES_TEXT = {
     },
     TABLE: {
         COLUMNS: {
-            REPORTING_YEAR: 'Звітній рік',
+            REPORTING_YEAR: 'Звітний рік',
             TYPE: 'Тип',
             CATEGORY: 'Категорія',
             AMOUNT_UAH: 'Сума UAH',


### PR DESCRIPTION
## Github ticket

* [3302](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3302#issue-5131194986)

## Description

The main goal of this PR is to fix a grammatical error in Ukrainian localization text within the Reports section (Admin panel). Replaced the misspelled word "Звітній" with the correct form "Звітний" in field labels, dropdown placeholders, and table headers.

## How it looks

<img width="807" height="806" alt="Знімок екрана 2026-08-13 144352" src="https://github.com/user-attachments/assets/6a4854f1-64a9-47b7-8cd9-493e9ff9fec5" />

## Summary of change

- `src/const/admin/reports.ts`: Corrected spelling from "Звітній" to "Звітний" in `REPORTING_YEAR_LABEL`, `REPORTING_YEAR_PLACEHOLDER`, and table column `REPORTING_YEAR`.

## How to recreate changes

1. Open Admin panel and log in as an admin user.
2. Navigate to the **Reports** section ('Звіт та аналітика').
3. Click on 'Редагувати Доходи та витрати' -> 'Програмні витрати' -> '+ Витрати по програмі'.
4. Inspect the 'Звітний рік' field label and its dropdown placeholder text "Оберіть звітний рік".
5. Check the corresponding column header in the reports table.

## CHECK LIST
- [ ] New tests was added or existing was modified
- [ ] Changes has severe impact on users
- [ ] Changes has medium impact on users
- [x] Changes has light impact on users
- [ ] Test coverage was updated
- [ ] PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Ukrainian wording for “reporting year” in modal labels, table columns, and related placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->