### PR TITLE
Feature/issue-1856-1860 [Programs] Translate and edit translation for a program category MANUALLY

### DIFF
--- a/src/components/admin/translation-controls/TranslationControls.module.scss
+++ b/src/components/admin/translation-controls/TranslationControls.module.scss
@@ -9,6 +9,10 @@
     align-items: center;
     gap: 10px;
     margin: 0.5rem 0;
+
+    &.has-generate-button {
+        justify-content: flex-start;
+    }
 }
 
 .language-select {

--- a/src/components/admin/translation-controls/TranslationControls.test.tsx
+++ b/src/components/admin/translation-controls/TranslationControls.test.tsx
@@ -11,6 +11,7 @@ jest.mock('@/components/admin/button/Button', () => ({
             data-testid="generate-btn"
             className={props.className}
             disabled={props.disabled}
+            aria-hidden={props['aria-hidden']}
             onClick={props.onClick}
             type={props.type}
         >
@@ -59,20 +60,22 @@ describe('TranslationControls', () => {
         expect(button).toHaveAttribute('type', 'button');
     });
 
-    it('renders the generate button as disabled and hidden by default', () => {
+    it('renders the generate button as disabled, hidden and aria-hidden by default', () => {
         render(<TranslationControls {...defaultProps} />);
 
         const button = screen.getByTestId('generate-btn');
         expect(button).toBeDisabled();
         expect(button).toHaveClass('disable');
+        expect(button).toHaveAttribute('aria-hidden', 'true');
     });
 
-    it('keeps the generate button hidden regardless of generateDisabled when hideGenerateButton is not overridden', () => {
+    it('keeps the generate button disabled and aria-hidden regardless of generateDisabled when hideGenerateButton is not overridden', () => {
         render(<TranslationControls {...defaultProps} generateDisabled={false} />);
 
         const button = screen.getByTestId('generate-btn');
-        expect(button).toBeEnabled();
+        expect(button).toBeDisabled();
         expect(button).toHaveClass('disable');
+        expect(button).toHaveAttribute('aria-hidden', 'true');
     });
 
     it('shows the generate button as disabled (not hidden) when hideGenerateButton is false and generateDisabled is true', () => {
@@ -81,6 +84,7 @@ describe('TranslationControls', () => {
         const button = screen.getByTestId('generate-btn');
         expect(button).toBeDisabled();
         expect(button).not.toHaveClass('disable');
+        expect(button).toHaveAttribute('aria-hidden', 'false');
     });
 
     it('shows the generate button as enabled when hideGenerateButton and generateDisabled are both false', () => {
@@ -89,6 +93,7 @@ describe('TranslationControls', () => {
         const button = screen.getByTestId('generate-btn');
         expect(button).toBeEnabled();
         expect(button).not.toHaveClass('disable');
+        expect(button).toHaveAttribute('aria-hidden', 'false');
     });
 
     it.skip('disables the button when isSubmitting is true', () => {

--- a/src/components/admin/translation-controls/TranslationControls.test.tsx
+++ b/src/components/admin/translation-controls/TranslationControls.test.tsx
@@ -67,16 +67,24 @@ describe('TranslationControls', () => {
         expect(button).toHaveClass('disable');
     });
 
-    it('renders the generate button as disabled and hidden when generateDisabled is true', () => {
-        render(<TranslationControls {...defaultProps} generateDisabled={true} />);
+    it('keeps the generate button hidden regardless of generateDisabled when hideGenerateButton is not overridden', () => {
+        render(<TranslationControls {...defaultProps} generateDisabled={false} />);
 
         const button = screen.getByTestId('generate-btn');
-        expect(button).toBeDisabled();
+        expect(button).toBeEnabled();
         expect(button).toHaveClass('disable');
     });
 
-    it('renders the generate button as enabled and visible when generateDisabled is false', () => {
-        render(<TranslationControls {...defaultProps} generateDisabled={false} />);
+    it('shows the generate button as disabled (not hidden) when hideGenerateButton is false and generateDisabled is true', () => {
+        render(<TranslationControls {...defaultProps} hideGenerateButton={false} generateDisabled={true} />);
+
+        const button = screen.getByTestId('generate-btn');
+        expect(button).toBeDisabled();
+        expect(button).not.toHaveClass('disable');
+    });
+
+    it('shows the generate button as enabled when hideGenerateButton and generateDisabled are both false', () => {
+        render(<TranslationControls {...defaultProps} hideGenerateButton={false} generateDisabled={false} />);
 
         const button = screen.getByTestId('generate-btn');
         expect(button).toBeEnabled();

--- a/src/components/admin/translation-controls/TranslationControls.test.tsx
+++ b/src/components/admin/translation-controls/TranslationControls.test.tsx
@@ -59,12 +59,28 @@ describe('TranslationControls', () => {
         expect(button).toHaveAttribute('type', 'button');
     });
 
-    it('renders the generate button as disabled and hidden', () => {
+    it('renders the generate button as disabled and hidden by default', () => {
         render(<TranslationControls {...defaultProps} />);
 
         const button = screen.getByTestId('generate-btn');
         expect(button).toBeDisabled();
         expect(button).toHaveClass('disable');
+    });
+
+    it('renders the generate button as disabled and hidden when generateDisabled is true', () => {
+        render(<TranslationControls {...defaultProps} generateDisabled={true} />);
+
+        const button = screen.getByTestId('generate-btn');
+        expect(button).toBeDisabled();
+        expect(button).toHaveClass('disable');
+    });
+
+    it('renders the generate button as enabled and visible when generateDisabled is false', () => {
+        render(<TranslationControls {...defaultProps} generateDisabled={false} />);
+
+        const button = screen.getByTestId('generate-btn');
+        expect(button).toBeEnabled();
+        expect(button).not.toHaveClass('disable');
     });
 
     it.skip('disables the button when isSubmitting is true', () => {

--- a/src/components/admin/translation-controls/TranslationControls.test.tsx
+++ b/src/components/admin/translation-controls/TranslationControls.test.tsx
@@ -96,6 +96,18 @@ describe('TranslationControls', () => {
         expect(button).toHaveAttribute('aria-hidden', 'false');
     });
 
+    it('centers the container when the generate button is hidden (default)', () => {
+        const { container } = render(<TranslationControls {...defaultProps} />);
+
+        expect(container.firstChild).not.toHaveClass('has-generate-button');
+    });
+
+    it('left-aligns the container when the generate button is shown', () => {
+        const { container } = render(<TranslationControls {...defaultProps} hideGenerateButton={false} />);
+
+        expect(container.firstChild).toHaveClass('has-generate-button');
+    });
+
     it.skip('disables the button when isSubmitting is true', () => {
         render(<TranslationControls {...defaultProps} isSubmitting={true} />);
 

--- a/src/components/admin/translation-controls/TranslationControls.tsx
+++ b/src/components/admin/translation-controls/TranslationControls.tsx
@@ -12,6 +12,7 @@ interface TranslationControlsProps {
     onLanguageChange: (language: LocalizationLanguage) => void;
     onGenerate?: () => void;
     generateDisabled?: boolean;
+    hideGenerateButton?: boolean;
 }
 
 export const TranslationControls = ({
@@ -20,6 +21,7 @@ export const TranslationControls = ({
     onLanguageChange,
     onGenerate,
     generateDisabled = true,
+    hideGenerateButton = true,
 }: TranslationControlsProps) => {
     return (
         <div className={styles.container}>
@@ -42,7 +44,7 @@ export const TranslationControls = ({
                 )}
             </div>
             <Button
-                className={cn(styles['generate-button'], { [styles.disable]: generateDisabled })}
+                className={cn(styles['generate-button'], { [styles.disable]: hideGenerateButton })}
                 buttonStyle="primary"
                 disabled={generateDisabled}
                 onClick={onGenerate}

--- a/src/components/admin/translation-controls/TranslationControls.tsx
+++ b/src/components/admin/translation-controls/TranslationControls.tsx
@@ -46,7 +46,8 @@ export const TranslationControls = ({
             <Button
                 className={cn(styles['generate-button'], { [styles.disable]: hideGenerateButton })}
                 buttonStyle="primary"
-                disabled={generateDisabled}
+                disabled={generateDisabled || hideGenerateButton}
+                aria-hidden={hideGenerateButton}
                 onClick={onGenerate}
                 type="button"
             >

--- a/src/components/admin/translation-controls/TranslationControls.tsx
+++ b/src/components/admin/translation-controls/TranslationControls.tsx
@@ -11,6 +11,7 @@ interface TranslationControlsProps {
     selectedLanguage: LocalizationLanguage | null;
     onLanguageChange: (language: LocalizationLanguage) => void;
     onGenerate?: () => void;
+    generateDisabled?: boolean;
 }
 
 export const TranslationControls = ({
@@ -18,6 +19,7 @@ export const TranslationControls = ({
     selectedLanguage,
     onLanguageChange,
     onGenerate,
+    generateDisabled = true,
 }: TranslationControlsProps) => {
     return (
         <div className={styles.container}>
@@ -40,9 +42,9 @@ export const TranslationControls = ({
                 )}
             </div>
             <Button
-                className={cn(styles['generate-button'], styles.disable)}
+                className={cn(styles['generate-button'], { [styles.disable]: generateDisabled })}
                 buttonStyle="primary"
-                disabled={true}
+                disabled={generateDisabled}
                 onClick={onGenerate}
                 type="button"
             >

--- a/src/components/admin/translation-controls/TranslationControls.tsx
+++ b/src/components/admin/translation-controls/TranslationControls.tsx
@@ -24,7 +24,7 @@ export const TranslationControls = ({
     hideGenerateButton = true,
 }: TranslationControlsProps) => {
     return (
-        <div className={styles.container}>
+        <div className={cn(styles.container, { [styles['has-generate-button']]: !hideGenerateButton })}>
             <div className={styles['language-select']}>
                 {selectedLanguage && (
                     <Select<string>

--- a/src/pages/admin/programs/components/translate-program-category-form/TranslateProgramCategoryForm.module.scss
+++ b/src/pages/admin/programs/components/translate-program-category-form/TranslateProgramCategoryForm.module.scss
@@ -1,0 +1,5 @@
+.form {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}

--- a/src/pages/admin/programs/components/translate-program-category-form/TranslateProgramCategoryForm.module.scss
+++ b/src/pages/admin/programs/components/translate-program-category-form/TranslateProgramCategoryForm.module.scss
@@ -24,7 +24,7 @@
             border-radius: 8px;
 
             &:hover {
-                background-color: #8c8c84;
+                background-color: c.$grey-800;
             }
         }
     }

--- a/src/pages/admin/programs/components/translate-program-category-form/TranslateProgramCategoryForm.module.scss
+++ b/src/pages/admin/programs/components/translate-program-category-form/TranslateProgramCategoryForm.module.scss
@@ -1,5 +1,31 @@
+@use '@/assets/sass/variables/colors' as c;
+
 .form {
     display: flex;
     flex-direction: column;
     gap: 15px;
+
+    :global(.singleselect-options) {
+        max-height: 120px;
+        overflow-y: scroll;
+        scrollbar-color: c.$grey-700 transparent;
+
+        &::-webkit-scrollbar {
+            width: 8px;
+        }
+
+        &::-webkit-scrollbar-track {
+            background: transparent;
+            border-radius: 8px;
+        }
+
+        &::-webkit-scrollbar-thumb {
+            background-color: c.$grey-700;
+            border-radius: 8px;
+
+            &:hover {
+                background-color: #8c8c84;
+            }
+        }
+    }
 }

--- a/src/pages/admin/programs/components/translate-program-category-form/TranslateProgramCategoryForm.test.tsx
+++ b/src/pages/admin/programs/components/translate-program-category-form/TranslateProgramCategoryForm.test.tsx
@@ -1,7 +1,11 @@
 import React, { createRef } from 'react';
 import { createEvent, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { TranslateProgramCategoryForm, TranslateProgramCategoryFormRef } from './TranslateProgramCategoryForm';
+import {
+    TranslateProgramCategoryForm,
+    TranslateProgramCategoryFormRef,
+    TranslateProgramCategoryFormValues,
+} from './TranslateProgramCategoryForm';
 import { ProgramCategory } from '@/types/admin/programs';
 import { VisibilityStatus } from '@/types/admin/common';
 import { PROGRAM_CATEGORY_VALIDATION_FUNCTIONS } from '@/validation/admin/program-category-schema/program-category-schema';
@@ -108,16 +112,29 @@ describe('TranslateProgramCategoryForm', () => {
         expect(screen.getByTestId('input-name')).toBeEnabled();
     });
 
-    it('resets the name field whenever the selected category changes', () => {
-        renderForm();
+    it('fills the name field from initialData', () => {
+        renderForm({ initialData: { categoryId: 1, name: 'Existing translation' } });
 
-        fireEvent.change(screen.getByTestId('category-select'), { target: { value: '1' } });
-        fireEvent.change(screen.getByTestId('input-name'), { target: { value: 'Translated name' } });
-        expect(screen.getByTestId('input-name')).toHaveValue('Translated name');
+        expect(screen.getByTestId('input-name')).toHaveValue('Existing translation');
+    });
+
+    it('pre-selects the category when selectedCategory prop is provided', () => {
+        renderForm({ selectedCategory: mockCategories[1] });
+
+        expect(screen.getByTestId('category-select')).toHaveValue('2');
+        expect(screen.getByTestId('input-name')).toBeEnabled();
+    });
+
+    it('calls onCategoryChange with the selected category and null on clear', () => {
+        const onCategoryChange = jest.fn();
+
+        renderForm({ onCategoryChange });
 
         fireEvent.change(screen.getByTestId('category-select'), { target: { value: '2' } });
+        expect(onCategoryChange).toHaveBeenCalledWith(mockCategories[1]);
 
-        expect(screen.getByTestId('input-name')).toHaveValue('');
+        fireEvent.change(screen.getByTestId('category-select'), { target: { value: '' } });
+        expect(onCategoryChange).toHaveBeenLastCalledWith(null);
     });
 
     it('updates the name value on change', () => {
@@ -161,16 +178,17 @@ describe('TranslateProgramCategoryForm', () => {
         });
     });
 
-    it('reports dirty state as soon as a category is selected, even without a name', async () => {
+    it('reports dirty state relative to initialData, not merely category selection', async () => {
         const onDirtyChange = jest.fn();
+        const initialData: TranslateProgramCategoryFormValues = { categoryId: 1, name: '' };
 
-        renderForm({ onDirtyChange });
+        renderForm({ initialData, selectedCategory: mockCategories[0], onDirtyChange });
 
         await waitFor(() => {
             expect(onDirtyChange).toHaveBeenCalledWith(false);
         });
 
-        fireEvent.change(screen.getByTestId('category-select'), { target: { value: '1' } });
+        fireEvent.change(screen.getByTestId('input-name'), { target: { value: 'Changed name' } });
 
         await waitFor(() => {
             expect(onDirtyChange).toHaveBeenLastCalledWith(true);

--- a/src/pages/admin/programs/components/translate-program-category-form/TranslateProgramCategoryForm.tsx
+++ b/src/pages/admin/programs/components/translate-program-category-form/TranslateProgramCategoryForm.tsx
@@ -7,6 +7,8 @@ import { VisibilityStatus } from '@/types/admin/common';
 import { ProgramCategory } from '@/types/admin/programs';
 import { PROGRAM_CATEGORY_VALIDATION_FUNCTIONS } from '@/validation/admin/program-category-schema/program-category-schema';
 import { forwardRef, useEffect, useState } from 'react';
+import cn from 'classnames';
+import styles from './TranslateProgramCategoryForm.module.scss';
 
 export interface TranslateProgramCategoryFormValues {
     categoryId: number | null;
@@ -106,7 +108,7 @@ export const TranslateProgramCategoryForm = forwardRef<
         return (
             <form
                 onSubmit={(e) => e.preventDefault()}
-                className="translate-program-category-form"
+                className={cn('translate-program-category-form', styles.form)}
                 id="translate-program-category-form"
                 noValidate
             >

--- a/src/pages/admin/programs/components/translate-program-category-form/TranslateProgramCategoryForm.tsx
+++ b/src/pages/admin/programs/components/translate-program-category-form/TranslateProgramCategoryForm.tsx
@@ -6,7 +6,7 @@ import { useFormManager } from '@/hooks/admin/use-form-manager/useFormManager';
 import { VisibilityStatus } from '@/types/admin/common';
 import { ProgramCategory } from '@/types/admin/programs';
 import { PROGRAM_CATEGORY_VALIDATION_FUNCTIONS } from '@/validation/admin/program-category-schema/program-category-schema';
-import { forwardRef, useEffect, useMemo } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 
 export interface TranslateProgramCategoryFormValues {
     categoryId: number | null;
@@ -27,9 +27,12 @@ export interface TranslateProgramCategoryFormRef {
 export interface TranslateProgramCategoryFormProps {
     onSubmit: (data: TranslateProgramCategoryFormValues, status?: VisibilityStatus) => void | Promise<void>;
     categories: ProgramCategory[];
+    initialData?: TranslateProgramCategoryFormValues | null;
     formDisabled?: boolean;
+    onCategoryChange?: (category: ProgramCategory | null) => void;
     onValidationChange?: (isValid: boolean) => void;
     onDirtyChange?: (isDirty: boolean) => void;
+    selectedCategory?: ProgramCategory | null;
 }
 
 const DEFAULT_FORM_STATE: TranslateProgramCategoryFormValues = {
@@ -51,7 +54,16 @@ export const TranslateProgramCategoryForm = forwardRef<
     TranslateProgramCategoryFormProps
 >(
     (
-        { onSubmit, categories, formDisabled, onValidationChange, onDirtyChange }: TranslateProgramCategoryFormProps,
+        {
+            onSubmit,
+            categories,
+            initialData = null,
+            formDisabled,
+            onCategoryChange,
+            onValidationChange,
+            onDirtyChange,
+            selectedCategory,
+        }: TranslateProgramCategoryFormProps,
         ref,
     ) => {
         const { formState, setFormState, errors, setErrors, isSubmitting, isDirty } = useFormManager<
@@ -59,25 +71,27 @@ export const TranslateProgramCategoryForm = forwardRef<
             TranslateProgramCategoryFormErrorState
         >({
             defaultFormState: DEFAULT_FORM_STATE,
-            initialData: null,
+            initialData,
             validateForm,
             onValidationChange,
             ref,
             onSubmit: (data, _status) => onSubmit(data),
         });
 
-        const activeCategory = useMemo(
-            () => categories.find((category) => category.id === formState.categoryId),
-            [categories, formState.categoryId],
-        );
+        const [localSelectedCategory, setLocalSelectedCategory] = useState<ProgramCategory | null>(null);
+        const activeCategory = selectedCategory !== undefined ? selectedCategory : localSelectedCategory;
 
         useEffect(() => {
             onDirtyChange?.(isDirty());
         }, [formState, isDirty, onDirtyChange]);
 
         const handleCategoryChange = (category: ProgramCategory | null) => {
-            setFormState({ categoryId: category?.id ?? null, name: '' });
-            setErrors({ name: undefined });
+            if (selectedCategory === undefined) {
+                setLocalSelectedCategory(category);
+            }
+            setFormState((prev) => ({ ...prev, categoryId: category?.id ?? null }));
+            setErrors((prev) => ({ ...prev, name: undefined }));
+            onCategoryChange?.(category);
         };
 
         const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -104,7 +118,7 @@ export const TranslateProgramCategoryForm = forwardRef<
                     getOptionName={(category) => category.name}
                     disabled={isSubmitting || formDisabled}
                     onChange={handleCategoryChange}
-                    value={activeCategory}
+                    value={activeCategory || undefined}
                     placeholder={COMMON_TEXT_ADMIN.FILTER.CATEGORY.SELECT_CATEGORY}
                     id="translate-program-category-select"
                 />

--- a/src/pages/admin/programs/components/translate-program-category-form/TranslateProgramCategoryForm.tsx
+++ b/src/pages/admin/programs/components/translate-program-category-form/TranslateProgramCategoryForm.tsx
@@ -80,6 +80,9 @@ export const TranslateProgramCategoryForm = forwardRef<
             onSubmit: (data, _status) => onSubmit(data),
         });
 
+        // Supports both controlled usage (parent passes selectedCategory, e.g. TranslateProgramCategoryModal)
+        // and standalone/uncontrolled usage (prop omitted entirely) by falling back to local state only in the
+        // latter case; when controlled, activeCategory always reflects the prop, never the local fallback.
         const [localSelectedCategory, setLocalSelectedCategory] = useState<ProgramCategory | null>(null);
         const activeCategory = selectedCategory !== undefined ? selectedCategory : localSelectedCategory;
 
@@ -88,9 +91,7 @@ export const TranslateProgramCategoryForm = forwardRef<
         }, [formState, isDirty, onDirtyChange]);
 
         const handleCategoryChange = (category: ProgramCategory | null) => {
-            if (selectedCategory === undefined) {
-                setLocalSelectedCategory(category);
-            }
+            setLocalSelectedCategory(category);
             setFormState((prev) => ({ ...prev, categoryId: category?.id ?? null }));
             setErrors((prev) => ({ ...prev, name: undefined }));
             onCategoryChange?.(category);

--- a/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.test.tsx
+++ b/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.test.tsx
@@ -16,12 +16,20 @@ jest.mock('@/components/admin/localization-modal/LocalizationModal', () => ({
 }));
 
 jest.mock('@/components/admin/translation-controls/TranslationControls', () => ({
-    TranslationControls: ({ selectedLanguage, languages, onLanguageChange, isSubmitting, generateDisabled }: any) => (
+    TranslationControls: ({
+        selectedLanguage,
+        languages,
+        onLanguageChange,
+        isSubmitting,
+        generateDisabled,
+        hideGenerateButton,
+    }: any) => (
         <div data-testid="translation-controls">
             <span data-testid="selected-language">{selectedLanguage?.code ?? 'none'}</span>
             <span data-testid="is-submitting">{String(isSubmitting)}</span>
             <span data-testid="languages-count">{String(languages?.length ?? 0)}</span>
             <span data-testid="generate-disabled">{String(generateDisabled)}</span>
+            <span data-testid="hide-generate-button">{String(hideGenerateButton)}</span>
             <button
                 data-testid="choose-last-language"
                 onClick={() => onLanguageChange?.(languages?.[languages.length - 1] ?? null)}
@@ -135,13 +143,15 @@ describe('TranslateProgramCategoryModal', () => {
         );
     });
 
-    it('disables Generate before a category is selected, enables it once one is chosen', () => {
+    it('keeps Generate visible (never hidden) and disables it before a category is selected, enables it once one is chosen', () => {
         renderModal();
 
+        expect(screen.getByTestId('hide-generate-button')).toHaveTextContent('false');
         expect(screen.getByTestId('generate-disabled')).toHaveTextContent('true');
 
         fireEvent.click(screen.getByTestId(`select-category-${CATEGORY_WITHOUT_LOCALIZATION.id}`));
 
+        expect(screen.getByTestId('hide-generate-button')).toHaveTextContent('false');
         expect(screen.getByTestId('generate-disabled')).toHaveTextContent('false');
     });
 

--- a/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.test.tsx
+++ b/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { ProgramCategory } from '@/types/admin/programs';
-import { LocalizationLanguage } from '@/types/common/language';
+import { LocalizationLanguage, TranslationStatus } from '@/types/common/language';
 import { TranslateProgramCategoryModal } from './TranslateProgramCategoryModal';
 
 let mockFormIsValid = true;
@@ -16,11 +16,12 @@ jest.mock('@/components/admin/localization-modal/LocalizationModal', () => ({
 }));
 
 jest.mock('@/components/admin/translation-controls/TranslationControls', () => ({
-    TranslationControls: ({ selectedLanguage, languages, onLanguageChange, isSubmitting }: any) => (
+    TranslationControls: ({ selectedLanguage, languages, onLanguageChange, isSubmitting, generateDisabled }: any) => (
         <div data-testid="translation-controls">
             <span data-testid="selected-language">{selectedLanguage?.code ?? 'none'}</span>
             <span data-testid="is-submitting">{String(isSubmitting)}</span>
             <span data-testid="languages-count">{String(languages?.length ?? 0)}</span>
+            <span data-testid="generate-disabled">{String(generateDisabled)}</span>
             <button
                 data-testid="choose-last-language"
                 onClick={() => onLanguageChange?.(languages?.[languages.length - 1] ?? null)}
@@ -36,7 +37,10 @@ jest.mock('../translate-program-category-form/TranslateProgramCategoryForm', () 
 
     return {
         TranslateProgramCategoryForm: React.forwardRef(
-            ({ onSubmit, onValidationChange, onDirtyChange, categories }: any, ref: React.Ref<any>) => {
+            (
+                { onSubmit, onValidationChange, onDirtyChange, onCategoryChange, categories, initialData }: any,
+                ref: React.Ref<any>,
+            ) => {
                 React.useImperativeHandle(ref, () => ({
                     submit: () => {
                         mockFormSubmit();
@@ -55,7 +59,21 @@ jest.mock('../translate-program-category-form/TranslateProgramCategoryForm', () 
                     <div
                         data-testid="translate-program-category-form"
                         data-categories={String(categories?.length ?? 0)}
-                    />
+                        data-initial={initialData ? JSON.stringify(initialData) : 'null'}
+                    >
+                        {categories?.map((category: ProgramCategory) => (
+                            <button
+                                key={category.id}
+                                data-testid={`select-category-${category.id}`}
+                                onClick={() => onCategoryChange?.(category)}
+                            >
+                                {category.name}
+                            </button>
+                        ))}
+                        <button data-testid="clear-category" onClick={() => onCategoryChange?.(null)}>
+                            clear
+                        </button>
+                    </div>
                 );
             },
         ),
@@ -74,10 +92,22 @@ const PL_LANGUAGE: LocalizationLanguage = {
     name: 'Polish',
 };
 
-const CATEGORY_LIST: ProgramCategory[] = [
-    { id: 1, name: 'Category 1', programsCount: 2 },
-    { id: 2, name: 'Category 2', programsCount: 4 },
-];
+const CATEGORY_WITHOUT_LOCALIZATION: ProgramCategory = { id: 1, name: 'Category 1', programsCount: 2 };
+
+const CATEGORY_WITH_EN_LOCALIZATION: ProgramCategory = {
+    id: 2,
+    name: 'Category 2',
+    programsCount: 4,
+    localizations: [
+        {
+            name: 'Category 2 EN',
+            language: { id: EN_LANGUAGE.id, code: EN_LANGUAGE.code },
+            translationStatus: TranslationStatus.Relevant,
+        },
+    ],
+};
+
+const CATEGORY_LIST: ProgramCategory[] = [CATEGORY_WITHOUT_LOCALIZATION, CATEGORY_WITH_EN_LOCALIZATION];
 
 describe('TranslateProgramCategoryModal', () => {
     const renderModal = (props: Partial<React.ComponentProps<typeof TranslateProgramCategoryModal>> = {}) => {
@@ -97,9 +127,61 @@ describe('TranslateProgramCategoryModal', () => {
         mockFormIsDirty = true;
     });
 
-    it('always renders with the "Додати переклад" title', () => {
+    it('renders with the "Додати переклад" title before a category is selected', () => {
         renderModal();
 
+        expect(screen.getByTestId('modal-title')).toHaveTextContent(
+            COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION,
+        );
+    });
+
+    it('disables Generate before a category is selected, enables it once one is chosen', () => {
+        renderModal();
+
+        expect(screen.getByTestId('generate-disabled')).toHaveTextContent('true');
+
+        fireEvent.click(screen.getByTestId(`select-category-${CATEGORY_WITHOUT_LOCALIZATION.id}`));
+
+        expect(screen.getByTestId('generate-disabled')).toHaveTextContent('false');
+    });
+
+    it('switches to edit mode and prefills the form when the selected category already has an EN translation', () => {
+        renderModal();
+
+        fireEvent.click(screen.getByTestId(`select-category-${CATEGORY_WITH_EN_LOCALIZATION.id}`));
+
+        expect(screen.getByTestId('modal-title')).toHaveTextContent(
+            COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.UPDATE_TRANSLATION,
+        );
+        expect(screen.getByTestId('translate-program-category-form')).toHaveAttribute(
+            'data-initial',
+            JSON.stringify({ categoryId: CATEGORY_WITH_EN_LOCALIZATION.id, name: 'Category 2 EN' }),
+        );
+    });
+
+    it('stays in add mode with an empty prefill when the selected category has no EN translation', () => {
+        renderModal();
+
+        fireEvent.click(screen.getByTestId(`select-category-${CATEGORY_WITHOUT_LOCALIZATION.id}`));
+
+        expect(screen.getByTestId('modal-title')).toHaveTextContent(
+            COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION,
+        );
+        expect(screen.getByTestId('translate-program-category-form')).toHaveAttribute(
+            'data-initial',
+            JSON.stringify({ categoryId: CATEGORY_WITHOUT_LOCALIZATION.id, name: '' }),
+        );
+    });
+
+    it('recomputes mode and prefill when switching between categories', () => {
+        renderModal();
+
+        fireEvent.click(screen.getByTestId(`select-category-${CATEGORY_WITH_EN_LOCALIZATION.id}`));
+        expect(screen.getByTestId('modal-title')).toHaveTextContent(
+            COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.UPDATE_TRANSLATION,
+        );
+
+        fireEvent.click(screen.getByTestId(`select-category-${CATEGORY_WITHOUT_LOCALIZATION.id}`));
         expect(screen.getByTestId('modal-title')).toHaveTextContent(
             COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION,
         );

--- a/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.test.tsx
+++ b/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.test.tsx
@@ -346,4 +346,45 @@ describe('TranslateProgramCategoryModal', () => {
 
         expect(screen.getByTestId('save-localization-btn')).toBeDisabled();
     });
+
+    it('resets the selected category (and with it, mode/prefill) when reopened after being closed', () => {
+        const onClose = jest.fn();
+
+        const { rerender } = render(
+            <TranslateProgramCategoryModal
+                isOpen={true}
+                onClose={onClose}
+                translatedLanguages={[EN_LANGUAGE]}
+                categories={CATEGORY_LIST}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId(`select-category-${CATEGORY_WITH_EN_LOCALIZATION.id}`));
+        expect(screen.getByTestId('modal-title')).toHaveTextContent(
+            COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.UPDATE_TRANSLATION,
+        );
+
+        rerender(
+            <TranslateProgramCategoryModal
+                isOpen={false}
+                onClose={onClose}
+                translatedLanguages={[EN_LANGUAGE]}
+                categories={CATEGORY_LIST}
+            />,
+        );
+
+        rerender(
+            <TranslateProgramCategoryModal
+                isOpen={true}
+                onClose={onClose}
+                translatedLanguages={[EN_LANGUAGE]}
+                categories={CATEGORY_LIST}
+            />,
+        );
+
+        expect(screen.getByTestId('modal-title')).toHaveTextContent(
+            COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION,
+        );
+        expect(screen.getByTestId('translate-program-category-form')).toHaveAttribute('data-initial', 'null');
+    });
 });

--- a/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.tsx
+++ b/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { LocalizationModal } from '@/components/admin/localization-modal/LocalizationModal';
 import { TranslationControls } from '@/components/admin/translation-controls/TranslationControls';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
+import { ModalMode } from '@/types/admin/common';
 import { ProgramCategory } from '@/types/admin/programs';
 import { LocalizationLanguage } from '@/types/common/language';
 import {
@@ -26,6 +27,7 @@ export const TranslateProgramCategoryModal = ({
     const formRef = useRef<TranslateProgramCategoryFormRef>(null);
     const [isFormValid, setIsFormValid] = useState(false);
     const [isDirty, setIsDirty] = useState(false);
+    const [selectedCategory, setSelectedCategory] = useState<ProgramCategory | null>(null);
 
     const englishLanguages = useMemo(() => translatedLanguages.filter((l) => l.code === 'en'), [translatedLanguages]);
 
@@ -47,6 +49,19 @@ export const TranslateProgramCategoryModal = ({
         }
     }, [isOpen]);
 
+    const existingLocalization = useMemo(() => {
+        if (!selectedCategory?.localizations || !language) return null;
+        return selectedCategory.localizations.find((loc) => loc.language.id === language.id) ?? null;
+    }, [selectedCategory, language]);
+
+    const mode = existingLocalization ? ModalMode.Edit : ModalMode.Add;
+    const isEditMode = mode === ModalMode.Edit;
+
+    const initialData = useMemo<TranslateProgramCategoryFormValues | null>(() => {
+        if (!selectedCategory) return null;
+        return { categoryId: selectedCategory.id, name: existingLocalization?.name ?? '' };
+    }, [selectedCategory, existingLocalization]);
+
     const handleSaveClick = () => {
         if (!formRef.current?.isValid()) return;
         formRef.current.submit();
@@ -59,11 +74,15 @@ export const TranslateProgramCategoryModal = ({
     // TODO: wire real persistence (create/update translation, close on success, toast, badge update) — see US #1858.
     const handleFormSubmit = async (_data: TranslateProgramCategoryFormValues) => {};
 
+    const modalTitle = isEditMode
+        ? COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.UPDATE_TRANSLATION
+        : COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION;
+
     return (
         <LocalizationModal
             isOpen={isOpen}
             onClose={onClose}
-            title={COMMON_TEXT_ADMIN.LOCALIZATION.FORM.TITLE.ADD_TRANSLATION}
+            title={modalTitle}
             onSave={handleSaveClick}
             isSubmitting={false}
             isFormValid={isFormValid}
@@ -76,11 +95,15 @@ export const TranslateProgramCategoryModal = ({
                     isSubmitting={false}
                     languages={englishLanguages}
                     onLanguageChange={setLanguage}
+                    generateDisabled={!selectedCategory}
                 />
             )}
             <TranslateProgramCategoryForm
                 ref={formRef}
                 categories={categories}
+                selectedCategory={selectedCategory}
+                initialData={initialData}
+                onCategoryChange={setSelectedCategory}
                 onValidationChange={setIsFormValid}
                 onDirtyChange={setIsDirty}
                 onSubmit={handleFormSubmit}

--- a/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.tsx
+++ b/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.tsx
@@ -46,6 +46,7 @@ export const TranslateProgramCategoryModal = ({
         if (!wasOpen && isOpen) {
             setIsFormValid(false);
             setIsDirty(false);
+            setSelectedCategory(null);
         }
     }, [isOpen]);
 

--- a/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.tsx
+++ b/src/pages/admin/programs/components/translate-program-category-modal/TranslateProgramCategoryModal.tsx
@@ -96,6 +96,7 @@ export const TranslateProgramCategoryModal = ({
                     languages={englishLanguages}
                     onLanguageChange={setLanguage}
                     generateDisabled={!selectedCategory}
+                    hideGenerateButton={false}
                 />
             )}
             <TranslateProgramCategoryForm

--- a/src/types/admin/programs.ts
+++ b/src/types/admin/programs.ts
@@ -17,8 +17,12 @@ export interface ProgramCategory {
     id: number;
     name: string;
     programsCount: number;
-    localizations?: EntityLocalization[];
+    localizations?: ProgramCategoryLocalization[];
     translationStatuses?: TranslationStatusInfo[];
+}
+
+export interface ProgramCategoryLocalization extends EntityLocalization {
+    name: string;
 }
 
 export interface HippotherapyProgramDto


### PR DESCRIPTION
## Github ticket

* [#1856](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1856)
* [#1860](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1860)

## Description

**#1856 (Translate program category in ENG manually).** As an Admin, I want to translate a program category in English manually, so that English-speaking visitors can see the translated program categories. Choosing a category in the "Переклад категорії" modal (added in #1855) now enables the "Згенерувати переклад" button, the "Назва" field becomes editable with a live character counter and a max-length limit, and "Зберегти переклад" activates once the entered name passes validation.

**#1860 (Edit translation for a program category).** As an Admin, I want to edit an existing translation for a program category, so that the English content stays accurate. Choosing a category that already has a saved English translation now prefills "Назва" with that translation and switches the modal title to "Редагувати переклад", on top of the same validation and button-activation behaviour as #1856.

No backend changes were needed: the endpoints and the `Localizations` payload on `ProgramCategory` were already delivered with #1855's backend PR.

## How it looks

<img width="1937" height="1210" alt="Screenshot 2026-08-17 115801" src="https://github.com/user-attachments/assets/e3c2e54f-606b-4a7c-a931-1511a5102bef" />
<img width="2022" height="1267" alt="Screenshot 2026-08-17 120130" src="https://github.com/user-attachments/assets/7c90924b-a04b-458f-afcb-44cecd6a9216" />

## Summary of change

- `TranslationControls.tsx`: split the old single `generateDisabled` behaviour into two props, `hideGenerateButton` (default `true`, keeps the button hidden for Program, TeamMember and TeamCategory modals, unchanged) and `generateDisabled` (controls the native `disabled` attribute, and with it the grey/blue color coming from the shared button styles).
- `TranslateProgramCategoryModal.tsx`: tracks the selected category, resolves `existingLocalization` for it from `selectedCategory.localizations`, derives `ModalMode.Add`/`ModalMode.Edit` from that, switches the modal title accordingly, and passes `hideGenerateButton={false}` plus `generateDisabled={!selectedCategory}` to `TranslationControls`.
- `TranslateProgramCategoryForm.tsx`: now accepts `selectedCategory`/`initialData`/`onCategoryChange` from the parent instead of owning category selection on its own; the name field is no longer force-cleared on category change, the parent-supplied `initialData` drives both the prefill for an already-translated category and the reset for an untranslated one.
- `types/admin/programs.ts`: added `ProgramCategoryLocalization` (extends `EntityLocalization` with `name`), since prefilling "Назва" needs the translated name that plain `EntityLocalization` did not expose.
- Tests: updated `TranslationControls.test.tsx`, `TranslateProgramCategoryForm.test.tsx` and `TranslateProgramCategoryModal.test.tsx` for the new props, the Add/Edit switch, and the prefill/reset behaviour.

Note: actually persisting the translation (API call, snackbar, badge refresh) is #1858, deleting a translation on category delete is #1859, and the "Згенерувати переклад" action itself is #1857/#1861. All three stay out of scope here and are tracked separately.

## How to recreate changes

1. Log in as an Administrator.
2. Navigate to the 'Програми' page.
3. Click the burger menu icon next to the category bar and select 'Додати переклад'.
4. In the opened modal, pick a category that has no saved English translation yet from the 'Категорія' dropdown.
5. Verify: 'Назва' becomes editable and stays empty, 'Згенерувати переклад' becomes enabled, the title stays 'Додати переклад'.
6. Type a name into 'Назва' and verify the character counter updates live, input past the max length is blocked, and 'Зберегти переклад' becomes enabled once the name is valid.
7. Close the modal, reopen it and pick a category that already has a saved English translation.
8. Verify: the title switches to 'Редагувати переклад' and 'Назва' is prefilled with the saved translation.
9. Without closing the modal, switch to a different category and verify 'Назва' and the title recalculate for it.
10. Pick a category, leave 'Назва' untouched and click 'X': verify the modal closes immediately, with no confirmation prompt.
11. Change 'Назва' and click 'X': verify the "Зміни будуть втрачені. Бажаєте продовжити?" prompt still appears.
12. Open the translate modal for a Program, a Team Member or a Team Category and verify 'Згенерувати переклад' is still hidden there, unchanged.



## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions
