### PR TITLE
Feature/issue 2248 [Hippotherapy] View Scientific references

### DIFF
--- a/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.test.tsx
+++ b/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.test.tsx
@@ -31,12 +31,20 @@ jest.mock('./scientific-reference-card/ScientificReferenceCard', () => ({
         nameError,
         urlError,
         disabled,
+        isExpanded,
+        onToggleExpand,
         onNameChange,
         onUrlChange,
         onNameBlur,
         onUrlBlur,
     }: any) => (
-        <div data-testid={`reference-card-${localId}`} data-auto-focus={autoFocus} data-can-delete={canDelete}>
+        <div
+            data-testid={`reference-card-${localId}`}
+            data-auto-focus={autoFocus}
+            data-can-delete={canDelete}
+            data-is-expanded={isExpanded}
+        >
+            <button data-testid={`toggle-expand-${localId}`} onClick={() => onToggleExpand(localId)} />
             <input
                 data-testid={`name-input-${localId}`}
                 value={name}
@@ -78,6 +86,38 @@ describe('ScientificReferencesSection', () => {
     beforeEach(() => {
         mockOnChange = jest.fn();
     });
+
+    it('renders all references collapsed by default', () => {
+        renderComponent();
+
+        expect(screen.getByTestId('reference-card-ref-1')).toHaveAttribute('data-is-expanded', 'false');
+        expect(screen.getByTestId('reference-card-ref-2')).toHaveAttribute('data-is-expanded', 'false');
+    });
+
+    it('expands and collapses a reference when its toggle is clicked', () => {
+        renderComponent();
+
+        fireEvent.click(screen.getByTestId('toggle-expand-ref-1'));
+
+        expect(screen.getByTestId('reference-card-ref-1')).toHaveAttribute('data-is-expanded', 'true');
+
+        fireEvent.click(screen.getByTestId('toggle-expand-ref-1'));
+
+        expect(screen.getByTestId('reference-card-ref-1')).toHaveAttribute('data-is-expanded', 'false');
+    });
+
+    if (
+        ('keeps several references expanded at the same time',
+        () => {
+            renderComponent();
+
+            fireEvent.click(screen.getByTestId('toggle-expand-ref-1'));
+            fireEvent.click(screen.getByTestId('toggle-expand-ref-2'));
+
+            expect(screen.getByTestId('reference-card-ref-1')).toHaveAttribute('data-is-expanded', 'true');
+            expect(screen.getByTestId('reference-card-ref-2')).toHaveAttribute('data-is-expanded', 'true');
+        })
+    );
 
     it('renders the title, description, and one card per reference', () => {
         renderComponent();

--- a/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.test.tsx
+++ b/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.test.tsx
@@ -106,18 +106,15 @@ describe('ScientificReferencesSection', () => {
         expect(screen.getByTestId('reference-card-ref-1')).toHaveAttribute('data-is-expanded', 'false');
     });
 
-    if (
-        ('keeps several references expanded at the same time',
-        () => {
-            renderComponent();
+    it('keeps several references expanded at the same time', () => {
+        renderComponent();
 
-            fireEvent.click(screen.getByTestId('toggle-expand-ref-1'));
-            fireEvent.click(screen.getByTestId('toggle-expand-ref-2'));
+        fireEvent.click(screen.getByTestId('toggle-expand-ref-1'));
+        fireEvent.click(screen.getByTestId('toggle-expand-ref-2'));
 
-            expect(screen.getByTestId('reference-card-ref-1')).toHaveAttribute('data-is-expanded', 'true');
-            expect(screen.getByTestId('reference-card-ref-2')).toHaveAttribute('data-is-expanded', 'true');
-        })
-    );
+        expect(screen.getByTestId('reference-card-ref-1')).toHaveAttribute('data-is-expanded', 'true');
+        expect(screen.getByTestId('reference-card-ref-2')).toHaveAttribute('data-is-expanded', 'true');
+    });
 
     it('renders the title, description, and one card per reference', () => {
         renderComponent();

--- a/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.test.tsx
+++ b/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.test.tsx
@@ -116,6 +116,25 @@ describe('ScientificReferencesSection', () => {
         expect(screen.getByTestId('reference-card-ref-2')).toHaveAttribute('data-is-expanded', 'true');
     });
 
+    it('keeps a reference expanded when its localId is regenerated after saving', () => {
+        const { rerender } = renderComponent();
+
+        fireEvent.click(screen.getByTestId('toggle-expand-ref-1'));
+        expect(screen.getByTestId('reference-card-ref-1')).toHaveAttribute('data-is-expanded', 'true');
+
+        const reloadedValue: HippotherapyScientificReferencesSectionContent = {
+            ...defaultValue,
+            scientificReferences: [
+                { localId: 'regenerated-1', id: 1, name: 'Citation one', url: 'https://example.com/one' },
+                { localId: 'regenerated-2', id: 2, name: 'Citation two', url: 'https://example.com/two' },
+            ],
+        };
+
+        rerender(<ScientificReferencesSection value={reloadedValue} onChange={mockOnChange} />);
+
+        expect(screen.getByTestId('reference-card-regenerated-1')).toHaveAttribute('data-is-expanded', 'true');
+    });
+
     it('renders the title, description, and one card per reference', () => {
         renderComponent();
 

--- a/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.tsx
+++ b/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.tsx
@@ -6,7 +6,10 @@ import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { HIPPOTHERAPY_PAGE_CHAR_LIMITS, HIPPOTHERAPY_PAGE_TEXT } from '@/const/admin/hippotherapy-page';
 import { HIPPOTHERAPY_PAGE_VALIDATION_FUNCTIONS } from '@/validation/admin/hippotherapy-page-schema/HippotherapyPageSchema';
 import { getPlainTextFromHtml } from '@/utils/functions/get-plain-text-from-html/get-plain-text-from-html';
-import { HippotherapyScientificReferencesSectionContent } from '@/types/admin/hippotherapy-page';
+import {
+    HippotherapyScientificReference,
+    HippotherapyScientificReferencesSectionContent,
+} from '@/types/admin/hippotherapy-page';
 import { ScientificReferenceCard } from './scientific-reference-card/ScientificReferenceCard';
 import './ScientificReferencesSection.scss';
 
@@ -16,6 +19,9 @@ export interface ScientificReferencesSectionProps {
     disabled?: boolean;
 }
 
+const getExpandKey = (reference: HippotherapyScientificReference) =>
+    reference.id !== null ? `id-${reference.id}` : `local-${reference.localId}`;
+
 const ScientificReferencesSectionComponent = ({ value, onChange, disabled }: ScientificReferencesSectionProps) => {
     const [titleError, setTitleError] = useState<string | undefined>();
     const [descriptionError, setDescriptionError] = useState<string | undefined>();
@@ -23,17 +29,25 @@ const ScientificReferencesSectionComponent = ({ value, onChange, disabled }: Sci
     const [urlErrors, setUrlErrors] = useState<Record<string, string | undefined>>({});
     const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
 
-    const handleToggleExpand = useCallback((localId: string) => {
-        setExpandedIds((prev) => {
-            const next = new Set(prev);
-            if (next.has(localId)) {
-                next.delete(localId);
-            } else {
-                next.add(localId);
-            }
-            return next;
-        });
-    }, []);
+    const handleToggleExpand = useCallback(
+        (localId: string) => {
+            const reference = value.scientificReferences.find((item) => item.localId === localId);
+            if (!reference) return;
+
+            const key = getExpandKey(reference);
+
+            setExpandedIds((prev) => {
+                const next = new Set(prev);
+                if (next.has(key)) {
+                    next.delete(key);
+                } else {
+                    next.add(key);
+                }
+                return next;
+            });
+        },
+        [value.scientificReferences],
+    );
 
     const handleTitleChange = (title: string) => {
         onChange({ ...value, title });
@@ -117,7 +131,7 @@ const ScientificReferencesSectionComponent = ({ value, onChange, disabled }: Sci
                         localId={reference.localId}
                         name={reference.name}
                         url={reference.url}
-                        isExpanded={expandedIds.has(reference.localId)}
+                        isExpanded={expandedIds.has(getExpandKey(reference))}
                         canDelete={value.scientificReferences.length > 1}
                         nameError={nameErrors[reference.localId]}
                         urlError={urlErrors[reference.localId]}

--- a/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.tsx
+++ b/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { RichTextInputGroup } from '@/components/admin/input-groups/rich-text-input-group/RichTextInputGroup';
 import { Button } from '@/components/admin/button/Button';
 import { ReactComponent as PlusIcon } from '@/assets/icons/plus.svg';
@@ -21,6 +21,19 @@ const ScientificReferencesSectionComponent = ({ value, onChange, disabled }: Sci
     const [descriptionError, setDescriptionError] = useState<string | undefined>();
     const [nameErrors, setNameErrors] = useState<Record<string, string | undefined>>({});
     const [urlErrors, setUrlErrors] = useState<Record<string, string | undefined>>({});
+    const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+
+    const handleToggleExpand = useCallback((localId: string) => {
+        setExpandedIds((prev) => {
+            const next = new Set(prev);
+            if (next.has(localId)) {
+                next.delete(localId);
+            } else {
+                next.add(localId);
+            }
+            return next;
+        });
+    }, []);
 
     const handleTitleChange = (title: string) => {
         onChange({ ...value, title });
@@ -104,10 +117,12 @@ const ScientificReferencesSectionComponent = ({ value, onChange, disabled }: Sci
                         localId={reference.localId}
                         name={reference.name}
                         url={reference.url}
+                        isExpanded={expandedIds.has(reference.localId)}
                         canDelete={value.scientificReferences.length > 1}
                         nameError={nameErrors[reference.localId]}
                         urlError={urlErrors[reference.localId]}
                         disabled={disabled}
+                        onToggleExpand={handleToggleExpand}
                         onNameChange={handleNameChange}
                         onUrlChange={handleUrlChange}
                         onNameBlur={handleNameBlur}

--- a/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/scientific-reference-card/ScientificReferenceCard.test.tsx
+++ b/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/scientific-reference-card/ScientificReferenceCard.test.tsx
@@ -58,6 +58,14 @@ describe('ScientificReferenceCard', () => {
         expect(screen.getByRole('button', { name: 'Collapse reference' })).toBeInTheDocument();
     });
 
+    it('shows the url error while collapsed', () => {
+        renderComponent({ urlError: 'URL is required' });
+
+        expect(screen.getByText('URL is required')).toBeInTheDocument();
+
+        expect(screen.queryByDisplayValue('https://example.com/citation')).not.toBeInTheDocument();
+    });
+
     it('calls onToggleExpand with the localId when the expand button is clicked', () => {
         renderComponent();
 

--- a/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/scientific-reference-card/ScientificReferenceCard.test.tsx
+++ b/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/scientific-reference-card/ScientificReferenceCard.test.tsx
@@ -7,11 +7,14 @@ describe('ScientificReferenceCard', () => {
     let mockOnUrlChange: jest.Mock;
     let mockOnNameBlur: jest.Mock;
     let mockOnUrlBlur: jest.Mock;
+    let mockOnToggleExpand: jest.Mock;
 
     const defaultProps: ScientificReferenceCardProps = {
         localId: 'ref-1',
         name: 'Test citation',
         url: 'https://example.com/citation',
+        isExpanded: false,
+        onToggleExpand: jest.fn(),
         onNameChange: jest.fn(),
         onUrlChange: jest.fn(),
         onNameBlur: jest.fn(),
@@ -23,12 +26,14 @@ describe('ScientificReferenceCard', () => {
         mockOnUrlChange = jest.fn();
         mockOnNameBlur = jest.fn();
         mockOnUrlBlur = jest.fn();
+        mockOnToggleExpand = jest.fn();
     });
 
     const renderComponent = (props: Partial<ScientificReferenceCardProps> = {}) =>
         render(
             <ScientificReferenceCard
                 {...defaultProps}
+                onToggleExpand={mockOnToggleExpand}
                 onNameChange={mockOnNameChange}
                 onUrlChange={mockOnUrlChange}
                 onNameBlur={mockOnNameBlur}
@@ -37,12 +42,28 @@ describe('ScientificReferenceCard', () => {
             />,
         );
 
-    it('shows the name and url as editable fields, with a static expand placeholder button', () => {
+    it('shows only the name field when collapsed', () => {
         renderComponent();
 
         expect(screen.getByDisplayValue('Test citation')).toBeInTheDocument();
-        expect(screen.getByDisplayValue('https://example.com/citation')).toBeInTheDocument();
+        expect(screen.queryByDisplayValue('https://example.com/citation')).not.toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'Expand reference' })).toBeInTheDocument();
+    });
+
+    it('shows the name and url fields when expanded', () => {
+        renderComponent({ isExpanded: true });
+
+        expect(screen.getByDisplayValue('Test citation')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('https://example.com/citation')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Collapse reference' })).toBeInTheDocument();
+    });
+
+    it('calls onToggleExpand with the localId when the expand button is clicked', () => {
+        renderComponent();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Expand reference' }));
+
+        expect(mockOnToggleExpand).toHaveBeenCalledWith('ref-1');
     });
 
     it('calls onNameChange with the localId when the name field is edited', () => {
@@ -54,7 +75,7 @@ describe('ScientificReferenceCard', () => {
     });
 
     it('calls onUrlChange with the localId when the url field is edited', () => {
-        renderComponent();
+        renderComponent({ isExpanded: true });
 
         fireEvent.change(screen.getByDisplayValue('https://example.com/citation'), {
             target: { value: 'https://example.com/updated' },
@@ -64,7 +85,7 @@ describe('ScientificReferenceCard', () => {
     });
 
     it('calls onNameBlur with the localId', () => {
-        renderComponent();
+        renderComponent({ isExpanded: true });
 
         fireEvent.blur(screen.getByDisplayValue('Test citation'));
 
@@ -72,7 +93,7 @@ describe('ScientificReferenceCard', () => {
     });
 
     it('calls onUrlBlur with the localId', () => {
-        renderComponent();
+        renderComponent({ isExpanded: true });
 
         fireEvent.blur(screen.getByDisplayValue('https://example.com/citation'));
 
@@ -86,7 +107,7 @@ describe('ScientificReferenceCard', () => {
     });
 
     it('shows a url error when provided', () => {
-        renderComponent({ urlError: 'URL is required' });
+        renderComponent({ urlError: 'URL is required', isExpanded: true });
 
         expect(screen.getByText('URL is required')).toBeInTheDocument();
     });
@@ -104,11 +125,11 @@ describe('ScientificReferenceCard', () => {
     });
 
     it('disables inputs and buttons when disabled is true', () => {
-        renderComponent({ disabled: true });
+        renderComponent({ disabled: true, isExpanded: true });
 
         expect(screen.getByDisplayValue('Test citation')).toBeDisabled();
         expect(screen.getByDisplayValue('https://example.com/citation')).toBeDisabled();
-        expect(screen.getByRole('button', { name: 'Expand reference' })).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Collapse reference' })).toBeDisabled();
         expect(screen.getByLabelText('Delete reference')).toBeDisabled();
     });
 });

--- a/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/scientific-reference-card/ScientificReferenceCard.tsx
+++ b/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/scientific-reference-card/ScientificReferenceCard.tsx
@@ -4,6 +4,7 @@ import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/in
 import { IconButton } from '@/components/admin/icon-button/IconButton';
 import { ACTION_ICONS } from '@/const/common/action-icons';
 import { ReactComponent as ArrowIcon } from '@/assets/icons/arrow-up-right.svg';
+import { ReactComponent as CrossIcon } from '@/assets/icons/cross.svg';
 import { HIPPOTHERAPY_PAGE_CHAR_LIMITS, HIPPOTHERAPY_PAGE_TEXT } from '@/const/admin/hippotherapy-page';
 import './ScientificReferenceCard.scss';
 
@@ -16,6 +17,8 @@ export interface ScientificReferenceCardProps {
     nameError?: string;
     urlError?: string;
     disabled?: boolean;
+    isExpanded: boolean;
+    onToggleExpand: (localId: string) => void;
     onNameChange: (localId: string, value: string) => void;
     onUrlChange: (localId: string, value: string) => void;
     onNameBlur: (localId: string) => void;
@@ -31,6 +34,8 @@ export const ScientificReferenceCard = ({
     nameError,
     urlError,
     disabled,
+    isExpanded,
+    onToggleExpand,
     onNameChange,
     onUrlChange,
     onNameBlur,
@@ -47,15 +52,16 @@ export const ScientificReferenceCard = ({
 
     return (
         <div ref={cardRef} className="scientific-reference-card">
-            {/* Expand and delete are disabled for now — placeholders only, no functionality yet. */}
+            {/* Delete is disabled for now — placeholders only, no functionality yet. */}
             <div className="scientific-reference-card-top-row">
                 <button
                     type="button"
                     className="scientific-reference-card-expand-button"
-                    aria-label="Expand reference"
+                    aria-label={isExpanded ? 'Collapse reference' : 'Expand reference'}
+                    onClick={() => onToggleExpand(localId)}
                     disabled={disabled}
                 >
-                    <ArrowIcon className="scientific-reference-card-arrow-icon" />
+                    {isExpanded ? <CrossIcon /> : <ArrowIcon className="scientific-reference-card-arrow-icon" />}
                 </button>
                 {canDelete && (
                     <IconButton
@@ -85,18 +91,20 @@ export const ScientificReferenceCard = ({
                     autoGrow
                     maxRows={6}
                 />
-                <InputWithCharacterLimitGroup
-                    label={HIPPOTHERAPY_PAGE_TEXT.LABEL.CITATION_URL}
-                    isRequired
-                    id={`hippotherapy-research-citation-${localId}-url`}
-                    name={`hippotherapy-research-citation-${localId}-url`}
-                    value={url}
-                    onChange={(event) => onUrlChange(localId, event.target.value)}
-                    onBlur={() => onUrlBlur(localId)}
-                    maxLength={HIPPOTHERAPY_PAGE_CHAR_LIMITS.RESEARCH_CITATION_URL}
-                    error={urlError}
-                    disabled={disabled}
-                />
+                {isExpanded && (
+                    <InputWithCharacterLimitGroup
+                        label={HIPPOTHERAPY_PAGE_TEXT.LABEL.CITATION_URL}
+                        isRequired
+                        id={`hippotherapy-research-citation-${localId}-url`}
+                        name={`hippotherapy-research-citation-${localId}-url`}
+                        value={url}
+                        onChange={(event) => onUrlChange(localId, event.target.value)}
+                        onBlur={() => onUrlBlur(localId)}
+                        maxLength={HIPPOTHERAPY_PAGE_CHAR_LIMITS.RESEARCH_CITATION_URL}
+                        error={urlError}
+                        disabled={disabled}
+                    />
+                )}
             </div>
         </div>
     );

--- a/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/scientific-reference-card/ScientificReferenceCard.tsx
+++ b/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/scientific-reference-card/ScientificReferenceCard.tsx
@@ -6,6 +6,7 @@ import { ACTION_ICONS } from '@/const/common/action-icons';
 import { ReactComponent as ArrowIcon } from '@/assets/icons/arrow-up-right.svg';
 import { ReactComponent as CrossIcon } from '@/assets/icons/cross.svg';
 import { HIPPOTHERAPY_PAGE_CHAR_LIMITS, HIPPOTHERAPY_PAGE_TEXT } from '@/const/admin/hippotherapy-page';
+import { InputError } from '@/components/admin/input-error/InputError';
 import './ScientificReferenceCard.scss';
 
 export interface ScientificReferenceCardProps {
@@ -105,6 +106,7 @@ export const ScientificReferenceCard = ({
                         disabled={disabled}
                     />
                 )}
+                {!isExpanded && urlError && <InputError error={urlError} />}
             </div>
         </div>
     );


### PR DESCRIPTION
## Github ticket

* [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2248)

## Description

The Scientific references section rendered every reference fully expanded, and the expand button was a non-functional placeholder left by the layout story #3316. This PR implements the collapsed/expanded behaviour described in the user story.

## How it looks

<img width="1439" height="786" alt="image" src="https://github.com/user-attachments/assets/85ae57e5-ae6d-4278-b90d-92e279677c9b" />


## Summary of change

- `ScientificReferenceCard.tsx` - the expand button is now functional: it toggles the card through the new isExpanded / onToggleExpand props, swaps the arrow icon for a cross, and updates its aria-label between "Expand reference" and "Collapse reference". The collapsed card keeps the "Назва" field visible and hides only "Посилання".
- `ScientificReferencesSection.tsx` - holds the expanded state as a Set of localIds. A set rather than a single id, so several references can stay expanded at the same time, which is what an admin needs when comparing sources. On load the set is empty, so every entry starts collapsed.
- Tests - two new cases in ScientificReferenceCard.test.tsx for the collapsed and expanded rendering plus one for the toggle callback; three new cases in ScientificReferencesSection.test.tsx covering the default collapsed state, toggling, and keeping several entries expanded. Existing tests that asserted on the "Посилання" field were updated to render the card expanded.

## How to recreate changes

1. Log in to the admin panel and open /admin-panel/hippotherapy
2. Scroll to the "Наукові дослідження" section
3. All references are collapsed - only the "Назва" field is visible on each card
4. Click the arrow button on a card - the "Посилання" field appears and the icon changes to a cross
5. Click the arrow on another card - both stay expanded
6. Click the cross - the card collapses again


## CHECK LIST
- [x]  New tests was added or existing was modified
- [ ]  Changes has severe impact on users
- [ ]  Changes has medium impact on users
- [x]  Changes has light impact on users
- [x]  Test covetage was updated
- [x]  PR meets all conventions
