### PR TITLE
Fix/issue 3376 [Admin panel][Profile company] Tooltip text is displayed on click instead of hover

### DIFF
--- a/src/components/admin/button-tooltip/ButtonTooltip.scss
+++ b/src/components/admin/button-tooltip/ButtonTooltip.scss
@@ -14,7 +14,7 @@
     display: flex;
 
     &:hover,
-    &:focus {
+    &:focus-visible {
         background-color: colors.$blue-50;
     }
 }

--- a/src/components/admin/button-tooltip/ButtonTooltip.test.tsx
+++ b/src/components/admin/button-tooltip/ButtonTooltip.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { ButtonTooltip, ButtonTooltipProps } from './ButtonTooltip';
 import { TooltipProps } from '../tooltip/Tooltip';
 
@@ -51,8 +51,14 @@ describe('ButtonTooltip', () => {
 
     const hoverButton = () => fireEvent.mouseEnter(getButton());
     const unhoverButton = () => fireEvent.mouseLeave(getButton());
-    const focusButton = () => fireEvent.focus(getButton());
-    const blurButton = () => fireEvent.blur(getButton());
+    const focusButton = () =>
+        act(() => {
+            getButton().focus();
+        });
+    const blurButton = () =>
+        act(() => {
+            getButton().blur();
+        });
 
     afterEach(() => {
         jest.clearAllMocks();

--- a/src/components/admin/button-tooltip/ButtonTooltip.test.tsx
+++ b/src/components/admin/button-tooltip/ButtonTooltip.test.tsx
@@ -49,6 +49,11 @@ describe('ButtonTooltip', () => {
     const clickTooltip = () => fireEvent.mouseDown(getTooltip()!);
     const clickOutside = () => fireEvent.mouseDown(document.body);
 
+    const hoverButton = () => fireEvent.mouseEnter(getButton());
+    const unhoverButton = () => fireEvent.mouseLeave(getButton());
+    const focusButton = () => fireEvent.focus(getButton());
+    const blurButton = () => fireEvent.blur(getButton());
+
     afterEach(() => {
         jest.clearAllMocks();
     });
@@ -61,6 +66,40 @@ describe('ButtonTooltip', () => {
         expect(getTooltip()).not.toBeInTheDocument();
     });
 
+    it('shows tooltip on mouse enter', () => {
+        renderButtonTooltip();
+        expect(getTooltip()).not.toBeInTheDocument();
+
+        hoverButton();
+        expect(getTooltip()).toBeInTheDocument();
+    });
+
+    it('hides tooltip on mouse leave', () => {
+        renderButtonTooltip();
+        hoverButton();
+        expect(getTooltip()).toBeInTheDocument();
+
+        unhoverButton();
+        expect(getTooltip()).not.toBeInTheDocument();
+    });
+
+    it('shows tooltip on focus', () => {
+        renderButtonTooltip();
+        expect(getTooltip()).not.toBeInTheDocument();
+
+        focusButton();
+        expect(getTooltip()).toBeInTheDocument();
+    });
+
+    it('hides tooltip on blur', () => {
+        renderButtonTooltip();
+        focusButton();
+        expect(getTooltip()).toBeInTheDocument();
+
+        blurButton();
+        expect(getTooltip()).not.toBeInTheDocument();
+    });
+
     it('shows tooltip when clicked', () => {
         renderButtonTooltip();
         clickButton();
@@ -70,13 +109,13 @@ describe('ButtonTooltip', () => {
         expect(getButton()).toHaveAttribute('aria-describedby');
     });
 
-    it('hides tooltip when clicked again', () => {
+    it('keeps tooltip visible when clicked again', () => {
         renderButtonTooltip();
         clickButton();
         expect(getTooltip()).toBeInTheDocument();
 
         clickButton();
-        expect(getTooltip()).not.toBeInTheDocument();
+        expect(getTooltip()).toBeInTheDocument();
     });
 
     it('hides tooltip when clicking outside', async () => {
@@ -115,19 +154,6 @@ describe('ButtonTooltip', () => {
 
         expect(button).toHaveAttribute('aria-expanded', 'true');
         expect(button).toHaveAttribute('aria-describedby');
-    });
-
-    it('handles button click and toggles tooltip', () => {
-        renderButtonTooltip();
-
-        // Test that clicking works (this implicitly tests the click handler which calls stopPropagation)
-        expect(getTooltip()).not.toBeInTheDocument();
-
-        clickButton();
-        expect(getTooltip()).toBeInTheDocument();
-
-        clickButton();
-        expect(getTooltip()).not.toBeInTheDocument();
     });
 
     it('does not hide tooltip when clicking on tooltip itself', async () => {

--- a/src/components/admin/button-tooltip/ButtonTooltip.tsx
+++ b/src/components/admin/button-tooltip/ButtonTooltip.tsx
@@ -15,14 +15,18 @@ export const ButtonTooltip = ({ children, position = 'bottom', isRenderInPortal 
     const wrapperRef = useRef<HTMLButtonElement>(null);
     const tooltipId = useId();
 
-    const toggleTooltip = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        setIsVisible((prev) => !prev);
-    };
+    const showTooltip = useCallback(() => {
+        setIsVisible(true);
+    }, []);
 
     const closeTooltip = useCallback(() => {
         setIsVisible(false);
     }, []);
+
+    const handleClick = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        showTooltip();
+    };
 
     useOnClickOutside({
         ignoreClickRefs: [wrapperRef],
@@ -35,7 +39,11 @@ export const ButtonTooltip = ({ children, position = 'bottom', isRenderInPortal 
             ref={wrapperRef}
             type="button"
             className="button-tooltip-wrapper"
-            onClick={toggleTooltip}
+            onClick={handleClick}
+            onMouseEnter={showTooltip}
+            onMouseLeave={closeTooltip}
+            onFocus={showTooltip}
+            onBlur={closeTooltip}
             aria-haspopup="true"
             aria-expanded={isVisible}
             aria-label="Show additional information"


### PR DESCRIPTION
## Github ticket

* https://github.com/ita-social-projects/VictoryCenter-Back/issues/3376

## Description

The info tooltip in the admin panel was displayed only after clicking the icon. According to the User Story it must appear on hover and on keyboard focus, without requiring a click.

## How it looks


https://github.com/user-attachments/assets/0c383be2-bcb6-407b-b56c-48cb8e808f74


## Summary of change

`ButtonTooltip.tsx` - the tooltip is now shown by onMouseEnter and onFocus, and hidden by onMouseLeave and onBlur. The click handler was kept for touch devices, but it no longer toggles: it only shows the tooltip. Toggling on click caused the tooltip to disappear while the cursor was still over the icon. useOnClickOutside was kept - it is what closes the tooltip after a tap on touch devices.

`ButtonTooltip.scss` - the icon kept its highlighted background after a click, because a clicked button retains focus and :focus styling stayed applied. Replaced :focus with :focus-visible, so the highlight is cleared once the cursor leaves. :focus-visible was chosen over removing the rule entirely, so the icon still has a visible state when reached with Tab.

`ButtonTooltip.test.tsx` - four tests added for hover and focus. One test was updated because click no longer toggles, and one duplicate test was removed.

## How to recreate changes

1. Open the admin panel -> Company Profile
2. Hover over any info icon next to a field label -> the tooltip appears immediately
3. Move the cursor away -> the tooltip disappears
4. Press Tab until the icon is focused -> the tooltip appears
5. Click the icon and move the cursor away -> the icon returns to its normal state

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip behavior for mouse and keyboard interactions.
  * Tooltips now remain visible after repeated clicks instead of unexpectedly toggling closed.
  * Keyboard focus styling is applied only when focus is visibly present.
  * Tooltips continue to close when focus or pointer interaction ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->