### PR TITLE
Fix/issue-3572 [Admin panel][Reports] Edit and Delete buttons remain enabled for other rows in edit mode

### DIFF
--- a/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
+++ b/src/pages/admin/reports/components/funds-expenditures-section/components/funds-expenditures-table/FundsExpendituresTable.tsx
@@ -180,6 +180,7 @@ export const FundsExpendituresTable = ({
     const [isSavingProgramYear, setIsSavingProgramYear] = useState(false);
     const headerCheckboxRef = useRef<HTMLInputElement | null>(null);
     const { tableWrapperRef, isMoveToTopVisible, handleTableScroll, moveToTop } = useTableScrollToTop(records.length);
+    const isProgramYearEditing = programYearEdit !== null;
     const {
         rowEditState,
         setRowEditState,
@@ -190,7 +191,7 @@ export const FundsExpendituresTable = ({
         renderAmountEditRow,
     } = useTableRowAmountEdit<RowEditState>({
         isEditing,
-        isRowActionsDisabled,
+        isRowActionsDisabled: isRowActionsDisabled || isProgramYearEditing,
         exchangeRate,
         mismatchMessage: FUNDS_EXPENDITURES_TEXT.MESSAGE.AMOUNT_USD_NOT_MATCH,
         isAcceptButtonDisabled: (state) => isAcceptButtonDisabled(state, exchangeRate),
@@ -223,7 +224,7 @@ export const FundsExpendituresTable = ({
 
     const handleStartRowEdit = useCallback(
         (record: EnrichedRecord) => {
-            if (rowEditState || isRowActionsDisabled) {
+            if (rowEditState || programYearEdit || isRowActionsDisabled) {
                 return;
             }
 
@@ -239,7 +240,7 @@ export const FundsExpendituresTable = ({
                 usdMismatchMessage: undefined,
             });
         },
-        [isRowActionsDisabled, rowEditState, setRowEditMode],
+        [isRowActionsDisabled, programYearEdit, rowEditState, setRowEditMode],
     );
 
     const handleStartProgramYearEdit = useCallback(() => {
@@ -437,7 +438,7 @@ export const FundsExpendituresTable = ({
         [moveToTop, rowEditState, programYearEdit],
     );
 
-    const isProgramYearEditing = programYearEdit !== null;
+    const isTableEditing = isAnyRowEditing || isProgramYearEditing;
     const isSavingInProgress = savingRecordId !== null;
     const sortedRecords = sortRecords(records, sort);
     const colSpan = isEditing ? 7 : 5;
@@ -473,7 +474,7 @@ export const FundsExpendituresTable = ({
                     <Button
                         buttonStyle="secondary"
                         className={styles['delete-selected-button']}
-                        disabled={isAnyRowEditing || isRowActionsDisabled}
+                        disabled={isTableEditing || isRowActionsDisabled}
                         onClick={() => onOpenBulkDelete?.()}
                     >
                         {FUNDS_EXPENDITURES_TEXT.BULK.DELETE_BUTTON}
@@ -505,7 +506,7 @@ export const FundsExpendituresTable = ({
                             <th className={styles.th}>{FUNDS_EXPENDITURES_TEXT.TABLE.COLUMNS.REPORTING_YEAR}</th>
                             <th
                                 className={cn(styles.th, styles.sortable, {
-                                    [styles['sortable-disabled']]: isAnyRowEditing,
+                                    [styles['sortable-disabled']]: isTableEditing,
                                 })}
                                 onClick={() => handleSort('type')}
                             >
@@ -516,7 +517,7 @@ export const FundsExpendituresTable = ({
                             </th>
                             <th
                                 className={cn(styles.th, styles.sortable, {
-                                    [styles['sortable-disabled']]: isAnyRowEditing,
+                                    [styles['sortable-disabled']]: isTableEditing,
                                 })}
                                 onClick={() => handleSort('categoryName')}
                             >
@@ -527,7 +528,7 @@ export const FundsExpendituresTable = ({
                             </th>
                             <th
                                 className={cn(styles.th, styles.sortable, {
-                                    [styles['sortable-disabled']]: isAnyRowEditing,
+                                    [styles['sortable-disabled']]: isTableEditing,
                                 })}
                                 onClick={() => handleSort('amountUah')}
                             >
@@ -538,7 +539,7 @@ export const FundsExpendituresTable = ({
                             </th>
                             <th
                                 className={cn(styles.th, styles.sortable, {
-                                    [styles['sortable-disabled']]: isAnyRowEditing,
+                                    [styles['sortable-disabled']]: isTableEditing,
                                 })}
                                 onClick={() => handleSort('amountUsd')}
                             >
@@ -671,7 +672,7 @@ export const FundsExpendituresTable = ({
                                                     type="checkbox"
                                                     className={styles['row-checkbox']}
                                                     aria-label={`Select record ${record.id}`}
-                                                    disabled={isAnyRowEditing}
+                                                    disabled={isTableEditing}
                                                     checked={selectedIds.includes(record.id)}
                                                     onChange={() => onToggleRecordSelection?.(record.id)}
                                                 />


### PR DESCRIPTION
## Github ticket

- Github ticket [#3572](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3572#issue-5256529384)

## Description

Fixed an issue in the Funds & Expenditures table where action buttons (edit/delete), selection checkboxes, and column sorting remained active for other records while editing the "Program" aggregate row.

## How it looks

<img width="1917" height="916" alt="Знімок екрана 2026-08-28 145431" src="https://github.com/user-attachments/assets/0b9eb47a-6cc3-4bc8-83c9-f8da9bfbf466" />

## Summary of change

- Added isTableEditing flag combining regular row editing and program aggregate row editing states.
- Passed combined disable flag to useTableRowAmountEdit hook to block row actions for all table entries during program row editing.
- Updated bulk actions, row checkboxes, and column headers sorting disable logic.
- Added missing programYearEdit dependency to handleStartRowEdit useCallback hook to fix ESLint warning.

## How to recreate changes

1.Admin is logged in
2. Admin is in edit mode on the "Доходи та витрати" page
3. Click the edit icon on the Program aggregate row 'Програмні'.
4. Verify that edit/delete buttons, checkboxes, and table sorting on other records are properly disabled.

## CHECK LIST

- [ ] New tests were added or existing were modified
- [ ] Changes have severe impact on users
- [ ] Changes have medium impact on users
- [x] Changes have light impact on users
- [ ] Test coverage was updated
- [x] PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented conflicting edits by allowing either row editing or program-year editing at one time.
  - Disabled row actions, bulk deletion, sorting, and record selection while edits are in progress.
  - Improved editing behavior to prevent unintended changes during program-year updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->