### PR TITLE
Fix/issue-3575 [Reports][Admin Panel] Character counter position for the 'Назва' fie…

### DIFF
--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.module.scss
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.module.scss
@@ -53,10 +53,6 @@
     width: 100%;
 }
 
-.inputError :global(.char-limit-input) {
-    border-color: c.$error;
-}
-
 .panel :global(.select-options) {
     width: 100%;
 }

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/common/add-funds-expenditures-category-modal/AddFundsExpendituresCategoryModal.tsx
@@ -2,7 +2,7 @@ import { FocusEvent, useCallback, useMemo, useRef, useState } from 'react';
 import cn from 'classnames';
 import { FUNDS_EXPENDITURES_TEXT, FUNDS_EXPENDITURES_VALIDATION } from '@/const/admin/reports';
 import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
-import { InputWithCharacterLimit } from '@/components/admin/input-with-character-limit/InputWithCharacterLimit';
+import { InputWithCharacterLimitGroup } from '@/components/admin/input-groups/input-with-character-limit-group/InputWithCharacterLimitGroup';
 import { Select } from '@/components/common/select/Select';
 import { Modal } from '@/components/common/modal/Modal';
 import { Button } from '@/components/admin/button/Button';
@@ -14,18 +14,6 @@ import {
     validateFundsExpendituresCategoryType,
 } from '@/validation/admin/reports-schema/funds-expenditures-category-schema/funds-expenditures-category-schema';
 import styles from './AddFundsExpendituresCategoryModal.module.scss';
-
-const renderInputWithError = (
-    input: React.ReactNode,
-    error?: string,
-    inputErrorClass?: string,
-    errorClass?: string,
-) => (
-    <>
-        <div className={cn({ [inputErrorClass || '']: Boolean(error) })}>{input}</div>
-        <p className={cn(errorClass, { [styles.errorHidden]: !error })}>{error ?? ' '}</p>
-    </>
-);
 
 interface AddFundsExpendituresCategoryModalProps {
     isOpen: boolean;
@@ -168,30 +156,23 @@ export const AddFundsExpendituresCategoryModal = ({
                                 </div>
 
                                 <div className={styles.field}>
-                                    <label className={styles.label}>
-                                        <span className={styles.required}>*</span>
-                                        {FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.NAME_LABEL}
-                                    </label>
-                                    {renderInputWithError(
-                                        <InputWithCharacterLimit
-                                            id="category-name"
-                                            name="categoryName"
-                                            value={name}
-                                            onChange={(e) => setName(e.target.value)}
-                                            onBlur={handleNameBlur}
-                                            maxLength={FUNDS_EXPENDITURES_VALIDATION.categoryNameMax}
-                                            maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
-                                                FUNDS_EXPENDITURES_VALIDATION.categoryNameMax,
-                                            )}
-                                            placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.NAME_PLACEHOLDER}
-                                            showCounter={true}
-                                            hasError={Boolean(nameError)}
-                                            className={styles.input}
-                                        />,
-                                        nameError,
-                                        styles.inputError,
-                                        styles.error,
-                                    )}
+                                    <InputWithCharacterLimitGroup
+                                        label={FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.NAME_LABEL}
+                                        isRequired={true}
+                                        id="category-name"
+                                        name="categoryName"
+                                        value={name}
+                                        onChange={(e) => setName(e.target.value)}
+                                        onBlur={handleNameBlur}
+                                        maxLength={FUNDS_EXPENDITURES_VALIDATION.categoryNameMax}
+                                        maxLimitWarning={COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMaxError(
+                                            FUNDS_EXPENDITURES_VALIDATION.categoryNameMax,
+                                        )}
+                                        placeholder={FUNDS_EXPENDITURES_TEXT.MODAL.CATEGORY.NAME_PLACEHOLDER}
+                                        error={nameError}
+                                        showCounterBelow={true}
+                                        className={styles.input}
+                                    />
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Github ticket

- [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3575)

## Description

In the admin panel's Reports section ("Звіт та аналітика" → "Доходи та витрати" → "Додати категорію"), the character counter for the "Назва" field rendered inside the input's border instead of below it, as required by the Figma design and test case #3474.

## How it looks

<img width="655" height="546" alt="image" src="https://github.com/user-attachments/assets/9f324b7a-6855-43cb-a3a6-dfa04ed21764" />

<img width="650" height="541" alt="image" src="https://github.com/user-attachments/assets/e04a3f23-bc1d-4d59-bbd1-b4e3041970c7" />

## Summary of change

- `AddFundsExpendituresCategoryModal.tsx` — replaced `InputWithCharacterLimit` (counter rendered inside the input) with `InputWithCharacterLimitGroup` + `showCounterBelow={true}`, matching the same component already used in `EditFundsExpendituresCategoryModal.tsx`. Removed the now-unused local `renderInputWithError` helper.
- `AddFundsExpendituresCategoryModal.module.scss` — removed the now-dead `.inputError` rule, which existed only to manually color the input border from the outside; `InputWithCharacterLimitGroup` handles error styling internally via the `error` prop.

## How to recreate changes

1. Open Admin Panel → "Звітність" → "Звіт та аналітика" → "Доходи та витрати" tab.
2. Click the category context menu → "Додати категорію".
3. Start typing in the "Назва" field.
4. Confirm the character counter (`x/50`) now renders below the input's border, not inside it — consistent with the "Редагувати категорію" modal.

## CHECK LIST

- [ ] New tests were added or existing were modified
- [ ] Changes have severe impact on users
- [ ] Changes have medium impact on users
- [x] Changes have light impact on users
- [ ] Test coverage was updated
- [x] PR meets all conventions