### PR TITLE
[Reports] [Admin Panel] Error message 'Дозволено лише цифри' incorrectly appears when typing a decimal comma in 'Сума (UAH)' and ''Сума(USD) fields

### DIFF
--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.test.ts
@@ -24,6 +24,14 @@ describe('FUNDS_EXPENDITURES_RECORD_VALIDATION_FUNCTIONS', () => {
         it('should keep only first two digits after comma', () => {
             expect(normalizeFundsExpendituresAmountInput('1200,5678')).toBe('1200,56');
         });
+
+        it('should drop trailing comma when trimEnd is true and no decimal digits exist', () => {
+            expect(normalizeFundsExpendituresAmountInput('1 200,', true)).toBe('1 200');
+        });
+
+        it('should keep trailing comma when trimEnd is false', () => {
+            expect(normalizeFundsExpendituresAmountInput('1 200,', false)).toBe('1 200,');
+        });
     });
 
     describe('validateFundsExpendituresAmount', () => {
@@ -99,6 +107,10 @@ describe('FUNDS_EXPENDITURES_RECORD_VALIDATION_FUNCTIONS', () => {
 
         it('should support dot input by normalizing it to comma', () => {
             expect(validateFundsExpendituresAmount('1 200.50', 'save')).toBeUndefined();
+        });
+
+        it('should not return error when user types a trailing comma', () => {
+            expect(validateFundsExpendituresAmount('1 200,', 'change')).toBeUndefined();
         });
     });
 

--- a/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
+++ b/src/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema.ts
@@ -31,9 +31,12 @@ export const normalizeFundsExpendituresAmountInput = (value: string | undefined 
         .slice(firstCommaIndex + 1)
         .replaceAll(/[\s,]/g, '')
         .slice(0, 2);
-    const normalized = `${integerPart},${decimalPart}`;
 
-    return trimEnd ? normalized.trim() : normalized;
+    if (trimEnd) {
+        return (decimalPart === '' ? integerPart : `${integerPart},${decimalPart}`).trim();
+    }
+
+    return `${integerPart},${decimalPart}`;
 };
 
 export const validateFundsExpendituresAmount = (


### PR DESCRIPTION
## Github ticket

* [3329](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3329)
* [3360](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3360)

## Description

This PR fixes a bug where the "Дозволено лише цифри" error message incorrectly appeared when users typed a valid decimal comma in the 'Сума (UAH)' and 'Сума (USD)' input fields within the 'Додати надходження' / 'Додати витрати по програмі' modals. The issue occurred because the validation was too strict during the `onChange` event.

## How it looks

The amount fields (both UAH and USD) now correctly handle in-progress decimal inputs. For example, entering `123,` will no longer instantly trigger a red error border and validation message, allowing the user to seamlessly finish typing the decimal part. Genuine invalid characters (like letters) will still immediately trigger the error.

## Summary of change

* **Schema & Normalization Fixes**: Modified the `normalizeFundsExpendituresAmountInput` utility function in `funds-expenditures-record-schema.ts`. Added logic to handle the `trimEnd` flag properly for trailing commas: while typing, a separator without fractional digits is kept so the user can finish the decimal, preventing the regex validation from failing prematurely. When finalizing (blur/save), the trailing comma is dropped.

## How to recreate changes

1. Log in as an admin.
2. Navigate to the 'Звіт та аналітика' -> 'Доходи та витрати' tab.
3. Open the 'Додати витрати по програмі' (or income) modal.
4. Focus on the 'Сума (UAH)' or 'Сума (USD)' field.
5. Attempt to type a number ending with a decimal comma (e.g., `12,`).
6. Observe that the "Дозволено лише цифри" error does NOT appear while you are actively typing the fractional part.
7. Click outside the input (triggering blur) leaving just `12,` and observe that strict validation successfully applies.
8. Type letters (e.g., `123a`) and verify the error still correctly appears.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions