### PR TITLE
Fix/issue-3331 [Partners] The Partners page is not loaded

### DIFF
--- a/src/utils/functions/mappers/common/localization/localization-mappers.ts
+++ b/src/utils/functions/mappers/common/localization/localization-mappers.ts
@@ -17,11 +17,12 @@ export type LocalizationLanguageSource = {
 export function mapLocalizationDtoToModel<TDto extends EntityLocalizationDto, TModel extends EntityLocalization>(
     dto: TDto,
 ): Omit<TDto, 'localizationInfoDto'> & TModel {
+    const raw = dto as unknown as { localizationInfoDto?: TModel['language']; language?: TModel['language'] };
     const { localizationInfoDto, ...rest } = dto;
 
     return {
         ...rest,
-        language: localizationInfoDto,
+        language: localizationInfoDto ?? raw.language,
     } as Omit<TDto, 'localizationInfoDto'> & TModel;
 }
 


### PR DESCRIPTION
## Github ticket

* [#3331](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3331#issue-5150504069)

## Description

This PR fixes the `Uncaught TypeError: Cannot read properties of undefined (reading 'code')` error on the partners page by adjusting the localization mapping fallback for DTOs returning `language` instead of `localizationInfoDto`.

## Summary of change

- Updated `mapLocalizationDtoToModel` in `localization-mappers.ts` to support `language` fallback property mapping.

## How to recreate changes

1. Run the application locally.
2. Navigate to `/partners-page` locally.
3. Verify that the page loads without runtime console errors.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the existing language setting when localization information is unavailable.
  * Continued prioritizing newly provided localization information when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->