### PR TITLE
Fix/issue-3359 [Reports][Admin panel] dashboard card truncates USD total instead of rounding to the nearest whole number

### DIFF
--- a/src/utils/functions/format-summary-amount/format-summary-amount.test.ts
+++ b/src/utils/functions/format-summary-amount/format-summary-amount.test.ts
@@ -22,4 +22,8 @@ describe('formatSummaryAmount', () => {
     it('should round up on .5 boundary values', () => {
         expect(formatSummaryAmount(9.5)).toBe('10');
     });
+
+    it('should round down on values below .5 boundary', () => {
+        expect(formatSummaryAmount(9.49)).toBe('9');
+    });
 });

--- a/src/utils/functions/format-summary-amount/format-summary-amount.test.ts
+++ b/src/utils/functions/format-summary-amount/format-summary-amount.test.ts
@@ -6,14 +6,14 @@ describe('formatSummaryAmount', () => {
     });
 
     it('should format integer with thousand separators', () => {
-        expect(formatSummaryAmount(7265)).toBe('7 265');
+        expect(formatSummaryAmount(7265)).toBe('7 265');
     });
 
-    it('should truncate decimals without rounding', () => {
-        expect(formatSummaryAmount(1249854.99)).toBe('1 249 854');
+    it('should round decimals to nearest integer', () => {
+        expect(formatSummaryAmount(1249854.99)).toBe('1 249 855');
     });
 
-    it('should not round up on .9 values', () => {
-        expect(formatSummaryAmount(9.9)).toBe('9');
+    it('should round up on .9 values', () => {
+        expect(formatSummaryAmount(9.9)).toBe('10');
     });
 });

--- a/src/utils/functions/format-summary-amount/format-summary-amount.test.ts
+++ b/src/utils/functions/format-summary-amount/format-summary-amount.test.ts
@@ -1,19 +1,25 @@
 import { formatSummaryAmount } from '@/utils/functions/format-summary-amount/format-summary-amount';
 
+const normalizeSpaces = (value: string) => value.replace(/\u00a0/g, ' ');
+
 describe('formatSummaryAmount', () => {
     it('should return empty string when value is undefined', () => {
         expect(formatSummaryAmount()).toBe('');
     });
 
     it('should format integer with thousand separators', () => {
-        expect(formatSummaryAmount(7265)).toBe('7 265');
+        expect(normalizeSpaces(formatSummaryAmount(7265))).toBe('7 265');
     });
 
     it('should round decimals to nearest integer', () => {
-        expect(formatSummaryAmount(1249854.99)).toBe('1 249 855');
+        expect(normalizeSpaces(formatSummaryAmount(1249854.99))).toBe('1 249 855');
     });
 
     it('should round up on .9 values', () => {
         expect(formatSummaryAmount(9.9)).toBe('10');
+    });
+
+    it('should round up on .5 boundary values', () => {
+        expect(formatSummaryAmount(9.5)).toBe('10');
     });
 });

--- a/src/utils/functions/format-summary-amount/format-summary-amount.ts
+++ b/src/utils/functions/format-summary-amount/format-summary-amount.ts
@@ -3,5 +3,5 @@ export const formatSummaryAmount = (value?: number): string => {
         return '';
     }
 
-    return Math.trunc(value).toLocaleString('uk-UA');
+    return Math.round(value).toLocaleString('uk-UA');
 };


### PR DESCRIPTION
## Github ticket

* [Github issue #3359](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3359#issue-5171779029)

## Description

This PR fixes the USD total calculation on the 'Всього Програмні Витрати' summary card. Previously, the decimal part was being truncated with `Math.trunc`, causing values with a decimal part ≥ 0.5 to display as truncated whole numbers instead of being rounded up.

## How it looks

<img width="1370" height="657" alt="Знімок екрана 2026-08-18 143054" src="https://github.com/user-attachments/assets/cdb85c21-67ba-4928-b731-51cd7088f92a" />

## Summary of change

Replaced `Math.trunc` with `Math.round` in `\src\utils\functions\format-summary-amount\format-summary-amount.ts` to apply standard mathematical rounding for summary card values.

## How to recreate changes

1. Click tab ‘Звіт та аналітика’
2. Click button ‘Редагувати Доходи та витрати’
3. Click sub tab 'Доходи та витрати'
4. Navigate to 'Програмні' category record and verify the USD sum — confirm the decimal part is ≥ 0,5
5. Click on the 'Програмні витрати' subtab.
6. Check the 'Всього програмні витрати' dashboard card.
7. Verify that when program expense records sum up to a USD value with a decimal part ≥ 0.5 (e.g. 4 286,7 USD), the USD total on the card is rounded up to the nearest whole number (e.g. 4 287 USD) instead of being truncated.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Summary amounts are now rounded correctly before being displayed.
  * Ukrainian-locale number formatting now shows more accurate values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->