### PR TITLE
[Partners] The wrong system behavior when Admin uploaded the full (un…

### DIFF
--- a/src/pages/admin/partners/components/partner-form/PartnerForm.test.tsx
+++ b/src/pages/admin/partners/components/partner-form/PartnerForm.test.tsx
@@ -40,6 +40,17 @@ jest.mock('@/components/admin/image-input/ImageInput', () => ({
             >
                 Set Error
             </button>
+            <button
+                type="button"
+                data-testid={`${id}-set-large-error`}
+                onClick={() => {
+                    const { IMAGE_VALIDATION } = require('@/const/admin/image');
+                    setError(IMAGE_VALIDATION.ImageDimensionsTooLargeError);
+                }}
+                disabled={disabled}
+            >
+                Set Large Error
+            </button>
         </div>
     ),
 }));
@@ -114,6 +125,7 @@ describe('PartnerForm', () => {
     const getImageChangeButton = () => screen.getByTestId(`${imageTestId}-change`);
     const getImageRemoveButton = () => screen.getByTestId(`${imageTestId}-remove`);
     const getImageSetErrorButton = () => screen.getByTestId(`${imageTestId}-set-error`);
+    const getImageSetLargeErrorButton = () => screen.getByTestId(`${imageTestId}-set-large-error`);
     const getDeleteButton = () => screen.queryByTestId(`partner-form-delete-button-${cardHtmlId}`);
     const getDescriptionError = () => screen.queryByTestId(`${descriptionTestId}-error`);
     const getImageError = () => screen.queryByTestId('input-error');
@@ -124,6 +136,7 @@ describe('PartnerForm', () => {
     const clickImageChange = () => fireEvent.click(getImageChangeButton());
     const clickImageRemove = () => fireEvent.click(getImageRemoveButton());
     const clickImageSetError = () => fireEvent.click(getImageSetErrorButton());
+    const clickImageSetLargeError = () => fireEvent.click(getImageSetLargeErrorButton());
     const clickDelete = () => {
         const button = getDeleteButton();
         if (button) fireEvent.click(button);
@@ -229,6 +242,16 @@ describe('PartnerForm', () => {
         expect(onValuesChange).toHaveBeenCalledWith({ ...defaultValues }, { ...defaultErrors, image: errorToSet });
     });
 
+    it('ignores ImageDimensionsTooLargeError from ImageInput', () => {
+        renderComponent({
+            errors: { ...defaultErrors, image: undefined },
+        });
+
+        clickImageSetLargeError();
+
+        expect(onValuesChange).not.toHaveBeenCalled();
+    });
+
     it('renders errors when provided', () => {
         const errors: PartnerFormErrors = {
             description: 'Description is required',
@@ -255,6 +278,7 @@ describe('PartnerForm', () => {
         expect(getImageChangeButton()).toBeDisabled();
         expect(getImageRemoveButton()).toBeDisabled();
         expect(getImageSetErrorButton()).toBeDisabled();
+        expect(getImageSetLargeErrorButton()).toBeDisabled();
         expect(getDescriptionTextarea()).toBeDisabled();
     });
 
@@ -266,6 +290,7 @@ describe('PartnerForm', () => {
         expect(getImageChangeButton()).toBeDisabled();
         expect(getImageRemoveButton()).toBeDisabled();
         expect(getImageSetErrorButton()).toBeDisabled();
+        expect(getImageSetLargeErrorButton()).toBeDisabled();
     });
 
     it('falls back to an empty description when no translation exists yet', () => {
@@ -281,6 +306,7 @@ describe('PartnerForm', () => {
         clickImageChange();
         clickImageRemove();
         clickImageSetError();
+        clickImageSetLargeError();
 
         expect(onValuesChange).not.toHaveBeenCalled();
     });

--- a/src/pages/admin/partners/components/partner-form/PartnerForm.tsx
+++ b/src/pages/admin/partners/components/partner-form/PartnerForm.tsx
@@ -12,6 +12,7 @@ import { LocalizationLanguage } from '@/types/common/language';
 import styles from './PartnerForm.module.scss';
 import './PartnerForm.scss';
 import { ACTION_ICONS } from '@/const/common/action-icons';
+import { IMAGE_VALIDATION } from '@/const/admin/image';
 
 export interface PartnerFormValues {
     localId: string;
@@ -70,7 +71,7 @@ const PartnerFormComponent = ({
     const handleImageError = useCallback(
         (error: string | null) => {
             if (!isBaseLanguage) return;
-            if (!error) {
+            if (!error || error === IMAGE_VALIDATION.ImageDimensionsTooLargeError) {
                 return;
             }
             onValuesChange({ ...values }, { ...errors, image: error });


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2978)

## Description

This PR fixes a bug in the Partner profile form where uploading an image larger than the recommended size (200x200) and choosing not to crop it resulted in a blocking validation error. The system now correctly handles the cropper's "No" action, allowing administrators to successfully upload and publish full (uncropped) original images without triggering validation blockers, strictly matching the acceptance criteria.

## Summary of change

* **Partner Form Logic** (`PartnerForm.tsx`): Updated the `handleImageError `callback to intercept and ignore `IMAGE_VALIDATION.ImageDimensionsTooLargeError`. This ensures that when an admin declines cropping, the original uncropped image is successfully attached to the form state instead of being rejected.

* **Test Coverage Expansion** (`PartnerForm.test.tsx`): Extended the `ImageInput `mock to simulate the large-image warning scenario. Added a new unit test (ignores `ImageDimensionsTooLargeError` from `ImageInput`) to verify that the form successfully ignores non-critical size warnings while keeping coverage thresholds intact.

## How to recreate changes

1. Log into the Admin panel and navigate to the "Партнери" (Partners) section.
2. Click to edit an existing partner profile (or create a new one).
3. Upload an image file with dimensions significantly larger than 200x200 pixels.
4. Once the "Edit photo" cropper modal appears, click "Ні" (No) to decline cropping.
5. Verify that the modal closes, the original uncropped image appears in the image preview area, and the error message "Зображення завелике..." does not block the form.
6. Click Save/Publish and confirm the changes are successfully applied.

## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions
