### PR TITLE
Fix/issue-2754 [Feedback][Localization]  Static English localization and i18n consistency test

### DIFF
--- a/src/locales/18n-consistency.test.ts
+++ b/src/locales/18n-consistency.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+
+function getKeyPaths(obj: any, prefix = ''): string[] {
+    return Object.keys(obj).flatMap((key) => {
+        const path = prefix ? `${prefix}.${key}` : key;
+        const value = obj[key];
+        return typeof value === 'object' && value !== null && !Array.isArray(value) ? getKeyPaths(value, path) : [path];
+    });
+}
+
+function getValueAtPath(obj: any, key: string): any {
+    return key.split('.').reduce((o, k) => o?.[k], obj);
+}
+
+function readTranslationFile(dir: string, locale: string, namespace: string): any {
+    const filePath = path.join(dir, locale, `${namespace}.json`);
+    try {
+        return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    } catch (err) {
+        throw new Error(`Failed to read translation file "${filePath}": ${(err as Error).message}`);
+    }
+}
+
+const LOCALES_DIR = __dirname;
+const LOCALES = ['uk', 'en'];
+const BASE_LOCALE = 'uk';
+const OTHER_LOCALES = LOCALES.filter((locale) => locale !== BASE_LOCALE);
+
+// format 'namespace.locale.KEY.PATH'
+const ALLOWED_EMPTY_VALUES = new Set<string>(['history.en.YEAR_SUFFIX']);
+
+const namespaces = Array.from(
+    new Set(
+        LOCALES.flatMap((locale) =>
+            fs
+                .readdirSync(path.join(LOCALES_DIR, locale))
+                .filter((f) => f.endsWith('.json'))
+                .map((f) => f.replace('.json', '')),
+        ),
+    ),
+).sort();
+
+describe.each(namespaces)('%s.json translation integrity', (namespace) => {
+    const translations = Object.fromEntries(
+        LOCALES.map((locale) => [locale, readTranslationFile(LOCALES_DIR, locale, namespace)]),
+    );
+
+    it('should have identical key structure across locales', () => {
+        const baseKeys = getKeyPaths(translations[BASE_LOCALE]).sort();
+        for (const locale of OTHER_LOCALES) {
+            expect(getKeyPaths(translations[locale]).sort()).toEqual(baseKeys);
+        }
+    });
+
+    it('should not have empty translation values', () => {
+        for (const locale of LOCALES) {
+            const keys = getKeyPaths(translations[locale]);
+            for (const key of keys) {
+                const allowlistId = `${namespace}.${locale}.${key}`;
+                if (ALLOWED_EMPTY_VALUES.has(allowlistId)) {
+                    continue;
+                }
+
+                const value = getValueAtPath(translations[locale], key);
+                if (value === '') {
+                    throw new Error(
+                        `${locale}/${namespace}.json: "${key}" is empty. ` +
+                            `If this is intentional, add "${allowlistId}" to ALLOWED_EMPTY_VALUES.`,
+                    );
+                }
+            }
+        }
+    });
+
+    it('should have matching value types across locales', () => {
+        const baseKeys = getKeyPaths(translations[BASE_LOCALE]);
+        for (const locale of OTHER_LOCALES) {
+            for (const key of baseKeys) {
+                const baseValue = getValueAtPath(translations[BASE_LOCALE], key);
+                const localeValue = getValueAtPath(translations[locale], key);
+
+                if (Array.isArray(baseValue) !== Array.isArray(localeValue)) {
+                    throw new Error(
+                        `${locale}/${namespace}.json: "${key}" array/type mismatch ` +
+                            `(${BASE_LOCALE}: ${Array.isArray(baseValue) ? 'array' : typeof baseValue}, ` +
+                            `${locale}: ${Array.isArray(localeValue) ? 'array' : typeof localeValue})`,
+                    );
+                }
+                expect(typeof localeValue).toBe(typeof baseValue);
+            }
+        }
+    });
+});

--- a/src/locales/en/success.json
+++ b/src/locales/en/success.json
@@ -14,6 +14,6 @@
         "READ_STORY": "Read the story"
     },
     "VIDEO_SECTION": {
-        "TITLE": "Feedbacks"
+        "TITLE": "Video reviews"
     }
 }

--- a/src/locales/en/success.json
+++ b/src/locales/en/success.json
@@ -1,19 +1,19 @@
 {
     "SLOGAN": {
-        "FIRST_TEXT": "Від",
-        "SECOND_TEXT": "першого",
-        "THIRD_TEXT": "знайомства",
-        "FOURTH_TEXT": "до",
-        "FIFTH_TEXT": "історії",
-        "SIXTH_TEXT": "успіху"
+        "FIRST_TEXT": "From",
+        "SECOND_TEXT": "first",
+        "THIRD_TEXT": "meeting",
+        "FOURTH_TEXT": "to",
+        "FIFTH_TEXT": "success",
+        "SIXTH_TEXT": "story"
     },
     "REVIEWS": {
-        "TITLE": "Що кажуть учасники"
+        "TITLE": "What the participants say"
     },
     "ARTICLES": {
-        "READ_STORY": "Прочитати історію"
+        "READ_STORY": "Read the story"
     },
     "VIDEO_SECTION": {
-        "TITLE": "Відеовідгуки"
+        "TITLE": "Feedbacks"
     }
 }

--- a/src/locales/i18n-consistency.test.ts
+++ b/src/locales/i18n-consistency.test.ts
@@ -1,35 +1,72 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, afterAll } from '@jest/globals';
 import fs from 'fs';
 import path from 'path';
 
-function getKeyPaths(obj: any, prefix = ''): string[] {
+function getKeyPaths(obj: Record<string, unknown>, prefix = ''): string[] {
     return Object.keys(obj).flatMap((key) => {
-        const path = prefix ? `${prefix}.${key}` : key;
+        const keyPath = prefix ? `${prefix}.${key}` : key;
         const value = obj[key];
-        return typeof value === 'object' && value !== null && !Array.isArray(value) ? getKeyPaths(value, path) : [path];
+        return typeof value === 'object' && value !== null && !Array.isArray(value)
+            ? getKeyPaths(value as Record<string, unknown>, keyPath)
+            : [keyPath];
     });
 }
 
-function getValueAtPath(obj: any, key: string): any {
-    return key.split('.').reduce((o, k) => o?.[k], obj);
+function getValueAtPath(obj: Record<string, unknown>, key: string): unknown {
+    return key.split('.').reduce<unknown>((o, k) => (o as Record<string, unknown> | undefined)?.[k], obj);
 }
 
-function readTranslationFile(dir: string, locale: string, namespace: string): any {
+function readTranslationFile(dir: string, locale: string, namespace: string): Record<string, unknown> {
     const filePath = path.join(dir, locale, `${namespace}.json`);
+
+    let raw: string;
     try {
-        return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+        raw = fs.readFileSync(filePath, 'utf-8');
     } catch (err) {
         throw new Error(`Failed to read translation file "${filePath}": ${(err as Error).message}`);
     }
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch (err) {
+        throw new Error(`Failed to parse translation file "${filePath}": ${(err as Error).message}`);
+    }
+
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        throw new Error(
+            `Invalid translation file "${filePath}": expected a JSON object at the top level, got ` +
+                `${Array.isArray(parsed) ? 'array' : parsed === null ? 'null' : typeof parsed}`,
+        );
+    }
+
+    return parsed as Record<string, unknown>;
+}
+
+function buildAllowlistId(namespace: string, locale: string, key: string): string {
+    return `${namespace}.${locale}.${key}`;
 }
 
 const LOCALES_DIR = __dirname;
+
+if (!fs.existsSync(LOCALES_DIR) || !fs.statSync(LOCALES_DIR).isDirectory()) {
+    throw new Error(`Locales directory not found: "${LOCALES_DIR}"`);
+}
+
 const LOCALES = ['uk', 'en'];
 const BASE_LOCALE = 'uk';
 const OTHER_LOCALES = LOCALES.filter((locale) => locale !== BASE_LOCALE);
 
-// format 'namespace.locale.KEY.PATH'
-const ALLOWED_EMPTY_VALUES = new Set<string>(['history.en.YEAR_SUFFIX']);
+for (const locale of LOCALES) {
+    const localeDir = path.join(LOCALES_DIR, locale);
+    if (!fs.existsSync(localeDir) || !fs.statSync(localeDir).isDirectory()) {
+        throw new Error(`Missing locale directory: "${localeDir}"`);
+    }
+}
+
+// format: buildAllowlistId(namespace, locale, key) -> 'namespace.locale.KEY.PATH'
+const ALLOWED_EMPTY_VALUES = new Set<string>([buildAllowlistId('history', 'en', 'YEAR_SUFFIX')]);
+const usedAllowlistEntries = new Set<string>();
 
 const namespaces = Array.from(
     new Set(
@@ -58,8 +95,9 @@ describe.each(namespaces)('%s.json translation integrity', (namespace) => {
         for (const locale of LOCALES) {
             const keys = getKeyPaths(translations[locale]);
             for (const key of keys) {
-                const allowlistId = `${namespace}.${locale}.${key}`;
+                const allowlistId = buildAllowlistId(namespace, locale, key);
                 if (ALLOWED_EMPTY_VALUES.has(allowlistId)) {
+                    usedAllowlistEntries.add(allowlistId);
                     continue;
                 }
 
@@ -93,4 +131,13 @@ describe.each(namespaces)('%s.json translation integrity', (namespace) => {
             }
         }
     });
+});
+
+afterAll(() => {
+    if (usedAllowlistEntries.size !== ALLOWED_EMPTY_VALUES.size) {
+        const unused = Array.from(ALLOWED_EMPTY_VALUES).filter((id) => !usedAllowlistEntries.has(id));
+        throw new Error(
+            `Unused entries in ALLOWED_EMPTY_VALUES (remove them or fix the key/locale/namespace): ${unused.join(', ')}`,
+        );
+    }
 });

--- a/src/locales/i18n-consistency.test.ts
+++ b/src/locales/i18n-consistency.test.ts
@@ -70,6 +70,7 @@ describe.each(namespaces)('%s.json translation integrity', (namespace) => {
                             `If this is intentional, add "${allowlistId}" to ALLOWED_EMPTY_VALUES.`,
                     );
                 }
+                expect(value).not.toBe('');
             }
         }
     });

--- a/src/pages/public/stories-of-victory-page/components/slogan/SloganSection.test.tsx
+++ b/src/pages/public/stories-of-victory-page/components/slogan/SloganSection.test.tsx
@@ -9,20 +9,11 @@ jest.mock('react-i18next', () => ({
     useTranslation: jest.fn(),
 }));
 
-const TRANSLATIONS: Record<string, string> = {
-    'SLOGAN.FIRST_TEXT': 'First Text',
-    'SLOGAN.SECOND_TEXT': 'Second Text',
-    'SLOGAN.THIRD_TEXT': 'Third Text',
-    'SLOGAN.FOURTH_TEXT': 'Fourth Text',
-    'SLOGAN.FIFTH_TEXT': 'Fifth Text',
-    'SLOGAN.SIXTH_TEXT': 'Sixth Text',
-};
-
 describe('SloganSection', () => {
     beforeEach(() => {
         const { useTranslation } = require('react-i18next');
         (useTranslation as jest.Mock).mockReturnValue({
-            t: (key: string) => TRANSLATIONS[key] || key,
+            t: (key: string) => key,
             i18n: { changeLanguage: jest.fn() },
         });
     });
@@ -53,12 +44,12 @@ describe('SloganSection', () => {
 
     it('should render all translation keys', () => {
         render(<SloganSection />);
-        expect(screen.getByText('First Text')).toBeInTheDocument();
-        expect(screen.getByText('Second Text')).toBeInTheDocument();
-        expect(screen.getByText('Third Text')).toBeInTheDocument();
-        expect(screen.getByText('Fourth Text')).toBeInTheDocument();
-        expect(screen.getByText('Fifth Text')).toBeInTheDocument();
-        expect(screen.getByText('Sixth Text')).toBeInTheDocument();
+        expect(screen.getByText('SLOGAN.FIRST_TEXT')).toBeInTheDocument();
+        expect(screen.getByText('SLOGAN.SECOND_TEXT')).toBeInTheDocument();
+        expect(screen.getByText('SLOGAN.THIRD_TEXT')).toBeInTheDocument();
+        expect(screen.getByText('SLOGAN.FOURTH_TEXT')).toBeInTheDocument();
+        expect(screen.getByText('SLOGAN.FIFTH_TEXT')).toBeInTheDocument();
+        expect(screen.getByText('SLOGAN.SIXTH_TEXT')).toBeInTheDocument();
     });
 
     it('should render br elements', () => {
@@ -73,7 +64,7 @@ describe('SloganSection', () => {
         let firstTextSpan: Element | null = null;
 
         for (let i = 0; i < spans.length; i++) {
-            if (spans[i].textContent === 'First Text') {
+            if (spans[i].textContent === 'SLOGAN.FIRST_TEXT') {
                 firstTextSpan = spans[i];
                 break;
             }


### PR DESCRIPTION
## Github ticket
* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2754)
  
## Summary of issue

As a visitor, I want to view feedbacks (Stories of Victory) in the English language so that I can understand participants' feedback even if I speak only English.

Initially, the static English translations for the Victory stories page was written by ukranian language. Furthermore, there was no automated mechanism on the frontend client to verify that translation JSON files had identical key structures across different locales (like UK and EN). This could lead to runtime issues where missing keys fell back to raw key strings on the UI.

## Summary of change

*   **Static Translations**: Updated `src/locales/en/success.json` with accurate and complete English translations covering the `SLOGAN`, `REVIEWS`, `ARTICLES`, and `VIDEO_SECTION` blocks, aligning with the defined localization strategy.
*   **Locales Integrity Test**: Added a highly robust, dynamic unit test suite (`src/locales/18n-consistency.test.ts`) that automatically scans the locale directory using `fs` and validates translation file integrity across all namespaces (`success`, `history`, `donate`, etc.). The test guarantees:
    1.  **Identical Key Structures**: Ensures that all translation keys match perfectly between `uk` and `en` locales (no missing keys).
    2.  **No Empty Values**: Prevents accidental empty string values (`""`), with an explicit allowlist (like `history.en.YEAR_SUFFIX`) for valid empty exceptions.
    3.  **Type Consistency**: Ensures matching value types, verifying that if a value is an array in UA, it is also an array in EN.

## Testing approach

*   **Automated Testing**: Executed the test suite using `npm run test` (or `npm test`) inside `VictoryCenter-Client`. Verified that the new `8n-consistency.test.ts` successfully scans all namespaces and passes, ensuring 100% structural and key-matching compliance between English and Ukrainian JSON files.
*   **Manual Verification**: 
    1.  Launched the React application locally and navigated to the VIctory stories page (`localhost:3000/stories`)
    2.  Toggled the language switcher to **"EN"**
    3.  Verified that all static copy—specifically the Slogan Section, Review Articles Section, and Swiper Reviews Section—rendered correctly using the newly added English static translation strings.

## Expected result
*   The "Victory stories" (Історії успіху) page successfully supports English localization for its static content.
*   All translation JSON files are completely preventing missing keys or structural mismatches from reaching production.

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Updated English translations for the slogan, reviews heading, article link, and video section title.

* **Tests**
  * Added automated checks to verify translation keys, value types, and non-empty content remain consistent across supported locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->