### PR TITLE
Fix/issue-3407 [Admin Panel][Team] Character counter position in the name field

### DIFF
--- a/src/pages/admin/team/components/team-category-modal/TeamCategoryModal.tsx
+++ b/src/pages/admin/team/components/team-category-modal/TeamCategoryModal.tsx
@@ -295,6 +295,7 @@ export const TeamCategoryModal = (props: TeamCategoryModalProps) => {
 
                         <InputWithCharacterLimitGroup
                             isRequired
+                            showCounterBelow
                             label={TEAM_CATEGORY_TEXT.FORM.LABEL.NAME}
                             error={errors.name}
                             value={formState.name}


### PR DESCRIPTION
## JIRA or Github ticker

https://github.com/ita-social-projects/VictoryCenter-Back/issues/3407

## Description

The character counter for the 'Назва' field was inside the input 
border, while the 'Опис' counter is correctly positioned below the textarea. 
According to Figma mockup both should be below the field.

## How it looks

<img width="1212" height="1126" alt="image" src="https://github.com/user-attachments/assets/e5b1a9fb-5d0f-4f08-95cf-2da565a4b5fb" />

## Summary of change

`InputWithCharacterLimitGroup` already supports a `showCounterBelow` prop, 
which renders the counter below the field instead of inside it. It just 
wasn't passed in `TeamCategoryModal`, so the default (false) kept the 
counter inside the input.

## How to recreate changes

1. Log in as admin
2. Navigate to the Team page
3. Open the 'Редагувати категорію' modal
4. The counter for 'Назва' is now below the input, aligned with 'Опис'
5. Clear the field - the counter still shows 0/20 below the input


## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions
