### PR TITLE
Fix/issue-3445 [Team] [Admin Panel] 'Назва' and 'Опис' fields in the 'Редагувати категорію' do not trim or collapse multiple consecutive spaces on edit

### DIFF
--- a/src/const/admin/team.ts
+++ b/src/const/admin/team.ts
@@ -113,6 +113,7 @@ export const TEAM_CATEGORY_VALIDATION = {
         getMinError: () => `Не менше ${TEAM_CATEGORY_VALIDATION.name.min} символів`,
         getMaxError: () => `Не більше ${TEAM_CATEGORY_VALIDATION.name.max} символів`,
         getDuplicateNameError: () => COMMON_TEXT_ADMIN.CATEGORIES.FORM.MESSAGE.ALREADY_CONTAIN_CATEGORY_WITH_NAME,
+        getNoSpacesError: () => 'Назва не повинна містити пробіли на початку або в кінці',
     },
     description: {
         min: 5,
@@ -120,6 +121,7 @@ export const TEAM_CATEGORY_VALIDATION = {
         getRequiredError: () => 'Опис обов’язковий',
         getMinError: () => `Не менше ${TEAM_CATEGORY_VALIDATION.description.min} символів`,
         getMaxError: () => `Не більше ${TEAM_CATEGORY_VALIDATION.description.max} символів`,
+        getNoSpacesError: () => 'Опис не повинен містити пробіли на початку або в кінці',
     },
     teamMembersCount: {
         getHasTeamMembersCountError: (count: number) => `Категорія містить ${count} членів команди`,

--- a/src/validation/admin/team-category-schema/team-category-schema.test.ts
+++ b/src/validation/admin/team-category-schema/team-category-schema.test.ts
@@ -5,10 +5,14 @@ describe('TeamCategoryValidationSchema', () => {
     const validName = 'N'.repeat(TEAM_CATEGORY_VALIDATION.name.min + 1);
     const shortName = 'N'.repeat(TEAM_CATEGORY_VALIDATION.name.min - 1);
     const longName = 'N'.repeat(TEAM_CATEGORY_VALIDATION.name.max + 1);
+    const leadingSpaceName = ` ${validName}`;
+    const trailingSpaceName = `${validName} `;
 
     const validDescription = 'D'.repeat(TEAM_CATEGORY_VALIDATION.description.min + 1);
     const shortDescription = 'D'.repeat(TEAM_CATEGORY_VALIDATION.description.min - 1);
     const longDescription = 'D'.repeat(TEAM_CATEGORY_VALIDATION.description.max + 1);
+    const leadingSpaceDescription = ` ${validDescription}`;
+    const trailingSpaceDescription = `${validDescription} `;
 
     describe('name validation', () => {
         it('passes with valid name', async () => {
@@ -42,6 +46,18 @@ describe('TeamCategoryValidationSchema', () => {
         it('fails when name is too long', async () => {
             expect(TEAM_CATEGORY_VALIDATION_FUNCTIONS.validateName(longName)).toBe(
                 TEAM_CATEGORY_VALIDATION.name.getMaxError(),
+            );
+        });
+
+        it('fails when name has a leading space', async () => {
+            expect(TEAM_CATEGORY_VALIDATION_FUNCTIONS.validateName(leadingSpaceName)).toBe(
+                TEAM_CATEGORY_VALIDATION.name.getNoSpacesError(),
+            );
+        });
+
+        it('fails when name has a trailing space', async () => {
+            expect(TEAM_CATEGORY_VALIDATION_FUNCTIONS.validateName(trailingSpaceName)).toBe(
+                TEAM_CATEGORY_VALIDATION.name.getNoSpacesError(),
             );
         });
     });
@@ -78,6 +94,18 @@ describe('TeamCategoryValidationSchema', () => {
         it('fails when description is too long', async () => {
             expect(TEAM_CATEGORY_VALIDATION_FUNCTIONS.validateDescription(longDescription)).toBe(
                 TEAM_CATEGORY_VALIDATION.description.getMaxError(),
+            );
+        });
+        
+        it('fails when description has a leading space', async () => {
+            expect(TEAM_CATEGORY_VALIDATION_FUNCTIONS.validateDescription(leadingSpaceDescription)).toBe(
+                TEAM_CATEGORY_VALIDATION.description.getNoSpacesError(),
+            );
+        });
+
+        it('fails when description has a trailing space', async () => {
+            expect(TEAM_CATEGORY_VALIDATION_FUNCTIONS.validateDescription(trailingSpaceDescription)).toBe(
+                TEAM_CATEGORY_VALIDATION.description.getNoSpacesError(),
             );
         });
     });

--- a/src/validation/admin/team-category-schema/team-category-schema.ts
+++ b/src/validation/admin/team-category-schema/team-category-schema.ts
@@ -3,14 +3,22 @@ import * as Yup from 'yup';
 
 export const TeamCategoryValidationSchema = Yup.object({
     name: Yup.string()
-        .trim()
         .required(TEAM_CATEGORY_VALIDATION.name.getRequiredError())
+        .test(
+            'no-leading-trailing-spaces',
+            TEAM_CATEGORY_VALIDATION.name.getNoSpacesError(),
+            (value) => value === value?.trim(),
+        )
         .min(TEAM_CATEGORY_VALIDATION.name.min, TEAM_CATEGORY_VALIDATION.name.getMinError())
         .max(TEAM_CATEGORY_VALIDATION.name.max, TEAM_CATEGORY_VALIDATION.name.getMaxError()),
 
     description: Yup.string()
-        .trim()
         .required(TEAM_CATEGORY_VALIDATION.description.getRequiredError())
+        .test(
+            'no-leading-trailing-spaces',
+            TEAM_CATEGORY_VALIDATION.description.getNoSpacesError(),
+            (value) => value === value?.trim(),
+        )
         .min(TEAM_CATEGORY_VALIDATION.description.min, TEAM_CATEGORY_VALIDATION.description.getMinError())
         .max(TEAM_CATEGORY_VALIDATION.description.max, TEAM_CATEGORY_VALIDATION.description.getMaxError()),
 });


### PR DESCRIPTION
## Github ticker

* [3445](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3445)

## Description

Adds client-side validation preventing the 'Назва' and 'Опис' fields in the Team Category edit
modal from being saved with leading/trailing spaces. 

## How it looks

<img width="677" height="560" alt="{69043ED5-0BC9-4939-975A-AF62139613E3}" src="https://github.com/user-attachments/assets/5b537eea-ca14-48a4-a95e-27c4f9b07486" />
<img width="706" height="595" alt="{E342F102-6EF6-4A02-B89A-9932C11BACD3}" src="https://github.com/user-attachments/assets/806fa5e0-990e-436e-98f2-5b8fdc111db5" />

## Summary of change

- **`team.ts`**: Added `getNoSpacesError()` messages for `name` and `description`.
- **`team-category-schema.ts`**: Added a `no-leading-trailing-spaces` Yup `.test()` to both fields.
- **`team-category-schema.test.ts`**: Added tests covering leading-space and trailing-space cases
  for both `name` and `description`.

## How to recreate changes

1. Open 'Редагувати категорію' modal in the admin panel.
2. Enter a name or description with a leading or trailing space.
3. Observe the validation error preventing the space from being saved.

## CHECK LIST
- [x] New tests was added or existing was modified
- [ ] Changes has severe impact on users
- [ ] Changes has medium impact on users
- [x] Changes has light impact on users
- [x] Test covetage was updated
- [x] PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Team category names and descriptions now reject leading or trailing spaces.
  * Invalid spacing displays a clear validation message.
  * Input is no longer silently trimmed, helping users correct formatting themselves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->