### PR TITLE
fix: address code review findings from PR #559 (issue-2887)

### DIFF
--- a/src/pages/admin/events/EventsPageAdmin.scss
+++ b/src/pages/admin/events/EventsPageAdmin.scss
@@ -1,0 +1,26 @@
+@use '@/assets/sass/variables/colors';
+
+.events-page {
+    &-wrapper {
+        display: flex;
+        flex-direction: column;
+        gap: 3.375rem;
+        height: 100vh;
+        width: 100%;
+        padding: 2.5rem;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    &-toolbar-container {
+        flex-shrink: 0;
+    }
+
+    &-list-container {
+        flex-grow: 1;
+        min-height: 0;
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+    }
+}

--- a/src/pages/admin/events/EventsPageAdmin.test.tsx
+++ b/src/pages/admin/events/EventsPageAdmin.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { EventsPageAdmin } from './EventsPageAdmin';
+import { useAdminClient } from '@/hooks/admin/use-admin-client/useAdminClient';
+import { AdminPanelToolbarProps } from '@/components/admin/admin-panel-toolbar/AdminPageToolbar';
+import { EVENTS_TEXT } from '@/const/admin/events';
+
+jest.mock('@/hooks/admin/use-admin-client/useAdminClient', () => ({
+    useAdminClient: jest.fn(),
+}));
+
+jest.mock('@/hooks/admin/use-localization-toolkit/useLocalizationToolkit', () => ({
+    useLocalizationToolkit: () => ({
+        allLanguages: [{ id: 1, code: 'uk', name: 'Українська' }],
+        onLanguageChange: jest.fn(),
+        onTranslationStatusFilterChange: jest.fn(),
+    }),
+}));
+
+jest.mock('@/services/api/admin/events/events-api', () => ({
+    EventsApi: {
+        fetchEventSearchItems: jest.fn(),
+        fetchEvents: jest.fn(),
+    },
+}));
+
+jest.mock('@/components/admin/admin-panel-toolbar/AdminPageToolbar', () => ({
+    AdminPanelToolbar: ({ placeholder, AddItemButtonText }: AdminPanelToolbarProps<any>) => (
+        <div data-testid="events-toolbar">
+            <span>{placeholder}</span>
+            <span>{AddItemButtonText}</span>
+        </div>
+    ),
+}));
+
+const mockedUseAdminClient = useAdminClient as jest.Mock;
+
+describe('EventsPageAdmin', () => {
+    beforeEach(() => {
+        mockedUseAdminClient.mockReturnValue({});
+    });
+
+    it('renders the toolbar with the events placeholder and add-item text', () => {
+        render(<EventsPageAdmin />);
+
+        expect(screen.getByTestId('events-page-content')).toBeInTheDocument();
+        expect(screen.getByTestId('events-toolbar')).toBeInTheDocument();
+        expect(screen.getByText(EVENTS_TEXT.PLACEHOLDER.SEARCH_EVENTS)).toBeInTheDocument();
+        expect(screen.getByText(EVENTS_TEXT.BUTTON.ADD_EVENT)).toBeInTheDocument();
+    });
+
+    it('does not render an error message when there is no error', () => {
+        const { container } = render(<EventsPageAdmin />);
+
+        expect(container.querySelector('.error-message')).not.toBeInTheDocument();
+    });
+});

--- a/src/pages/admin/events/EventsPageAdmin.tsx
+++ b/src/pages/admin/events/EventsPageAdmin.tsx
@@ -8,6 +8,7 @@ import { PaginationRequestParams } from '@/hooks/admin/fetch/use-data-pagination
 import { PaginationResult, VisibilityStatus } from '@/types/admin/common';
 import { useLocalizationToolkit } from '@/hooks/admin/use-localization-toolkit/useLocalizationToolkit';
 import { EVENTS_TEXT } from '@/const/admin/events';
+import './EventsPageAdmin.scss';
 
 export const EventsPageAdmin = () => {
     const [statusFilter, setStatusFilter] = useState<VisibilityStatus | undefined>();
@@ -41,8 +42,8 @@ export const EventsPageAdmin = () => {
     }, []);
 
     return (
-        <div className="programs-page-wrapper" data-testid="programs-page-content">
-            <div className="programs-page-toolbar-container">
+        <div className="events-page-wrapper" data-testid="events-page-content">
+            <div className="events-page-toolbar-container">
                 <AdminPanelToolbar<EventSearchItemData>
                     getSearchItemKey={(item) => item.id}
                     getSearchItemLabel={(item) => item.name}
@@ -60,7 +61,7 @@ export const EventsPageAdmin = () => {
                     maxCharactersToSearch={UI_CONFIG.SEARCH_BAR.MAX_CHARACTERS_FOR_SEARCH.EVENTS}
                 />
             </div>
-            <div className="programs-page-list-container">
+            <div className="events-page-list-container">
                 {error.message && <div className="error-message">{error.message}</div>}
             </div>
         </div>

--- a/src/pages/admin/events/EventsPageAdmin.tsx
+++ b/src/pages/admin/events/EventsPageAdmin.tsx
@@ -16,14 +16,7 @@ export const EventsPageAdmin = () => {
     const client = useAdminClient();
 
     const setErrorState = useCallback((message: string, type: EventsErrorType) => setError({ message, type }), []);
-    const {
-        allLanguages,
-        // translationLanguages,
-        // selectedLanguage,
-        onLanguageChange,
-        // translationStatusFilter,
-        onTranslationStatusFilterChange,
-    } = useLocalizationToolkit({
+    const { allLanguages, onLanguageChange, onTranslationStatusFilterChange } = useLocalizationToolkit({
         setErrorState,
     });
 
@@ -45,9 +38,6 @@ export const EventsPageAdmin = () => {
     // Toolbar handlers
     const onStatusFilterChange = useCallback((status: VisibilityStatus | undefined) => {
         setStatusFilter(status);
-        // setIsSearchResultView(false);
-        // setSearchProgramId(undefined);
-        // updateSearchedProgram(null);
     }, []);
 
     return (
@@ -57,7 +47,6 @@ export const EventsPageAdmin = () => {
                     getSearchItemKey={(item) => item.id}
                     getSearchItemLabel={(item) => item.name}
                     fetchSearchItems={getEventSearchItems}
-                    // renderSearchItemComponent={<div>Search Item</div>}
                     placeholder={EVENTS_TEXT.PLACEHOLDER.SEARCH_EVENTS}
                     onSearchClear={() => null}
                     statusFilter={statusFilter}

--- a/src/services/api/admin/events/events-api.test.ts
+++ b/src/services/api/admin/events/events-api.test.ts
@@ -1,0 +1,61 @@
+import { EventsApi } from './events-api';
+import { API_ROUTES } from '@/const/common/api-routes/main-api';
+import { VisibilityStatus } from '@/types/admin/common';
+import { TranslationStatusFilter } from '@/types/common/language';
+import { AxiosInstance } from 'axios';
+
+describe('EventsApi', () => {
+    const mockGet = jest.fn();
+    const client = { get: mockGet } as unknown as AxiosInstance;
+
+    beforeEach(() => {
+        mockGet.mockReset();
+    });
+
+    describe('fetchEvents', () => {
+        it('calls the Events endpoint with the pagination, status, and translation params and returns the data', async () => {
+            const mockResponse = { data: { items: [], total: 0 } };
+            mockGet.mockResolvedValueOnce(mockResponse);
+
+            const result = await EventsApi.fetchEvents(
+                client,
+                1,
+                0,
+                5,
+                TranslationStatusFilter.Outdated,
+                VisibilityStatus.Published,
+            );
+
+            expect(mockGet).toHaveBeenCalledWith(API_ROUTES.EVENTS.BASE, {
+                params: {
+                    categoryId: 1,
+                    offset: 0,
+                    limit: 5,
+                    status: VisibilityStatus.Published,
+                    translationStatusFilter: TranslationStatusFilter.Outdated,
+                },
+            });
+            expect(result).toEqual(mockResponse.data);
+        });
+    });
+
+    describe('fetchEventSearchItems', () => {
+        it('calls the Events search endpoint with the search term, pagination, and abort signal', async () => {
+            const mockResponse = { data: { items: [], total: 0 } };
+            mockGet.mockResolvedValueOnce(mockResponse);
+            const signal = new AbortController().signal;
+
+            const result = await EventsApi.fetchEventSearchItems(client, 'test', 0, 5, signal);
+
+            expect(mockGet).toHaveBeenCalledWith(API_ROUTES.EVENTS.SEARCH, {
+                params: {
+                    searchTerm: 'test',
+                    offset: 0,
+                    limit: 5,
+                },
+                signal,
+            });
+            expect(result).toEqual(mockResponse.data);
+        });
+    });
+});


### PR DESCRIPTION
## JIRA or Github ticker

- Follow-up to [VictoryCenter-Back#2887](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2887), review of [#559](https://github.com/ita-social-projects/VictoryCenter-Client/pull/559)

## Description

This PR contains fixes found during a code review of #559 (Events admin page layout). Three Medium-severity issues were identified by comparing the PR's diff against the linked issue's acceptance criteria and against conventions established by the other admin content components (Programs, WhoWeAre, Faq, Team). No Critical issues were found, and no functional/visual behavior is intended to change — these are code-quality and test-coverage fixes only.

## Summary of change

- **Remove dead commented-out code in `EventsPageAdmin.tsx`.** Several inert commented-out lines were left over from development: destructured-but-unused `translationLanguages`/`selectedLanguage`/`translationStatusFilter` (confirmed unnecessary — `LocalizationToolkitProps` only ever requires `languages`/`onLanguageChange`/`onTranslationStatusFilterChange`), commented calls to state setters that don't exist in this file (`setIsSearchResultView`, `setSearchProgramId`, `updateSearchedProgram`), and a commented-out `renderSearchItemComponent` prop.
- **Give `EventsPageAdmin` its own stylesheet.** The component rendered with `className="programs-page-wrapper"` / `"programs-page-toolbar-container"` / `"programs-page-list-container"` and `data-testid="programs-page-content"` — all copy-pasted from `ProgramsPageContent`. Those classes live in `ProgramsPageContent.scss` (a plain, non-module stylesheet) which `EventsPageAdmin` never imports; it only rendered styled because that stylesheet happens to already be globally injected elsewhere in the bundle — an implicit, undocumented coupling that would silently break if Programs' markup were ever renamed. Every other admin content component owns a co-located stylesheet, so added `EventsPageAdmin.scss` with the same layout rules (renamed `events-page-*`) and updated the JSX to match.
- **Add missing tests.** PR #559's own checklist left "New tests was added or existing was modified" unchecked. `EventsPageAdmin.tsx` and `events-api.ts` are the two new files with runtime logic and had zero coverage (the third new file, `types/admin/events.ts`, is pure type declarations — consistent with the repo convention of not testing type-only files). Added `EventsPageAdmin.test.tsx` (toolbar renders with the right placeholder/add-item text; no error message when there's no error) and `events-api.test.ts` (`fetchEvents`/`fetchEventSearchItems` call the right endpoint/params and return `response.data`), following the mocking patterns already used in `ProgramsPageContent.test.tsx` and `programs-api.test.ts`.

A few Minor issues were also noted during review but intentionally left unfixed (per Critical/Medium-only fix policy): scratch "test method"/"test interface, will need adjustments" comments in `events-api.ts` and `types/admin/events.ts`; `EventsApi.fetchEvents` and `EventsLocalizableFields` are defined but not yet used anywhere; `EventsDto` doesn't extend `EventsLocalizableFields` the way the equivalent Programs types do. None of PR #559's linked issue's 11 acceptance criteria (status badges, category tabs, empty state, edit/delete icons, etc.) are implemented yet, but #559 explicitly scopes itself to "Create the layout" only, so that reads as intentional incremental scoping rather than a defect — worth the author/reviewer confirming whether #559 is meant to land standalone or is stacked ahead of a follow-up PR that closes VictoryCenter-Back#2887.

## How to recreate changes

1. Check out `feature/issue-2887-code-review` and navigate to `/admin-panel/events` — the page renders identically to before (no visual change).
2. `npx tsc --noEmit --ignoreDeprecations 5.0` — 0 errors (note: plain `tsc --noEmit` fails on this repo's `tsconfig.json` `ignoreDeprecations: "6.0"` under the installed TS 5.9.3 — a pre-existing, unrelated config issue).
3. `npm run lint` — 0 errors, 0 warnings.
4. `npm run test:cover` — 511 suites / 5713 tests passing, all four coverage thresholds pass.
5. `npm run build` — compiles successfully.

## CHECK LIST

- [x] New tests were added or existing were modified
- [ ] Changes have severe impact on users
- [ ] Changes have medium impact on users
- [x] Changes have light impact on users
- [x] Test coverage was updated
- [x] PR meets all conventions