### PR TITLE
Fix/issue 3001 (Pdf reports do not update on the fly when admin modifies them through the admin panel)

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -5,4 +5,4 @@ REACT_APP_PROXY_TARGET=https://backend.victorycenter.online/api
 REACT_APP_BACKEND_URL=/api
 # If you want to use your own backend, set the REACT_APP_BACKEND_URL in .env.local to your backend URL.
 REACT_APP_CF_TURNSTILE_SITE_KEY=1x00000000000000000000AA
-SIGNALR_PDF_REPORTS_URL=
+REACT_APP_SIGNALR_PDF_REPORTS_URL=https://backend.victorycenter.online/hubs/reports

--- a/.env.development
+++ b/.env.development
@@ -5,3 +5,4 @@ REACT_APP_PROXY_TARGET=https://backend.victorycenter.online/api
 REACT_APP_BACKEND_URL=/api
 # If you want to use your own backend, set the REACT_APP_BACKEND_URL in .env.local to your backend URL.
 REACT_APP_CF_TURNSTILE_SITE_KEY=1x00000000000000000000AA
+SIGNALR_PDF_REPORTS_URL=

--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ SSL_KEY_FILE=certs/localhost-key.pem
 SSL_CRT_FILE=certs/localhost-cert.pem
 REACT_APP_PROXY_TARGET=https://backend.historycode.online/api
 REACT_APP_BACKEND_URL=/api
+REACT_APP_SIGNALR_PDF_REPORTS_URL=https://backend.victorycenter.online/hubs/reports
 ```
 
 ## AI Assistant Setup

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
                 "@lexical/html": "^0.39.0",
                 "@lexical/react": "^0.39.0",
                 "@lexical/selection": "^0.39.0",
+                "@microsoft/signalr": "^10.0.11",
                 "@mui/material": "^7.3.1",
                 "axios": "^1.10.0",
                 "classnames": "^2.5.1",
@@ -2633,7 +2634,6 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
             "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
-            "dev": true,
             "optional": true,
             "peer": true,
             "dependencies": {
@@ -2645,7 +2645,6 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
             "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
-            "dev": true,
             "optional": true,
             "peer": true,
             "dependencies": {
@@ -2656,7 +2655,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
             "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
-            "dev": true,
             "optional": true,
             "peer": true,
             "dependencies": {
@@ -4626,6 +4624,40 @@
                 "yjs": ">=13.5.22"
             }
         },
+        "node_modules/@microsoft/signalr": {
+            "version": "10.0.11",
+            "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-10.0.11.tgz",
+            "integrity": "sha512-FulOJ2EEtKvLQcswe/U7v8pzyXyk7Jua5xgWJPPwyQU/2Z9ORvKcVjyO75VvLsem+CJ1ORRexJ+7Bz1FCei2aw==",
+            "license": "MIT",
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "eventsource": "^2.0.2",
+                "fetch-cookie": "^2.0.3",
+                "node-fetch": "^2.6.7",
+                "ws": "^7.5.10"
+            }
+        },
+        "node_modules/@microsoft/signalr/node_modules/ws": {
+            "version": "7.5.13",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+            "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@mui/core-downloads-tracker": {
             "version": "7.3.1",
             "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.1.tgz",
@@ -4849,7 +4881,6 @@
             "version": "0.2.12",
             "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
             "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
-            "dev": true,
             "optional": true,
             "peer": true,
             "dependencies": {
@@ -4928,7 +4959,6 @@
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
             "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
-            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -4968,7 +4998,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4989,7 +5018,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5010,7 +5038,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5031,7 +5058,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5052,7 +5078,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5073,7 +5098,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5094,7 +5118,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5115,7 +5138,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5136,7 +5158,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5157,7 +5178,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5178,7 +5198,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5199,7 +5218,6 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5220,7 +5238,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5849,7 +5866,6 @@
             "version": "0.10.1",
             "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
             "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-            "dev": true,
             "optional": true,
             "peer": true,
             "dependencies": {
@@ -6565,7 +6581,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "android"
@@ -6579,7 +6594,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "android"
@@ -6593,7 +6607,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "darwin"
@@ -6607,7 +6620,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "darwin"
@@ -6621,7 +6633,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "freebsd"
@@ -6635,7 +6646,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -6649,7 +6659,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -6663,7 +6672,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -6677,7 +6685,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -6691,7 +6698,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -6705,7 +6711,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -6719,7 +6724,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -6733,7 +6737,6 @@
             "cpu": [
                 "s390x"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -6747,7 +6750,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -6761,7 +6763,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -6775,7 +6776,6 @@
             "cpu": [
                 "wasm32"
             ],
-            "dev": true,
             "optional": true,
             "peer": true,
             "dependencies": {
@@ -6792,7 +6792,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "win32"
@@ -6806,7 +6805,6 @@
             "cpu": [
                 "ia32"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "win32"
@@ -6820,7 +6818,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "optional": true,
             "os": [
                 "win32"
@@ -6991,6 +6988,18 @@
             "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
             "deprecated": "Use your platform's native atob() and btoa() methods instead",
             "license": "BSD-3-Clause"
+        },
+        "node_modules/abort-controller": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "license": "MIT",
+            "dependencies": {
+                "event-target-shim": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=6.5"
+            }
         },
         "node_modules/accepts": {
             "version": "1.3.8",
@@ -9505,7 +9514,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
             "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-            "dev": true,
             "license": "Apache-2.0",
             "optional": true,
             "bin": {
@@ -10840,6 +10848,15 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/event-target-shim": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/eventemitter3": {
             "version": "4.0.7",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -10853,6 +10870,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.x"
+            }
+        },
+        "node_modules/eventsource": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+            "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/execa": {
@@ -11227,6 +11253,16 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "bser": "2.1.1"
+            }
+        },
+        "node_modules/fetch-cookie": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-2.2.0.tgz",
+            "integrity": "sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==",
+            "license": "Unlicense",
+            "dependencies": {
+                "set-cookie-parser": "^2.4.8",
+                "tough-cookie": "^4.0.0"
             }
         },
         "node_modules/file-entry-cache": {
@@ -17949,9 +17985,50 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
             "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-            "dev": true,
             "license": "MIT",
             "optional": true
+        },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/node-fetch/node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "license": "MIT"
+        },
+        "node_modules/node-fetch/node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/node-fetch/node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
         },
         "node_modules/node-forge": {
             "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "@lexical/html": "^0.39.0",
         "@lexical/react": "^0.39.0",
         "@lexical/selection": "^0.39.0",
+        "@microsoft/signalr": "^10.0.11",
         "@mui/material": "^7.3.1",
         "axios": "^1.10.0",
         "classnames": "^2.5.1",

--- a/src/hooks/public/SignalR/useSignalR.test.ts
+++ b/src/hooks/public/SignalR/useSignalR.test.ts
@@ -1,0 +1,83 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSignalR } from './useSignalR';
+import { HubConnectionBuilder } from '@microsoft/signalr';
+
+jest.mock('@microsoft/signalr', () => {
+    const mockConnection = {
+        start: jest.fn(),
+        stop: jest.fn(),
+        on: jest.fn(),
+        off: jest.fn(),
+    };
+    return {
+        HubConnectionBuilder: jest.fn().mockImplementation(() => ({
+            withUrl: jest.fn().mockReturnThis(),
+            withAutomaticReconnect: jest.fn().mockReturnThis(),
+            build: jest.fn().mockReturnValue(mockConnection),
+        })),
+    };
+});
+
+describe('useSignalR', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+    });
+
+    it('should successfully establish a connection', async () => {
+        const mockStart = jest.fn().mockResolvedValue(undefined);
+        (HubConnectionBuilder as jest.Mock).mockImplementation(() => ({
+            withUrl: jest.fn().mockReturnThis(),
+            withAutomaticReconnect: jest.fn().mockReturnThis(),
+            build: jest.fn().mockReturnValue({ start: mockStart, stop: jest.fn() }),
+        }));
+
+        const { result } = renderHook(() => useSignalR('http://test-url.com'));
+
+        await waitFor(() => {
+            expect(result.current).not.toBeNull();
+        });
+        expect(mockStart).toHaveBeenCalledTimes(1);
+    });
+
+    it('should retry connection on failure and eventually succeed', async () => {
+        const mockStart = jest
+            .fn()
+            .mockRejectedValueOnce(new Error('Failed to connect'))
+            .mockResolvedValueOnce(undefined);
+
+        (HubConnectionBuilder as jest.Mock).mockImplementation(() => ({
+            withUrl: jest.fn().mockReturnThis(),
+            withAutomaticReconnect: jest.fn().mockReturnThis(),
+            build: jest.fn().mockReturnValue({ start: mockStart, stop: jest.fn() }),
+        }));
+
+        const { result } = renderHook(() => useSignalR('http://test-url.com'));
+
+        jest.advanceTimersByTime(1000);
+
+        await waitFor(() => {
+            expect(result.current).not.toBeNull();
+        });
+        expect(mockStart).toHaveBeenCalledTimes(2);
+    });
+
+    it('should call stop on unmount', async () => {
+        const mockStop = jest.fn();
+        (HubConnectionBuilder as jest.Mock).mockImplementation(() => ({
+            withUrl: jest.fn().mockReturnThis(),
+            withAutomaticReconnect: jest.fn().mockReturnThis(),
+            build: jest.fn().mockReturnValue({ start: jest.fn().mockResolvedValue(undefined), stop: mockStop }),
+        }));
+
+        const { unmount } = renderHook(() => useSignalR('http://test-url.com'));
+        unmount();
+
+        expect(mockStop).toHaveBeenCalled();
+    });
+});

--- a/src/hooks/public/SignalR/useSignalR.test.ts
+++ b/src/hooks/public/SignalR/useSignalR.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor, act } from '@testing-library/react';
 import { useSignalR } from './useSignalR';
 import { HubConnectionBuilder } from '@microsoft/signalr';
 
@@ -59,11 +59,18 @@ describe('useSignalR', () => {
 
         const { result } = renderHook(() => useSignalR('http://test-url.com'));
 
-        jest.advanceTimersByTime(1000);
+        await waitFor(() => {
+            expect(mockStart).toHaveBeenCalledTimes(1);
+        });
+
+        await act(async () => {
+            jest.advanceTimersByTime(1000);
+        });
 
         await waitFor(() => {
             expect(result.current).not.toBeNull();
         });
+        
         expect(mockStart).toHaveBeenCalledTimes(2);
     });
 
@@ -76,6 +83,7 @@ describe('useSignalR', () => {
         }));
 
         const { unmount } = renderHook(() => useSignalR('http://test-url.com'));
+        
         unmount();
 
         expect(mockStop).toHaveBeenCalled();

--- a/src/hooks/public/SignalR/useSignalR.test.ts
+++ b/src/hooks/public/SignalR/useSignalR.test.ts
@@ -70,7 +70,7 @@ describe('useSignalR', () => {
         await waitFor(() => {
             expect(result.current).not.toBeNull();
         });
-        
+
         expect(mockStart).toHaveBeenCalledTimes(2);
     });
 
@@ -83,7 +83,7 @@ describe('useSignalR', () => {
         }));
 
         const { unmount } = renderHook(() => useSignalR('http://test-url.com'));
-        
+
         unmount();
 
         expect(mockStop).toHaveBeenCalled();

--- a/src/hooks/public/SignalR/useSignalR.ts
+++ b/src/hooks/public/SignalR/useSignalR.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from 'react';
+import { HubConnection, HubConnectionBuilder } from '@microsoft/signalr';
+
+export const useSignalR = (url: string): HubConnection | null => {
+    const [connection, setConnection] = useState<HubConnection | null>(null);
+
+    useEffect(() => {
+        const newConnection = new HubConnectionBuilder().withUrl(url).withAutomaticReconnect().build();
+
+        newConnection
+            .start()
+            .then(() => {
+                setConnection(newConnection);
+            })
+            .catch((err: Error) => {
+                console.error('SignalR Connection Error: ', err);
+            });
+
+        return () => {
+            newConnection.stop();
+        };
+    }, [url]);
+
+    return connection;
+};

--- a/src/hooks/public/SignalR/useSignalR.ts
+++ b/src/hooks/public/SignalR/useSignalR.ts
@@ -1,22 +1,39 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { HubConnection, HubConnectionBuilder } from '@microsoft/signalr';
 
 export const useSignalR = (url: string): HubConnection | null => {
     const [connection, setConnection] = useState<HubConnection | null>(null);
+    const isMounted = useRef(true);
 
     useEffect(() => {
+        isMounted.current = true;
+
         const newConnection = new HubConnectionBuilder().withUrl(url).withAutomaticReconnect().build();
 
-        newConnection
-            .start()
-            .then(() => {
-                setConnection(newConnection);
-            })
-            .catch((err: Error) => {
-                console.error('SignalR Connection Error: ', err);
-            });
+        let retryCount = 0;
+        const maxRetries = 5;
+
+        const startConnection = async () => {
+            try {
+                await newConnection.start();
+                if (isMounted.current) {
+                    setConnection(newConnection);
+                }
+            } catch (err) {
+                console.error(`SignalR Connection Error (Attempt ${retryCount + 1}): `, err);
+
+                if (retryCount < maxRetries && isMounted.current) {
+                    const timeout = Math.pow(2, retryCount) * 1000;
+                    retryCount++;
+                    setTimeout(startConnection, timeout);
+                }
+            }
+        };
+
+        startConnection();
 
         return () => {
+            isMounted.current = false;
             newConnection.stop();
         };
     }, [url]);

--- a/src/hooks/public/SignalR/useSignalR.ts
+++ b/src/hooks/public/SignalR/useSignalR.ts
@@ -20,8 +20,6 @@ export const useSignalR = (url: string): HubConnection | null => {
                     setConnection(newConnection);
                 }
             } catch (err) {
-                console.error(`SignalR Connection Error (Attempt ${retryCount + 1}): `, err);
-
                 if (retryCount < maxRetries && isMounted.current) {
                     const timeout = Math.pow(2, retryCount) * 1000;
                     retryCount++;

--- a/src/pages/public/reports-page/components/reports-section/ReportsSection.test.tsx
+++ b/src/pages/public/reports-page/components/reports-section/ReportsSection.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ReportsSection } from './ReportsSection';
 import { PdfReportsApi } from '@/services/api/admin/reports/pdf-reports/pdf-reports-api';
 import { localizationLanguagesDataFetch } from '@/services/api/public/localization/languages/languages-api';
+import { useSignalR } from '@/hooks/public/SignalR/useSignalR';
 
 jest.mock('./ReportsSection.module.scss', () => ({
     root: 'root-class',
@@ -34,6 +35,10 @@ jest.mock('@/services/api/admin/reports/pdf-reports/pdf-reports-api', () => ({
     },
 }));
 
+jest.mock('@/hooks/public/SignalR/useSignalR', () => ({
+    useSignalR: jest.fn(),
+}));
+
 jest.mock('./report-item', () => ({
     ReportItem: ({ label }: any) => <div data-testid="report-item-mock">{label}</div>,
 }));
@@ -45,19 +50,30 @@ const makeReport = (id: number) => ({
     fileSizeBytes: 1024,
     createdAt: '2024-01-01',
     priority: id,
+    languageId: 1,
 });
 
 describe('ReportsSection', () => {
+    let mockSignalROn: jest.Mock;
+    let mockSignalROff: jest.Mock;
+
     beforeEach(() => {
         jest.clearAllMocks();
         (localizationLanguagesDataFetch as jest.Mock).mockResolvedValue([{ id: 1, code: 'uk', name: 'Ukrainian' }]);
+
+        mockSignalROn = jest.fn();
+        mockSignalROff = jest.fn();
+
+        (useSignalR as jest.Mock).mockReturnValue({
+            on: mockSignalROn,
+            off: mockSignalROff,
+        });
     });
 
     describe('without overflow (<= 2 items)', () => {
         it('renders all items and no toggle button', async () => {
             (PdfReportsApi.getAllByLanguageId as jest.Mock).mockResolvedValueOnce({
                 items: [makeReport(1), makeReport(2)],
-                total: 2,
             });
 
             render(<ReportsSection />);
@@ -75,7 +91,6 @@ describe('ReportsSection', () => {
         beforeEach(() => {
             (PdfReportsApi.getAllByLanguageId as jest.Mock).mockResolvedValue({
                 items: manyReports,
-                total: manyReports.length,
             });
         });
 
@@ -103,6 +118,99 @@ describe('ReportsSection', () => {
             await user.click(screen.getByText('reports.showLess'));
             expect(screen.getAllByTestId('report-item-mock')).toHaveLength(2);
             expect(screen.getByText('reports.showMore')).toBeInTheDocument();
+        });
+    });
+
+    describe('SignalR real-time updates', () => {
+        const initialReports = [makeReport(1), makeReport(2)];
+
+        beforeEach(() => {
+            (PdfReportsApi.getAllByLanguageId as jest.Mock).mockResolvedValue({
+                items: initialReports,
+            });
+        });
+
+        it('adds a new report when PdfReportCreated is received', async () => {
+            render(<ReportsSection />);
+            await waitFor(() => expect(screen.getAllByTestId('report-item-mock')).toHaveLength(2));
+
+            const createdCallback = mockSignalROn.mock.calls.find((call) => call[0] === 'PdfReportCreated')[1];
+
+            act(() => {
+                createdCallback(makeReport(99));
+            });
+
+            const user = userEvent.setup();
+            await user.click(screen.getByText('reports.showMore'));
+
+            await waitFor(() => {
+                expect(screen.getAllByTestId('report-item-mock')).toHaveLength(3);
+                expect(screen.getByText('Звіт 99')).toBeInTheDocument();
+            });
+        });
+
+        it('updates an existing report when PdfReportUpdated is received', async () => {
+            render(<ReportsSection />);
+            await waitFor(() => expect(screen.getAllByTestId('report-item-mock')).toHaveLength(2));
+
+            const updatedCallback = mockSignalROn.mock.calls.find((call) => call[0] === 'PdfReportUpdated')[1];
+
+            act(() => {
+                updatedCallback({ ...makeReport(1), name: 'Updated Title.pdf' });
+            });
+
+            await waitFor(() => {
+                expect(screen.getByText('Updated Title')).toBeInTheDocument();
+            });
+        });
+
+        it('removes a report when PdfReportDeleted is received', async () => {
+            render(<ReportsSection />);
+            await waitFor(() => expect(screen.getAllByTestId('report-item-mock')).toHaveLength(2));
+
+            const deletedCallback = mockSignalROn.mock.calls.find((call) => call[0] === 'PdfReportDeleted')[1];
+
+            act(() => {
+                deletedCallback(1);
+            });
+
+            await waitFor(() => {
+                expect(screen.getAllByTestId('report-item-mock')).toHaveLength(1);
+                expect(screen.queryByText('Звіт 1')).not.toBeInTheDocument();
+            });
+        });
+
+        it('refetches all reports when PdfReportsReordered is received', async () => {
+            render(<ReportsSection />);
+            await waitFor(() => expect(screen.getAllByTestId('report-item-mock')).toHaveLength(2));
+
+            (PdfReportsApi.getAllByLanguageId as jest.Mock).mockResolvedValueOnce({
+                items: [makeReport(3), makeReport(4), makeReport(5)],
+            });
+
+            const reorderedCallback = mockSignalROn.mock.calls.find((call) => call[0] === 'PdfReportsReordered')[1];
+
+            await act(async () => {
+                await reorderedCallback(1);
+            });
+
+            const user = userEvent.setup();
+            await user.click(screen.getByText('reports.showMore'));
+
+            await waitFor(() => {
+                expect(screen.getAllByTestId('report-item-mock')).toHaveLength(3);
+                expect(screen.getByText('Звіт 5')).toBeInTheDocument();
+            });
+        });
+
+        it('cleans up SignalR event listeners on unmount', () => {
+            const { unmount } = render(<ReportsSection />);
+            unmount();
+
+            expect(mockSignalROff).toHaveBeenCalledWith('PdfReportCreated', expect.any(Function));
+            expect(mockSignalROff).toHaveBeenCalledWith('PdfReportUpdated', expect.any(Function));
+            expect(mockSignalROff).toHaveBeenCalledWith('PdfReportDeleted', expect.any(Function));
+            expect(mockSignalROff).toHaveBeenCalledWith('PdfReportsReordered', expect.any(Function));
         });
     });
 });

--- a/src/pages/public/reports-page/components/reports-section/ReportsSection.tsx
+++ b/src/pages/public/reports-page/components/reports-section/ReportsSection.tsx
@@ -55,10 +55,10 @@ export const ReportsSection = () => {
             }
         };
 
-        signalRConnection.on('PdfReportCreated', handlePdfCreated);
+        signalRConnection.on('PdfReportAction', handlePdfCreated);
 
         return () => {
-            signalRConnection.off('PdfReportCreated', handlePdfCreated);
+            signalRConnection.off('PdfReportAction', handlePdfCreated);
         };
     }, [signalRConnection, currentLanguage]);
 

--- a/src/pages/public/reports-page/components/reports-section/ReportsSection.tsx
+++ b/src/pages/public/reports-page/components/reports-section/ReportsSection.tsx
@@ -40,7 +40,6 @@ export const ReportsSection = () => {
             }
             return fetchedReports;
         } catch (err) {
-            console.error('Failed to fetch reports', err);
             return [];
         }
     }, []);

--- a/src/pages/public/reports-page/components/reports-section/ReportsSection.tsx
+++ b/src/pages/public/reports-page/components/reports-section/ReportsSection.tsx
@@ -6,6 +6,7 @@ import { useLocale } from '@/hooks/common/use-locale/useLocale';
 import { localizationLanguagesDataFetch } from '@/services/api/public/localization/languages/languages-api';
 import { PdfReportsApi } from '@/services/api/admin/reports/pdf-reports/pdf-reports-api';
 import { PdfReportDto } from '@/types/admin/pdf-section';
+import { useSignalR } from '@/hooks/public/SignalR/useSignalR';
 import styles from './ReportsSection.module.scss';
 
 const INITIAL_VISIBLE_COUNT = 2;
@@ -15,6 +16,8 @@ export const ReportsSection = () => {
     const { currentLanguage } = useLocale();
     const [isExpanded, setIsExpanded] = useState(false);
     const [reports, setReports] = useState<PdfReportDto[]>([]);
+
+    const signalRConnection = useSignalR(process.env.SIGNALR_PDF_REPORTS_URL || 'https://localhost:5001/hubs/reports');
 
     useEffect(() => {
         let mounted = true;
@@ -33,6 +36,31 @@ export const ReportsSection = () => {
             mounted = false;
         };
     }, [currentLanguage]);
+
+    useEffect(() => {
+        if (!signalRConnection) return;
+
+        const handlePdfCreated = async (updatedLanguageId: number) => {
+            try {
+                const languages = await localizationLanguagesDataFetch();
+                const langCode = currentLanguage?.startsWith('en') ? 'en' : 'uk';
+                const language = languages.find((l) => l.code === langCode);
+
+                if (language && language.id === updatedLanguageId) {
+                    const result = await PdfReportsApi.getAllByLanguageId(language.id, { offset: 0, limit: 1000 });
+                    setReports(result.items);
+                }
+            } catch (err) {
+                console.error('Failed to refetch reports on SignalR event', err);
+            }
+        };
+
+        signalRConnection.on('PdfReportCreated', handlePdfCreated);
+
+        return () => {
+            signalRConnection.off('PdfReportCreated', handlePdfCreated);
+        };
+    }, [signalRConnection, currentLanguage]);
 
     const hasOverflow = reports.length > INITIAL_VISIBLE_COUNT;
     const visibleReports = hasOverflow && !isExpanded ? reports.slice(0, INITIAL_VISIBLE_COUNT) : reports;

--- a/src/pages/public/reports-page/components/reports-section/ReportsSection.tsx
+++ b/src/pages/public/reports-page/components/reports-section/ReportsSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReportItem } from './report-item';
 import { Button } from '@/components/public/ui/button';
@@ -10,6 +10,7 @@ import { useSignalR } from '@/hooks/public/SignalR/useSignalR';
 import styles from './ReportsSection.module.scss';
 
 const INITIAL_VISIBLE_COUNT = 2;
+const FETCH_LIMIT = 50;
 
 export const ReportsSection = () => {
     const { t } = useTranslation('reportsPage');
@@ -17,50 +18,99 @@ export const ReportsSection = () => {
     const [isExpanded, setIsExpanded] = useState(false);
     const [reports, setReports] = useState<PdfReportDto[]>([]);
 
-    const signalRConnection = useSignalR(process.env.SIGNALR_PDF_REPORTS_URL || 'https://localhost:5001/hubs/reports');
+    const activeLanguageIdRef = useRef<number | null>(null);
+
+    const signalRConnection = useSignalR(process.env.REACT_APP_SIGNALR_PDF_REPORTS_URL || '');
+
+    const fetchAllReports = useCallback(async (languageId: number) => {
+        let offset = 0;
+        let hasMore = true;
+        let fetchedReports: PdfReportDto[] = [];
+
+        try {
+            while (hasMore) {
+                const result = await PdfReportsApi.getAllByLanguageId(languageId, { offset, limit: FETCH_LIMIT });
+                fetchedReports = [...fetchedReports, ...result.items];
+
+                if (result.items.length < FETCH_LIMIT) {
+                    hasMore = false;
+                } else {
+                    offset += FETCH_LIMIT;
+                }
+            }
+            return fetchedReports;
+        } catch (err) {
+            console.error('Failed to fetch reports', err);
+            return [];
+        }
+    }, []);
 
     useEffect(() => {
         let mounted = true;
-        const fetchReports = async () => {
-            try {
-                const languages = await localizationLanguagesDataFetch();
-                const langCode = currentLanguage?.startsWith('en') ? 'en' : 'uk';
-                const language = languages.find((l) => l.code === langCode);
-                if (!language || !mounted) return;
-                const result = await PdfReportsApi.getAllByLanguageId(language.id, { offset: 0, limit: 1000 });
-                if (mounted) setReports(result.items);
-            } catch {}
+
+        const initFetch = async () => {
+            const languages = await localizationLanguagesDataFetch();
+            const langCode = currentLanguage?.startsWith('en') ? 'en' : 'uk';
+            const language = languages.find((l) => l.code === langCode);
+
+            if (!language || !mounted) return;
+
+            activeLanguageIdRef.current = language.id;
+            const fetchedReports = await fetchAllReports(language.id);
+
+            if (mounted) {
+                setReports(fetchedReports);
+            }
         };
-        fetchReports();
+
+        initFetch();
+
         return () => {
             mounted = false;
         };
-    }, [currentLanguage]);
+    }, [currentLanguage, fetchAllReports]);
 
     useEffect(() => {
         if (!signalRConnection) return;
 
-        const handlePdfCreated = async (updatedLanguageId: number) => {
-            try {
-                const languages = await localizationLanguagesDataFetch();
-                const langCode = currentLanguage?.startsWith('en') ? 'en' : 'uk';
-                const language = languages.find((l) => l.code === langCode);
+        let mounted = true;
 
-                if (language && language.id === updatedLanguageId) {
-                    const result = await PdfReportsApi.getAllByLanguageId(language.id, { offset: 0, limit: 1000 });
-                    setReports(result.items);
-                }
-            } catch (err) {
-                console.error('Failed to refetch reports on SignalR event', err);
+        const handleCreated = (newReport: PdfReportDto) => {
+            if (!mounted || activeLanguageIdRef.current !== newReport.languageId) return;
+            setReports((prev) => [newReport, ...prev]);
+        };
+
+        const handleUpdated = (updatedReport: PdfReportDto) => {
+            if (!mounted || activeLanguageIdRef.current !== updatedReport.languageId) return;
+            setReports((prev) => prev.map((r) => (r.id === updatedReport.id ? updatedReport : r)));
+        };
+
+        const handleDeleted = (deletedId: number) => {
+            if (!mounted) return;
+            setReports((prev) => prev.filter((r) => r.id !== deletedId));
+        };
+
+        const handleReordered = async (languageId: number) => {
+            if (!mounted || activeLanguageIdRef.current !== languageId) return;
+            const updatedReports = await fetchAllReports(languageId);
+            if (mounted) {
+                setReports(updatedReports);
             }
         };
 
-        signalRConnection.on('PdfReportAction', handlePdfCreated);
+        signalRConnection.on('PdfReportCreated', handleCreated);
+        signalRConnection.on('PdfReportUpdated', handleUpdated);
+        signalRConnection.on('PdfReportDeleted', handleDeleted);
+        signalRConnection.on('PdfReportsReordered', handleReordered);
 
         return () => {
-            signalRConnection.off('PdfReportAction', handlePdfCreated);
+            mounted = false;
+            signalRConnection.off('PdfReportCreated', handleCreated);
+            signalRConnection.off('PdfReportUpdated', handleUpdated);
+            signalRConnection.off('PdfReportDeleted', handleDeleted);
+            signalRConnection.off('PdfReportsReordered', handleReordered);
         };
-    }, [signalRConnection, currentLanguage]);
+    }, [signalRConnection, fetchAllReports]);
 
     const hasOverflow = reports.length > INITIAL_VISIBLE_COUNT;
     const visibleReports = hasOverflow && !isExpanded ? reports.slice(0, INITIAL_VISIBLE_COUNT) : reports;
@@ -77,7 +127,7 @@ export const ReportsSection = () => {
                     <ReportItem
                         key={report.id}
                         fileUrl={PdfReportsApi.getPublicFileUrl(report.id)}
-                        label={report.name.replace(/\.pdf$/i, '')}
+                        label={report?.name?.replace(/\.pdf$/i, '') || 'Unnamed Report'}
                         buttonLabel={t('actions.downloadPdf')}
                     />
                 ))}


### PR DESCRIPTION
Environment:
Windows 10 
Chrome 151.0.7922.174

Issue ticket link
Github ticket: https://github.com/ita-social-projects/VictoryCenter-Back/issues/3001

Summary of issue:
The newly uploaded PDF file does not appear on the Public 'Звітність' page automatically. It only becomes visible after a manual page reload which is not a correct behaviour according to the user story. #1326

Summary of change:
SignalR library was implemented in a form of a custom hook that lets pdf reports component to listen to incoming messages about admin updating them.

How to recreate changes
1. Open admin panel => page "Звіти" => tab "Звіт та аналітика"  => subtab "PDF Файли"
2. Open the "Звітність" page on the public side of application
3. Make changes to reports through the admin panel
4. See changes to appear on the public side without a manual reload

How to reproduce changes locally:
1. Switch both your local back and front to the branch fix/issue-3001
2. Run both of them
3. As an admin open your panel => page "Звіти" => tab "Звіт та аналітика"  => subtab "PDF Файли"
4. Simultaniously open the "Звітність" page on the public side of application as a default user
5. Make changes to reports through the admin panel
6. See changes to appear on the public side without a manual reload

CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [+]  Changes has medium impact on users
- [ ]  Changes has light impact on users
- [ ]  Test covetage was updated
- [+]  PR meets all conventions
