### PR TITLE
Feature/issue 2258 [Hippotherapy] Scientific references adding

### DIFF
--- a/src/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup.tsx
+++ b/src/components/admin/input-groups/text-area-with-character-limit-group/TextAreaWithCharacterLimitGroup.tsx
@@ -18,6 +18,7 @@ export interface TextAreaWithCharacterLimitGroupProps extends TextAreaWithCharac
     maxLimitWarning?: string;
     isWhiteLabel?: boolean;
     errorCounterContainerClassName?: string;
+    normalizeValue?: (value: string) => string;
 }
 
 export const TextAreaWithCharacterLimitGroup = ({
@@ -40,6 +41,7 @@ export const TextAreaWithCharacterLimitGroup = ({
     errorCounterContainerClassName,
     autoGrow,
     maxRows,
+    normalizeValue,
 }: TextAreaWithCharacterLimitGroupProps) => {
     const [localWarning, setLocalWarning] = useState<string | null>(null);
     const counterId = `${id}-character-count`;
@@ -63,6 +65,7 @@ export const TextAreaWithCharacterLimitGroup = ({
                 onWarningChange={setLocalWarning}
                 autoGrow={autoGrow}
                 maxRows={maxRows}
+                normalizeValue={normalizeValue}
             />
             <InputErrorWithCharacterCounter
                 error={localWarning || error}

--- a/src/components/admin/textarea-with-character-limit/TextAreaWithCharacterLimit.test.tsx
+++ b/src/components/admin/textarea-with-character-limit/TextAreaWithCharacterLimit.test.tsx
@@ -1,5 +1,5 @@
 import React, { createRef } from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { TextAreaWithCharacterLimit, TextAreaWithCharacterLimitProps } from './TextAreaWithCharacterLimit';
 
@@ -213,12 +213,23 @@ describe('TextAreaWithCharacterLimit', () => {
         expect(getTextArea().value).toBe('');
     });
 
-    it('re-syncs the displayed value with the value prop after a change', async () => {
+    it('normalises the typed value when normalizeValue is provided', () => {
+        renderTextAreaWithCharacterLimit({
+            value: 'Hello',
+            normalizeValue: (text: string) => text.replace(/ +/g, ' ').replace(/^ +/, ''),
+        });
+
+        typeInTextArea('  Hello   world ');
+
+        expect(getTextArea()).toHaveValue('Hello world ');
+    });
+
+    it('keeps the typed value as is when normalizeValue is not provided', () => {
         renderTextAreaWithCharacterLimit({ value: 'Hello' });
 
         typeInTextArea('Hello  world');
 
-        await waitFor(() => expect(getTextArea()).toHaveValue('Hello'));
+        expect(getTextArea()).toHaveValue('Hello  world');
     });
 
     describe('auto-grow functionality', () => {

--- a/src/components/admin/textarea-with-character-limit/TextAreaWithCharacterLimit.test.tsx
+++ b/src/components/admin/textarea-with-character-limit/TextAreaWithCharacterLimit.test.tsx
@@ -1,5 +1,5 @@
 import React, { createRef } from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { TextAreaWithCharacterLimit, TextAreaWithCharacterLimitProps } from './TextAreaWithCharacterLimit';
 
@@ -211,6 +211,14 @@ describe('TextAreaWithCharacterLimit', () => {
     it('renders empty string when value is undefined', () => {
         renderTextAreaWithCharacterLimit({ value: undefined as any });
         expect(getTextArea().value).toBe('');
+    });
+
+    it('re-syncs the displayed value with the value prop after a change', async () => {
+        renderTextAreaWithCharacterLimit({ value: 'Hello' });
+
+        typeInTextArea('Hello  world');
+
+        await waitFor(() => expect(getTextArea()).toHaveValue('Hello'));
     });
 
     describe('auto-grow functionality', () => {

--- a/src/components/admin/textarea-with-character-limit/TextAreaWithCharacterLimit.tsx
+++ b/src/components/admin/textarea-with-character-limit/TextAreaWithCharacterLimit.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import cn from 'classnames';
 import { ReactComponent as RemoveIcon } from '@/assets/icons/remove-query.svg';
 import { useInputWithCharacterLimit } from '@/hooks/admin/use-input-with-character-limit/useInputWithCharacterLimit';
@@ -21,6 +21,7 @@ export interface TextAreaWithCharacterLimitProps {
     onWarningChange?: (warning: string | null) => void;
     autoGrow?: boolean;
     maxRows?: number;
+    normalizeValue?: (value: string) => string;
 }
 
 export const TextAreaWithCharacterLimit = forwardRef<HTMLTextAreaElement, TextAreaWithCharacterLimitProps>(
@@ -42,16 +43,11 @@ export const TextAreaWithCharacterLimit = forwardRef<HTMLTextAreaElement, TextAr
             onWarningChange,
             autoGrow = false,
             maxRows = 10,
+            normalizeValue,
         },
         ref,
     ) => {
         const [localValue, setLocalValue] = useState(value ?? '');
-
-        const valueRef = useRef(value);
-
-        useLayoutEffect(() => {
-            valueRef.current = value;
-        }, [value]);
 
         useEffect(() => {
             setLocalValue(value ?? '');
@@ -85,11 +81,19 @@ export const TextAreaWithCharacterLimit = forwardRef<HTMLTextAreaElement, TextAr
             });
 
         const onInternalChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-            setLocalValue(e.target.value);
+            const rawValue = e.target.value;
+            const nextValue = normalizeValue ? normalizeValue(rawValue) : rawValue;
+
+            if (normalizeValue && nextValue !== rawValue) {
+                const rawCaret = e.target.selectionStart ?? rawValue.length;
+                const nextCaret = normalizeValue(rawValue.slice(0, rawCaret)).length;
+
+                e.target.value = nextValue;
+                e.target.setSelectionRange(nextCaret, nextCaret);
+            }
+
+            setLocalValue(nextValue);
             handleChange(e);
-            Promise.resolve().then(() => {
-                setLocalValue(valueRef.current ?? '');
-            });
         };
 
         useEffect(() => {

--- a/src/components/admin/textarea-with-character-limit/TextAreaWithCharacterLimit.tsx
+++ b/src/components/admin/textarea-with-character-limit/TextAreaWithCharacterLimit.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
+import React, { forwardRef, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import cn from 'classnames';
 import { ReactComponent as RemoveIcon } from '@/assets/icons/remove-query.svg';
 import { useInputWithCharacterLimit } from '@/hooks/admin/use-input-with-character-limit/useInputWithCharacterLimit';
@@ -47,6 +47,12 @@ export const TextAreaWithCharacterLimit = forwardRef<HTMLTextAreaElement, TextAr
     ) => {
         const [localValue, setLocalValue] = useState(value ?? '');
 
+        const valueRef = useRef(value);
+
+        useLayoutEffect(() => {
+            valueRef.current = value;
+        }, [value]);
+
         useEffect(() => {
             setLocalValue(value ?? '');
         }, [value]);
@@ -81,6 +87,9 @@ export const TextAreaWithCharacterLimit = forwardRef<HTMLTextAreaElement, TextAr
         const onInternalChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
             setLocalValue(e.target.value);
             handleChange(e);
+            Promise.resolve().then(() => {
+                setLocalValue(valueRef.current ?? '');
+            });
         };
 
         useEffect(() => {

--- a/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.test.tsx
+++ b/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.test.tsx
@@ -286,22 +286,6 @@ describe('ScientificReferencesSection', () => {
         expect(getAddButton()).toBeEnabled();
     });
 
-    it('collapses consecutive spaces in the name while typing', () => {
-        renderComponent();
-
-        fireEvent.change(screen.getByTestId('name-input-ref-1'), {
-            target: { value: '  Hello   world ' },
-        });
-
-        expect(mockOnChange).toHaveBeenCalledWith(
-            expect.objectContaining({
-                scientificReferences: expect.arrayContaining([
-                    expect.objectContaining({ localId: 'ref-1', name: 'Hello world ' }),
-                ]),
-            }),
-        );
-    });
-
     it('ignores a toggle for a reference that is no longer in the list', () => {
         renderComponent();
 

--- a/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.test.tsx
+++ b/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.test.tsx
@@ -325,4 +325,15 @@ describe('ScientificReferencesSection', () => {
             screen.getByText(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(HIPPOTHERAPY_PAGE_TEXT.MIN_LENGTH)),
         ).toBeInTheDocument();
     });
+
+    it('keeps the add button disabled when a value only passes validation thanks to trailing spaces', () => {
+        renderComponent({
+            value: {
+                ...defaultValue,
+                scientificReferences: [{ localId: 'ref-1', id: 1, name: 'ab', url: 'https://example.com/one' }],
+            },
+        });
+
+        expect(getAddButton()).toBeDisabled();
+    });
 });

--- a/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.test.tsx
+++ b/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.test.tsx
@@ -314,7 +314,7 @@ describe('ScientificReferencesSection', () => {
         renderComponent({
             value: {
                 ...defaultValue,
-                scientificReferences: [{ localId: 'ref-1', id: 1, name: 'ab', url: 'https://example.com/one' }],
+                scientificReferences: [{ localId: 'ref-1', id: 1, name: 'ab         ', url: 'https://example.com/one' }],
             },
         });
 

--- a/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.test.tsx
+++ b/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.test.tsx
@@ -314,7 +314,9 @@ describe('ScientificReferencesSection', () => {
         renderComponent({
             value: {
                 ...defaultValue,
-                scientificReferences: [{ localId: 'ref-1', id: 1, name: 'ab         ', url: 'https://example.com/one' }],
+                scientificReferences: [
+                    { localId: 'ref-1', id: 1, name: 'ab         ', url: 'https://example.com/one' },
+                ],
             },
         });
 

--- a/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.test.tsx
+++ b/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.test.tsx
@@ -45,6 +45,7 @@ jest.mock('./scientific-reference-card/ScientificReferenceCard', () => ({
             data-is-expanded={isExpanded}
         >
             <button data-testid={`toggle-expand-${localId}`} onClick={() => onToggleExpand(localId)} />
+            <button data-testid={`toggle-unknown-${localId}`} onClick={() => onToggleExpand('unknown-local-id')} />
             <input
                 data-testid={`name-input-${localId}`}
                 value={name}
@@ -85,6 +86,11 @@ describe('ScientificReferencesSection', () => {
 
     beforeEach(() => {
         mockOnChange = jest.fn();
+
+        if (!(global as any).crypto) {
+            Object.defineProperty(global, 'crypto', { value: {}, configurable: true, writable: true });
+        }
+        (global as any).crypto.randomUUID = jest.fn(() => 'generated-uuid');
     });
 
     it('renders all references collapsed by default', () => {
@@ -246,5 +252,77 @@ describe('ScientificReferencesSection', () => {
         fireEvent.change(screen.getByTestId('url-input-ref-1'), { target: { value: 'https://example.com/fixed' } });
 
         expect(screen.queryByText(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.FIELD_REQUIRED)).not.toBeInTheDocument();
+    });
+
+    it('adds a new empty reference at the end of the list when the add button is clicked', () => {
+        renderComponent();
+
+        fireEvent.click(getAddButton());
+
+        expect(mockOnChange).toHaveBeenCalledWith(
+            expect.objectContaining({
+                scientificReferences: [
+                    ...defaultValue.scientificReferences,
+                    expect.objectContaining({ localId: 'generated-uuid', id: null, name: '', url: '' }),
+                ],
+            }),
+        );
+    });
+
+    it('disables the add button while a reference is incomplete', () => {
+        renderComponent({
+            value: {
+                ...defaultValue,
+                scientificReferences: [{ localId: 'ref-1', id: 1, name: '', url: '' }],
+            },
+        });
+
+        expect(getAddButton()).toBeDisabled();
+    });
+
+    it('enables the add button when every reference is filled in', () => {
+        renderComponent();
+
+        expect(getAddButton()).toBeEnabled();
+    });
+
+    it('collapses consecutive spaces in the name while typing', () => {
+        renderComponent();
+
+        fireEvent.change(screen.getByTestId('name-input-ref-1'), {
+            target: { value: '  Hello   world ' },
+        });
+
+        expect(mockOnChange).toHaveBeenCalledWith(
+            expect.objectContaining({
+                scientificReferences: expect.arrayContaining([
+                    expect.objectContaining({ localId: 'ref-1', name: 'Hello world ' }),
+                ]),
+            }),
+        );
+    });
+
+    it('ignores a toggle for a reference that is no longer in the list', () => {
+        renderComponent();
+
+        fireEvent.click(screen.getByTestId('toggle-unknown-ref-1'));
+
+        expect(screen.getByTestId('reference-card-ref-1')).toHaveAttribute('data-is-expanded', 'false');
+        expect(screen.getByTestId('reference-card-ref-2')).toHaveAttribute('data-is-expanded', 'false');
+    });
+
+    it('validates the trimmed name on blur', () => {
+        renderComponent({
+            value: {
+                ...defaultValue,
+                scientificReferences: [{ localId: 'ref-1', id: 1, name: 'ab ', url: 'https://example.com/one' }],
+            },
+        });
+
+        fireEvent.blur(screen.getByTestId('name-input-ref-1'));
+
+        expect(
+            screen.getByText(COMMON_TEXT_ADMIN.VALIDATION_MESSAGE.getMinError(HIPPOTHERAPY_PAGE_TEXT.MIN_LENGTH)),
+        ).toBeInTheDocument();
     });
 });

--- a/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.tsx
+++ b/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useState } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 import { RichTextInputGroup } from '@/components/admin/input-groups/rich-text-input-group/RichTextInputGroup';
 import { Button } from '@/components/admin/button/Button';
 import { ReactComponent as PlusIcon } from '@/assets/icons/plus.svg';
@@ -6,6 +6,8 @@ import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { HIPPOTHERAPY_PAGE_CHAR_LIMITS, HIPPOTHERAPY_PAGE_TEXT } from '@/const/admin/hippotherapy-page';
 import { HIPPOTHERAPY_PAGE_VALIDATION_FUNCTIONS } from '@/validation/admin/hippotherapy-page-schema/HippotherapyPageSchema';
 import { getPlainTextFromHtml } from '@/utils/functions/get-plain-text-from-html/get-plain-text-from-html';
+import { getNormalizedInputTextWhileTyping } from '@/utils/functions/formatters/text-formatters';
+
 import {
     HippotherapyScientificReference,
     HippotherapyScientificReferencesSectionContent,
@@ -28,6 +30,17 @@ const ScientificReferencesSectionComponent = ({ value, onChange, disabled }: Sci
     const [nameErrors, setNameErrors] = useState<Record<string, string | undefined>>({});
     const [urlErrors, setUrlErrors] = useState<Record<string, string | undefined>>({});
     const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+    const [newReferenceLocalId, setNewReferenceLocalId] = useState<string | null>(null);
+
+    const areAllReferencesValid = useMemo(
+        () =>
+            value.scientificReferences.every(
+                (reference) =>
+                    !HIPPOTHERAPY_PAGE_VALIDATION_FUNCTIONS.validateText(reference.name) &&
+                    !HIPPOTHERAPY_PAGE_VALIDATION_FUNCTIONS.validateText(reference.url),
+            ),
+        [value.scientificReferences],
+    );
 
     const handleToggleExpand = useCallback(
         (localId: string) => {
@@ -49,6 +62,23 @@ const ScientificReferencesSectionComponent = ({ value, onChange, disabled }: Sci
         [value.scientificReferences],
     );
 
+    const handleAddReference = useCallback(() => {
+        const newReference: HippotherapyScientificReference = {
+            localId: crypto.randomUUID(),
+            id: null,
+            name: '',
+            url: '',
+        };
+
+        onChange({
+            ...value,
+            scientificReferences: [...value.scientificReferences, newReference],
+        });
+
+        setExpandedIds((prev) => new Set(prev).add(getExpandKey(newReference)));
+        setNewReferenceLocalId(newReference.localId);
+    }, [onChange, value]);
+
     const handleTitleChange = (title: string) => {
         onChange({ ...value, title });
         setTitleError(HIPPOTHERAPY_PAGE_VALIDATION_FUNCTIONS.validateText(getPlainTextFromHtml(title)));
@@ -60,14 +90,16 @@ const ScientificReferencesSectionComponent = ({ value, onChange, disabled }: Sci
     };
 
     const handleNameChange = (localId: string, name: string) => {
+        const normalisedName = getNormalizedInputTextWhileTyping(name);
+
         const scientificReferences = value.scientificReferences.map((reference) =>
-            reference.localId === localId ? { ...reference, name } : reference,
+            reference.localId === localId ? { ...reference, name: normalisedName } : reference,
         );
         onChange({ ...value, scientificReferences });
         if (nameErrors[localId] !== undefined) {
             setNameErrors((prev) => ({
                 ...prev,
-                [localId]: HIPPOTHERAPY_PAGE_VALIDATION_FUNCTIONS.validateText(name),
+                [localId]: HIPPOTHERAPY_PAGE_VALIDATION_FUNCTIONS.validateText(normalisedName),
             }));
         }
     };
@@ -86,7 +118,7 @@ const ScientificReferencesSectionComponent = ({ value, onChange, disabled }: Sci
         const reference = value.scientificReferences.find((item) => item.localId === localId);
         setNameErrors((prev) => ({
             ...prev,
-            [localId]: HIPPOTHERAPY_PAGE_VALIDATION_FUNCTIONS.validateText(reference?.name ?? ''),
+            [localId]: HIPPOTHERAPY_PAGE_VALIDATION_FUNCTIONS.validateText((reference?.name ?? '').trim()),
         }));
     };
 
@@ -94,7 +126,7 @@ const ScientificReferencesSectionComponent = ({ value, onChange, disabled }: Sci
         const reference = value.scientificReferences.find((item) => item.localId === localId);
         setUrlErrors((prev) => ({
             ...prev,
-            [localId]: HIPPOTHERAPY_PAGE_VALIDATION_FUNCTIONS.validateText(reference?.url ?? ''),
+            [localId]: HIPPOTHERAPY_PAGE_VALIDATION_FUNCTIONS.validateText((reference?.url ?? '').trim()),
         }));
     };
 
@@ -132,6 +164,7 @@ const ScientificReferencesSectionComponent = ({ value, onChange, disabled }: Sci
                         name={reference.name}
                         url={reference.url}
                         isExpanded={expandedIds.has(getExpandKey(reference))}
+                        autoFocus={reference.localId === newReferenceLocalId}
                         canDelete={value.scientificReferences.length > 1}
                         nameError={nameErrors[reference.localId]}
                         urlError={urlErrors[reference.localId]}
@@ -143,12 +176,12 @@ const ScientificReferencesSectionComponent = ({ value, onChange, disabled }: Sci
                         onUrlBlur={handleUrlBlur}
                     />
                 ))}
-                {/* Adding new references is disabled for now — placeholder only, no add functionality yet. */}
                 <Button
                     buttonStyle="primary"
                     type="button"
                     className="scientific-references-section-add-button"
-                    disabled={disabled}
+                    onClick={handleAddReference}
+                    disabled={disabled || !areAllReferencesValid}
                 >
                     {HIPPOTHERAPY_PAGE_TEXT.BUTTON.ADD_REFERENCE}
                     <PlusIcon />

--- a/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.tsx
+++ b/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.tsx
@@ -6,7 +6,6 @@ import { COMMON_TEXT_ADMIN } from '@/const/admin/common';
 import { HIPPOTHERAPY_PAGE_CHAR_LIMITS, HIPPOTHERAPY_PAGE_TEXT } from '@/const/admin/hippotherapy-page';
 import { HIPPOTHERAPY_PAGE_VALIDATION_FUNCTIONS } from '@/validation/admin/hippotherapy-page-schema/HippotherapyPageSchema';
 import { getPlainTextFromHtml } from '@/utils/functions/get-plain-text-from-html/get-plain-text-from-html';
-import { getNormalizedInputTextWhileTyping } from '@/utils/functions/formatters/text-formatters';
 
 import {
     HippotherapyScientificReference,
@@ -90,16 +89,14 @@ const ScientificReferencesSectionComponent = ({ value, onChange, disabled }: Sci
     };
 
     const handleNameChange = (localId: string, name: string) => {
-        const normalisedName = getNormalizedInputTextWhileTyping(name);
-
         const scientificReferences = value.scientificReferences.map((reference) =>
-            reference.localId === localId ? { ...reference, name: normalisedName } : reference,
+            reference.localId === localId ? { ...reference, name } : reference,
         );
         onChange({ ...value, scientificReferences });
         if (nameErrors[localId] !== undefined) {
             setNameErrors((prev) => ({
                 ...prev,
-                [localId]: validateReferenceText(normalisedName),
+                [localId]: validateReferenceText(name),
             }));
         }
     };

--- a/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.tsx
+++ b/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/ScientificReferencesSection.tsx
@@ -24,6 +24,8 @@ export interface ScientificReferencesSectionProps {
 const getExpandKey = (reference: HippotherapyScientificReference) =>
     reference.id !== null ? `id-${reference.id}` : `local-${reference.localId}`;
 
+const validateReferenceText = (text: string) => HIPPOTHERAPY_PAGE_VALIDATION_FUNCTIONS.validateText(text.trim());
+
 const ScientificReferencesSectionComponent = ({ value, onChange, disabled }: ScientificReferencesSectionProps) => {
     const [titleError, setTitleError] = useState<string | undefined>();
     const [descriptionError, setDescriptionError] = useState<string | undefined>();
@@ -35,9 +37,7 @@ const ScientificReferencesSectionComponent = ({ value, onChange, disabled }: Sci
     const areAllReferencesValid = useMemo(
         () =>
             value.scientificReferences.every(
-                (reference) =>
-                    !HIPPOTHERAPY_PAGE_VALIDATION_FUNCTIONS.validateText(reference.name) &&
-                    !HIPPOTHERAPY_PAGE_VALIDATION_FUNCTIONS.validateText(reference.url),
+                (reference) => !validateReferenceText(reference.name) && !validateReferenceText(reference.url),
             ),
         [value.scientificReferences],
     );
@@ -99,7 +99,7 @@ const ScientificReferencesSectionComponent = ({ value, onChange, disabled }: Sci
         if (nameErrors[localId] !== undefined) {
             setNameErrors((prev) => ({
                 ...prev,
-                [localId]: HIPPOTHERAPY_PAGE_VALIDATION_FUNCTIONS.validateText(normalisedName),
+                [localId]: validateReferenceText(normalisedName),
             }));
         }
     };
@@ -110,7 +110,7 @@ const ScientificReferencesSectionComponent = ({ value, onChange, disabled }: Sci
         );
         onChange({ ...value, scientificReferences });
         if (urlErrors[localId] !== undefined) {
-            setUrlErrors((prev) => ({ ...prev, [localId]: HIPPOTHERAPY_PAGE_VALIDATION_FUNCTIONS.validateText(url) }));
+            setUrlErrors((prev) => ({ ...prev, [localId]: validateReferenceText(url) }));
         }
     };
 
@@ -118,7 +118,7 @@ const ScientificReferencesSectionComponent = ({ value, onChange, disabled }: Sci
         const reference = value.scientificReferences.find((item) => item.localId === localId);
         setNameErrors((prev) => ({
             ...prev,
-            [localId]: HIPPOTHERAPY_PAGE_VALIDATION_FUNCTIONS.validateText((reference?.name ?? '').trim()),
+            [localId]: validateReferenceText(reference?.name ?? ''),
         }));
     };
 
@@ -126,7 +126,7 @@ const ScientificReferencesSectionComponent = ({ value, onChange, disabled }: Sci
         const reference = value.scientificReferences.find((item) => item.localId === localId);
         setUrlErrors((prev) => ({
             ...prev,
-            [localId]: HIPPOTHERAPY_PAGE_VALIDATION_FUNCTIONS.validateText((reference?.url ?? '').trim()),
+            [localId]: validateReferenceText(reference?.url ?? ''),
         }));
     };
 

--- a/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/scientific-reference-card/ScientificReferenceCard.test.tsx
+++ b/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/scientific-reference-card/ScientificReferenceCard.test.tsx
@@ -140,4 +140,12 @@ describe('ScientificReferenceCard', () => {
         expect(screen.getByRole('button', { name: 'Collapse reference' })).toBeDisabled();
         expect(screen.getByLabelText('Delete reference')).toBeDisabled();
     });
+
+    it('collapses consecutive spaces in the name while typing', () => {
+        renderComponent();
+
+        fireEvent.change(screen.getByDisplayValue('Test citation'), { target: { value: '  Hello   world ' } });
+
+        expect(mockOnNameChange).toHaveBeenCalledWith('ref-1', 'Hello world ');
+    });
 });

--- a/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/scientific-reference-card/ScientificReferenceCard.tsx
+++ b/src/pages/admin/hippotherapy-page/components/sections/scientific-references-section/scientific-reference-card/ScientificReferenceCard.tsx
@@ -8,6 +8,7 @@ import { ReactComponent as CrossIcon } from '@/assets/icons/cross.svg';
 import { HIPPOTHERAPY_PAGE_CHAR_LIMITS, HIPPOTHERAPY_PAGE_TEXT } from '@/const/admin/hippotherapy-page';
 import { InputError } from '@/components/admin/input-error/InputError';
 import './ScientificReferenceCard.scss';
+import { getNormalizedInputTextWhileTyping } from '@/utils/functions/formatters/text-formatters';
 
 export interface ScientificReferenceCardProps {
     localId: string;
@@ -91,6 +92,7 @@ export const ScientificReferenceCard = ({
                     rows={2}
                     autoGrow
                     maxRows={6}
+                    normalizeValue={getNormalizedInputTextWhileTyping}
                 />
                 {isExpanded && (
                     <InputWithCharacterLimitGroup

--- a/src/utils/functions/formatters/text-formatters.test.ts
+++ b/src/utils/functions/formatters/text-formatters.test.ts
@@ -85,6 +85,10 @@ describe('text-formatters', () => {
         it('should keep a trailing space so the next word can be typed', () => {
             expect(getNormalizedInputTextWhileTyping('Hello ')).toBe('Hello ');
         });
+
+        it('should keep newlines untouched', () => {
+            expect(getNormalizedInputTextWhileTyping('Hello\nworld')).toBe('Hello\nworld');
+        });
     });
 
     describe('getTrimmedInputText', () => {

--- a/src/utils/functions/formatters/text-formatters.test.ts
+++ b/src/utils/functions/formatters/text-formatters.test.ts
@@ -1,4 +1,10 @@
-import { generateInitials, getNormalizedInputText, getTrimmedInputText, parseDescriptionList } from './text-formatters';
+import {
+    generateInitials,
+    getNormalizedInputText,
+    getNormalizedInputTextWhileTyping,
+    getTrimmedInputText,
+    parseDescriptionList,
+} from './text-formatters';
 
 describe('text-formatters', () => {
     describe('generateInitials', () => {
@@ -64,6 +70,20 @@ describe('text-formatters', () => {
 
         it('should not modify already normalized text', () => {
             expect(getNormalizedInputText('hello world')).toBe('hello world');
+        });
+    });
+
+    describe('getNormalizedInputTextWhileTyping', () => {
+        it('should collapse consecutive into a single one', () => {
+            expect(getNormalizedInputTextWhileTyping('Hello   world')).toBe('Hello world');
+        });
+
+        it('should remove leading spaces', () => {
+            expect(getNormalizedInputTextWhileTyping('   Hello')).toBe('Hello');
+        });
+
+        it('should keep a trailing space so the next word can be typed', () => {
+            expect(getNormalizedInputTextWhileTyping('Hello ')).toBe('Hello ');
         });
     });
 

--- a/src/utils/functions/formatters/text-formatters.ts
+++ b/src/utils/functions/formatters/text-formatters.ts
@@ -11,6 +11,8 @@ export const generateInitials = (fullName: string, maxInitials: number = 2): str
 export const getNormalizedInputText = (text: string, prefix = ''): string =>
     text.slice(prefix.length).trim().replace(/\s+/g, ' ');
 
+export const getNormalizedInputTextWhileTyping = (text: string): string => text.replace(/\s+/g, ' ').trimStart();
+
 export const getTrimmedInputText = (text: string, prefix = ''): string => text.slice(prefix.length).trim();
 
 export const parseDescriptionList = (description?: string) => {

--- a/src/utils/functions/formatters/text-formatters.ts
+++ b/src/utils/functions/formatters/text-formatters.ts
@@ -11,7 +11,7 @@ export const generateInitials = (fullName: string, maxInitials: number = 2): str
 export const getNormalizedInputText = (text: string, prefix = ''): string =>
     text.slice(prefix.length).trim().replace(/\s+/g, ' ');
 
-export const getNormalizedInputTextWhileTyping = (text: string): string => text.replace(/\s+/g, ' ').trimStart();
+export const getNormalizedInputTextWhileTyping = (text: string): string => text.replace(/ +/g, ' ').replace(/^ +/, '');
 
 export const getTrimmedInputText = (text: string, prefix = ''): string => text.slice(prefix.length).trim();
 


### PR DESCRIPTION
## Github ticket

- [Github ticket](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2258)

## Description

The "Додати +" button was a placeholder. This PR implements adding a new scientific reference and applies space management to the "Назва" field.

## How it looks

https://github.com/user-attachments/assets/700ec538-9751-4f26-8b7a-f26b0ffe749e

## Summary of change

- `ScientificReferencesSection.tsx` - "Додати +" adds a new empty reference at the end of the list, expanded and focused. The button is disabled while any reference is incomplete and re-enabled once all are valid. Space management is applied to "Назва" on every keystroke.
- `text-formatters.ts` - added `getNormalizedInputTextWhileTyping`. It collapses consecutive spaces and strips leading ones, but keeps a trailing space.
- `TextAreaWithCharacterLimit.tsx` - required for the above. Unlike `InputWithCharacterLimit`, it never re-synced its internal localValue back to the value prop, so a parent could not correct what the user typed.
- Bug found while testing: blur validation ran against the untrimmed value, so 9 characters plus a space passed a minimum of 10. Both blur handlers now validate the trimmed value.
- "Опублікувати" needed no change - `isHippotherapyPageContentValid` already covers references.

Out of scope: validation rules themselves [#2250](https://github.com/ita-social-projects/VictoryCenter-Back/issues/2250). This section delegates to `HIPPOTHERAPY_PAGE_VALIDATION_FUNCTIONS.validateText`. Once it merges, these call sites will need the explicit length argument.

## How to recreate changes

1. Open /admin-panel/hippotherapy - "Наукові дослідження"
2. Click "Додати +" - a new expanded entry appears at the bottom, focused, with counters 0/150 and 0/1000; the button becomes disabled
3. Fill in both fields - "Додати +" become active again
4. In "Назва" type two spaces in a row - they collapse into one; a leading space is not accepted
5. Type 9 characters plus a space and click away - the value is trimmed and the minimum-length error appears

## CHECK LIST

- [x] New tests were added or existing were modified
- [ ] Changes have severe impact on users
- [ ] Changes have medium impact on users
- [x] Changes have light impact on users
- [x] Test coverage was updated
- [x] PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to create scientific references with generated identifiers.
  - New references open automatically for editing.
  - Add controls are disabled when existing references have incomplete or invalid details.
  - Reference names are normalized while typing and trimmed before validation.
  - Textarea inputs can now normalize content while preserving the typing position.

- **Bug Fixes**
  - Improved textarea behavior when external values change.
  - Ignored expand/collapse actions for references no longer in the list.
  - Preserved newlines while normalizing spaces in reference names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->