### PR TITLE
Fix/issue-2875 [Team Page] Admin Panel, Add Category. Character counter for the "Назва" field is displayed in the wrong position

### DIFF
--- a/src/pages/admin/team/components/team-category-modal/TeamCategoryModal.tsx
+++ b/src/pages/admin/team/components/team-category-modal/TeamCategoryModal.tsx
@@ -305,6 +305,7 @@ export const TeamCategoryModal = (props: TeamCategoryModalProps) => {
                             id={getFieldId('name')}
                             maxLength={TEAM_CATEGORY_VALIDATION.name.max}
                             disabled={isSubmitting}
+                            showCounterBelow={true}
                         />
 
                         <TextAreaWithCharacterLimitGroup

--- a/src/pages/admin/team/components/translate-team-category-form/TranslateTeamCategoryForm.tsx
+++ b/src/pages/admin/team/components/translate-team-category-form/TranslateTeamCategoryForm.tsx
@@ -138,6 +138,7 @@ export const TranslateTeamCategoryForm = forwardRef<TranslateTeamCategoryFormRef
                     maxLength={TEAM_CATEGORY_VALIDATION.name.max}
                     name={'name'}
                     id={'name'}
+                    showCounterBelow={true}
                 />
 
                 <TextAreaWithCharacterLimitGroup


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2875)

## Description

<!--- Please decripe the main goal of this PR and why it was created --->
This PR fixes the visibility bug of the counter for the "Назва" field in the Add Category form. According to the Figma design(https://www.figma.com/design/mZTSCb4NVC31facfhy6Gu1/Victory-Center-Admin-Panel?node-id=13870-10043), the counter is supposed to show under the input field. Translate Category had the same issue with the "Назва" field, so it was fixed as well.
## How it looked

- For Add Category
<img width="719" height="554" alt="Screenshot 2026-08-17 111014" src="https://github.com/user-attachments/assets/a7ecb0b1-57e6-4c98-80ad-efb4e757a01e" />

- For Translate Category
<img width="719" height="720" alt="Screenshot 2026-08-17 111033" src="https://github.com/user-attachments/assets/be147727-d9cc-4219-a36c-00b5398faff0" />

<!--- Please provide iamges(screenshots or screen recording) of changes --->

## How it looks now

- For Add Category
<img width="714" height="600" alt="Screenshot 2026-08-17 111208" src="https://github.com/user-attachments/assets/09e7e5ae-729f-4316-95ff-4710b22f1ff8" />

- For Translate Category
<img width="715" height="772" alt="Screenshot 2026-08-17 111325" src="https://github.com/user-attachments/assets/3eca3243-7cee-4afc-a961-8affdb3288ea" />

## Summary of change
The `showCounterBelow` in the `InputWithCharacterLimitGroup.tsx` is `false` by default. Modified `TeamCategoryModal.tsx` and `TranslateTeamCategoryForm.tsx` to implement `showCounterBelow={true}` in the `<InputWithCharacterLimitGroup...>` to ensure that counter will be under the input field.
<!--- Please specify what was changed --->

## How to recreate changes
1. Log in to the **Admin Panel**.
2. Navigate to the **Team** (Команда) page.
3. Add category.
4. Observe: The counter is under the "Назва" field in popup window.
5. Add translation to the new category or already existing one.
6. Observe: The counter is also under the "Назва" field in popup window.
<!--- Please provide short instruction step-by-step how to see changes that was implemented by this PR --->
<!--- Please provide short instruction step-by-step how to see changes that was implemented by this PR --->


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions
