### PR TITLE
docs: enhance codex skills

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -45,8 +45,9 @@ OpenAI Codex skills use a directory with a required `SKILL.md` file containing
   reports only unresolved `MISSING`, `PARTIAL`, or `INCORRECT` story gaps.
 - `victory-center-verification` - proportionate evidence-gathering workflow for
   targeted tests, typecheck, lint, build, or skipped-check reporting.
-- `victory-center-pr-review` - lightweight PR/diff review workflow focused on
-  correctness, regressions, risk, and missed tests.
+- `victory-center-pr-review` - read-only PR/diff review workflow focused on
+  concrete correctness, regression, architecture, security, accessibility, and
+  test risks.
 
 ## Planning Workflow
 

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -37,7 +37,12 @@ OpenAI Codex skills use a directory with a required `SKILL.md` file containing
 - `victory-center-task-decomposition` - breaks large-story plans into stable
   `T-*` implementation tasks linked to acceptance criteria.
 - `victory-center-implementation` - implementation workflow for focused code
-  changes in this React/TypeScript application.
+  changes in this React/TypeScript application. For large stories it may consume
+  optional story, analysis, plan, and task artifacts.
+- `victory-center-convergence` - read-only requirement completeness check that
+  reports only unresolved `MISSING`, `PARTIAL`, or `INCORRECT` story gaps.
+- `victory-center-verification` - proportionate evidence-gathering workflow for
+  targeted tests, typecheck, lint, build, or skipped-check reporting.
 - `victory-center-pr-review` - lightweight PR/diff review workflow focused on
   correctness, regressions, risk, and missed tests.
 
@@ -45,13 +50,13 @@ OpenAI Codex skills use a directory with a required `SKILL.md` file containing
 
 Use the planning workflow only when it earns its cost:
 
-- Small task: request -> implementation. Planning artifacts are usually
-  unnecessary.
+- Small task: request -> implementation -> proportionate verification. Planning
+  artifacts are usually unnecessary.
 - Medium feature: request -> story analysis when useful -> planning ->
-  implementation.
+  implementation -> verification.
 - Large story: story -> story analysis -> planning -> task decomposition ->
-  implementation by `T-*` units. Later workflow stages may add convergence and
-  verification artifacts, but those stages are not implemented here.
+  implementation by `T-*` units -> convergence -> resolve gaps -> verification
+  -> optional PR review.
 
 The requirement authority order is:
 
@@ -67,6 +72,13 @@ Lower layers may clarify or decompose higher layers, but they must not silently
 remove requirements, weaken requirements, change product behavior, or mark work
 out of scope without support from the original request or explicit user
 clarification.
+
+Completing every `T-*` task does not prove story completeness. Convergence
+checks whether the implementation satisfies the original story and `AC-*`
+requirements. Verification checks what evidence demonstrates that the
+implementation works. PR review remains a separate quality/risk pass for
+correctness, regressions, maintainability, security, accessibility, and test
+gaps.
 
 ## Temporary Work Artifacts
 
@@ -87,6 +99,8 @@ Potential artifacts:
   expectations.
 - `tasks.md` - stable large-story task checklist using `T-001`, `T-002`, and so
   on.
+- Later workflow stages may add `convergence.md` for unresolved story gaps and
+  `verification.md` for concise verification evidence.
 
 Lifecycle principles:
 
@@ -102,4 +116,6 @@ Lifecycle principles:
 - Cleanup must target only agent-created work artifacts for that story. Do not
   use broad destructive cleanup, and do not delete incomplete work merely
   because one implementation session ended.
+- Implementation does not delete work artifacts automatically. Incomplete work
+  remains resumable; cleanup is a later lifecycle/rules concern.
 

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -9,6 +9,8 @@ Claude or Copilot instructions in `.claude/`, `.github/`, or `CLAUDE.md`.
 - `config.toml` - project-scoped Codex settings and review guidance.
 - `rules/default.rules` - conservative command approval rules for this repo.
 - `skills/` - Codex skills written in the OpenAI `SKILL.md` format.
+- `work/` - optional temporary runtime artifacts for large or resumable Codex
+  work.
 
 OpenAI Codex skills use a directory with a required `SKILL.md` file containing
 `name` and `description` front matter. Rules use Codex `.rules` files under a
@@ -26,8 +28,78 @@ OpenAI Codex skills use a directory with a required `SKILL.md` file containing
 
 ## Skills
 
+- `victory-center-story-analysis` - turns a non-trivial story/request into
+  stable acceptance criteria, assumptions, ambiguities, constraints, edge cases,
+  and out-of-scope boundaries before planning.
+- `victory-center-planning` - converts accepted requirements into an
+  implementation-oriented plan with affected areas, AC mapping, risks, and
+  verification expectations.
+- `victory-center-task-decomposition` - breaks large-story plans into stable
+  `T-*` implementation tasks linked to acceptance criteria.
 - `victory-center-implementation` - implementation workflow for focused code
   changes in this React/TypeScript application.
 - `victory-center-pr-review` - lightweight PR/diff review workflow focused on
   correctness, regressions, risk, and missed tests.
+
+## Planning Workflow
+
+Use the planning workflow only when it earns its cost:
+
+- Small task: request -> implementation. Planning artifacts are usually
+  unnecessary.
+- Medium feature: request -> story analysis when useful -> planning ->
+  implementation.
+- Large story: story -> story analysis -> planning -> task decomposition ->
+  implementation by `T-*` units. Later workflow stages may add convergence and
+  verification artifacts, but those stages are not implemented here.
+
+The requirement authority order is:
+
+```text
+user story / explicit user clarification
+-> acceptance criteria
+-> implementation plan
+-> tasks
+-> implementation
+```
+
+Lower layers may clarify or decompose higher layers, but they must not silently
+remove requirements, weaken requirements, change product behavior, or mark work
+out of scope without support from the original request or explicit user
+clarification.
+
+## Temporary Work Artifacts
+
+For large or resumable stories, Codex may create a runtime directory:
+
+```text
+.codex/work/<story-slug>/
+```
+
+Potential artifacts:
+
+- `story.md` - original story/request text or a faithful working copy, explicit
+  user clarifications, and important supplied issue/requirement references.
+- `analysis.md` - acceptance criteria such as `AC-1`, assumptions, ambiguities,
+  constraints, edge cases, and out-of-scope boundaries.
+- `plan.md` - implementation approach, affected areas, AC-to-area mapping,
+  ordering, risks, scope boundaries, re-plan triggers, and verification
+  expectations.
+- `tasks.md` - stable large-story task checklist using `T-001`, `T-002`, and so
+  on.
+
+Lifecycle principles:
+
+- Create artifacts only when work is large or complex enough to benefit from
+  durable state or resumability.
+- Update artifacts as analysis, planning, and task decomposition legitimately
+  evolve.
+- Resume later work by reading the relevant story directory first.
+- Treat temporary artifacts as working memory; they never override the original
+  user request or explicit clarification.
+- Do not rewrite the story into an easier version and then treat that rewrite as
+  authoritative.
+- Cleanup must target only agent-created work artifacts for that story. Do not
+  use broad destructive cleanup, and do not delete incomplete work merely
+  because one implementation session ended.
 

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -28,6 +28,8 @@ OpenAI Codex skills use a directory with a required `SKILL.md` file containing
 
 ## Skills
 
+- `victory-center-project-patterns` - read-only discovery for the closest
+  existing implementation pattern and directly related files.
 - `victory-center-story-analysis` - turns a non-trivial story/request into
   stable acceptance criteria, assumptions, ambiguities, constraints, edge cases,
   and out-of-scope boundaries before planning.
@@ -48,15 +50,18 @@ OpenAI Codex skills use a directory with a required `SKILL.md` file containing
 
 ## Planning Workflow
 
-Use the planning workflow only when it earns its cost:
+Use the planning workflow only when it earns its cost.
+`victory-center-project-patterns` is a supporting discovery skill, not a
+mandatory artifact-producing phase.
 
-- Small task: request -> implementation -> proportionate verification. Planning
-  artifacts are usually unnecessary.
-- Medium feature: request -> story analysis when useful -> planning ->
-  implementation -> verification.
-- Large story: story -> story analysis -> planning -> task decomposition ->
-  implementation by `T-*` units -> convergence -> resolve gaps -> verification
-  -> optional PR review.
+- Small task: request -> nearby inspection/project-patterns when needed ->
+  implementation -> proportionate verification. Planning artifacts are usually
+  unnecessary.
+- Medium feature: request -> story analysis when useful -> project-patterns ->
+  planning -> implementation -> verification.
+- Large story: story -> story analysis -> project-patterns -> planning -> task
+  decomposition -> implementation by `T-*` units -> convergence -> resolve gaps
+  -> verification -> optional PR review.
 
 The requirement authority order is:
 
@@ -79,6 +84,19 @@ requirements. Verification checks what evidence demonstrates that the
 implementation works. PR review remains a separate quality/risk pass for
 correctness, regressions, maintainability, security, accessibility, and test
 gaps.
+
+## Stage Responsibilities
+
+- Story analysis: define what the request requires and produce `AC-*` outcomes.
+- Project patterns: find repository evidence for how similar work is already
+  implemented.
+- Planning: define how accepted requirements should be implemented.
+- Task decomposition: split large plans into stable `T-*` implementation units.
+- Implementation: make the changes and update active task state when used.
+- Convergence: re-check the implementation against the original story and
+  report only unresolved requirement gaps.
+- Verification: gather proportionate evidence that the implementation works.
+- PR review: assess final quality and risk when requested.
 
 ## Temporary Work Artifacts
 
@@ -109,6 +127,8 @@ Lifecycle principles:
 - Update artifacts as analysis, planning, and task decomposition legitimately
   evolve.
 - Resume later work by reading the relevant story directory first.
+- Reconcile resumed artifacts with current `git status`, relevant diffs, and
+  current code before treating technical assumptions as current.
 - Treat temporary artifacts as working memory; they never override the original
   user request or explicit clarification.
 - Do not rewrite the story into an easier version and then treat that rewrite as

--- a/.codex/skills/victory-center-convergence/SKILL.md
+++ b/.codex/skills/victory-center-convergence/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: victory-center-convergence
+description: Read-only check that a large or complex Victory Center implementation satisfies the original story and acceptance criteria without becoming PR review or verification.
+---
+
+# Victory Center Convergence
+
+Use this skill after a large or complex story has been implemented and the
+question is whether the actual implementation converged with the original
+story. Do not make convergence mandatory for tiny fixes.
+
+## Responsibility
+
+Re-evaluate the original requirements against the actual implementation. This
+is a read-only completeness check, not general code review, test execution,
+refactoring, or implementation.
+
+## When To Use
+
+Use convergence when:
+
+- A large story was decomposed into multiple `T-*` tasks.
+- Several project layers were changed.
+- Implementation happened across multiple passes or sessions.
+- Many `AC-*` entries exist.
+- The user asks whether the story is actually complete.
+- All implementation tasks appear done but completeness still needs an
+  independent check.
+
+## Evidence Hierarchy
+
+Inspect in this authority order:
+
+1. Original user story/request.
+2. Explicit user clarifications.
+3. Acceptance criteria.
+4. Plan.
+5. Tasks.
+6. Actual code or diff.
+7. Tests only as supporting evidence.
+
+Tasks are implementation aids, not proof of completeness. Even if every `T-*`
+is checked, independently re-check the original story and `AC-*` entries.
+
+## Checks
+
+For each requirement, compare expected behavior with the actual implementation
+and report only unresolved gaps:
+
+- `MISSING` - the requirement is not implemented.
+- `PARTIAL` - some required behavior exists, but not all of it.
+- `INCORRECT` - implementation exists but does not match the requirement.
+
+Do not report style or code-smell findings unless they directly prevent
+requirement satisfaction.
+
+## Output Contract
+
+User-facing output must contain only unresolved requirement gaps:
+
+```text
+[MISSING] AC-4 - Edit flow support
+Expected:
+...
+
+Found:
+...
+
+Evidence:
+- relevant file(s)
+```
+
+If no unresolved gaps are found, say:
+
+```text
+Convergence complete. No unmet, partial, or incorrectly implemented story requirements were found.
+```
+
+Do not output a verbose successful-AC checklist.
+
+## Temporary Artifact
+
+When the active workflow already uses durable work artifacts, convergence may
+update `.codex/work/<story-slug>/convergence.md`. Keep it limited to current
+unresolved gaps. When a later pass resolves a gap, remove it from the artifact
+instead of keeping a historical success log.
+
+## Gap Resolution Handoff
+
+Convergence itself stays read-only. If gaps are found, implementation may later
+resolve them. Reuse an existing unchecked `T-*` task when it already represents
+the gap. Add a new `T-*` with the next unused ID only when the gap is materially
+independent work.
+
+Do not declare story completion until convergence reports no unresolved gaps,
+unless the user explicitly accepts or waives a known gap.
+
+## Boundaries
+
+This skill must not:
+
+- Edit application code.
+- Modify tests.
+- Fix gaps.
+- Alter acceptance criteria.
+- Rewrite the plan to hide discrepancies.
+- Mark tasks complete.
+- Perform cleanup.
+- Run broad refactors.
+- Replace verification or PR review.

--- a/.codex/skills/victory-center-convergence/SKILL.md
+++ b/.codex/skills/victory-center-convergence/SKILL.md
@@ -42,6 +42,12 @@ Inspect in this authority order:
 Tasks are implementation aids, not proof of completeness. Even if every `T-*`
 is checked, independently re-check the original story and `AC-*` entries.
 
+Use `victory-center-project-patterns` only as supporting evidence for expected
+technical project behavior; do not turn convergence into pattern enforcement.
+
+When resuming from work artifacts, compare them with current code and relevant
+diffs before treating technical assumptions as current.
+
 ## Checks
 
 For each requirement, compare expected behavior with the actual implementation

--- a/.codex/skills/victory-center-implementation/SKILL.md
+++ b/.codex/skills/victory-center-implementation/SKILL.md
@@ -19,6 +19,9 @@ verify the touched behavior, and report what changed.
    - `.codex/work/<story-slug>/analysis.md`
    - `.codex/work/<story-slug>/plan.md`
    - `.codex/work/<story-slug>/tasks.md`
+
+   Reconcile resumed artifacts with current `git status`, relevant diffs, and
+   current code before trusting technical assumptions.
 4. Inspect the closest existing examples before coding:
    - Components: `src/components/`, `src/pages/`
    - Hooks: `src/hooks/`
@@ -35,6 +38,10 @@ verify the touched behavior, and report what changed.
 
 Planning artifacts are optional. Small fixes must still be able to move directly
 from request to implementation.
+
+For non-trivial changes where the closest local pattern is unclear, use
+`victory-center-project-patterns` or perform equivalent bounded nearby
+inspection before creating a new approach.
 
 ## Requirement Authority
 
@@ -82,6 +89,9 @@ discovers materially larger scope, such as a new dependency, API contract
 change, shared abstraction affecting unrelated areas, significantly more files
 than expected, conflict with established project patterns, an invalid technical
 direction, or one task splitting into several independent units.
+
+Re-planning may update the technical plan or task decomposition, but it must not
+weaken requirements.
 
 Inspect the repository first when the issue may be resolved from existing
 behavior. Ask the user only when a real product decision or requirement

--- a/.codex/skills/victory-center-implementation/SKILL.md
+++ b/.codex/skills/victory-center-implementation/SKILL.md
@@ -13,7 +13,13 @@ verify the touched behavior, and report what changed.
 
 1. Read `AGENTS.md` first for shared project rules.
 2. Check `git status --short` before editing and preserve unrelated user work.
-3. Inspect the closest existing examples before coding:
+3. For medium or large stories, inspect relevant planning artifacts when they
+   exist:
+   - Original user request or `.codex/work/<story-slug>/story.md`
+   - `.codex/work/<story-slug>/analysis.md`
+   - `.codex/work/<story-slug>/plan.md`
+   - `.codex/work/<story-slug>/tasks.md`
+4. Inspect the closest existing examples before coding:
    - Components: `src/components/`, `src/pages/`
    - Hooks: `src/hooks/`
    - API services: `src/services/api/`
@@ -21,11 +27,65 @@ verify the touched behavior, and report what changed.
    - Validation: `src/validation/`
    - Locale strings: `src/locales/uk/`, `src/locales/en/`
    - Tests and mocks near the changed file
-4. Identify the minimal set of files required for the request.
-5. Edit only those files. Do not touch `.claude/`, `.github/`, or `CLAUDE.md`
+5. Identify the minimal set of files required for the request.
+6. Edit only those files. Do not touch `.claude/`, `.github/`, or `CLAUDE.md`
    unless explicitly requested.
-6. Run the narrowest useful verification. Prefer targeted tests first, then
+7. Run the narrowest useful verification. Prefer targeted tests first, then
    broader lint/build checks when risk or scope justifies them.
+
+Planning artifacts are optional. Small fixes must still be able to move directly
+from request to implementation.
+
+## Requirement Authority
+
+Respect this order:
+
+```text
+user story / explicit user clarification
+-> acceptance criteria
+-> implementation plan
+-> tasks
+-> implementation
+```
+
+Implementation must not silently weaken an `AC-*`, remove an `AC-*`,
+reinterpret product behavior for convenience, or treat a completed task list as
+proof that the story is complete. If a lower-level artifact conflicts with the
+original requirement, the higher-level requirement wins. Later explicit user
+clarification wins over older planning artifacts.
+
+## Task-Aware Implementation
+
+For large stories with `tasks.md`, work in meaningful `T-*` units:
+
+1. Confirm the task's referenced `AC-*` entries still exist.
+2. Inspect declared dependencies before editing.
+3. Inspect the closest relevant code before editing.
+4. Keep task scope narrow.
+
+Move a task checkbox to `[x]` only when the intended implementation unit exists,
+the relevant behavior is minimally checked, and no known blocking issue remains
+for that task. Do not mark `[x]` merely because files were edited.
+
+When useful, add short task evidence such as files changed, targeted check run,
+or result. Keep `tasks.md` concise; it should not become an activity log.
+
+## Newly Discovered Work
+
+Small, directly necessary work that clearly belongs to the current task may stay
+inside that task. Materially separate work should become a new `T-*` task using
+the next unused ID, mapped to relevant `AC-*` entries, with a short discovery
+note when the reason is not obvious.
+
+Reconsider the plan instead of silently expanding it when implementation
+discovers materially larger scope, such as a new dependency, API contract
+change, shared abstraction affecting unrelated areas, significantly more files
+than expected, conflict with established project patterns, an invalid technical
+direction, or one task splitting into several independent units.
+
+Inspect the repository first when the issue may be resolved from existing
+behavior. Ask the user only when a real product decision or requirement
+clarification is required.
 
 ## Project Rules To Preserve
 
@@ -50,6 +110,13 @@ verify the touched behavior, and report what changed.
 - Keep components focused; split only when the current change would make the
   component meaningfully harder to test or review.
 - Preserve existing naming, import order, exports, test placement, and format.
+- Do not perform convergence inside implementation.
+- Do not declare the whole story complete merely because all `T-*` tasks are
+  checked.
+- Do not turn implementation into PR review.
+- Do not modify temporary artifacts unrelated to the current story.
+- Do not clean up `.codex/work/<story-slug>/` automatically during
+  implementation.
 
 ## Tests And Docs
 

--- a/.codex/skills/victory-center-planning/SKILL.md
+++ b/.codex/skills/victory-center-planning/SKILL.md
@@ -13,7 +13,8 @@ a line-by-line coding script.
 
 Convert accepted requirements into a practical technical strategy. Read
 `AGENTS.md` for project conventions and inspect existing repository patterns
-before proposing new abstractions.
+before proposing new abstractions. Use `victory-center-project-patterns` when
+the closest existing implementation pattern is not already clear.
 
 ## Inputs
 

--- a/.codex/skills/victory-center-planning/SKILL.md
+++ b/.codex/skills/victory-center-planning/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: victory-center-planning
+description: Plan technical implementation for Victory Center requirements by mapping accepted ACs to affected areas, likely files, order, risks, and verification expectations.
+---
+
+# Victory Center Planning
+
+Use this skill for medium and large Victory Center work after the request is
+understood. Planning should be implementation-oriented, but it should not become
+a line-by-line coding script.
+
+## Responsibility
+
+Convert accepted requirements into a practical technical strategy. Read
+`AGENTS.md` for project conventions and inspect existing repository patterns
+before proposing new abstractions.
+
+## Inputs
+
+- Original story/request.
+- Story analysis and `AC-*` acceptance criteria when available.
+- Relevant repository context.
+- Existing project conventions from `AGENTS.md`.
+
+## Workflow
+
+1. Confirm the acceptance criteria or the effective requirements being planned.
+2. Inspect the closest existing implementation pattern before proposing the
+   approach.
+3. Define the implementation approach and affected project areas.
+4. Identify likely files or file groups, keeping paths approximate when exact
+   files still require implementation-time discovery.
+5. Map `AC-*` items to implementation areas.
+6. Describe dependencies or ordering between major steps.
+7. Define the expected test strategy and verification expectations before
+   coding.
+8. Record risks, scope boundaries, and re-plan triggers.
+9. For large or resumable stories, optionally write durable planning output to
+   `.codex/work/<story-slug>/plan.md`.
+
+## Scope Expansion Rule
+
+Reconsider the plan instead of silently expanding it when implementation later
+discovers materially larger scope, such as:
+
+- Unexpected API contract changes.
+- A new dependency.
+- A shared abstraction affecting unrelated features.
+- Substantially more files or areas than expected.
+- A new independent implementation unit.
+
+## Output Contract
+
+Return or record:
+
+- Implementation approach.
+- Affected project areas and likely files/file groups.
+- AC-to-area mapping.
+- Major step order and dependencies.
+- Test strategy and verification expectations.
+- Risks and scope boundaries.
+- Re-plan triggers.
+
+## Boundaries
+
+This skill must not:
+
+- Modify application code.
+- Weaken or reinterpret acceptance criteria.
+- Generate microscopic tasks.
+- Perform implementation.
+- Perform convergence, verification, or PR review.

--- a/.codex/skills/victory-center-pr-review/SKILL.md
+++ b/.codex/skills/victory-center-pr-review/SKILL.md
@@ -1,73 +1,196 @@
 ---
 name: victory-center-pr-review
-description: Review Victory Center branches, PR diffs, or local changes. Use for code review, implementation analysis, risk assessment, regression hunting, duplicate logic checks, and missed test identification.
+description: Review Victory Center PRs, branches, diffs, or local changes for concrete correctness, regression, security, accessibility, architecture, and test risks. Read-only by default.
 ---
 
 # Victory Center PR Review
 
-Use this skill when Codex is asked to review a PR, branch, diff, or local change
-set. The goal is high-signal findings, not a rewrite.
+Use this skill when Codex is asked to review a PR, branch, diff, or local change set. The primary question is: "What concrete issues in this PR/diff could break behavior, violate important project contracts, introduce regressions, or create meaningful maintenance risk?"
+
+Review is read-only by default: review first, findings first, no automatic fixes, and no automatic commits. If the user explicitly asks to fix findings, handle that as a separate follow-up implementation workflow.
 
 ## Review Setup
 
-1. Read `AGENTS.md` for shared rules.
-2. Determine the comparison base from the user request. If none is given, inspect
-   the current branch and use a reasonable base such as `main` only when it is
-   locally available.
-3. List changed files and commits, then read the changed files in full enough to
-   understand behavior.
-4. Inspect nearby unchanged code when it affects the reviewed behavior.
-5. Do not modify files during review unless the user asks for fixes.
+1. Read `AGENTS.md` for shared project rules.
+2. Determine the comparison base from the user request.
+3. If no base is provided, inspect the current branch and use a reasonable local base such as `main` only when it is actually available. Do not invent unavailable remote state.
+4. Inspect `git status --short`, changed files, relevant commits, and changed diff.
+5. Read changed files with enough surrounding context to understand behavior. Do not review only isolated hunks when full-file context is needed.
+6. Inspect nearby unchanged code when it affects the changed path.
+7. Use `victory-center-project-patterns` when a finding depends on whether the change follows an established repository pattern.
 
 Useful commands:
 
 ```bash
 git status --short
+git branch --show-current
 git diff --name-only <base>...HEAD
 git diff <base>...HEAD -- <path>
 git log --oneline <base>..HEAD
 ```
 
-## What To Look For
+## Scope Discipline
 
-Prioritize issues that can break users or slow maintainers:
+Prioritize issues introduced or materially affected by the current change. Pre-existing issues should generally not be reported unless the change makes them newly reachable, makes them worse, materially affects correctness of changed behavior, or the user explicitly requested a broader audit.
 
-- React correctness: hook rule violations, stale closures, missing effect
-  cleanup, unstable dependencies, render-time mutation, bad keys in dynamic lists.
-- TypeScript correctness: `any`, unsafe casts, overly broad props, missing null
-  handling, mismatched API shapes.
-- Project architecture drift: raw admin axios calls instead of `adminClient`,
-  bypassed `useFormManager`, missing Yup validation, relative source imports,
-  hardcoded text, missing locale entries, duplicated constants or mappers.
-- API/data fetching risks: missing cancellation for public fetches, missing
-  error handling, broken loading states, wrong auth boundary.
-- Security: unsanitized HTML, unsafe user-provided URLs, exposed secrets, token
-  handling changes.
-- Accessibility: unlabeled form inputs, non-keyboard interactive elements,
-  broken modal/focus behavior, image alt regressions.
-- Test gaps: changed behavior without regression tests, missing edge cases for
-  empty/null/error/loading states, brittle translated-text assertions.
-- Unnecessary changes: formatting churn, unrelated files, broad refactors,
-  duplicate logic, or new abstractions that do not pay for themselves.
+If a relevant issue is clearly pre-existing, label it as pre-existing and keep it secondary. Do not turn PR review into whole-repository cleanup.
+
+## What To Review
+
+### Behavioral Correctness
+
+Look for wrong business logic, missing branches, mismatched create/edit behavior, wrong state transitions, broken loading/error/empty behavior, incorrect null/undefined assumptions, wrong ordering/filtering/mapping, regressions from changed defaults, and dead or unreachable behavior introduced by the diff.
+
+### React Correctness
+
+Look for conditional or loop-level hook calls, stale closures, incomplete effect/callback dependencies, missing effect cleanup, async lifecycle issues, render-time mutation, unstable derived objects/arrays used as hook dependencies, unnecessary derived state, invalid list keys, and behavior that breaks under re-render or remount.
+
+Do not report theoretical micro-optimizations unless they create a concrete bug risk.
+
+### TypeScript Correctness
+
+Look for new `any`, unsafe casts that hide real mismatches, overly broad prop/function types, incorrect optional/null assumptions, API response shape mismatches, enum/string mismatches, lost discriminated-union safety, incorrect generic usage, and types that permit invalid runtime states.
+
+Do not report every cast. Report casts only when they materially hide risk or contradict the actual data shape.
+
+### Victory Center Architecture And Patterns
+
+Use repository evidence and `victory-center-project-patterns` when needed. Review for material departures from established patterns such as:
+
+- Raw authenticated axios usage instead of the established admin-client path.
+- Public fetch code bypassing the standard data-fetch or cancellation pattern.
+- Raw React Hook Form usage where project convention requires `useFormManager`.
+- Validation bypassing established Yup or project schema organization.
+- Hardcoded user-facing strings instead of i18n.
+- Missing locale counterpart.
+- Wrong placement of constants, types, validation, or images.
+- Relative source imports where `@/*` is the established convention.
+- New UI abstractions duplicating existing reusable components.
+- Duplicated mappers, constants, or helpers that already exist.
+- Rich-text rendering bypassing established sanitization or normalization.
+
+Do not report minor pattern differences unless they create real correctness or maintenance risk.
+
+### API And Data Flow
+
+Check request/response mapping, public request cancellation, auth client boundaries, missing or incorrect error handling, broken loading-state transitions, stale requests updating state, missing guards for absent IDs/data, wrong endpoint or payload shape, inconsistent create/update/delete flows, and optimistic behavior without rollback when required.
+
+### Security
+
+Check changed behavior for unsanitized HTML, unsafe user-provided URLs, `javascript:` or equivalent URL risks, exposed secrets or credentials, unsafe auth/token handling, unintended privileged API usage, dangerous data injection into HTML/URLs, and changes that weaken established sanitization.
+
+Keep security findings concrete and evidence-based. Do not produce generic security warnings.
+
+### Accessibility
+
+Review changed UI for meaningful regressions: unlabeled controls, non-keyboard interactive elements, broken focus management, modal/dialog focus problems, missing meaningful alt text, inaccessible state indication, invalid heading structure introduced by the change, and clickable non-semantic containers without equivalent keyboard support.
+
+Do not report subjective visual preferences as accessibility issues.
+
+### Tests
+
+Review whether changed behavior is actually tested. Look for:
+
+- Bug fixes without regression tests.
+- New behavior with only render-smoke coverage.
+- Missing empty/null/error/loading cases when relevant.
+- Tests that mock away the behavior they claim to test.
+- Brittle translated-text assertions when better local patterns exist.
+- Mocks that do not expose needed `jest.fn()` behavior.
+- Assertions that pass without exercising meaningful behavior.
+- Missing create/edit counterpart coverage.
+- Changed API mapping without request/payload assertions.
+- Changed conditional rendering without both sides tested.
+
+Do not require every edge case for every change. Prioritize gaps that could allow the reviewed regression to reappear.
+
+### Scope And Churn
+
+Check for unrelated formatting churn, unrelated files, broad refactors mixed into feature work, unnecessary abstractions, duplicated logic, unjustified file moves, unjustified dependency changes, test rewrites that hide behavior changes, and generated or incidental noise.
+
+Only report these when they meaningfully increase review risk or maintenance burden.
+
+## Finding Standard
+
+Every finding must be grounded in observable evidence. A finding should include severity, location, concrete problem, impact, evidence, and a concrete fix direction.
+
+Preferred shape:
+
+```text
+[High] src/.../ProgramForm.tsx:84
+
+Problem:
+...
+
+Impact:
+...
+
+Evidence:
+...
+
+Fix:
+...
+```
+
+Reject speculative findings. Do not report vague performance concerns, generic best-practice advice, style preferences, theoretical maintainability concerns with no concrete consequence, or bugs unsupported by the code. When confidence is low, gather more repository evidence, run a narrow confirmation check when appropriate, or omit the finding.
 
 ## Severity
 
-- Critical: likely runtime break, data loss, auth/security issue, or major user
-  regression.
-- High: incorrect behavior in a common flow, missed validation, broken API
-  contract, or important test gap.
-- Medium: maintainability issue likely to cause bugs, duplicated logic, fragile
-  implementation, or accessibility regression.
-- Low: minor issue worth fixing but not merge-blocking.
+- Critical: security/auth vulnerability, data loss, guaranteed runtime break in an important flow, destructive behavior, or severe permission boundary failure.
+- High: incorrect behavior in a common flow, broken API contract, major regression, required validation missing, incorrect create/edit behavior, or feature does not work as intended.
+- Medium: plausible bug risk, fragile hook/state behavior, important accessibility regression, duplicated/shared logic likely to diverge, meaningful missing test for changed behavior, or established architecture pattern bypassed with concrete risk.
+- Low: localized maintainability defect, minor test weakness, clarity issue with real maintenance cost, or non-blocking cleanup worth addressing.
+
+Severity reflects impact and likelihood, not ease of fixing. Do not inflate severity to make findings look important.
+
+## Relationship To Other Workflow Skills
+
+PR review is not convergence. Convergence asks whether implementation satisfied the full original story. PR review asks what defects, regressions, risks, or maintainability problems are present in the change. If story/AC context is available, PR review may mention a requirement mismatch when it manifests as an actual defect, but it should not reproduce the convergence workflow.
+
+PR review is not full verification. Prefer static/code-context review first. You may run narrowly targeted verification only when it materially increases confidence in a concrete finding and command policy permits it. Do not automatically run the full suite, coverage, lint, or build unless the user explicitly requested review plus verification or the review task itself requires that evidence.
+
+If verification evidence already exists, inspect and use it. If relevant checks were not run, state that as a review limitation rather than assuming success.
+
+## Coverage And Commits
+
+Do not manage coverage thresholds as part of ordinary PR review. Report a finding if the diff lowers thresholds to make the branch pass, removes meaningful tests without justification, or materially weakens test coverage for changed behavior.
+
+Do not manage commits during review. Do not regroup commits, commit fixes, enforce commit ordering, or create commit messages unless explicitly requested.
+
+## Review Workflow
+
+1. Establish base and review scope.
+2. Inspect status, changed files, commits, and diff.
+3. Read changed files in context.
+4. Inspect nearby code and project patterns where needed.
+5. Collect candidate findings.
+6. Reject speculative, style-only, and unrelated pre-existing findings.
+7. Classify severity by impact and likelihood.
+8. Optionally confirm a concrete finding with narrow verification.
+9. Output findings first.
+
+Do not make fixes during this workflow.
 
 ## Output Format
 
-Lead with findings. For each finding include severity, file/line, the problem,
-why it matters, and a concrete fix direction. Keep summaries brief and secondary.
+Lead directly with findings ordered by severity: Critical, High, Medium, Low. Within the same severity, prioritize user impact and confidence.
 
-If no issues are found, say that clearly and mention any verification limits,
-such as tests not run or unavailable base branch.
+For each finding include:
 
-Do not list style preferences as findings unless they create real risk in this
-project.
+- Severity.
+- File and line when available.
+- Problem.
+- Impact.
+- Evidence.
+- Fix direction.
+
+If no actionable findings are found, say:
+
+```text
+No actionable review findings found.
+```
+
+Then briefly state review limits, such as base branch unavailable, tests not run, verification evidence unavailable, or only local diff reviewed.
+
+Do not produce a large success checklist. Do not list passed review categories.
 

--- a/.codex/skills/victory-center-project-patterns/SKILL.md
+++ b/.codex/skills/victory-center-project-patterns/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: victory-center-project-patterns
+description: Find the closest existing Victory Center implementation pattern and related files for a requested feature, component, form, API flow, hook, validation rule, localization flow, test pattern, or similar task.
+---
+
+# Victory Center Project Patterns
+
+Use this skill when Codex needs repository evidence for how Victory Center
+already implements something similar. It supports planning, implementation,
+convergence, and review, but it is not a mandatory stage for tiny edits when
+the relevant pattern is already obvious from nearby files.
+
+## Responsibility
+
+Answer the question: "How does Victory Center already implement something like
+this?"
+
+Find the closest canonical implementation pattern and directly related files.
+Prefer repository evidence over generic React or TypeScript advice.
+
+## When To Use
+
+Use this skill when:
+
+- Planning a non-trivial feature.
+- Implementation needs an existing example before creating a new approach.
+- Repository structure is unfamiliar.
+- Deciding whether a reusable component, hook, service, mapper, or abstraction
+  already exists.
+- Convergence needs supporting evidence for expected project behavior.
+- Review needs to understand whether code departed from an established pattern.
+
+Do not require it when the immediate files already make the pattern clear.
+
+## Search Strategy
+
+Use bounded repository inspection:
+
+1. Start with direct names and domain terms from the request.
+2. Find the closest domain or feature matches.
+3. Inspect the strongest 1-3 candidate implementations.
+4. Follow only direct supporting files relevant to the pattern.
+5. Stop when there is enough evidence to identify the established approach.
+
+Do not scan every component, API service, test, or locale file unless the user
+explicitly asks for an exhaustive inventory.
+
+## Related Files To Consider
+
+Include only layers that matter to the request:
+
+- Component or page.
+- Hook or context.
+- API service.
+- Type or interface.
+- Validation schema.
+- Constants.
+- Localization files.
+- Styles.
+- Tests or mocks.
+
+For a form feature, usually inspect the form component, `useFormManager` usage,
+validation, types, API mapping, locale keys, and tests. For a public fetch flow,
+usually inspect the page/component, `useDataFetch`, API service, cancellation,
+loading/error/empty handling, and tests. For an admin API flow, usually inspect
+the caller, `useAdminClient()`, service method, request/response types,
+error/user feedback, and tests.
+
+These are discovery heuristics, not mandatory checklists.
+
+## Choosing The Canonical Pattern
+
+Do not blindly pick the first match. Prefer examples that are:
+
+- Actively used.
+- Structurally close to the requested work.
+- Consistent with `AGENTS.md`.
+- Repeated elsewhere in the repository.
+- Reasonably current relative to surrounding code.
+
+If existing implementations conflict, report the conflict concisely and prefer
+the pattern best supported by current project conventions. Do not silently
+invent a new standard.
+
+## Output Contract
+
+For a concrete question, return a concise result shaped like:
+
+```markdown
+### Closest existing pattern
+
+- `src/.../Example.tsx` - why this is the closest match.
+
+### Related implementation
+
+- Type: `src/types/...`
+- API: `src/services/api/...`
+- Validation: `src/validation/...`
+- Constants: `src/const/...`
+- Locale keys: `src/locales/uk/...`, `src/locales/en/...`
+- Styles/tests: relevant files only.
+
+### Pattern to preserve
+
+- Repository-specific rules demonstrated by the evidence.
+
+### Differences / cautions
+
+- Meaningful differences between the reference and requested change.
+```
+
+If no good pattern exists, say so clearly. Then identify the closest partial
+references and the project conventions that still constrain a new
+implementation.
+
+## Discovery And Requirements
+
+Project patterns provide technical evidence. They do not determine product
+requirements and do not override this authority order:
+
+```text
+user story / explicit user clarification
+-> acceptance criteria
+-> implementation plan
+-> tasks
+-> implementation
+```
+
+Repository behavior may resolve technical questions such as which API client
+pattern is standard, where validation lives, or how locale keys are structured.
+It must not become a new product requirement unless the story or `AC-*` requires
+it.
+
+## Boundaries
+
+This skill must not:
+
+- Modify application files.
+- Refactor code.
+- Create new abstractions.
+- Alter requirements.
+- Update `AC-*` or `T-*`.
+- Run convergence.
+- Perform PR review.
+- Generate temporary work artifacts merely for discovery.
+- Run broad test, lint, build, typecheck, or coverage commands.

--- a/.codex/skills/victory-center-story-analysis/SKILL.md
+++ b/.codex/skills/victory-center-story-analysis/SKILL.md
@@ -13,7 +13,9 @@ small, obvious changes usually do not need durable analysis artifacts.
 
 Convert the original request into a stable requirement model while preserving
 the user's intent. Read `AGENTS.md` first for shared project rules, then inspect
-repository context when existing behavior can answer an ambiguity.
+repository context when existing behavior can answer an ambiguity. Use
+`victory-center-project-patterns` when repository behavior can resolve a
+technical ambiguity without making a product decision.
 
 ## Authority Order
 

--- a/.codex/skills/victory-center-story-analysis/SKILL.md
+++ b/.codex/skills/victory-center-story-analysis/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: victory-center-story-analysis
+description: Analyze non-trivial Victory Center stories before planning by extracting acceptance criteria, assumptions, ambiguities, constraints, edge cases, and out-of-scope boundaries.
+---
+
+# Victory Center Story Analysis
+
+Use this skill when Codex needs to understand a non-trivial user story or
+request before implementation planning. Keep it lightweight for routine fixes:
+small, obvious changes usually do not need durable analysis artifacts.
+
+## Responsibility
+
+Convert the original request into a stable requirement model while preserving
+the user's intent. Read `AGENTS.md` first for shared project rules, then inspect
+repository context when existing behavior can answer an ambiguity.
+
+## Authority Order
+
+```text
+user story / explicit user clarification
+-> acceptance criteria
+-> implementation plan
+-> tasks
+-> implementation
+```
+
+Lower layers may clarify or decompose higher layers, but must never silently
+remove a requirement, weaken a requirement, change product behavior, or mark
+something out of scope without support from the original request or explicit
+clarification.
+
+## Workflow
+
+1. Preserve the original user story/request and any explicit clarifications.
+2. Extract explicit acceptance criteria as stable IDs: `AC-1`, `AC-2`, and so
+   on.
+3. Identify assumptions, ambiguities, constraints, edge cases implied by the
+   story, and relevant out-of-scope boundaries.
+4. Inspect existing code or documentation before asking the user questions when
+   the answer can reasonably be derived from the repository.
+5. Separate observed project behavior, reasonable technical inference, and
+   product decisions that require user clarification.
+6. For large or resumable stories, optionally write durable analysis to
+   `.codex/work/<story-slug>/analysis.md`.
+
+## Output Contract
+
+Return or record:
+
+- Original request summary.
+- Acceptance criteria using `AC-*` IDs.
+- Observed project behavior.
+- Technical assumptions and inferences.
+- Ambiguities or product decisions that still need clarification.
+- Constraints, edge cases, and out-of-scope notes.
+
+## Boundaries
+
+This skill must not:
+
+- Modify source code.
+- Create implementation tasks.
+- Decide implementation details prematurely.
+- Invent product requirements.
+- Ask questions when repository inspection can reasonably answer them.
+- Treat `.codex/work/` artifacts as more authoritative than the original story
+  or explicit user clarification.

--- a/.codex/skills/victory-center-task-decomposition/SKILL.md
+++ b/.codex/skills/victory-center-task-decomposition/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: victory-center-task-decomposition
+description: Decompose large Victory Center implementation plans into stable T-* tasks linked to acceptance criteria without changing product requirements.
+---
+
+# Victory Center Task Decomposition
+
+Use this skill only for large stories where a durable task list will help
+implementation proceed in stable units. Do not make it mandatory for routine
+feature work or small fixes.
+
+## Responsibility
+
+Convert a sufficiently large implementation plan into executable tasks while
+preserving acceptance criteria as the source of what must be true.
+
+## Inputs
+
+- Original story/request.
+- Story analysis and `AC-*` acceptance criteria.
+- Implementation plan.
+- Relevant scope boundaries and re-plan triggers.
+
+## Task IDs
+
+Use monotonically increasing stable IDs:
+
+```text
+T-001
+T-002
+T-003
+```
+
+Rules:
+
+- IDs are never reused.
+- If a task is cancelled or deferred, do not renumber later tasks.
+- Newly discovered tasks receive the next unused ID.
+- Task order may evolve, but identity must remain stable.
+
+## Task Syntax
+
+Prefer concise checklist entries:
+
+```markdown
+- [ ] T-001 [AC-1] Add request/response types for the publishing flow
+- [ ] T-008 [AC-2, AC-4] Add focused regression tests for failed publish requests
+- [ ] T-012 [AC-3] Wire publish state into the existing admin form
+  Depends on: T-004, T-009
+```
+
+Add dependency metadata only when it provides real implementation value.
+
+## Task Granularity
+
+A task should represent one meaningful implementation unit or small outcome.
+
+Good examples:
+
+- Add request/response types for the publishing flow.
+- Add admin API method for publishing a program.
+- Wire publish state into the existing admin form.
+- Add focused regression tests for failed publish requests.
+
+Bad examples:
+
+- Open file.
+- Read component.
+- Add import.
+- Rename variable.
+- Implement feature.
+- Fix everything.
+
+For a normal large story, prefer tens of meaningful tasks rather than dozens of
+microscopic editor operations.
+
+## AC Traceability
+
+Every implementation task should reference relevant `AC-*` IDs when possible.
+Technical enabling tasks that do not directly satisfy one AC may reference
+multiple ACs or be clearly marked as shared/cross-cutting.
+
+Acceptance criteria define what must be true. Tasks define how the
+implementation intends to achieve it. Completing every task does not prove the
+story is complete; a later convergence pass must independently re-check the
+original requirements.
+
+## Task Lifecycle
+
+Use checkboxes as implementation state:
+
+- `[ ]` = not yet completed.
+- `[x]` = implementation unit completed and minimally verified.
+
+Do not mark `[x]` merely because a file was edited. If implementation discovers
+a materially separate piece of work, add a new `T-*` task instead of silently
+making an existing task much broader.
+
+For large stories, durable task state should map to
+`.codex/work/<story-slug>/tasks.md`. Prefer one `tasks.md` by default. Split
+into multiple task files only when one task file becomes difficult to navigate.
+
+## Boundaries
+
+This skill must not:
+
+- Alter acceptance criteria.
+- Redefine product behavior.
+- Hide dropped requirements.
+- Treat task completion as proof of story completion.
+- Modify application code.

--- a/.codex/skills/victory-center-verification/SKILL.md
+++ b/.codex/skills/victory-center-verification/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: victory-center-verification
+description: Gather proportionate evidence that a Victory Center implementation works, using targeted tests and checks without replacing convergence or PR review.
+---
+
+# Victory Center Verification
+
+Use this skill after implementation, and after convergence for large stories
+when convergence is part of the workflow. Verification asks what evidence
+demonstrates that the implementation is correct and safe enough to finish.
+
+## Responsibility
+
+Gather proportionate evidence that the completed implementation works.
+Verification is distinct from convergence:
+
+- Convergence asks whether the whole story was implemented.
+- Verification asks whether there is evidence that the implementation works.
+
+## Inputs
+
+When available, inspect:
+
+- Original story and `AC-*` entries.
+- Changed files.
+- Plan verification strategy.
+- `T-*` tasks.
+- Convergence result.
+- Relevant `package.json` scripts.
+- Nearby existing tests.
+
+If convergence still has unresolved gaps, verification may still run targeted
+checks, but it must clearly state that story completeness remains unresolved.
+Do not treat verification success as convergence success.
+
+## Strategy
+
+Prefer the narrowest useful evidence first:
+
+1. Inspect the changed diff.
+2. Run targeted relevant tests.
+3. Run TypeScript check when source or types changed.
+4. Run lint when appropriate.
+5. Run broader tests, build, or coverage only when risk or scope justifies them.
+
+Use existing repository commands and Codex command rules. Relevant commands may
+include:
+
+```bash
+npx craco test --watchAll=false --forceExit --testPathPattern=...
+npx tsc --noEmit
+npm run lint
+npm run build
+npm run test:cover
+```
+
+Do not require every change to run every command.
+
+## AC Evidence
+
+When practical, map evidence back to `AC-*` entries internally and summarize it
+concisely. Do not produce a large requirement matrix unless the user requests
+one.
+
+## Result States
+
+Use these states:
+
+- `PASS` - required checks passed and no known blocking verification issue
+  remains.
+- `PARTIAL` - some relevant checks passed but meaningful evidence is missing.
+- `FAIL` - a relevant check failed or expected behavior is contradicted.
+- `SKIPPED` - a check was intentionally not run, with a reason.
+
+Report residual risk only when meaningful.
+
+## Temporary Artifact
+
+For large or resumable stories already using `.codex/work/<story-slug>/`,
+verification may write `.codex/work/<story-slug>/verification.md`.
+
+Keep it concise:
+
+- Checks run.
+- Result.
+- Skipped checks and why.
+- Residual risk if any.
+
+Do not create this artifact for small work that does not otherwise use durable
+work state.
+
+## Boundaries
+
+This skill must not:
+
+- Redefine product requirements.
+- Silently fix implementation.
+- Perform broad refactors.
+- Replace convergence.
+- Replace PR review.
+- Change coverage thresholds unless explicitly requested by the user.
+- Run destructive commands.
+
+If checks reveal an implementation issue, report it and return control to
+implementation.

--- a/.codex/skills/victory-center-verification/SKILL.md
+++ b/.codex/skills/victory-center-verification/SKILL.md
@@ -33,6 +33,9 @@ If convergence still has unresolved gaps, verification may still run targeted
 checks, but it must clearly state that story completeness remains unresolved.
 Do not treat verification success as convergence success.
 
+When resuming from work artifacts, reconcile the planned verification strategy
+with the current changed files before choosing checks.
+
 ## Strategy
 
 Prefer the narrowest useful evidence first:

--- a/.codex/work/.gitignore
+++ b/.codex/work/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## JIRA or Github ticker

N/A - tooling improvement

## Description

This PR expands `.codex/` into a staged, project-aware workflow for small fixes, medium features, and large user stories.

It adds:

- story analysis and explicit AC-*
- project-pattern discovery
- implementation planning
- stable `T-*` task decomposition
- optional `.codex/work/<story-slug>/` state for resumable work
- task-aware implementation
- read-only convergence for `MISSING` / `PARTIAL` / `INCORRECT` gaps
- separate verification
- safer routing and command boundaries

The workflow stays lightweight for small tasks and scales up only when complexity requires it.

Same workflow can be made for other agents like Claude or Copilot. This PR precisely aims to add this workflow for Codex.

## How it looks

Tooling only - no visual changes to the application.

The Codex workflow was validated against a real large story before implementation. For the planning-only pass, Codex:

- analyzed the original story and linked behavior specifications
- inspected existing frontend implementation and closest repository patterns
- identified already implemented vs missing behavior
- created temporary resumable work artifacts under `.codex/work/<story-slug>/`
- stopped before application code changes, as requested

<details>
<summary><strong>1. Story analysis and planning PoC</strong></summary>

### Input

Codex (_5.5 Medium_) was given [story #3149](https://github.com/ita-social-projects/VictoryCenter-Back/issues/3149) and asked to stop before implementation.

It:
- extracted `AC-*`
- inspected existing project patterns
- created an implementation plan
- decomposed the work into stable `T-*`
- created temporary resumable artifacts under:
```text
.codex/work/add-event-news-category/
├── story.md
├── analysis.md
├── plan.md
└── tasks.md
```

It also identified existing partial Events-category behavior and reused nearby Programs/Reports/input patterns instead of inventing a new flow.

No application code, tests, commits, `.claude/`, .`github/`, or `CLAUDE.md` were changed.

### Screenshots
<img width="340" alt="image" src="https://github.com/user-attachments/assets/f634c8bd-181a-45d4-a5d3-bf93993c5da9" />
<br />
<img width="340" alt="image" src="https://github.com/user-attachments/assets/368425ac-76cf-4c6b-aa54-f0f240aa3eab" />
 <br />
<img width="340" alt="image" src="https://github.com/user-attachments/assets/ad80e9f2-e2f7-41a7-9b77-7afe7b8a4a3c" />
<br />

</details>

<details>

<summary><strong>2. Task-driven implementation PoC</strong></summary>

Codex (_5.4 Medium_) continued from the existing `.codex/work/add-event-news-category/` artifacts and implemented the story by following the planned `T-*` tasks.

Key results:

- completed the Events admin add-category flow
- added API/type support and validation normalization
- reused/extented existing shared input patterns instead of introducing a separate implementation
- updated `tasks.md` with implementation progress
- recorded verification evidence in `verification.md`
- intentionally stopped before convergence

Verification:

- targeted Jest tests passed
- `npx tsc --noEmit` was blocked by a pre-existing `tsconfig.json` `ignoreDeprecations` issue

### Screenshots

<img width="340" alt="image" src="https://github.com/user-attachments/assets/27967586-45e2-4c2d-b303-b8e711ef123e" />
<br />
<img width="340" alt="image" src="https://github.com/user-attachments/assets/808d6a85-aac9-433f-8681-a6f374fc333c" />

</details>

<details>

<summary><strong>3. Story convergence PoC</strong></summary>

After implementation, Codex (_5.4 Medium_) ran a separate read-only convergence pass against the original story and acceptance criteria.

It found one unresolved gap:

- `[PARTIAL] AC-1` - the required `Додати категорію` option is present, but the same context menu also contains `Редагувати`, so the implemented behavior does not fully match the story expectation.

No code was modified during convergence. The finding was written to `.codex/work/add-event-news-category/convergence.md`.

### Screenshot

<img width="340" alt="image" src="https://github.com/user-attachments/assets/ec4659c4-29f3-4e14-a83c-94e8c5972a69" />

</details>

## Summary of change

### Added Codex skills

- `victory-center-story-analysis` - extracts story requirements, acceptance criteria, assumptions, constraints, and ambiguities
- `victory-center-project-patterns` - finds the closest existing Victory Center implementation patterns and related files
- `victory-center-planning` - maps requirements to implementation areas, risks, scope, and verification strategy
- `victory-center-task-decomposition` - breaks large stories into stable `T-*` implementation units mapped to `AC-*`
- `victory-center-convergence` - performs a read-only completeness check against the original story and reports only `MISSING`, `PARTIAL`, or `INCORRECT` gaps
- `victory-center-verification` - gathers implementation evidence through proportionate tests, typecheck, lint/build, and diff inspection

### Updated existing Codex guidance

- `victory-center-implementation`
- `victory-center-pr-review`
- `.codex/README.md`
- `.codex/config.toml`
- `.codex/rules/*`

### Temporary work artifacts

Large or resumable stories may use:

```text
.codex/work/<story-slug>/
├── story.md
├── analysis.md
├── plan.md
├── tasks.md
├── convergence.md
└── verification.md
```

## How to recreate changes

1. Open Codex in this repository with the project `.codex/` layer trusted.
2. Small task: ask Codex to implement it directly.
3. Medium feature: ask for analysis + planning before implementation.
4. Large story: ask Codex to create `AC-*`, inspect project patterns, build a plan, decompose into `T-*`, and use `.codex/work/<story-slug>/` when useful.
5. Implement using the generated tasks.
6. Run convergence and resolve any `MISSING`, `PARTIAL`, or `INCORRECT` gaps.
7. Run final verification.
8. Use the PR-review workflow separately for branch/diff review.

## Usage note

The staged workflow may use more context and tokens than a direct implementation prompt.

Usage mainly depends on:

- model and reasoning level
- story size
- number of files inspected
- use of `.codex/work/`
- number of implementation/convergence passes
- verification output

Small tasks intentionally skip heavier stages when they are not needed.

## CHECK LIST

- [ ] New tests were added or existing were modified
- [ ] Changes have severe impact on users
- [ ] Changes have medium impact on users
- [x] Changes have light impact on users
- [ ] Test coverage was updated
- [x] PR meets all conventions
