### PR TITLE
Fix/issue-2622 [Programs] The layout and components of the Programs page is not adaptive to Mobile (< 768px).

### DIFF
--- a/src/components/public/program-card/ProgramCardProgramsPage.module.scss
+++ b/src/components/public/program-card/ProgramCardProgramsPage.module.scss
@@ -118,3 +118,9 @@
         max-height 0.5s ease,
         opacity 0.4s ease 0.1s;
 }
+
+@media (max-width: 767px) {
+    .description {
+        display: none;
+    }
+}


### PR DESCRIPTION
Github ticket [#2622](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2622)

## Description

This PR fixes the program card layout on mobile devices. The program description is now hidden on screens smaller than 768px to prevent unnecessary spacing and improve the card layout on smaller screens.

## How it looks

Before changes were made:

<img width="373" height="498" alt="image" src="https://github.com/user-attachments/assets/3e287f2e-24da-4554-9122-552d6fd37862" />

Program description was displayed on mobile devices.

After changes were made:

<img width="375" height="449" alt="image" src="https://github.com/user-attachments/assets/33b98e3b-af98-4628-a832-b462788a44a8" />


Program description is hidden on screens smaller than 768px.

## **Summary of change**

- Updated ProgramCardProgramsPage.module.scss.
- Added a media query for screens smaller than 768px that hides the program description.

## **How to recreate changes**

1. Fetch branch with the changes to your local machine.
2. Switch to the branch.
3. Run frontend locally.
4. Go to the page with program cards.
5. Resize the browser window to less than 768px.
6. Verify that the program description is not displayed.
7. Resize the browser window to 768px or wider.
8. Verify that the program description is displayed on hover.


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions