### PR TITLE
Fix/issue-3383 [Team] [Admin Panel] Missing period in confirmation pop-up text 'Зміни будуть втрачені. Бажаєте продовжити?'

### DIFF
--- a/src/const/admin/common.ts
+++ b/src/const/admin/common.ts
@@ -54,8 +54,8 @@ export const COMMON_TEXT_ADMIN = {
 
     QUESTION: {
         SAVE_CHANGES: 'Зберегти зміни?',
-        CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE: 'Зміни будуть втрачені\nБажаєте продовжити?',
-        CHANGE_LANGUAGE_UNSAVED_CHANGES: 'Зміни будуть втрачені\nБажаєте змінити мову?',
+        CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE: 'Зміни будуть втрачені.\nБажаєте продовжити?',
+        CHANGE_LANGUAGE_UNSAVED_CHANGES: 'Зміни будуть втрачені.\nБажаєте змінити мову?',
         REMOVE_FROM_PUBLICATION: 'Зняти з публікації?',
         PUBLISH_CHANGES: 'Опублікувати зміни?',
     },


### PR DESCRIPTION
## JIRA or Github ticker

* [3383](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3383)
* Related User Story: [#1169](https://github.com/ita-social-projects/VictoryCenter-Back/issues/1169)

## Description

The main goal of this PR is to fix a punctuation issue in the confirmation pop-ups across the admin panel. Previously, the warning messages regarding unsaved changes were missing a period at the end of the first sentence, which was inconsistent with other pop-ups in the system. This PR adds the missing periods to ensure grammatical correctness and UI consistency.

## How it looks

<img width="647" height="295" alt="image" src="https://github.com/user-attachments/assets/df9d7a3c-7d92-4f95-8da3-7114d54b2835" />

## Summary of change

* Updated the `COMMON_TEXT_ADMIN.QUESTION` object in `src/const/admin/common.ts`.
* Added a missing period (`.`) to the `CHANGES_WILL_BE_LOST_WISH_TO_CONTINUE` string constant.
* Added a missing period (`.`) to the `CHANGE_LANGUAGE_UNSAVED_CHANGES` string constant.

## How to recreate changes

1. Log in to the application as an Admin.
2. Navigate to the **Team** page.
3. Open the **'Додати категорію'** modal.
4. Fill in at least one field in the modal.
5. Click the **'X'** button to close the modal.
6. Verify the confirmation pop-up displays the text with the correct punctuation: *'Зміни будуть втрачені. Бажаєте продовжити?'* (Ensure there is a period after 'втрачені').
7. (Optional) Trigger a language change with unsaved changes to verify the updated *'Зміни будуть втрачені. Бажаєте змінити мову?'* text as well.

## CHECK LIST
- [ ] New tests was added or existing was modified
- [ ] Changes has severe impact on users
- [ ] Changes has medium impact on users
- [x] Changes has light impact on users
- [ ] Test coverage was updated
- [x] PR meets all conventions