### PR TITLE
Fix/issue-2872 [Front-End][Admin][Team page] Validation is configured to allow category descriptions more than 5 characters long as it's stated in the user story.

### DIFF
--- a/src/const/admin/team.ts
+++ b/src/const/admin/team.ts
@@ -107,7 +107,7 @@ export const TEAM_IMAGE_PLACEHOLDER = {
 
 export const TEAM_CATEGORY_VALIDATION = {
     name: {
-        min: 10,
+        min: 5,
         max: 20,
         getRequiredError: () => 'Назва обов’язкова',
         getMinError: () => `Не менше ${TEAM_CATEGORY_VALIDATION.name.min} символів`,
@@ -115,7 +115,7 @@ export const TEAM_CATEGORY_VALIDATION = {
         getDuplicateNameError: () => COMMON_TEXT_ADMIN.CATEGORIES.FORM.MESSAGE.ALREADY_CONTAIN_CATEGORY_WITH_NAME,
     },
     description: {
-        min: 10,
+        min: 5,
         max: 200,
         getRequiredError: () => 'Опис обов’язковий',
         getMinError: () => `Не менше ${TEAM_CATEGORY_VALIDATION.description.min} символів`,


### PR DESCRIPTION
Github ticket #525 

Description
This PR fixes bug when both fields - "Назва" and "Опис" in "Додати категорію" modal require a minimum of 10 characters.

How it looks

Before changes were made:
<img width="578" height="487" alt="635462570-a9053d87-40c5-409c-b6d5-6cc0f27915cc" src="https://github.com/user-attachments/assets/3a5e64fa-5049-41d1-ae10-ad0097bb2c9f" />

After changes were made:
<img width="987" height="725" alt="image" src="https://github.com/user-attachments/assets/e29a7704-2833-44f9-9b78-a84fb1f27ada" />

Summary of change
TEAM_CATEGORY_VALIDATION constants object was changed:

<img width="366" height="86" alt="image" src="https://github.com/user-attachments/assets/6872afe2-7fd5-4630-8942-26373c6e8f96" />

<img width="157" height="65" alt="image" src="https://github.com/user-attachments/assets/ef94bb72-27fb-4100-b1f7-c3985e09daef" />

How to recreate changes
1. Fetch branch fix/issue-2872 to your local machine
2. Switch to the branch
3. Run frontend locally
4. Go to this url: https://localhost:3000/admin-panel/team
5. Click "Додати категорію"
6. Fill up the inputs with the values of necessary length and click outside of the input field
7. No error must appear below the form

CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [+ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [+ ]  PR meets all conventions
