### PR TITLE
Fix/issue-3377-3379 [Admin panel][Profile company] Info tooltip is di…

### DIFF
--- a/src/const/admin/company-profile.ts
+++ b/src/const/admin/company-profile.ts
@@ -55,6 +55,7 @@ export const COMPANY_PROFILE_TEXT = {
 
     SOCIAL_MEDIA_TAB: {
         SECTION_TITLE: 'Соціальні мережі',
+        TOOLTIP: 'Використовується для відображення у футері та на сторінці контакти',
         PLATFORMS: {
             FACEBOOK: 'Facebook',
             INSTAGRAM: 'Instagram',

--- a/src/pages/admin/company-profile/components/company-profile-social-media-tab/CompanyProfileSocialMediaTab.module.scss
+++ b/src/pages/admin/company-profile/components/company-profile-social-media-tab/CompanyProfileSocialMediaTab.module.scss
@@ -138,3 +138,11 @@
         fill: currentColor;
     }
 }
+
+.social-media-tab-container :global(.tooltip-popup) {
+    width: 197px;
+    height: 80px;
+    padding: 8px 12px;
+    gap: 4px;
+    line-height: 24px;
+}

--- a/src/pages/admin/company-profile/components/company-profile-social-media-tab/CompanyProfileSocialMediaTab.test.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-social-media-tab/CompanyProfileSocialMediaTab.test.tsx
@@ -72,6 +72,10 @@ describe('CompanyProfileSocialMediaTab', () => {
         render(<Wrapper disabled={true} />);
         expect(screen.getByText(COMPANY_PROFILE_TEXT.SOCIAL_MEDIA_TAB.SECTION_TITLE)).toBeInTheDocument();
         expect(screen.getByTestId('profile-tooltip')).toBeInTheDocument();
+
+        expect(screen.getByTestId('profile-tooltip')).toHaveTextContent(
+            COMPANY_PROFILE_TEXT.SOCIAL_MEDIA_TAB.TOOLTIP
+        );
     });
 
     it('does not show add dropdown when disabled=true (view mode)', () => {

--- a/src/pages/admin/company-profile/components/company-profile-social-media-tab/CompanyProfileSocialMediaTab.test.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-social-media-tab/CompanyProfileSocialMediaTab.test.tsx
@@ -72,10 +72,7 @@ describe('CompanyProfileSocialMediaTab', () => {
         render(<Wrapper disabled={true} />);
         expect(screen.getByText(COMPANY_PROFILE_TEXT.SOCIAL_MEDIA_TAB.SECTION_TITLE)).toBeInTheDocument();
         expect(screen.getByTestId('profile-tooltip')).toBeInTheDocument();
-
-        expect(screen.getByTestId('profile-tooltip')).toHaveTextContent(
-            COMPANY_PROFILE_TEXT.SOCIAL_MEDIA_TAB.TOOLTIP
-        );
+        expect(screen.getByTestId('profile-tooltip')).toHaveTextContent(COMPANY_PROFILE_TEXT.SOCIAL_MEDIA_TAB.TOOLTIP);
     });
 
     it('does not show add dropdown when disabled=true (view mode)', () => {

--- a/src/pages/admin/company-profile/components/company-profile-social-media-tab/CompanyProfileSocialMediaTab.tsx
+++ b/src/pages/admin/company-profile/components/company-profile-social-media-tab/CompanyProfileSocialMediaTab.tsx
@@ -102,7 +102,11 @@ export const CompanyProfileSocialMediaTab = ({ disabled }: CompanyProfileSocialM
                 <h2 className={styles['social-media-tab-title']}>
                     {COMPANY_PROFILE_TEXT.SOCIAL_MEDIA_TAB.SECTION_TITLE}
                 </h2>
-                <ButtonTooltip position="bottom">Опубліковано на: Профайл</ButtonTooltip>
+                <ButtonTooltip position="bottom">
+                    <span className={styles['social-media-tooltip-text']}>
+                        {COMPANY_PROFILE_TEXT.SOCIAL_MEDIA_TAB.TOOLTIP}
+                    </span>
+                </ButtonTooltip>
             </div>
 
             {!disabled && (


### PR DESCRIPTION
## Github ticket

* [3377](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3377)
* [3379](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3379)

## Description

This PR fixes two UI bugs within the 'Соціальні мережі' tab under the 'Профіль компанії' section (/admin-panel/company-profile):

* Tooltip Text Fix (#3379): Replaced the incorrect placeholder text ("Опубліковано на: профайл") with the correct requirement text ("Використовується для відображення у футері та на сторінці контакти") sourced from constants.

* Tooltip Layout Fix (#3377): Fixed the info tooltip width and styling to match Figma designs.

## How it looks

<img width="254" height="181" alt="image" src="https://github.com/user-attachments/assets/b7a4dc36-ded5-49b1-b377-c503094fe300" />

## Summary of change

* **Constants Update**: Added the `TOOLTIP `property inside `SOCIAL_MEDIA_TAB `in `company-profile.ts` to adhere to project conventions.

* **Component & Styles Update**: Updated the `ButtonTooltip` text in `CompanyProfileSocialMediaTab.tsx` to use the new constant, and applied global scoped styles in `CompanyProfileSocialMediaTab.module.scss`.

## How to recreate changes

1. Open the Профіль компанії section. (/admin-panel/company-profile)
2. Select the Соціальні мережі tab.
3. Hover over the info icon next to the Соціальні мережі heading.
4. Observe the tooltip.

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions