### PR TITLE
Fix/issue-3313 [Reports][Admin Panel] USD amount isn't automatically cleared when clearing UAH amount field

### DIFF
--- a/src/utils/functions/update-funds-amounts/update-funds-amounts.test.ts
+++ b/src/utils/functions/update-funds-amounts/update-funds-amounts.test.ts
@@ -268,6 +268,39 @@ describe('updateFundsAmounts', () => {
             expect(result.amountUah).toBe('');
         });
 
+        it.each([
+            ['change', undefined],
+            ['blur', 'Field is required'],
+        ] as const)('should clear amountUsd when amountUah becomes empty on %s trigger', (trigger, uahError) => {
+            const stateWithUsd: FundsAmountsState = {
+                amountUah: '100',
+                amountUsd: '30',
+                errors: {
+                    amountUah: 'Previous UAH error',
+                    amountUsd: 'Previous USD error',
+                },
+            };
+
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('');
+            mockValidateFundsExpendituresAmount.mockImplementation(
+                (value: string, currentTrigger?: 'change' | 'blur' | 'save') => {
+                    if (value === '') {
+                        return currentTrigger === 'blur' ? 'Field is required' : undefined;
+                    }
+
+                    return undefined;
+                },
+            );
+
+            const updater = updateFundsAmounts('amountUah', '', '33.5', trigger);
+            const result = updater(stateWithUsd);
+
+            expect(result.amountUah).toBe('');
+            expect(result.amountUsd).toBe('');
+            expect(result.errors.amountUsd).toBeUndefined();
+            expect(result.errors.amountUah).toBe(uahError);
+        });
+
         it('should handle very large amounts', () => {
             const largeAmount = '999999999.99';
             mockNormalizeFundsExpendituresAmountInput.mockReturnValue(largeAmount);

--- a/src/utils/functions/update-funds-amounts/update-funds-amounts.test.ts
+++ b/src/utils/functions/update-funds-amounts/update-funds-amounts.test.ts
@@ -295,6 +295,7 @@ describe('updateFundsAmounts', () => {
             const updater = updateFundsAmounts('amountUah', '', '33.5', trigger);
             const result = updater(stateWithUsd);
 
+            expect(mockGetConvertedAmount).not.toHaveBeenCalled();
             expect(result.amountUah).toBe('');
             expect(result.amountUsd).toBe('');
             expect(result.errors.amountUsd).toBeUndefined();

--- a/src/utils/functions/update-funds-amounts/update-funds-amounts.test.ts
+++ b/src/utils/functions/update-funds-amounts/update-funds-amounts.test.ts
@@ -302,6 +302,47 @@ describe('updateFundsAmounts', () => {
             expect(result.errors.amountUah).toBe(uahError);
         });
 
+        it('should apply validation error for non-empty amountUah after clearing', () => {
+            const stateWithUsd: FundsAmountsState = {
+                amountUah: '100',
+                amountUsd: '30',
+                errors: {
+                    amountUah: undefined,
+                    amountUsd: 'Previous USD error',
+                },
+            };
+
+            mockNormalizeFundsExpendituresAmountInput.mockImplementation((input) => input ?? '');
+            mockValidateFundsExpendituresAmount.mockImplementation(
+                (value: string, currentTrigger?: 'change' | 'blur' | 'save') => {
+                    if (value === '') {
+                        return currentTrigger === 'blur' ? 'Field is required' : undefined;
+                    }
+
+                    if (value === '150') {
+                        return 'Invalid amount';
+                    }
+
+                    return undefined;
+                },
+            );
+
+            const clearUpdater = updateFundsAmounts('amountUah', '', '33.5', 'change');
+            const clearedState = clearUpdater(stateWithUsd);
+
+            expect(clearedState.amountUah).toBe('');
+            expect(clearedState.amountUsd).toBe('');
+            expect(clearedState.errors.amountUah).toBeUndefined();
+
+            const invalidUpdater = updateFundsAmounts('amountUah', '150', '33.5', 'change');
+            const result = invalidUpdater(clearedState);
+
+            expect(result.amountUah).toBe('150');
+            expect(result.errors.amountUah).toBe('Invalid amount');
+            expect(result.amountUsd).toBe('');
+            expect(mockGetConvertedAmount).not.toHaveBeenCalled();
+        });
+
         it('should handle very large amounts', () => {
             const largeAmount = '999999999.99';
             mockNormalizeFundsExpendituresAmountInput.mockReturnValue(largeAmount);

--- a/src/utils/functions/update-funds-amounts/update-funds-amounts.ts
+++ b/src/utils/functions/update-funds-amounts/update-funds-amounts.ts
@@ -29,12 +29,17 @@ export const updateFundsAmounts = (
         let nextAmountUahError = field === 'amountUah' ? currentFieldError : prev.errors.amountUah;
         let nextAmountUsdError = field === 'amountUsd' ? currentFieldError : prev.errors.amountUsd;
 
-        if (!currentFieldError && field === 'amountUah') {
-            const convertedAmount = getConvertedAmount(normalized, exchangeRate);
+        if (field === 'amountUah') {
+            if (normalized === '') {
+                nextAmountUsd = '';
+                nextAmountUsdError = undefined;
+            } else if (!currentFieldError) {
+                const convertedAmount = getConvertedAmount(normalized, exchangeRate);
 
-            if (convertedAmount !== null) {
-                nextAmountUsd = convertedAmount;
-                nextAmountUsdError = validateFundsExpendituresAmount(convertedAmount, trigger);
+                if (convertedAmount !== null) {
+                    nextAmountUsd = convertedAmount;
+                    nextAmountUsdError = validateFundsExpendituresAmount(convertedAmount, trigger);
+                }
             }
         }
 

--- a/src/utils/functions/update-funds-amounts/update-funds-amounts.ts
+++ b/src/utils/functions/update-funds-amounts/update-funds-amounts.ts
@@ -36,7 +36,10 @@ export const updateFundsAmounts = (
             } else if (!currentFieldError) {
                 const convertedAmount = getConvertedAmount(normalized, exchangeRate);
 
-                if (convertedAmount !== null) {
+                if (convertedAmount === null) {
+                    nextAmountUsd = '';
+                    nextAmountUsdError = undefined;
+                } else {
                     nextAmountUsd = convertedAmount;
                     nextAmountUsdError = validateFundsExpendituresAmount(convertedAmount, trigger);
                 }

--- a/src/utils/functions/update-funds-amounts/update-funds-amounts.ts
+++ b/src/utils/functions/update-funds-amounts/update-funds-amounts.ts
@@ -33,7 +33,9 @@ export const updateFundsAmounts = (
             if (normalized === '') {
                 nextAmountUsd = '';
                 nextAmountUsdError = undefined;
-            } else if (!currentFieldError) {
+            }
+
+            if (normalized !== '' && !currentFieldError) {
                 const convertedAmount = getConvertedAmount(normalized, exchangeRate);
 
                 if (convertedAmount !== null) {

--- a/src/utils/functions/update-funds-amounts/update-funds-amounts.ts
+++ b/src/utils/functions/update-funds-amounts/update-funds-amounts.ts
@@ -36,10 +36,7 @@ export const updateFundsAmounts = (
             } else if (!currentFieldError) {
                 const convertedAmount = getConvertedAmount(normalized, exchangeRate);
 
-                if (convertedAmount === null) {
-                    nextAmountUsd = '';
-                    nextAmountUsdError = undefined;
-                } else {
+                if (convertedAmount !== null) {
                     nextAmountUsd = convertedAmount;
                     nextAmountUsdError = validateFundsExpendituresAmount(convertedAmount, trigger);
                 }


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3313)

## Description

This PR resolves an issue where clearing the 'Сума (UAH)' input field in the funds expenditures record modal did not automatically clear the converted value in the 'Сума (USD)' field. 

Previously, clearing the UAH input left the stale converted USD value behind because conversion logic only ran when non-empty inputs passed validation.

## How it looks

https://github.com/user-attachments/assets/07336e9c-b3ad-47de-888d-306bb156417c

## Summary of change

* **Auto-clearing USD amount (`updateFundsAmounts`)**: Updated `updateFundsAmounts` logic to explicitly reset `nextAmountUsd` to an empty string (`''`) and clear `nextAmountUsdError` whenever the normalized UAH input value is empty (`normalized === ''`).
* **Unit Tests (`updateFundsAmounts.test.ts`)**: Added unit tests covering USD amount/error clearing logic for both `change` and `blur` triggers when the UAH input becomes empty.

## How to recreate changes

1. Log in as an Admin and navigate to **"Звітність"** -> **"Звіт та аналітика"** -> **"Доходи та витрати"**.
2. Click **"Редагувати Доходи та витрати"** navigate to **"Програмні витрати"** tab and click **"+ Витрата по програмі"**.
3. Enter a numeric value in the **"Сума (UAH)"** field (e.g., `120`).
4. Verify that **"Сума (USD)"** is automatically populated with the converted value.
5. Completely clear the value in the **"Сума (UAH)"** field.
6. Observe that the **"Сума (USD)"** field is now automatically cleared as well, leaving both amount fields empty.

## CHECK LIST
- [x] New tests was added or existing was modified
- [ ] Changes has severe impact on users
- [ ] Changes has medium impact on users
- [x] Changes has light impact on users
- [ ] Test coverage was updated
- [x] PR meets all conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clearing the UAH amount now also clears the converted USD amount and its validation message.
  * USD conversion only occurs when a valid, non-empty UAH amount is provided.
  * Converted USD values continue to receive validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->