### PR TITLE
[Events] Admin: Create layout for Events page

### DIFF
--- a/src/components/admin/admin-navigation/AdminNavigation.tsx
+++ b/src/components/admin/admin-navigation/AdminNavigation.tsx
@@ -11,6 +11,53 @@ import './AdminNavigation.scss';
 export const AdminNavigation = () => {
     const { logout } = useAdminContext();
 
+    const navItems = [
+        {
+            link: ADMIN_ROUTES.MAIN.FULL,
+            text: COMMON_TEXT_ADMIN.TAB.MAIN,
+        },
+        {
+            link: ADMIN_ROUTES.PROFILE_COMPANY.FULL,
+            text: COMMON_TEXT_ADMIN.TAB.PROFILE_COMPANY,
+        },
+        {
+            link: ADMIN_ROUTES.REPORTS.FULL,
+            text: COMMON_TEXT_ADMIN.TAB.REPORTS,
+        },
+        {
+            link: ADMIN_ROUTES.TEAM.FULL,
+            text: COMMON_TEXT_ADMIN.TAB.TEAM_MEMBERS,
+        },
+        {
+            link: ADMIN_ROUTES.PROGRAMS.FULL,
+            text: COMMON_TEXT_ADMIN.TAB.PROGRAMS,
+        },
+        {
+            link: ADMIN_ROUTES.DONATE.FULL,
+            text: COMMON_TEXT_ADMIN.TAB.DONATE,
+        },
+        {
+            link: ADMIN_ROUTES.HISTORY.FULL,
+            text: COMMON_TEXT_ADMIN.TAB.HISTORY,
+        },
+        {
+            link: ADMIN_ROUTES.FAQ.FULL,
+            text: COMMON_TEXT_ADMIN.TAB.FAQ,
+        },
+        {
+            link: ADMIN_ROUTES.WHO_WE_ARE.FULL,
+            text: COMMON_TEXT_ADMIN.TAB.WHO_WE_ARE,
+        },
+        {
+            link: ADMIN_ROUTES.EVENTS.FULL,
+            text: COMMON_TEXT_ADMIN.TAB.EVENTS,
+        },
+        {
+            link: ADMIN_ROUTES.PARTNERS.FULL,
+            text: COMMON_TEXT_ADMIN.TAB.PARTNERS,
+        },
+    ];
+
     return (
         <div className="admin-navigation">
             <div>
@@ -19,125 +66,20 @@ export const AdminNavigation = () => {
                 </div>
                 <div className="admin-pages">
                     <nav>
-                        <NavLink
-                            to={ADMIN_ROUTES.MAIN.FULL}
-                            end
-                            className={({ isActive }) =>
-                                classNames('admin-page-link', {
-                                    'admin-pages-selected': isActive,
-                                })
-                            }
-                        >
-                            {COMMON_TEXT_ADMIN.TAB.MAIN}
-                        </NavLink>
-
-                        <NavLink
-                            to={ADMIN_ROUTES.PROFILE_COMPANY.FULL}
-                            end
-                            className={({ isActive }) =>
-                                classNames('admin-page-link', {
-                                    'admin-pages-selected': isActive,
-                                })
-                            }
-                        >
-                            {COMMON_TEXT_ADMIN.TAB.PROFILE_COMPANY}
-                        </NavLink>
-
-                        <NavLink
-                            to={ADMIN_ROUTES.REPORTS.FULL}
-                            end
-                            className={({ isActive }) =>
-                                classNames('admin-page-link', {
-                                    'admin-pages-selected': isActive,
-                                })
-                            }
-                        >
-                            {COMMON_TEXT_ADMIN.TAB.REPORTS}
-                        </NavLink>
-
-                        <NavLink
-                            to={ADMIN_ROUTES.TEAM.FULL}
-                            end
-                            className={({ isActive }) =>
-                                classNames('admin-page-link', {
-                                    'admin-pages-selected': isActive,
-                                })
-                            }
-                        >
-                            {COMMON_TEXT_ADMIN.TAB.TEAM_MEMBERS}
-                        </NavLink>
-
-                        <NavLink
-                            to={ADMIN_ROUTES.PROGRAMS.FULL}
-                            end
-                            className={({ isActive }) =>
-                                classNames('admin-page-link', {
-                                    'admin-pages-selected': isActive,
-                                })
-                            }
-                        >
-                            {COMMON_TEXT_ADMIN.TAB.PROGRAMS}
-                        </NavLink>
-
-                        <NavLink
-                            to={ADMIN_ROUTES.DONATE.FULL}
-                            end
-                            className={({ isActive }) =>
-                                classNames('admin-page-link', {
-                                    'admin-pages-selected': isActive,
-                                })
-                            }
-                        >
-                            {COMMON_TEXT_ADMIN.TAB.DONATE}
-                        </NavLink>
-
-                        <NavLink
-                            to={ADMIN_ROUTES.HISTORY.FULL}
-                            end
-                            className={({ isActive }) =>
-                                classNames('admin-page-link', {
-                                    'admin-pages-selected': isActive,
-                                })
-                            }
-                        >
-                            {COMMON_TEXT_ADMIN.TAB.HISTORY}
-                        </NavLink>
-
-                        <NavLink
-                            to={ADMIN_ROUTES.FAQ.FULL}
-                            end
-                            className={({ isActive }) =>
-                                classNames('admin-page-link', {
-                                    'admin-pages-selected': isActive,
-                                })
-                            }
-                        >
-                            {COMMON_TEXT_ADMIN.TAB.FAQ}
-                        </NavLink>
-
-                        <NavLink
-                            to={ADMIN_ROUTES.WHO_WE_ARE.FULL}
-                            end
-                            className={({ isActive }) =>
-                                classNames('admin-page-link', {
-                                    'admin-pages-selected': isActive,
-                                })
-                            }
-                        >
-                            {COMMON_TEXT_ADMIN.TAB.WHO_WE_ARE}
-                        </NavLink>
-
-                        <NavLink
-                            to={ADMIN_ROUTES.PARTNERS.FULL}
-                            end
-                            className={({ isActive }) =>
-                                classNames('admin-page-link', {
-                                    'admin-pages-selected': isActive,
-                                })
-                            }
-                        >
-                            {COMMON_TEXT_ADMIN.TAB.PARTNERS}
-                        </NavLink>
+                        {navItems.map((nav) => (
+                            <NavLink
+                                key={nav.link}
+                                to={nav.link}
+                                end
+                                className={({ isActive }) =>
+                                    classNames('admin-page-link', {
+                                        'admin-pages-selected': isActive,
+                                    })
+                                }
+                            >
+                                {nav.text}
+                            </NavLink>
+                        ))}
                     </nav>
                 </div>
             </div>

--- a/src/const/admin/common.ts
+++ b/src/const/admin/common.ts
@@ -9,6 +9,7 @@ export const COMMON_TEXT_ADMIN = {
         HISTORY: 'Історія',
         FAQ: 'Часті питання',
         WHO_WE_ARE: 'Хто ми',
+        EVENTS: 'Новини і події',
         PARTNERS: 'Партнери',
     },
 
@@ -149,6 +150,7 @@ export const UI_CONFIG = {
         MAX_CHARACTERS_FOR_SEARCH: {
             FAQ: 150,
             PROGRAMS: 90,
+            EVENTS: 90,
             TEAM_MEMBERS: 50,
         },
     },

--- a/src/const/admin/events.ts
+++ b/src/const/admin/events.ts
@@ -1,0 +1,8 @@
+export const EVENTS_TEXT = {
+    BUTTON: {
+        ADD_EVENT: 'Додати новину, подію',
+    },
+    PLACEHOLDER: {
+        SEARCH_EVENTS: 'Введіть назву',
+    },
+};

--- a/src/const/admin/routes.ts
+++ b/src/const/admin/routes.ts
@@ -28,6 +28,10 @@ export const ADMIN_ROUTES = {
         PATH: 'who-we-are',
         FULL: '/admin-panel/who-we-are',
     },
+    EVENTS: {
+        PATH: 'events',
+        FULL: '/admin-panel/events',
+    },
     PARTNERS: {
         PATH: 'partners',
         FULL: '/admin-panel/partners',

--- a/src/const/common/api-routes/main-api.ts
+++ b/src/const/common/api-routes/main-api.ts
@@ -66,6 +66,12 @@ export const API_ROUTES = {
         PREVIEWS: 'WhoWeAre/previews',
         PUBLIC: 'WhoWeArePage',
     },
+    EVENTS: {
+        BASE: 'Events',
+        SEARCH: 'Events/search',
+        PUBLISHED: 'Events/published',
+        BY_SLUG: 'Events/slug',
+    },
     WHO_WE_ARE_CONTENT_LOCALIZATIONS: {
         BASE: 'WhoWeAreContentLocalizations',
     },

--- a/src/pages/admin/events/EventsPageAdmin.scss
+++ b/src/pages/admin/events/EventsPageAdmin.scss
@@ -1,0 +1,26 @@
+@use '@/assets/sass/variables/colors';
+
+.events-page {
+    &-wrapper {
+        display: flex;
+        flex-direction: column;
+        gap: 3.375rem;
+        height: 100vh;
+        width: 100%;
+        padding: 2.5rem;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    &-toolbar-container {
+        flex-shrink: 0;
+    }
+
+    &-list-container {
+        flex-grow: 1;
+        min-height: 0;
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+    }
+}

--- a/src/pages/admin/events/EventsPageAdmin.test.tsx
+++ b/src/pages/admin/events/EventsPageAdmin.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { EventsPageAdmin } from './EventsPageAdmin';
+import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
+import { AdminPanelToolbarProps } from '@/components/admin/admin-panel-toolbar/AdminPageToolbar';
+import { EVENTS_TEXT } from '@/const/admin/events';
+
+jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
+    useAdminClient: jest.fn(),
+}));
+
+jest.mock('@/hooks/admin/use-localization-toolkit/useLocalizationToolkit', () => ({
+    useLocalizationToolkit: () => ({
+        allLanguages: [{ id: 1, code: 'uk', name: 'Українська' }],
+        onLanguageChange: jest.fn(),
+        onTranslationStatusFilterChange: jest.fn(),
+    }),
+}));
+
+jest.mock('@/services/api/admin/events/events-api', () => ({
+    EventsApi: {
+        fetchEventSearchItems: jest.fn(),
+        fetchEvents: jest.fn(),
+    },
+}));
+
+jest.mock('@/components/admin/admin-panel-toolbar/AdminPageToolbar', () => ({
+    AdminPanelToolbar: ({ placeholder, AddItemButtonText }: AdminPanelToolbarProps<any>) => (
+        <div data-testid="events-toolbar">
+            <span>{placeholder}</span>
+            <span>{AddItemButtonText}</span>
+        </div>
+    ),
+}));
+
+const mockedUseAdminClient = useAdminClient as jest.Mock;
+
+describe('EventsPageAdmin', () => {
+    beforeEach(() => {
+        mockedUseAdminClient.mockReturnValue({});
+    });
+
+    it('renders the toolbar with the events placeholder and add-item text', () => {
+        render(<EventsPageAdmin />);
+
+        expect(screen.getByTestId('events-page-content')).toBeInTheDocument();
+        expect(screen.getByTestId('events-toolbar')).toBeInTheDocument();
+        expect(screen.getByText(EVENTS_TEXT.PLACEHOLDER.SEARCH_EVENTS)).toBeInTheDocument();
+        expect(screen.getByText(EVENTS_TEXT.BUTTON.ADD_EVENT)).toBeInTheDocument();
+    });
+
+    it('does not render an error message when there is no error', () => {
+        const { container } = render(<EventsPageAdmin />);
+
+        expect(container.querySelector('.error-message')).not.toBeInTheDocument();
+    });
+});

--- a/src/pages/admin/events/EventsPageAdmin.tsx
+++ b/src/pages/admin/events/EventsPageAdmin.tsx
@@ -1,0 +1,79 @@
+import { useCallback, useState } from 'react';
+import { UI_CONFIG } from '@/const/admin/common';
+import { AdminPanelToolbar } from '@/components/admin/admin-panel-toolbar/AdminPageToolbar';
+import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
+import { EventsApi } from '@/services/api/admin/events/events-api';
+import { EventSearchItemData, ErrorState, EventsErrorType } from '@/types/admin/events';
+import { PaginationRequestParams } from '@/hooks/admin/fetch/use-data-pagination-fetch/useDataPaginationFetch';
+import { PaginationResult, VisibilityStatus } from '@/types/admin/common';
+import { useLocalizationToolkit } from '@/hooks/admin/use-localization-toolkit/useLocalizationToolkit';
+import { EVENTS_TEXT } from '@/const/admin/events';
+
+export const EventsPageAdmin = () => {
+    const [statusFilter, setStatusFilter] = useState<VisibilityStatus | undefined>();
+    const [error, setError] = useState<ErrorState>({ message: null, type: null });
+
+    const client = useAdminClient();
+
+    const setErrorState = useCallback((message: string, type: EventsErrorType) => setError({ message, type }), []);
+    const {
+        allLanguages,
+        // translationLanguages,
+        // selectedLanguage,
+        onLanguageChange,
+        // translationStatusFilter,
+        onTranslationStatusFilterChange,
+    } = useLocalizationToolkit({
+        setErrorState,
+    });
+
+    const getEventSearchItems = useCallback(
+        async (
+            searchTerm: string,
+            paginationRequest: PaginationRequestParams,
+        ): Promise<PaginationResult<EventSearchItemData>> =>
+            EventsApi.fetchEventSearchItems(
+                client,
+                searchTerm,
+                paginationRequest.offset as number,
+                paginationRequest.limit as number,
+                paginationRequest.requestOptions?.cancellationSignal,
+            ),
+        [client],
+    );
+
+    // Toolbar handlers
+    const onStatusFilterChange = useCallback((status: VisibilityStatus | undefined) => {
+        setStatusFilter(status);
+        // setIsSearchResultView(false);
+        // setSearchProgramId(undefined);
+        // updateSearchedProgram(null);
+    }, []);
+
+    return (
+        <div className="programs-page-wrapper" data-testid="programs-page-content">
+            <div className="programs-page-toolbar-container">
+                <AdminPanelToolbar<EventSearchItemData>
+                    getSearchItemKey={(item) => item.id}
+                    getSearchItemLabel={(item) => item.name}
+                    fetchSearchItems={getEventSearchItems}
+                    // renderSearchItemComponent={<div>Search Item</div>}
+                    placeholder={EVENTS_TEXT.PLACEHOLDER.SEARCH_EVENTS}
+                    onSearchClear={() => null}
+                    statusFilter={statusFilter}
+                    onStatusFilterChange={onStatusFilterChange}
+                    onAddItem={() => null}
+                    AddItemButtonText={EVENTS_TEXT.BUTTON.ADD_EVENT}
+                    onSuggestionSelect={() => null}
+                    languages={allLanguages}
+                    onLanguageChange={onLanguageChange}
+                    onTranslationStatusFilterChange={onTranslationStatusFilterChange}
+                    maxCharactersToSearch={UI_CONFIG.SEARCH_BAR.MAX_CHARACTERS_FOR_SEARCH.EVENTS}
+                />
+            </div>
+            <div className="programs-page-list-container">
+                {error.message && <div className="error-message">{error.message}</div>}
+            </div>
+        </div>
+    );
+};

--- a/src/pages/admin/events/EventsPageAdmin.tsx
+++ b/src/pages/admin/events/EventsPageAdmin.tsx
@@ -8,6 +8,7 @@ import { PaginationRequestParams } from '@/hooks/admin/fetch/use-data-pagination
 import { PaginationResult, VisibilityStatus } from '@/types/admin/common';
 import { useLocalizationToolkit } from '@/hooks/admin/use-localization-toolkit/useLocalizationToolkit';
 import { EVENTS_TEXT } from '@/const/admin/events';
+import './EventsPageAdmin.scss';
 
 export const EventsPageAdmin = () => {
     const [statusFilter, setStatusFilter] = useState<VisibilityStatus | undefined>();
@@ -41,8 +42,8 @@ export const EventsPageAdmin = () => {
     }, []);
 
     return (
-        <div className="programs-page-wrapper" data-testid="programs-page-content">
-            <div className="programs-page-toolbar-container">
+        <div className="events-page-wrapper" data-testid="events-page-content">
+            <div className="events-page-toolbar-container">
                 <AdminPanelToolbar<EventSearchItemData>
                     getSearchItemKey={(item) => item.id}
                     getSearchItemLabel={(item) => item.name}
@@ -60,7 +61,7 @@ export const EventsPageAdmin = () => {
                     maxCharactersToSearch={UI_CONFIG.SEARCH_BAR.MAX_CHARACTERS_FOR_SEARCH.EVENTS}
                 />
             </div>
-            <div className="programs-page-list-container">
+            <div className="events-page-list-container">
                 {error.message && <div className="error-message">{error.message}</div>}
             </div>
         </div>

--- a/src/pages/admin/events/EventsPageAdmin.tsx
+++ b/src/pages/admin/events/EventsPageAdmin.tsx
@@ -16,14 +16,7 @@ export const EventsPageAdmin = () => {
     const client = useAdminClient();
 
     const setErrorState = useCallback((message: string, type: EventsErrorType) => setError({ message, type }), []);
-    const {
-        allLanguages,
-        // translationLanguages,
-        // selectedLanguage,
-        onLanguageChange,
-        // translationStatusFilter,
-        onTranslationStatusFilterChange,
-    } = useLocalizationToolkit({
+    const { allLanguages, onLanguageChange, onTranslationStatusFilterChange } = useLocalizationToolkit({
         setErrorState,
     });
 
@@ -45,9 +38,6 @@ export const EventsPageAdmin = () => {
     // Toolbar handlers
     const onStatusFilterChange = useCallback((status: VisibilityStatus | undefined) => {
         setStatusFilter(status);
-        // setIsSearchResultView(false);
-        // setSearchProgramId(undefined);
-        // updateSearchedProgram(null);
     }, []);
 
     return (
@@ -57,7 +47,6 @@ export const EventsPageAdmin = () => {
                     getSearchItemKey={(item) => item.id}
                     getSearchItemLabel={(item) => item.name}
                     fetchSearchItems={getEventSearchItems}
-                    // renderSearchItemComponent={<div>Search Item</div>}
                     placeholder={EVENTS_TEXT.PLACEHOLDER.SEARCH_EVENTS}
                     onSearchClear={() => null}
                     statusFilter={statusFilter}

--- a/src/routes/app-router/AppRouter.jsx
+++ b/src/routes/app-router/AppRouter.jsx
@@ -23,6 +23,7 @@ import { FaqPanel } from '@/pages/admin/faq/FaqPanel';
 import { HippotherapyPage } from '@/pages/public/hippotherapy-page/HippotherapyPage';
 import { PartnersPage } from '@/pages/public/partners-page/PartnersPage';
 import { WhoWeArePageAdmin } from '@/pages/admin/who-we-are/WhoWeArePageAdmin';
+import { EventsPageAdmin } from '@/pages/admin/events/EventsPageAdmin';
 import { PartnerPanel } from '@/pages/admin/partners/PartnerPanel';
 import { ReportsPage } from '@/pages/public/reports-page';
 import { ContactUsPage } from '@/pages/public/contact-us';
@@ -86,6 +87,7 @@ export const AppRouter = () => {
                             <Route path={ADMIN_ROUTES.DONATE.PATH} element={<DonatePageAdmin />} />
                             <Route path={ADMIN_ROUTES.FAQ.PATH} element={<FaqPanel />} />
                             <Route path={ADMIN_ROUTES.WHO_WE_ARE.PATH} element={<WhoWeArePageAdmin />} />
+                            <Route path={ADMIN_ROUTES.EVENTS.PATH} element={<EventsPageAdmin />} />
                             <Route path={ADMIN_ROUTES.PARTNERS.PATH} element={<PartnerPanel />} />
                             <Route path={ADMIN_ROUTES.PROFILE_COMPANY.PATH} element={<CompanyProfileContent />} />
                             <Route path={ADMIN_ROUTES.REPORTS.PATH} element={<ReportsPanelContent />} />

--- a/src/services/api/admin/events/events-api.test.ts
+++ b/src/services/api/admin/events/events-api.test.ts
@@ -1,0 +1,61 @@
+import { EventsApi } from './events-api';
+import { API_ROUTES } from '@/const/common/api-routes/main-api';
+import { VisibilityStatus } from '@/types/admin/common';
+import { TranslationStatusFilter } from '@/types/common/language';
+import { AxiosInstance } from 'axios';
+
+describe('EventsApi', () => {
+    const mockGet = jest.fn();
+    const client = { get: mockGet } as unknown as AxiosInstance;
+
+    beforeEach(() => {
+        mockGet.mockReset();
+    });
+
+    describe('fetchEvents', () => {
+        it('calls the Events endpoint with the pagination, status, and translation params and returns the data', async () => {
+            const mockResponse = { data: { items: [], total: 0 } };
+            mockGet.mockResolvedValueOnce(mockResponse);
+
+            const result = await EventsApi.fetchEvents(
+                client,
+                1,
+                0,
+                5,
+                TranslationStatusFilter.Outdated,
+                VisibilityStatus.Published,
+            );
+
+            expect(mockGet).toHaveBeenCalledWith(API_ROUTES.EVENTS.BASE, {
+                params: {
+                    categoryId: 1,
+                    offset: 0,
+                    limit: 5,
+                    status: VisibilityStatus.Published,
+                    translationStatusFilter: TranslationStatusFilter.Outdated,
+                },
+            });
+            expect(result).toEqual(mockResponse.data);
+        });
+    });
+
+    describe('fetchEventSearchItems', () => {
+        it('calls the Events search endpoint with the search term, pagination, and abort signal', async () => {
+            const mockResponse = { data: { items: [], total: 0 } };
+            mockGet.mockResolvedValueOnce(mockResponse);
+            const signal = new AbortController().signal;
+
+            const result = await EventsApi.fetchEventSearchItems(client, 'test', 0, 5, signal);
+
+            expect(mockGet).toHaveBeenCalledWith(API_ROUTES.EVENTS.SEARCH, {
+                params: {
+                    searchTerm: 'test',
+                    offset: 0,
+                    limit: 5,
+                },
+                signal,
+            });
+            expect(result).toEqual(mockResponse.data);
+        });
+    });
+});

--- a/src/services/api/admin/events/events-api.ts
+++ b/src/services/api/admin/events/events-api.ts
@@ -1,0 +1,45 @@
+import { AxiosInstance } from 'axios';
+import { VisibilityStatus, PaginationResult } from '@/types/admin/common';
+import { TranslationStatusFilter } from '@/types/common/language';
+import { EventsDto, EventSearchItemData } from '@/types/admin/events';
+import { API_ROUTES } from '@/const/common/api-routes/main-api';
+
+export const EventsApi = {
+    fetchEvents: async (
+        client: AxiosInstance,
+        categoryId: number,
+        offset: number,
+        limit: number,
+        translationStatusFilter?: TranslationStatusFilter | null,
+        status?: VisibilityStatus,
+    ): Promise<PaginationResult<EventsDto>> => {
+        const response = await client.get<PaginationResult<EventsDto>>(API_ROUTES.EVENTS.BASE, {
+            params: {
+                categoryId,
+                offset,
+                limit,
+                status,
+                translationStatusFilter,
+            },
+        });
+        return response.data;
+    },
+    // test method
+    fetchEventSearchItems: async (
+        client: AxiosInstance,
+        searchTerm: string,
+        offset: number,
+        limit: number,
+        signal?: AbortSignal,
+    ): Promise<PaginationResult<EventSearchItemData>> => {
+        const response = await client.get<PaginationResult<EventSearchItemData>>(API_ROUTES.EVENTS.SEARCH, {
+            params: {
+                searchTerm,
+                offset,
+                limit,
+            },
+            signal,
+        });
+        return response.data;
+    },
+};

--- a/src/types/admin/events.ts
+++ b/src/types/admin/events.ts
@@ -1,0 +1,26 @@
+// this is a test type most probably will need adjustments in the future
+export type EventsErrorType = 'categories' | 'events' | 'search';
+export interface ErrorState {
+    message: string | null;
+    type: EventsErrorType | null;
+}
+// this is a test interface and most probably will need adjustments in the future
+export interface EventSearchItemData {
+    id: number;
+    name: string;
+    categories: string[];
+}
+// this is a test interface and most probably will need adjustments in the future
+export interface EventsLocalizableFields {
+    name: string;
+    description: string;
+    location: string;
+    participantsCount: string;
+    meetingsCount: string;
+}
+// this is a test interface and most probably will need adjustments in the future
+export interface EventsDto {
+    id: number;
+    name: string;
+    description: string;
+}


### PR DESCRIPTION
## JIRA or Github ticker

https://github.com/ita-social-projects/VictoryCenter-Back/issues/2887

## Description

Create the layout for Events admin page

## How it looks

<img width="1917" height="1069" alt="Screenshot 2026-08-18 093745" src="https://github.com/user-attachments/assets/d7b06635-a38d-446d-8df2-4c02da34c261" />


## Summary of change

Create the layout for Events admin page

## How to recreate changes

/admin-panel/events


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR meets all conventions
