### PR TITLE
[Reports][Admin Panel] Confirmation pop-up 'Зміни будуть видалені. Ба…

### DIFF
--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.scss
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.scss
@@ -1,13 +1,1 @@
 /* LEGACY CSS */
-
-.delete-file-confirmation-modal {
-    width: 440px;
-
-    .modal-header-text {
-        line-height: 36px;
-    }
-
-    .modal-footer {
-        margin-top: 30px;
-    }
-}

--- a/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.tsx
+++ b/src/pages/admin/reports/components/pdf-files-section/components/pdf-files-table/PdfFilesTable.tsx
@@ -374,7 +374,6 @@ export const PdfFilesTable: React.FC<PdfFilesTableProps> = ({
                 onConfirm={handleDeleteConfirm}
                 onCancel={handleDeleteCancel}
                 isButtonsDisabled={isDeleting}
-                className="delete-file-confirmation-modal"
             />
         </div>
     );


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3447)

## Description

This PR fixes the UI of the delete confirmation modal in the "PDF Файли" tab within the Reports section to match the Figma design.

## How it looks

<img width="507" height="228" alt="image" src="https://github.com/user-attachments/assets/c23d7d15-8ae5-4a12-990a-1c5e67124d87" />

## Summary of change

* **UI/UX Refactoring** (`PdfFilesTable.tsx`): Removed the legacy custom class (`className="delete-file-confirmation-modal")` from the `<ConfirmationModal/>` component. This allows the modal to successfully inherit its standard, globally configured styling (horizontal button layout, compact width).

* **Style Cleanup** (`PdfFilesTable.scss`): Deleted the obsolete `SCSS` overrides that were forcing incorrect width and overriding the modal's internal flex properties.

## How to recreate changes

1. Log in as an Admin
2. Navigate to Reports section
3. Click tab ‘Звіт та аналітика’
4. Click sub tab 'PDF Файли'
5. Navigate to the list of pdf
6. Click 'Delete' button
7. Compare the resulting confirmation pop-up 'Зміни будуть видалені. Бажаєте продовжити?' with the Figma design (https://www.figma.com/design/mZTSCb4NVC31facfhy6Gu1/Victory-Center-Admin-Panel?node-id=17884-21169&t=dz2Z72E1tTXhlBGm-0)

## CHECK LIST
- [ ]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [ ]  Test covetage was updated
- [x]  PR meets all conventions
