### PR TITLE
Fix/issue-3503-3570 The 'Сума UAH' field is not recalculated.

### DIFF
--- a/src/hooks/admin/use-amount-blur/useAmountBlur.test.ts
+++ b/src/hooks/admin/use-amount-blur/useAmountBlur.test.ts
@@ -21,13 +21,14 @@ const triggerAmountUsdBlur = (hook: ReturnType<typeof useAmountBlur>, formState:
 };
 
 describe('useAmountBlur', () => {
-    it('sets usdMismatchMessage when USD does not match converted UAH value on blur', () => {
+    it('recalculates amountUah from amountUsd and clears usdMismatchMessage on blur', () => {
         const { result } = renderHook(() => useAmountBlur('40'));
 
         const nextState = triggerAmountUsdBlur(result.current, createFormState({ amountUah: '100', amountUsd: '999' }));
 
-        expect(result.current.usdMismatchMessage).toBe(FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH);
+        expect(result.current.usdMismatchMessage).toBeUndefined();
         expect(nextState.amountUsd).toBe('999');
+        expect(nextState.amountUah).toBe('39960');
         expect(nextState.errors.amountUsd).toBeUndefined();
     });
 
@@ -45,5 +46,33 @@ describe('useAmountBlur', () => {
         const nextState = triggerAmountUsdBlur(result.current, createFormState({ amountUah: '100', amountUsd: '0' }));
 
         expect(nextState.errors.amountUsd).toBe(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_NOT_ZERO);
+        expect(nextState.amountUah).toBe('100');
+    });
+
+    it('does not recalculate amountUsd when amountUah is blurred with an invalid value', () => {
+        const { result } = renderHook(() => useAmountBlur('40'));
+
+        const setFormState = jest.fn();
+        let nextState: any;
+        act(() => {
+            result.current.handleAmountBlur('amountUah', setFormState);
+            nextState = setFormState.mock.calls[0][0](createFormState({ amountUah: '0', amountUsd: '2,5' }));
+        });
+
+        expect(nextState.errors.amountUah).toBeTruthy();
+        expect(nextState.amountUsd).toBe('2,5');
+        expect(result.current.usdMismatchMessage).toBeUndefined();
+    });
+
+    it('suppresses usdMismatchMessage when suppressMismatchCheck is true, even if the raw value cannot be converted', () => {
+        const { result } = renderHook(() => useAmountBlur('40'));
+
+        const setFormState = jest.fn();
+        act(() => {
+            result.current.handleAmountBlur('amountUsd', setFormState, true);
+            setFormState.mock.calls[0][0](createFormState({ amountUah: '100', amountUsd: '1234567890' }));
+        });
+
+        expect(result.current.usdMismatchMessage).toBeUndefined();
     });
 });

--- a/src/hooks/admin/use-amount-blur/useAmountBlur.ts
+++ b/src/hooks/admin/use-amount-blur/useAmountBlur.ts
@@ -2,10 +2,6 @@ import { useCallback, useState } from 'react';
 import { FUNDS_EXPENDITURES_TEXT } from '@/const/admin/reports';
 import { updateFundsAmounts } from '@/utils/functions/update-funds-amounts/update-funds-amounts';
 import { isUsdAmountMismatch } from '@/utils/functions/validate-usd-amount-mismatch/validate-usd-amount-mismatch';
-import {
-    normalizeFundsExpendituresAmountInput,
-    validateFundsExpendituresAmount,
-} from '@/validation/admin/reports-schema/funds-expenditures-record-schema/funds-expenditures-record-schema';
 
 export const getUsdMismatchMessage = (
     amountUah: string,
@@ -23,40 +19,23 @@ export const useAmountBlur = (exchangeRate: string | null, customMismatchMessage
             setFormState: React.Dispatch<React.SetStateAction<any>>,
             suppressMismatchCheck = false,
         ) => {
-            if (field === 'amountUsd') {
-                setFormState((prev: any) => {
-                    const normalizedAmountUsd = normalizeFundsExpendituresAmountInput(prev.amountUsd, true);
-                    const amountUsdError = validateFundsExpendituresAmount(normalizedAmountUsd, 'blur');
-
-                    setUsdMismatchMessage(
-                        suppressMismatchCheck
-                            ? undefined
-                            : getUsdMismatchMessage(
-                                  prev.amountUah,
-                                  normalizedAmountUsd,
-                                  exchangeRate,
-                                  customMismatchMessage,
-                              ),
-                    );
-
-                    return {
-                        ...prev,
-                        amountUsd: normalizedAmountUsd,
-                        errors: {
-                            ...prev.errors,
-                            amountUsd: amountUsdError,
-                        },
-                    };
-                });
-                return;
-            }
-
             setFormState((prev: any) => {
                 const updated = {
                     ...prev,
                     ...updateFundsAmounts(field, prev[field], exchangeRate, 'blur')(prev),
                 };
-                setUsdMismatchMessage(undefined);
+
+                setUsdMismatchMessage(
+                    field === 'amountUsd' && !suppressMismatchCheck
+                        ? getUsdMismatchMessage(
+                              updated.amountUah,
+                              updated.amountUsd,
+                              exchangeRate,
+                              customMismatchMessage,
+                          )
+                        : undefined,
+                );
+
                 return updated;
             });
         },

--- a/src/hooks/admin/use-funds-amount-edit/useFundsAmountEdit.test.ts
+++ b/src/hooks/admin/use-funds-amount-edit/useFundsAmountEdit.test.ts
@@ -14,6 +14,12 @@ const convertUahToUsd = (uah: number, rate: number) => {
     return rounded % 1 === 0 ? String(rounded) : String(rounded).replace('.', ',');
 };
 
+const convertUsdToUah = (usd: number, rate: number) => {
+    const converted = usd * rate;
+    const rounded = Number.parseFloat(converted.toFixed(2));
+    return rounded % 1 === 0 ? String(rounded) : String(rounded).replace('.', ',');
+};
+
 jest.mock('@/utils/functions/update-funds-amounts/update-funds-amounts', () => ({
     updateFundsAmounts:
         (field: 'amountUah' | 'amountUsd', value: string, exchangeRate: string | null, trigger: 'change' | 'blur') =>
@@ -24,10 +30,14 @@ jest.mock('@/utils/functions/update-funds-amounts/update-funds-amounts', () => (
             let nextAmountUah = field === 'amountUah' ? value : state.amountUah;
             let nextAmountUsd = field === 'amountUsd' ? value : state.amountUsd;
 
-            const canConvert = field === 'amountUah' && rate !== null && !Number.isNaN(numericValue);
+            const canConvert = rate !== null && !Number.isNaN(numericValue);
 
-            if (canConvert) {
+            if (canConvert && field === 'amountUah') {
                 nextAmountUsd = convertUahToUsd(numericValue, rate);
+            }
+
+            if (canConvert && field === 'amountUsd') {
+                nextAmountUah = convertUsdToUah(numericValue, rate);
             }
 
             const errors: Record<string, string | undefined> = {
@@ -157,6 +167,37 @@ describe('useFundsAmountEdit', () => {
 
             expect(next.amountUsd).toBe('1190,48');
         });
+
+        it('should recalculate UAH when USD amount changes with a valid exchange rate', () => {
+            const setEditState = jest.fn();
+            const { result } = renderHook(() =>
+                useFundsAmountEdit({ exchangeRate: '40', mismatchMessage: MISMATCH_MESSAGE, setEditState }),
+            );
+
+            act(() => {
+                result.current.handleAmountChange(1, 'amountUsd', '8 000');
+            });
+
+            const next = applyUpdater(setEditState, makeState());
+
+            expect(next.amountUah).toBe('320000');
+        });
+
+        it('should not recalculate UAH when exchange rate is null', () => {
+            const setEditState = jest.fn();
+            const { result } = renderHook(() =>
+                useFundsAmountEdit({ exchangeRate: null, mismatchMessage: MISMATCH_MESSAGE, setEditState }),
+            );
+
+            act(() => {
+                result.current.handleAmountChange(1, 'amountUsd', '8 000');
+            });
+
+            const prev = makeState({ amountUah: '7 265' });
+            const next = applyUpdater(setEditState, prev);
+
+            expect(next.amountUah).toBe('7 265');
+        });
     });
 
     describe('handleAmountBlur', () => {
@@ -206,6 +247,21 @@ describe('useFundsAmountEdit', () => {
             const next = applyUpdater(setEditState, makeState());
 
             expect(next.usdMismatchMessage).toBeUndefined();
+        });
+
+        it('should recalculate UAH when USD amount is blurred', () => {
+            const setEditState = jest.fn();
+            const { result } = renderHook(() =>
+                useFundsAmountEdit({ exchangeRate: '42', mismatchMessage: MISMATCH_MESSAGE, setEditState }),
+            );
+
+            act(() => {
+                result.current.handleAmountBlur(1, 'amountUsd');
+            });
+
+            const next = applyUpdater(setEditState, makeState({ amountUah: '7 265', amountUsd: '4 200' }));
+
+            expect(next.amountUah).toBe('176400');
         });
 
         it('should clear usdMismatchMessage on UAH blur', () => {

--- a/src/hooks/admin/use-funds-expenditures-record-form/useFundsExpendituresRecordForm.test.ts
+++ b/src/hooks/admin/use-funds-expenditures-record-form/useFundsExpendituresRecordForm.test.ts
@@ -96,13 +96,12 @@ describe('useFundsExpendituresRecordForm', () => {
         expect(result.current.formState.amountUsd).toBe('');
     });
 
-    it('blocks submit when UAH and USD amounts mismatch the exchange rate', () => {
+    it('recalculates UAH and enables submit when USD is changed manually', () => {
         const { result } = renderUseFundsForm();
 
         act(() => {
             result.current.handleReportingYearChange('2026');
             result.current.handleCategoryChange(3);
-            result.current.handleAmountFieldChange('amountUah')('100');
             result.current.handleAmountFieldChange('amountUsd')('15');
         });
 
@@ -110,18 +109,18 @@ describe('useFundsExpendituresRecordForm', () => {
             result.current.handleAmountBlur('amountUsd');
         });
 
-        expect(result.current.usdMismatchMessage).toBe(FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH);
-        expect(result.current.isSubmitDisabled).toBe(true);
+        expect(result.current.formState.amountUah).toBe('150');
+        expect(result.current.usdMismatchMessage).toBeUndefined();
+        expect(result.current.isSubmitDisabled).toBe(false);
     });
 
-    it('blocks handleConfirmAdd on mismatch even without a preceding USD blur', async () => {
+    it('submits successfully after USD is changed manually without a preceding blur', async () => {
         const onSubmit = jest.fn().mockResolvedValue(true);
         const { result } = renderUseFundsForm({ onSubmit });
 
         act(() => {
             result.current.handleReportingYearChange('2026');
             result.current.handleCategoryChange(3);
-            result.current.handleAmountFieldChange('amountUah')('100');
             result.current.handleAmountFieldChange('amountUsd')('15');
         });
 
@@ -131,8 +130,13 @@ describe('useFundsExpendituresRecordForm', () => {
             await result.current.handleConfirmAdd();
         });
 
-        expect(onSubmit).not.toHaveBeenCalled();
-        expect(result.current.usdMismatchMessage).toBe(FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH);
+        expect(onSubmit).toHaveBeenCalledWith({
+            categoryId: 3,
+            reportingYear: '2026',
+            amountUah: '150',
+            amountUsd: '15',
+            type: 'income',
+        });
     });
 
     it('blocks submit and surfaces required error when reporting year is missing', async () => {
@@ -155,26 +159,32 @@ describe('useFundsExpendituresRecordForm', () => {
         expect(result.current.formState.errors.reportingYear).toBe(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED);
     });
 
-    it('disables submit button and blocks save when USD amount does not match UAH exchange rate', async () => {
+    it('recalculates UAH and allows save when USD amount is changed with a different exchange rate', async () => {
         const onSubmit = jest.fn().mockResolvedValue(true);
         const { result } = renderUseFundsForm({ exchangeRate: '45.00', onSubmit });
 
         act(() => {
             result.current.handleReportingYearChange('2026');
             result.current.handleCategoryChange(3);
-            result.current.handleAmountFieldChange('amountUah')('450');
             result.current.handleAmountFieldChange('amountUsd')('15');
             result.current.handleAmountBlur('amountUsd');
         });
 
-        expect(result.current.usdMismatchMessage).toBe(FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH);
-        expect(result.current.isSubmitDisabled).toBe(true);
+        expect(result.current.formState.amountUah).toBe('675');
+        expect(result.current.usdMismatchMessage).toBeUndefined();
+        expect(result.current.isSubmitDisabled).toBe(false);
 
         await act(async () => {
             await result.current.handleConfirmAdd();
         });
 
-        expect(onSubmit).not.toHaveBeenCalled();
+        expect(onSubmit).toHaveBeenCalledWith({
+            categoryId: 3,
+            reportingYear: '2026',
+            amountUah: '675',
+            amountUsd: '15',
+            type: 'income',
+        });
     });
 
     it('sets reporting year required error on blur', () => {

--- a/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.test.ts
+++ b/src/hooks/admin/use-program-expense-record-form/useProgramExpenseRecordForm.test.ts
@@ -81,13 +81,12 @@ describe('useProgramExpenseRecordForm', () => {
         expect(result.current.isSubmitDisabled).toBe(false);
     });
 
-    it('blocks submit when UAH and USD amounts mismatch the exchange rate', () => {
+    it('recalculates UAH and enables submit when USD is changed manually', () => {
         const { result } = renderUseProgramExpenseForm();
 
         act(() => {
             result.current.handleReportingYearChange('2026');
             result.current.handleProgramChange(2);
-            result.current.handleAmountFieldChange('amountUah')('400');
             result.current.handleAmountFieldChange('amountUsd')('999');
         });
 
@@ -95,18 +94,18 @@ describe('useProgramExpenseRecordForm', () => {
             result.current.handleAmountBlur('amountUsd');
         });
 
-        expect(result.current.usdMismatchMessage).toBe(PROGRAM_EXPENSES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH);
-        expect(result.current.isSubmitDisabled).toBe(true);
+        expect(result.current.formState.amountUah).toBe('39960');
+        expect(result.current.usdMismatchMessage).toBeUndefined();
+        expect(result.current.isSubmitDisabled).toBe(false);
     });
 
-    it('blocks submitRecord on mismatch even without a preceding USD blur', async () => {
+    it('submits successfully after USD is changed manually without a preceding blur', async () => {
         const onSubmit = jest.fn().mockResolvedValue(true);
         const { result } = renderUseProgramExpenseForm({ onSubmit });
 
         act(() => {
             result.current.handleReportingYearChange('2026');
             result.current.handleProgramChange(2);
-            result.current.handleAmountFieldChange('amountUah')('400');
             result.current.handleAmountFieldChange('amountUsd')('999');
         });
 
@@ -116,18 +115,33 @@ describe('useProgramExpenseRecordForm', () => {
             await result.current.handleSave();
         });
 
-        expect(onSubmit).not.toHaveBeenCalled();
+        expect(onSubmit).toHaveBeenCalledWith({
+            programId: 2,
+            programName: 'Program B',
+            reportingYear: '2026',
+            amountUah: '39960',
+            amountUsd: '999',
+        });
     });
 
-    it('validates amount fields on change and blur', () => {
+    it('validates amountUah max digits on change', () => {
         const { result } = renderUseProgramExpenseForm();
 
         act(() => {
             result.current.handleAmountFieldChange('amountUah')('1234567890');
-            result.current.handleAmountFieldChange('amountUsd')('0');
         });
 
         expect(result.current.formState.errors.amountUah).toBe(FUNDS_EXPENDITURES_TEXT.VALIDATION.AMOUNT_MAX_DIGITS);
+        expect(result.current.formState.errors.amountUsd).toBeUndefined();
+    });
+
+    it('validates amountUsd not-zero error on blur', () => {
+        const { result } = renderUseProgramExpenseForm();
+
+        act(() => {
+            result.current.handleAmountFieldChange('amountUsd')('0');
+        });
+
         expect(result.current.formState.errors.amountUsd).toBeUndefined();
 
         act(() => {
@@ -263,12 +277,11 @@ describe('useProgramExpenseRecordForm', () => {
         expect(result.current.formState.amountUsd).toBe('2,5');
     });
 
-    it('does not recalculate UAH when USD is changed manually', () => {
+    it('automatically converts USD to UAH when USD amount is entered', () => {
         const { result } = renderUseProgramExpenseForm({ exchangeRate: '40' });
 
         act(() => {
-            result.current.handleAmountFieldChange('amountUah')('100');
-            result.current.handleAmountFieldChange('amountUsd')('999');
+            result.current.handleAmountFieldChange('amountUsd')('2,5');
         });
 
         expect(result.current.formState.amountUah).toBe('100');
@@ -343,7 +356,7 @@ describe('useProgramExpenseRecordForm', () => {
             });
         });
 
-        it('still blocks saving a legacy record once its amounts are actively edited to mismatch the current rate', () => {
+        it('recalculates UAH and allows saving a legacy record once its amounts are actively edited', () => {
             const { result } = renderUseProgramExpenseForm({ recordToEdit, exchangeRate: '40' });
 
             act(() => {
@@ -354,8 +367,9 @@ describe('useProgramExpenseRecordForm', () => {
                 result.current.handleAmountBlur('amountUsd');
             });
 
-            expect(result.current.usdMismatchMessage).toBe(PROGRAM_EXPENSES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH);
-            expect(result.current.isSubmitDisabled).toBe(true);
+            expect(result.current.formState.amountUah).toBe('600');
+            expect(result.current.usdMismatchMessage).toBeUndefined();
+            expect(result.current.isSubmitDisabled).toBe(false);
         });
 
         it('does not trigger program unique validation error when choosing its own program ID', () => {

--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.test.tsx
@@ -699,7 +699,7 @@ describe('FundsExpendituresTable', () => {
             expect(screen.getByLabelText('Accept record 1')).toBeDisabled();
         });
 
-        it('should show USD mismatch message in the UI when amounts do not match', () => {
+        it('should recalculate UAH and show no mismatch message when USD is changed manually', () => {
             renderTable({ isEditing: true, exchangeRate: '40' });
 
             fireEvent.click(screen.getByLabelText('Edit record 1'));
@@ -707,21 +707,7 @@ describe('FundsExpendituresTable', () => {
             fireEvent.change(screen.getByLabelText('Amount USD record 1'), { target: { value: '201' } });
             fireEvent.blur(screen.getByLabelText('Amount USD record 1'));
 
-            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH)).toBeInTheDocument();
-        });
-
-        it('should clear USD mismatch message from UI when UAH amount is changed', () => {
-            renderTable({ isEditing: true, exchangeRate: '40' });
-
-            fireEvent.click(screen.getByLabelText('Edit record 1'));
-            fireEvent.change(screen.getByLabelText('Amount UAH record 1'), { target: { value: '8 000' } });
-            fireEvent.change(screen.getByLabelText('Amount USD record 1'), { target: { value: '201' } });
-            fireEvent.blur(screen.getByLabelText('Amount USD record 1'));
-
-            expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH)).toBeInTheDocument();
-
-            fireEvent.change(screen.getByLabelText('Amount UAH record 1'), { target: { value: 'abc' } });
-
+            expect(screen.getByLabelText('Amount UAH record 1')).toHaveValue('8040');
             expect(screen.queryByText(FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH)).not.toBeInTheDocument();
         });
     });

--- a/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.test.tsx
+++ b/src/pages/admin/reports/components/program-expenses-section/components/common/add-program-expense-record-modal/AddProgramExpenseRecordModal.test.tsx
@@ -359,7 +359,7 @@ describe('AddProgramExpenseRecordModal', () => {
         expect(getCategoryInput()).toHaveValue('');
     });
 
-    it('auto-fills USD when UAH is entered and shows mismatch message on manual USD change', () => {
+    it('auto-fills USD when UAH is entered and recalculates UAH when USD is changed manually', () => {
         renderModal({ exchangeRate: '40' });
 
         fireEvent.change(screen.getByTestId('add-program-expense-amount-uah'), { target: { value: '100' } });
@@ -369,7 +369,8 @@ describe('AddProgramExpenseRecordModal', () => {
         fireEvent.change(screen.getByTestId('add-program-expense-amount-usd'), { target: { value: '999' } });
         fireEvent.blur(screen.getByTestId('add-program-expense-amount-usd'));
 
-        expect(screen.getByText(FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH)).toBeInTheDocument();
+        expect(screen.getByTestId('add-program-expense-amount-uah')).toHaveValue('39960');
+        expect(screen.queryByText(FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH)).not.toBeInTheDocument();
     });
 
     it('blocks closing the add confirmation dialog when submitting is pending', async () => {

--- a/src/utils/functions/get-converted-amount/get-converted-amount.test.ts
+++ b/src/utils/functions/get-converted-amount/get-converted-amount.test.ts
@@ -34,4 +34,38 @@ describe('getConvertedAmount', () => {
         expect(getConvertedAmount('   ', '40')).toBeNull();
         expect(getConvertedAmount('abc', '40')).toBeNull();
     });
+
+    it('defaults to uahToUsd direction when direction is omitted', () => {
+        expect(getConvertedAmount('100', '3')).toBe(getConvertedAmount('100', '3', 'uahToUsd'));
+    });
+
+    describe('usdToUah direction', () => {
+        it('returns UAH when converting from USD', () => {
+            expect(getConvertedAmount('100', '42', 'usdToUah')).toBe('4200');
+        });
+
+        it('returns null when exchange rate is empty', () => {
+            expect(getConvertedAmount('100', '', 'usdToUah')).toBeNull();
+        });
+
+        it('returns null when exchange rate is zero', () => {
+            expect(getConvertedAmount('100', '0', 'usdToUah')).toBeNull();
+        });
+
+        it('rounds to two decimals', () => {
+            expect(getConvertedAmount('33,335', '2', 'usdToUah')).toBe('66,67');
+        });
+
+        it('returns null for empty or invalid source amount', () => {
+            expect(getConvertedAmount('', '40', 'usdToUah')).toBeNull();
+            expect(getConvertedAmount('   ', '40', 'usdToUah')).toBeNull();
+            expect(getConvertedAmount('abc', '40', 'usdToUah')).toBeNull();
+        });
+
+        it('round-trips a uahToUsd conversion back to the original UAH amount', () => {
+            const usd = getConvertedAmount('11904,76', '42', 'uahToUsd');
+            expect(usd).toBe('283,45');
+            expect(getConvertedAmount(usd as string, '42', 'usdToUah')).toBe('11904,9');
+        });
+    });
 });

--- a/src/utils/functions/get-converted-amount/get-converted-amount.ts
+++ b/src/utils/functions/get-converted-amount/get-converted-amount.ts
@@ -3,7 +3,13 @@ import { formatNumberDecimalComma } from '@/utils/functions/formatters/format-nu
 
 const roundToTwoDecimals = (value: number): number => Math.round((value + Number.EPSILON) * 100) / 100;
 
-export const getConvertedAmount = (value: string, exchangeRate: string | null | undefined): string | null => {
+export type AmountConversionDirection = 'uahToUsd' | 'usdToUah';
+
+export const getConvertedAmount = (
+    value: string,
+    exchangeRate: string | null | undefined,
+    direction: AmountConversionDirection = 'uahToUsd',
+): string | null => {
     const parsedExchangeRate = parseAmount(exchangeRate ?? '');
     if (parsedExchangeRate <= 0) {
         return null;
@@ -15,7 +21,8 @@ export const getConvertedAmount = (value: string, exchangeRate: string | null | 
     }
 
     const parsedCurrentAmount = parseAmount(value);
-    const convertedAmount = parsedCurrentAmount / parsedExchangeRate;
+    const convertedAmount =
+        direction === 'uahToUsd' ? parsedCurrentAmount / parsedExchangeRate : parsedCurrentAmount * parsedExchangeRate;
 
     const roundedConvertedAmount = roundToTwoDecimals(convertedAmount);
 

--- a/src/utils/functions/update-funds-amounts/update-funds-amounts.test.ts
+++ b/src/utils/functions/update-funds-amounts/update-funds-amounts.test.ts
@@ -137,10 +137,23 @@ describe('updateFundsAmounts', () => {
 
             expect(result.amountUah).toBe('100');
             expect(result.amountUsd).toBe('3');
-            expect(mockGetConvertedAmount).toHaveBeenCalledWith('100', '33.5');
+            expect(mockGetConvertedAmount).toHaveBeenCalledWith('100', '33.5', 'uahToUsd');
         });
 
-        it('should not convert amountUsd to amountUah when no error', () => {
+        it('should convert amountUsd to amountUah when no error', () => {
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('3.5');
+            mockValidateFundsExpendituresAmount.mockReturnValueOnce(undefined).mockReturnValueOnce(undefined);
+            mockGetConvertedAmount.mockReturnValue('117,25');
+
+            const updater = updateFundsAmounts('amountUsd', '3.5', '33.5', 'change');
+            const result = updater(initialState);
+
+            expect(result.amountUsd).toBe('3.5');
+            expect(result.amountUah).toBe('117,25');
+            expect(mockGetConvertedAmount).toHaveBeenCalledWith('3.5', '33.5', 'usdToUah');
+        });
+
+        it('should not convert amountUah when converting amountUsd returns null', () => {
             mockNormalizeFundsExpendituresAmountInput.mockReturnValue('3.5');
             mockValidateFundsExpendituresAmount.mockReturnValueOnce(undefined);
             mockGetConvertedAmount.mockReturnValue(null);
@@ -150,7 +163,7 @@ describe('updateFundsAmounts', () => {
 
             expect(result.amountUsd).toBe('3.5');
             expect(result.amountUah).toBe('100');
-            expect(mockGetConvertedAmount).not.toHaveBeenCalled();
+            expect(mockGetConvertedAmount).toHaveBeenCalledWith('3.5', '33.5', 'usdToUah');
         });
 
         it('should not convert if conversion returns null', () => {
@@ -198,7 +211,7 @@ describe('updateFundsAmounts', () => {
             const result = updater(initialState);
 
             expect(result.amountUah).toBe('100');
-            expect(mockGetConvertedAmount).toHaveBeenCalledWith('100', null);
+            expect(mockGetConvertedAmount).toHaveBeenCalledWith('100', null, 'uahToUsd');
         });
     });
 
@@ -300,6 +313,40 @@ describe('updateFundsAmounts', () => {
             expect(result.amountUsd).toBe('');
             expect(result.errors.amountUsd).toBeUndefined();
             expect(result.errors.amountUah).toBe(uahError);
+        });
+
+        it.each([
+            ['change', undefined],
+            ['blur', 'Field is required'],
+        ] as const)('should clear amountUah when amountUsd becomes empty on %s trigger', (trigger, usdError) => {
+            const stateWithUah: FundsAmountsState = {
+                amountUah: '30',
+                amountUsd: '100',
+                errors: {
+                    amountUah: 'Previous UAH error',
+                    amountUsd: 'Previous USD error',
+                },
+            };
+
+            mockNormalizeFundsExpendituresAmountInput.mockReturnValue('');
+            mockValidateFundsExpendituresAmount.mockImplementation(
+                (value: string, currentTrigger?: 'change' | 'blur' | 'save') => {
+                    if (value === '') {
+                        return currentTrigger === 'blur' ? 'Field is required' : undefined;
+                    }
+
+                    return undefined;
+                },
+            );
+
+            const updater = updateFundsAmounts('amountUsd', '', '33.5', trigger);
+            const result = updater(stateWithUah);
+
+            expect(mockGetConvertedAmount).not.toHaveBeenCalled();
+            expect(result.amountUsd).toBe('');
+            expect(result.amountUah).toBe('');
+            expect(result.errors.amountUah).toBeUndefined();
+            expect(result.errors.amountUsd).toBe(usdError);
         });
 
         it('should apply validation error for non-empty amountUah after clearing', () => {

--- a/src/utils/functions/update-funds-amounts/update-funds-amounts.ts
+++ b/src/utils/functions/update-funds-amounts/update-funds-amounts.ts
@@ -1,4 +1,7 @@
-import { getConvertedAmount } from '@/utils/functions/get-converted-amount/get-converted-amount';
+import {
+    AmountConversionDirection,
+    getConvertedAmount,
+} from '@/utils/functions/get-converted-amount/get-converted-amount';
 import {
     normalizeFundsExpendituresAmountInput,
     validateFundsExpendituresAmount,
@@ -13,6 +16,36 @@ export interface FundsAmountsState {
     };
 }
 
+interface OppositeAmount {
+    amount: string;
+    error?: string;
+}
+
+const computeOppositeAmount = (
+    normalized: string,
+    currentFieldError: string | undefined,
+    exchangeRate: string | null,
+    trigger: 'change' | 'blur',
+    direction: AmountConversionDirection,
+    fallback: OppositeAmount,
+): OppositeAmount => {
+    if (normalized === '') {
+        return { amount: '', error: undefined };
+    }
+
+    if (currentFieldError) {
+        return fallback;
+    }
+
+    const convertedAmount = getConvertedAmount(normalized, exchangeRate, direction);
+
+    if (convertedAmount === null) {
+        return fallback;
+    }
+
+    return { amount: convertedAmount, error: validateFundsExpendituresAmount(convertedAmount, trigger) };
+};
+
 export const updateFundsAmounts = (
     field: 'amountUah' | 'amountUsd',
     value: string,
@@ -24,42 +57,25 @@ export const updateFundsAmounts = (
         const normalized = normalizeFundsExpendituresAmountInput(value, shouldNormalize);
         const currentFieldError = validateFundsExpendituresAmount(value, trigger);
 
-        let nextAmountUah = field === 'amountUah' ? normalized : prev.amountUah;
-        let nextAmountUsd = field === 'amountUsd' ? normalized : prev.amountUsd;
-        let nextAmountUahError = field === 'amountUah' ? currentFieldError : prev.errors.amountUah;
-        let nextAmountUsdError = field === 'amountUsd' ? currentFieldError : prev.errors.amountUsd;
+        const direction: AmountConversionDirection = field === 'amountUah' ? 'uahToUsd' : 'usdToUah';
+        const fallback: OppositeAmount =
+            field === 'amountUah'
+                ? { amount: prev.amountUsd, error: prev.errors.amountUsd }
+                : { amount: prev.amountUah, error: prev.errors.amountUah };
 
-        if (field === 'amountUah') {
-            if (normalized === '') {
-                nextAmountUsd = '';
-                nextAmountUsdError = undefined;
-            }
+        const opposite = computeOppositeAmount(
+            normalized,
+            currentFieldError,
+            exchangeRate,
+            trigger,
+            direction,
+            fallback,
+        );
 
-            if (normalized !== '' && !currentFieldError) {
-                const convertedAmount = getConvertedAmount(normalized, exchangeRate, 'uahToUsd');
-
-                if (convertedAmount !== null) {
-                    nextAmountUsd = convertedAmount;
-                    nextAmountUsdError = validateFundsExpendituresAmount(convertedAmount, trigger);
-                }
-            }
-        }
-
-        if (field === 'amountUsd') {
-            if (normalized === '') {
-                nextAmountUah = '';
-                nextAmountUahError = undefined;
-            }
-
-            if (normalized !== '' && !currentFieldError) {
-                const convertedAmount = getConvertedAmount(normalized, exchangeRate, 'usdToUah');
-
-                if (convertedAmount !== null) {
-                    nextAmountUah = convertedAmount;
-                    nextAmountUahError = validateFundsExpendituresAmount(convertedAmount, trigger);
-                }
-            }
-        }
+        const nextAmountUah = field === 'amountUah' ? normalized : opposite.amount;
+        const nextAmountUsd = field === 'amountUsd' ? normalized : opposite.amount;
+        const nextAmountUahError = field === 'amountUah' ? currentFieldError : opposite.error;
+        const nextAmountUsdError = field === 'amountUsd' ? currentFieldError : opposite.error;
 
         return {
             ...prev,

--- a/src/utils/functions/update-funds-amounts/update-funds-amounts.ts
+++ b/src/utils/functions/update-funds-amounts/update-funds-amounts.ts
@@ -36,11 +36,27 @@ export const updateFundsAmounts = (
             }
 
             if (normalized !== '' && !currentFieldError) {
-                const convertedAmount = getConvertedAmount(normalized, exchangeRate);
+                const convertedAmount = getConvertedAmount(normalized, exchangeRate, 'uahToUsd');
 
                 if (convertedAmount !== null) {
                     nextAmountUsd = convertedAmount;
                     nextAmountUsdError = validateFundsExpendituresAmount(convertedAmount, trigger);
+                }
+            }
+        }
+
+        if (field === 'amountUsd') {
+            if (normalized === '') {
+                nextAmountUah = '';
+                nextAmountUahError = undefined;
+            }
+
+            if (normalized !== '' && !currentFieldError) {
+                const convertedAmount = getConvertedAmount(normalized, exchangeRate, 'usdToUah');
+
+                if (convertedAmount !== null) {
+                    nextAmountUah = convertedAmount;
+                    nextAmountUahError = validateFundsExpendituresAmount(convertedAmount, trigger);
                 }
             }
         }


### PR DESCRIPTION
## Github ticket

- [#3503](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3503)
- [#3570](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3570)

## Description

In the admin panel's Reports section, editing the "Сума USD" field did not recalculate the corresponding "Сума UAH" field — only the opposite direction (UAH → USD) worked. This affected two separate entry points that share the same underlying recalculation logic:

- **#3503** — the "Програмні витрати" Add/Edit record modal: entering a USD amount showed a "Сума в USD не відповідає сумі в UAH" error instead of recalculating UAH, blocking save entirely.
- **#3570** — inline row editing in the "Доходи та витрати" table (both "Надходження" and "Витрата"): the same one-directional behavior.

## Summary of change

- `get-converted-amount.ts` — added a `direction` parameter (`'uahToUsd' | 'usdToUah'`, defaults to the existing behavior) so the conversion formula can run in either direction.
- `update-funds-amounts.ts` — added a symmetric branch for `field === 'amountUsd'` that recalculates `amountUah`, mirroring the existing UAH→USD branch. This is the core fix.
- `useAmountBlur.ts` (used by the Add/Edit modals) — removed the special-cased USD-only blur handler that skipped recalculation entirely; both fields now go through the same `updateFundsAmounts` call on blur, matching the pattern already used by `useFundsAmountEdit.ts` (inline table editing, which required no production change).
- `useProgramExpenseRecordForm.ts` / `useFundsExpendituresRecordForm.ts` — no code changes needed; both hooks already delegated to the two files above and now recalculate correctly.
- Updated/added unit tests across all affected files (`get-converted-amount`, `update-funds-amounts`, `useAmountBlur`, `useFundsAmountEdit`, `useProgramExpenseRecordForm`, `useFundsExpendituresRecordForm`) plus the UI-level tests (`AddProgramExpenseRecordModal`, `FundsExpendituresTable`) that exercised the old one-directional behavior as "correct."

## How to recreate changes

**#3503:**
1. Open Admin Panel → "Звітність" → "Звіт та аналітика" → "Програмні витрати" tab → "Додати запис".
2. Enter a value in "Сума USD" only (leave UAH untouched or vice versa).
3. Confirm "Сума UAH" recalculates automatically and the record saves without a mismatch error.

**#3570:**
1. Open the "Доходи та витрати" tab → enter edit mode on any "Надходження" or "Витрата" row.
2. Change "Сума USD".
3. Confirm "Сума UAH" recalculates on screen before saving, and the saved value persists after a page refresh.

## CHECK LIST

- [x] New tests were added or existing were modified
- [ ] Changes have severe impact on users
- [x] Changes have medium impact on users
- [ ] Changes have light impact on users
- [x] Test coverage was updated
- [x] PR meets all conventions
